### PR TITLE
Re-routes most wall pipes on Cogmap 1

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -4461,15 +4461,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
-"arK" = (
-/obj/disposalpipe/segment/transport{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/purple/side{
-	dir = 4
-	},
-/area/station/science/lobby)
 "arM" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating/airless,
@@ -5472,7 +5463,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /turf/simulated/floor/white,
@@ -5920,11 +5911,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "awZ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big,
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor,
 /area/station/science/artifact)
 "axa" = (
 /obj/machinery/camera{
@@ -7993,7 +7988,7 @@
 	},
 /area/station/hydroponics/bay)
 "aDI" = (
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
 /area/station/science/testchamber)
 "aDJ" = (
@@ -11446,10 +11441,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
 "aON" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purple/corner{
 	dir = 1
 	},
@@ -13847,8 +13838,8 @@
 	},
 /area/station/crew_quarters/courtroom)
 "aVD" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/item/device/radio/intercom/medical{
+	dir = 8
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
@@ -15541,10 +15532,6 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bav" = (
@@ -15770,13 +15757,12 @@
 	},
 /area/station/engine/elect)
 "bbi" = (
-/obj/machinery/light/emergency{
-	dir = 4
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/disposalpipe/segment/transport,
-/turf/simulated/floor/purple/side{
-	dir = 4
-	},
+/turf/simulated/floor/plating,
 /area/station/science/lobby)
 "bbk" = (
 /turf/simulated/floor/grey/side{
@@ -19874,10 +19860,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/segment/transport{
+	icon_state = "pipe-c"
 	},
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "boW" = (
@@ -19944,9 +19929,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/switch_junction/right/west{
-	mail_tag = "place";
-	name = "research router"
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -24082,6 +24067,9 @@
 "bJt" = (
 /obj/table/auto,
 /obj/item/paper/blueprint/chart/system,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -24380,6 +24368,7 @@
 	},
 /area/station/science/teleporter)
 "bKm" = (
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bKn" = (
@@ -26361,6 +26350,10 @@
 /obj/item/kitchen/food_box/sugar_box{
 	pixel_y = 10
 	},
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -26401,11 +26394,15 @@
 	},
 /area/station/science/lobby)
 "bRh" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/science/lobby)
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/testchamber)
 "bRi" = (
 /obj/storage/closet/biohazard,
 /obj/decal/tile_edge/stripe/extra_big,
@@ -26764,10 +26761,6 @@
 	location = "Research"
 	},
 /obj/decal/stripe_caution,
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bSF" = (
@@ -26789,7 +26782,6 @@
 	icon_state = "4-8"
 	},
 /obj/landmark/halloween,
-/obj/disposalpipe/segment/transport,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -26819,9 +26811,8 @@
 	location = "depot";
 	name = "bot navigation beacon"
 	},
-/obj/disposalpipe/switch_junction/right/west{
-	mail_tag = "chemistry";
-	name = "chemistry router"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -26925,7 +26916,7 @@
 "bSZ" = (
 /obj/decal/stripe_caution,
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = "research","chemistry","test_chamber";
+	mail_tag = list("research","chemistry","test_chamber");
 	name = "research dept router"
 	},
 /turf/simulated/floor,
@@ -27149,7 +27140,6 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -27165,7 +27155,6 @@
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bTZ" = (
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/purple/corner,
 /area/station/science/lobby)
 "bUa" = (
@@ -27179,7 +27168,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "bUe" = (
@@ -27446,17 +27434,15 @@
 /area/station/science/lobby)
 "bVm" = (
 /obj/machinery/disposal,
-/obj/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/disposalpipe/trunk,
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
 /area/station/science/lobby)
 "bVo" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/disposalpipe/switch_junction/left/south{
+	mail_tag = "test_chamber";
+	name = "test chamber mail router"
 	},
 /turf/simulated/floor/purple/corner{
 	dir = 1
@@ -27464,7 +27450,7 @@
 /area/station/science/lobby)
 "bVp" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
+	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
@@ -27480,7 +27466,6 @@
 /obj/machinery/light/emergency{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
@@ -27506,7 +27491,6 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "bVx" = (
@@ -27533,29 +27517,22 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/disposalpipe/junction{
+	dir = 1
 	},
 /turf/simulated/floor/purple/corner{
 	dir = 8
 	},
 /area/station/hallway/primary/south)
 "bVF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/switch_junction{
-	desc = "An underfloor mail pipe.";
-	dir = 8;
-	icon_state = "pipe-sj2";
-	mail_tag = "medbay";
-	name = "medbay mail router"
+/obj/disposalpipe/switch_junction/left/east{
+	mail_tag = "chemistry";
+	name = "chemistry mail router"
 	},
 /turf/simulated/floor/purple/side{
-	dir = 1
+	dir = 4
 	},
-/area/station/hallway/primary/south)
+/area/station/science/lobby)
 "bVG" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -27808,8 +27785,8 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/segment{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -27823,34 +27800,27 @@
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bWy" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/science/lobby)
+/turf/space,
+/area/space)
 "bWz" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bWA" = (
 /obj/cable{
 	icon_state = "1-8"
-	},
-/obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment/transport{
-	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -27890,7 +27860,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "bWI" = (
@@ -28155,19 +28124,22 @@
 /area/station/science/lobby)
 "bXG" = (
 /obj/machinery/light,
-/obj/disposalpipe/trunk/mail{
-	dir = 1
-	},
 /obj/machinery/disposal/mail{
 	mail_tag = "research";
 	mailgroup = "science";
 	message = 1;
 	name = "mail chute-'Research'"
 	},
+/obj/disposalpipe/trunk/mail{
+	dir = 4
+	},
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "bXH" = (
-/obj/disposalpipe/segment,
+/obj/disposalpipe/switch_junction/left/south{
+	mail_tag = "research";
+	name = "research router"
+	},
 /turf/simulated/floor/purple/corner{
 	dir = 4
 	},
@@ -28188,10 +28160,6 @@
 	},
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
@@ -28318,17 +28286,13 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/toilets)
 "bYi" = (
-/obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/blue/corner,
 /area/station/hallway/primary/south)
 "bYj" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue/side{
 	dir = 0
 	},
@@ -28558,7 +28522,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -28581,9 +28545,6 @@
 	pixel_y = 6
 	},
 /obj/item/pen,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "bZh" = (
@@ -28779,7 +28740,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
@@ -29034,15 +28994,13 @@
 /area/station/science/bot_storage)
 "caH" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/transport{
+/obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/purple/side{
-	dir = 4
-	},
+/turf/simulated/floor,
 /area/station/science/lobby)
 "caN" = (
 /obj/cable{
@@ -29730,7 +29688,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/purple/corner{
 	dir = 1
 	},
@@ -30091,9 +30049,8 @@
 /area/station/science/artifact)
 "cej" = (
 /obj/reagent_dispensers/watertank/fountain,
-/obj/disposalpipe/segment/transport{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/purple/side{
 	dir = 8
@@ -30110,6 +30067,9 @@
 	},
 /obj/machinery/status_display{
 	pixel_y = 30
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/station/medical/medbay/lobby)
@@ -30139,7 +30099,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "cet" = (
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -30383,7 +30343,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment/transport{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
@@ -30405,10 +30365,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -30425,6 +30384,10 @@
 	location = "research";
 	name = "bot navigation beacon"
 	},
+/obj/disposalpipe/segment/transport{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/purple/corner{
 	dir = 8
 	},
@@ -30437,7 +30400,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
@@ -30452,7 +30415,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor/purple/side{
@@ -30463,7 +30426,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor/purple/side{
@@ -30478,7 +30441,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor/purple/side{
@@ -30499,21 +30462,28 @@
 /turf/simulated/floor/wood,
 /area/station/medical/medbay/lobby)
 "cfB" = (
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "red2"
 	},
 /area/station/medical/medbay/lobby)
 "cfC" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "red2"
 	},
 /area/station/medical/medbay/lobby)
 "cfD" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/disposalpipe/switch_junction/left/east{
+	mail_tag = "medbay";
+	name = "medbay mail router"
 	},
 /turf/simulated/floor/carpet{
 	dir = 5;
@@ -30827,7 +30797,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "cgG" = (
@@ -30854,7 +30824,7 @@
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "cgI" = (
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "cgJ" = (
@@ -30868,10 +30838,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/purple/side{
 	dir = 10
 	},
@@ -31221,7 +31191,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/transport,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/stairs,
 /area/station/science/lobby)
 "chS" = (
@@ -31248,7 +31218,6 @@
 	},
 /area/station/science/lobby)
 "chW" = (
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/stairs{
 	icon_state = "stairs_middle"
 	},
@@ -31257,6 +31226,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/stairs{
 	icon_state = "Stairs2_wide"
 	},
@@ -31468,14 +31438,12 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southeast)
 "ciN" = (
+/obj/lattice,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/purple/side{
 	dir = 4
 	},
-/area/station/science/lobby)
+/turf/space,
+/area/space)
 "ciO" = (
 /obj/machinery/floorflusher/minibrig,
 /obj/disposalpipe/trunk/ejection{
@@ -31535,7 +31503,6 @@
 	icon_state = "1-2"
 	},
 /obj/landmark/gps_waypoint,
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "ciX" = (
@@ -32004,7 +31971,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
 /area/station/science/artifact)
 "ckt" = (
@@ -32068,7 +32035,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/disposalpipe/segment/transport,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "cky" = (
@@ -32106,7 +32073,6 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "ckF" = (
@@ -32504,10 +32470,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "clV" = (
@@ -32602,12 +32564,13 @@
 	},
 /area/station/medical/medbay/lobby)
 "cmi" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/lattice,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/disposalpipe/segment/transport,
-/turf/simulated/floor,
-/area/station/science/lobby)
+/turf/space,
+/area/space)
 "cmj" = (
 /obj/machinery/disposal/morgue,
 /obj/disposalpipe/trunk/morgue,
@@ -32924,7 +32887,7 @@
 	icon_state = "0-4"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "cmY" = (
@@ -33150,7 +33113,7 @@
 /area/station/hangar/science)
 "cod" = (
 /obj/storage/closet/biohazard,
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
 /area/station/science/testchamber)
 "coe" = (
@@ -33200,6 +33163,10 @@
 /area/station/science/testchamber)
 "coj" = (
 /obj/machinery/portable_atmospherics/scrubber,
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "col" = (
@@ -33576,6 +33543,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "cpo" = (
@@ -33938,7 +33906,7 @@
 "cqk" = (
 /obj/stool/chair/office,
 /obj/decal/tile_edge/stripe/extra_big,
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -33949,7 +33917,7 @@
 	target_pressure = 250
 	},
 /obj/decal/tile_edge/stripe/extra_big,
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -33958,7 +33926,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -34426,9 +34394,10 @@
 	icon_state = "1-8"
 	},
 /obj/landmark/gps_waypoint,
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "cse" = (
@@ -35867,6 +35836,10 @@
 	},
 /obj/machinery/ai_status_display{
 	pixel_y = 28
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood,
 /area/station/medical/medbay/lobby)
@@ -39286,9 +39259,9 @@
 /area/station/security/secwing)
 "dSW" = (
 /obj/landmark/pest,
-/obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment/transport{
-	dir = 4
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -39673,7 +39646,6 @@
 /obj/mapping_helper/access/robotdepot,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "eiP" = (
@@ -40037,8 +40009,8 @@
 /area/station/crew_quarters/bar)
 "eup" = (
 /obj/decal/tile_edge/stripe/extra_big,
-/obj/item/device/radio/intercom/medical{
-	dir = 8
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
@@ -40533,10 +40505,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/north)
 "eIj" = (
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "eIp" = (
@@ -41187,9 +41156,6 @@
 /turf/simulated/floor/grime,
 /area/station/medical/robotics)
 "fiV" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/vending/coffee,
 /obj/cable{
 	icon_state = "0-2"
@@ -41459,10 +41425,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/transport{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "fqw" = (
@@ -41521,7 +41484,7 @@
 /turf/space,
 /area/space)
 "fsp" = (
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
 /area/station/science/artifact)
 "fsz" = (
@@ -43064,7 +43027,7 @@
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/access/chemistry,
-/obj/disposalpipe/segment/transport,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "gIq" = (
@@ -44785,8 +44748,7 @@
 	},
 /obj/landmark/start/job/scientist,
 /obj/disposalpipe/segment/transport{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -46828,15 +46790,6 @@
 /area/station/hangar/catering{
 	name = "Catering Hangar"
 	})
-"jKJ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/science/bot_storage)
 "jKQ" = (
 /obj/machinery/firealarm/south,
 /obj/cable{
@@ -47551,9 +47504,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -47695,7 +47645,7 @@
 /obj/item/device/radio/intercom/engineering{
 	dir = 1
 	},
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
@@ -49019,7 +48969,6 @@
 /area/station/engine/hotloop)
 "lyD" = (
 /obj/landmark/antagonist/blob,
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "lyK" = (
@@ -49282,7 +49231,7 @@
 /area/station/maintenance/solar/west)
 "lJY" = (
 /obj/machinery/firealarm/west,
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
@@ -49426,13 +49375,6 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/fitness)
-"lRT" = (
-/obj/mapping_helper/wingrille_spawn/auto,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/science/bot_storage)
 "lSC" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -49536,7 +49478,7 @@
 /obj/mapping_helper/access/artlab,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -52129,7 +52071,7 @@
 /obj/item/device/radio/intercom/medical{
 	dir = 1
 	},
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor/blue/side{
@@ -52558,10 +52500,6 @@
 "okN" = (
 /obj/machinery/light/emergency,
 /obj/machinery/firealarm/east,
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/blue/side{
 	dir = 6
 	},
@@ -54557,7 +54495,7 @@
 	dir = 4;
 	pixel_x = -15
 	},
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "pKu" = (
@@ -57695,7 +57633,7 @@
 /obj/item/device/radio/intercom/security{
 	dir = 1
 	},
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor/red/side,
@@ -60337,10 +60275,7 @@
 /area/station/wreckage)
 "ufo" = (
 /obj/storage/closet/biohazard,
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "ufy" = (
@@ -61422,12 +61357,16 @@
 /turf/simulated/floor/yellow/side,
 /area/station/storage/primary)
 "uRR" = (
-/obj/disposalpipe/segment,
-/obj/disposalpipe/segment/transport{
-	dir = 4
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor,
-/area/station/science/lobby)
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/space,
+/area/space)
 "uSJ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -61566,6 +61505,9 @@
 	dir = 4
 	},
 /obj/landmark/start/job/scientist,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -62287,11 +62229,12 @@
 /turf/simulated/floor/plating/jen,
 /area/station/engine/power)
 "vGo" = (
-/obj/disposalpipe/segment{
-	dir = 2;
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/mail{
+	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/science/lobby)
 "vGs" = (
 /obj/cable{
@@ -62385,17 +62328,12 @@
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "vJR" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/guardbot_dock,
-/obj/decal/stripe_caution,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/science/bot_storage)
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/lobby)
 "vKj" = (
 /obj/cable/yellow,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -64279,7 +64217,7 @@
 "xhn" = (
 /obj/stool/chair/office,
 /obj/decal/tile_edge/stripe/extra_big,
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment/transport{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
@@ -94498,9 +94436,9 @@ wuW
 bHW
 bHW
 ccV
-ceg
-csd
 awZ
+csd
+cbq
 cbq
 aph
 ckv
@@ -95102,9 +95040,9 @@ vqd
 car
 bHW
 ccX
-ccX
-lVy
 cgJ
+lVy
+ccX
 ccX
 ccX
 ccX
@@ -95408,11 +95346,11 @@ cej
 cft
 cgK
 chR
-cmi
+bVq
 ckx
-cmi
+bVq
 gIi
-cpl
+bRh
 bVw
 boS
 crp
@@ -95701,10 +95639,10 @@ bSz
 pif
 bVk
 lJY
-bXA
+cav
 bZe
-bXA
-bXA
+cav
+cav
 ccZ
 dSW
 bWz
@@ -96008,7 +95946,7 @@ bZf
 cas
 cbI
 cda
-caH
+cbI
 cfu
 sdX
 chS
@@ -96304,7 +96242,7 @@ bQX
 asW
 bJY
 bVm
-bWx
+caH
 bXC
 bVj
 cat
@@ -97207,9 +97145,9 @@ bLr
 sGk
 bIQ
 bQZ
-bWx
+fqc
 bKm
-bRh
+bKm
 fqc
 kHj
 dQf
@@ -97509,8 +97447,8 @@ pjv
 bOu
 bIQ
 uYN
-bWy
-bTY
+bau
+clU
 clU
 bWA
 bXG
@@ -97813,20 +97751,20 @@ bIQ
 bJt
 bpn
 eIj
-vGo
-uRR
+eIj
+eIj
 bXH
-cav
-cav
-cav
-cav
-cav
+bXA
+bXA
+bXA
+bXA
+bXA
 bVo
 bVp
 chW
 lyD
 ckE
-bVq
+bTY
 dxk
 coq
 cAL
@@ -98115,20 +98053,20 @@ bIQ
 hYn
 bSH
 bTZ
-bbi
-arK
-bWB
-ciN
-caw
-caw
 bVr
+bWB
+bWB
+bWB
+bWB
+bWB
+bVr
+bWB
+bWB
+bVF
+chX
 caw
 caw
 aJh
-chX
-bWB
-bWB
-bWB
 cjC
 cor
 djA
@@ -98425,8 +98363,8 @@ cax
 gzr
 bVj
 bVj
-vbI
-vbI
+bbi
+vGo
 vbI
 vbI
 vbI
@@ -98722,12 +98660,12 @@ bUb
 bVj
 cdb
 cdb
-lRT
+bZh
 bZh
 cdb
 cdb
-aap
-aaq
+cmi
+uRR
 aaq
 aaq
 aaq
@@ -99024,11 +98962,11 @@ bUa
 mRx
 bWE
 bXI
-vJR
+bZi
 bZi
 cbK
 cdb
-aaG
+bWy
 adC
 adC
 adC
@@ -99326,11 +99264,11 @@ nzS
 bVj
 bWF
 eCS
-jKJ
+eCS
 eCS
 cbL
 cdb
-aap
+ciN
 aaw
 aaw
 aaw
@@ -99632,7 +99570,7 @@ bXJ
 caB
 cbM
 cdb
-cel
+vJR
 cel
 cel
 cel
@@ -102646,9 +102584,9 @@ bSQ
 bSZ
 bUq
 bVE
-bLO
-bWU
-bLO
+bZG
+bXa
+bZG
 bYj
 cPw
 cmh
@@ -102947,8 +102885,8 @@ bOF
 vYJ
 qeD
 bUo
-bVF
-bZG
+bVH
+bLO
 bYi
 bZH
 okN

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -16555,12 +16555,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"bdq" = (
-/obj/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
 "bdr" = (
 /obj/grille/steel,
 /turf/simulated/floor/plating,
@@ -27617,12 +27611,14 @@
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "bVw" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/science/testchamber)
 "bVx" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -33358,14 +33354,16 @@
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "coi" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "coj" = (
 /obj/machinery/portable_atmospherics/scrubber,
+/obj/disposalpipe/segment/transport{
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "col" = (
@@ -33717,9 +33715,9 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor,
 /area/station/science/testchamber)
@@ -33735,8 +33733,9 @@
 /area/station/science/testchamber)
 "cpm" = (
 /obj/storage/closet/fire,
-/obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/transport,
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
@@ -33744,6 +33743,9 @@
 /obj/machinery/bot/firebot,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 9
@@ -33753,16 +33755,25 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
 /area/station/science/chemistry)
 "cpr" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
 /area/station/science/chemistry)
 "cps" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/purplewhite/corner{
 	dir = 1
 	},
@@ -33780,20 +33791,21 @@
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "cpv" = (
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
 /area/station/science/chemistry)
 "cpy" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "1-4"
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -33813,7 +33825,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/junction{
+/obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/white,
@@ -34153,20 +34165,24 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "cqv" = (
 /obj/machinery/drainage,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/purplewhite,
 /area/station/science/chemistry)
 "cqx" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/purplewhite,
 /area/station/science/chemistry)
 "cqy" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 6
@@ -34634,6 +34650,10 @@
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8;
 	pixel_x = 6
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
@@ -36896,9 +36916,8 @@
 	icon_state = "1-2"
 	},
 /obj/landmark/gps_waypoint,
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
@@ -38327,9 +38346,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "djA" = (
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
@@ -38754,8 +38772,20 @@
 	name = "Chemistry Privacy Shutters";
 	opacity = 0
 	},
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/disposalpipe/segment/mail{
+/obj/table/reinforced/auto,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/storage/box/beakerbox{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/machinery/door/firedoor/pyro{
+	dir = 4
+	},
+/obj/decal/stripe_delivery,
+/obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -42444,7 +42474,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "fZo" = (
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "fZG" = (
@@ -46149,6 +46178,9 @@
 /obj/stool/chair/office{
 	dir = 1
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
@@ -49414,6 +49446,10 @@
 /area/station/maintenance/east)
 "lJH" = (
 /mob/living/carbon/human/npc/monkey,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/purplewhite/corner,
 /area/station/science/chemistry)
 "lJN" = (
@@ -50130,10 +50166,10 @@
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "mov" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
@@ -53525,6 +53561,9 @@
 	icon_state = "0-4"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "oSX" = (
@@ -56173,9 +56212,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment{
+/obj/disposalpipe/trunk/mail{
 	dir = 8
 	},
+/obj/machinery/vending/player/chemicals,
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -57065,6 +57105,9 @@
 "rDD" = (
 /obj/landmark/start/job/scientist,
 /obj/stool/chair/office,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/purplewhite,
 /area/station/science/chemistry)
 "rDG" = (
@@ -61948,7 +61991,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "vhk" = (
-/obj/table/reinforced/auto,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/machinery/door/poddoor/pyro/shutters{
 	density = 0;
 	dir = 4;
@@ -61957,20 +62000,8 @@
 	name = "Chemistry Privacy Shutters";
 	opacity = 0
 	},
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/storage/box/beakerbox{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/machinery/door/firedoor/pyro{
+/obj/disposalpipe/segment/mail{
 	dir = 4
-	},
-/obj/decal/stripe_delivery,
-/obj/disposalpipe/segment{
-	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/science/chemistry)
@@ -62497,14 +62528,10 @@
 /area/station/turret_protected/ai_upload_foyer)
 "vHP" = (
 /obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/vending/player/chemicals,
-/obj/disposalpipe/trunk/mail{
-	dir = 8
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -95259,7 +95286,7 @@ ccX
 ccX
 ccX
 coh
-cpk
+coi
 cet
 cro
 crj
@@ -95560,8 +95587,8 @@ cmi
 ckx
 cmi
 gIi
-coi
 ciN
+bVw
 boS
 crp
 oel
@@ -97980,7 +98007,7 @@ coq
 cAL
 cqt
 fZo
-djA
+cpu
 ctg
 ctZ
 xal
@@ -98279,7 +98306,7 @@ bWB
 bWB
 cjC
 cor
-cpu
+djA
 lJH
 cpv
 csq
@@ -98581,7 +98608,7 @@ vbI
 bVj
 cne
 gNR
-cpu
+djA
 cqv
 wDL
 cne
@@ -98883,7 +98910,7 @@ aaq
 aap
 cne
 csU
-cpu
+djA
 rDD
 crw
 cne
@@ -99185,7 +99212,7 @@ adC
 aag
 cne
 csV
-cpu
+djA
 cqx
 crx
 wXJ
@@ -100394,7 +100421,7 @@ cmd
 dmk
 cox
 cpy
-bdq
+cqB
 cqB
 cqB
 cqB
@@ -100696,7 +100723,7 @@ cme
 cnk
 coy
 cpz
-bdq
+cqB
 cqB
 cqB
 dNX
@@ -100998,7 +101025,7 @@ bVR
 cnl
 coz
 cpA
-bVw
+cqB
 cqB
 cqB
 cqB

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -27441,7 +27441,7 @@
 /area/station/science/lobby)
 "bVo" = (
 /obj/disposalpipe/switch_junction/left/south{
-	mail_tag = "test_chamber";
+	mail_tag = "testchamber";
 	name = "test chamber mail router"
 	},
 /turf/simulated/floor/purple/corner{

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -2016,9 +2016,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "ahM" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -2500,7 +2499,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/ejection{
-	dir = 4
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
@@ -2537,7 +2536,6 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "ajq" = (
-/obj/disposalpipe/segment/ejection,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -2743,6 +2741,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/neutral/side{
 	dir = 1
 	},
@@ -2779,6 +2778,9 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
+/obj/disposalpipe/segment/ejection{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/routing/security)
 "aku" = (
@@ -2787,6 +2789,9 @@
 	},
 /obj/cable{
 	icon_state = "2-8"
+	},
+/obj/disposalpipe/segment/ejection{
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/routing/security)
@@ -2828,19 +2833,20 @@
 /area/station/crew_quarters/quartersA)
 "akF" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
+	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/quarters)
+/area/station/hallway/primary/south)
 "akG" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/navbeacon/tour/cog1/tour6,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "akH" = (
@@ -3061,7 +3067,6 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "alr" = (
-/obj/disposalpipe/segment/ejection,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -3088,6 +3093,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor,
 /area/station/routing/security)
 "alC" = (
@@ -3121,9 +3127,14 @@
 /turf/simulated/floor/purple/side,
 /area/station/crew_quarters/quarters)
 "alK" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters)
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/science/lobby)
 "alL" = (
 /obj/machinery/light_switch{
 	name = "S light switch";
@@ -3317,9 +3328,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/security)
 "amy" = (
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -3425,6 +3439,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "amS" = (
@@ -3433,6 +3450,9 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/secwing)
@@ -3576,11 +3596,15 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "anM" = (
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/secwing)
@@ -3657,6 +3681,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "anZ" = (
@@ -3839,11 +3864,11 @@
 /area/station/maintenance/solar/north)
 "aoS" = (
 /obj/stool,
-/obj/disposalpipe/segment/ejection{
-	dir = 4
-	},
 /obj/machinery/light/emergency{
 	dir = 8
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -3854,7 +3879,8 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aoU" = (
-/obj/disposalpipe/segment/ejection{
+/obj/disposalpipe/segment/mail{
+	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grime,
@@ -3912,9 +3938,15 @@
 	},
 /area/station/crew_quarters/locker)
 "aph" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor,
-/area/station/crew_quarters/locker)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/white,
+/area/station/science/artifact)
 "api" = (
 /obj/storage/secure/closet/personal,
 /turf/simulated/floor/neutral/side{
@@ -4020,13 +4052,15 @@
 /obj/machinery/disposal{
 	name = "Lay-Z Chef Cafeteria Chute"
 	},
-/obj/disposalpipe/trunk/food,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -15
+	},
+/obj/disposalpipe/trunk/food{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/kitchen)
@@ -4067,14 +4101,13 @@
 	dir = 8;
 	tag = "icon-xtra_bigstripe-edge (WEST)"
 	},
-/obj/disposalpipe/segment/produce,
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
 "apX" = (
-/obj/disposalpipe/segment/produce{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/segment/produce,
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
 "apY" = (
@@ -4095,16 +4128,27 @@
 	tag = ""
 	},
 /obj/decal/stripe_caution,
+/obj/disposalpipe/segment/ejection{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "aqo" = (
-/obj/disposalpipe/segment/ejection,
+/obj/disposalpipe/segment/ejection{
+	dir = 4
+	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aqp" = (
 /obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
+	},
+/obj/disposalpipe/segment/ejection{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -4273,9 +4317,12 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "aqR" = (
-/obj/disposalpipe/segment/food,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/bar)
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/medical/research)
 "aqS" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/disposalpipe/segment,
@@ -4308,6 +4355,10 @@
 /obj/stool/chair/comfy{
 	dir = 1
 	},
+/obj/disposalpipe/segment/produce{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
@@ -4327,9 +4378,8 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/produce{
+	dir = 4
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
@@ -4428,11 +4478,14 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "arK" = (
-/obj/disposalpipe/junction{
-	name = "ejection pipe"
+/obj/disposalpipe/segment/transport{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/science/lobby)
 "arM" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating/airless,
@@ -4549,7 +4602,6 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "ask" = (
-/obj/disposalpipe/segment/food,
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -4586,6 +4638,10 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen/freezer)
 "asx" = (
+/obj/disposalpipe/segment/produce{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
@@ -4686,11 +4742,14 @@
 	},
 /obj/machinery/drainage,
 /obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
 "asK" = (
 /obj/railing/orange/reinforced,
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/produce{
 	dir = 4
 	},
 /turf/simulated/floor/grasstodirt,
@@ -4702,15 +4761,16 @@
 /obj/machinery/light/emergency{
 	dir = 8
 	},
-/obj/disposalpipe/segment/produce,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
 /area/station/hallway/primary/east)
 "asN" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/disposalpipe/switch_junction{
+	dir = 2;
+	icon_state = "pipe-sj2";
+	mail_tag = "ranch";
+	name = "ranch mail router"
 	},
 /turf/simulated/floor/green/corner,
 /area/station/hallway/primary/east)
@@ -4790,6 +4850,7 @@
 	dir = 8
 	},
 /obj/decal/stripe_caution,
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor,
 /area/station/security/brig)
 "atc" = (
@@ -4839,7 +4900,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/barber_shop)
 "ati" = (
-/obj/disposalpipe/segment/mail,
 /obj/machinery/light{
 	dir = 8;
 	tag = ""
@@ -5017,13 +5077,13 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "atT" = (
-/obj/disposalpipe/segment/produce,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/railing/orange/reinforced{
 	dir = 8
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
 "atU" = (
@@ -5045,16 +5105,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ranch)
 "atX" = (
-/obj/railing/orange/reinforced{
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/grasstodirt{
-	dir = 1
-	},
-/area/station/ranch)
+/area/station/chapel/sanctuary)
 "atZ" = (
 /turf/simulated/floor/green/side{
 	dir = 9
@@ -5097,14 +5155,14 @@
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "aum" = (
-/obj/disposalpipe/segment/food{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/light/emergency{
 	dir = 8
 	},
 /obj/submachine/slot_machine,
+/obj/disposalpipe/segment/food{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aun" = (
@@ -5117,7 +5175,7 @@
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
-/obj/disposalpipe/segment/ejection,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aup" = (
@@ -5203,7 +5261,6 @@
 	},
 /area/station/crew_quarters/barber_shop)
 "auC" = (
-/obj/disposalpipe/segment/mail,
 /obj/fakeobject/pole{
 	pixel_x = -14
 	},
@@ -5259,7 +5316,6 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "auO" = (
-/obj/disposalpipe/segment/food,
 /obj/machinery/light{
 	dir = 8;
 	tag = ""
@@ -5281,7 +5337,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/disposalpipe/segment/transport,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
@@ -5407,46 +5462,40 @@
 /area/space)
 "avt" = (
 /obj/cable,
-/obj/disposalpipe/segment/brig{
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "avu" = (
-/obj/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2";
-	name = "brig pipe"
-	},
 /obj/machinery/light{
 	dir = 8;
 	tag = ""
 	},
 /obj/stool,
+/obj/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "avv" = (
-/obj/disposalpipe/junction{
-	dir = 4;
-	name = "brig pipe"
-	},
+/obj/disposalpipe/junction,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "avw" = (
-/obj/disposalpipe/segment/ejection,
-/obj/disposalpipe/segment/brig{
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
+/turf/simulated/floor/white,
+/area/station/science/artifact)
 "avx" = (
 /obj/submachine/ATM{
 	pixel_x = 32
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -5744,10 +5793,6 @@
 	},
 /obj/item/paper/book/from_file/hydroponicsguide,
 /obj/item/reagent_containers/glass/bottle/eyedrops,
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/green/side{
 	dir = 9
 	},
@@ -5759,9 +5804,6 @@
 	},
 /obj/table/auto,
 /obj/machinery/computer3/generic/personal,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -5770,13 +5812,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/produce,
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -5788,13 +5827,11 @@
 	message = "1";
 	name = "mail chute-'Hydroponics'"
 	},
-/obj/disposalpipe/trunk/mail{
-	dir = 8
-	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/disposalpipe/trunk/mail,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -5884,41 +5921,37 @@
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "awS" = (
-/obj/disposalpipe/segment/brig,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/grime,
+/area/station/maintenance/disposal)
 "awT" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/secwing)
 "awV" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/secwing)
+/turf/simulated/floor,
+/area/station/maintenance/east)
 "awW" = (
 /obj/item/cigbutt,
 /obj/decal/cleanable/dirt,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "awZ" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/barber_shop)
+/turf/simulated/floor/white,
+/area/station/science/artifact)
 "axa" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
 	name = "autoname - SS13";
 	tag = ""
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
 	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
@@ -5929,25 +5962,24 @@
 	desc = "A traditional barbershop chair, obviously a very old one at that.  What it is doing on a space station you haven't the foggiest.";
 	name = "Old Barber Chair"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/barber_shop)
 "axc" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/cable/orange{
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/area/station/crew_quarters/barber_shop)
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
+/area/space)
 "axd" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/decal/poster/wallsign/barber{
 	pixel_y = -16
 	},
@@ -5961,6 +5993,7 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 4
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
@@ -6124,7 +6157,6 @@
 /turf/simulated/floor/plating,
 /area/station/hydroponics/lobby)
 "axK" = (
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/green/corner{
 	dir = 1
 	},
@@ -6136,9 +6168,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/produce{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/lobby)
@@ -6146,29 +6177,27 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/junction{
+/obj/disposalpipe/segment{
 	dir = 8;
-	name = "produce pipe"
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/lobby)
 "axO" = (
-/obj/disposalpipe/segment/produce{
-	dir = 4
-	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/hydroponics/lobby)
 "axQ" = (
-/obj/disposalpipe/segment/produce{
-	dir = 4
+/obj/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
+/turf/simulated/floor/bluewhite{
+	dir = 1
+	},
+/area/station/medical/medbay/lobby)
 "axS" = (
 /obj/stool,
-/obj/disposalpipe/segment/produce{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "axT" = (
@@ -6190,10 +6219,10 @@
 	},
 /area/station/hydroponics/bay)
 "axY" = (
-/obj/disposalpipe/segment/ejection{
-	dir = 4
-	},
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/junction{
+	name = "ejection pipe"
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aya" = (
@@ -6225,7 +6254,6 @@
 	dir = 8;
 	tag = ""
 	},
-/obj/disposalpipe/segment/produce,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -6236,10 +6264,17 @@
 	name = "Interrogation Room Door Control";
 	pixel_y = 24
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/black,
 /area/station/security/main)
 "ayh" = (
 /obj/stool/chair/red,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/security/main)
 "ayj" = (
@@ -6275,10 +6310,6 @@
 /obj/table/reinforced/auto,
 /obj/window/cubicle{
 	dir = 8
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 1;
-	icon_state = "pipe-c"
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -6319,12 +6350,10 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/secwing)
 "ayx" = (
+/obj/mapping_helper/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/security/secwing)
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "ayy" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/secwing)
@@ -6469,10 +6498,10 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/disposalpipe/segment/produce,
 /turf/simulated/floor,
 /area/station/hydroponics/lobby)
 "azh" = (
@@ -6482,7 +6511,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -6491,20 +6520,16 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/station/hydroponics/lobby)
 "azk" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/conveyor/WE{
+	id = "garbage";
+	operating = 1
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "azm" = (
 /obj/table/auto,
 /obj/item/paper/book/from_file/hydroponicsguide{
@@ -6520,9 +6545,6 @@
 	},
 /area/station/hydroponics/bay)
 "azn" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -6534,7 +6556,7 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "azq" = (
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/produce{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
@@ -6563,7 +6585,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/pyro,
-/obj/disposalpipe/segment/produce,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -6582,9 +6603,6 @@
 	},
 /area/station/hallway/primary/east)
 "azz" = (
-/obj/disposalpipe/segment/produce{
-	dir = 4
-	},
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 5
 	},
@@ -6612,7 +6630,6 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "azI" = (
-/obj/disposalpipe/segment/mail,
 /obj/table/reinforced/auto,
 /obj/item/clipboard{
 	pixel_x = 8;
@@ -6644,50 +6661,48 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "azM" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/sanctuary)
 "azN" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
+/turf/simulated/floor/specialroom/bar,
+/area/station/security/secwing)
 "azO" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/disposalpipe/segment/brig,
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "azP" = (
-/obj/disposalpipe/segment/ejection,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/grime,
-/area/station/security/brig)
+/turf/simulated/floor/plating,
+/area/station/storage/warehouse)
 "azQ" = (
 /obj/stool,
 /obj/disposalpipe/switch_junction{
-	dir = 4;
-	mail_tag = "brig";
-	name = "brig mail router"
+	mail_tag = "security";
+	name = "security mail router";
+	dir = 4
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "azR" = (
 /obj/stool,
-/obj/disposalpipe/switch_junction{
-	dir = 4;
-	mail_tag = "dispatch";
-	name = "dispatch mail router"
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -6698,22 +6713,19 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "azU" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/secwing)
 "azV" = (
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/specialroom/bar,
-/area/station/security/secwing)
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "azW" = (
 /obj/stool/chair/couch{
 	dir = 8
@@ -6775,16 +6787,12 @@
 	},
 /area/station/crew_quarters/barber_shop)
 "aAe" = (
-/obj/disposalpipe/switch_junction{
-	dir = 4;
-	icon_state = "pipe-sj2";
-	mail_tag = "crew";
-	name = "crew quarters mail router"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/crew_quarters/locker)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor,
+/area/station/security/main)
 "aAf" = (
 /obj/shrub{
 	dir = 6
@@ -7046,7 +7054,7 @@
 	req_access_txt = "35"
 	},
 /obj/machinery/cashreg,
-/obj/disposalpipe/segment/produce{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor/green,
@@ -7054,7 +7062,7 @@
 "aAO" = (
 /obj/stool,
 /obj/disposalpipe/segment,
-/obj/disposalpipe/segment/produce{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor/green/side{
@@ -7062,11 +7070,10 @@
 	},
 /area/station/hydroponics/lobby)
 "aAP" = (
-/obj/disposalpipe/segment/produce{
+/obj/decal/stripe_delivery,
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/decal/stripe_delivery,
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/hydroponics/lobby)
 "aAQ" = (
@@ -7074,15 +7081,15 @@
 	codes_txt = "delivery;dir=8";
 	location = "Hydroponics"
 	},
-/obj/disposalpipe/segment/produce{
-	dir = 4
-	},
 /obj/machinery/light,
 /obj/machinery/light_switch{
 	name = "S light switch";
 	pixel_y = -24
 	},
 /obj/decal/stripe_caution,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hydroponics/lobby)
 "aAR" = (
@@ -7134,7 +7141,7 @@
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
 "aBb" = (
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/produce{
 	dir = 4
 	},
 /turf/simulated/floor/grass{
@@ -7191,7 +7198,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
 "aBq" = (
-/obj/disposalpipe/segment/mail,
 /obj/table/auto,
 /obj/item/decoration/ashtray{
 	pixel_x = 8;
@@ -7221,7 +7227,6 @@
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "aBu" = (
-/obj/disposalpipe/segment/brig,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -7229,6 +7234,7 @@
 	dir = 8;
 	tag = ""
 	},
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aBv" = (
@@ -7239,10 +7245,10 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aBw" = (
-/obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aBy" = (
@@ -7262,32 +7268,25 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/secwing)
 "aBD" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/decal/tile_edge/stripe/big{
-	dir = 1
-	},
-/turf/simulated/floor/blue/side{
-	dir = 1
-	},
-/area/station/crew_quarters/locker)
+/turf/simulated/floor,
+/area/station/science/testchamber)
 "aBF" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/locker)
 "aBG" = (
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
 	},
-/obj/decal/tile_edge/stripe/big{
-	dir = 1
+/obj/disposalpipe/segment{
+	dir = 8
 	},
-/turf/simulated/floor/blue/side{
-	dir = 1
-	},
-/area/station/crew_quarters/locker)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "aBH" = (
 /obj/decal/tile_edge/stripe/big{
 	dir = 1
@@ -7448,10 +7447,6 @@
 /obj/item/paper_bin,
 /obj/item/clipboard,
 /obj/item/pen,
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aCk" = (
@@ -7462,9 +7457,6 @@
 	req_access_txt = "35"
 	},
 /obj/item/hand_labeler,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aCm" = (
@@ -7535,24 +7527,21 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/stool/chair/red{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/black,
 /area/station/security/main)
 "aCC" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
 	},
 /obj/table/auto,
 /obj/item/paper/Port_A_Brig{
@@ -7577,13 +7566,13 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/disposalpipe/segment/brig,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/light/emergency{
 	dir = 8
 	},
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aCH" = (
@@ -7663,14 +7652,17 @@
 	persistent_id = "brig";
 	pixel_x = 32
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/security/main)
 "aCU" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/neutral/side{
-	dir = 1
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
-/area/station/hallway/primary/central)
+/turf/simulated/floor/engine{
+	allows_vehicles = 0
+	},
+/area/station/science/teleporter)
 "aCV" = (
 /obj/machinery/light{
 	dir = 4
@@ -7968,11 +7960,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aDz" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -8022,19 +8014,13 @@
 	},
 /area/station/hydroponics/bay)
 "aDI" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/produce,
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/hallway/primary/east)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor,
+/area/station/science/testchamber)
 "aDJ" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -8100,11 +8086,12 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "aDV" = (
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/security/main)
 "aEa" = (
 /obj/table/reinforced/auto,
 /obj/machinery/power/data_terminal,
@@ -8115,7 +8102,6 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aEb" = (
-/obj/disposalpipe/segment/brig,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -8126,6 +8112,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aEd" = (
@@ -8137,6 +8124,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aEe" = (
@@ -8146,6 +8136,9 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/secwing)
@@ -8170,6 +8163,9 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "aEg" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -8179,6 +8175,9 @@
 /area/station/hallway/primary/central)
 "aEj" = (
 /obj/disposalpipe/segment,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aEk" = (
@@ -8189,14 +8188,12 @@
 /area/station/hallway/primary/central)
 "aEl" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
+/turf/simulated/floor/carpet{
+	icon_state = "fred2"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/crew_quarters/info)
 "aEm" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -8418,11 +8415,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/switch_junction{
-	dir = 4;
-	icon_state = "pipe-sj2";
-	mail_tag = "ranch";
-	name = "ranch mail router"
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -8460,11 +8455,11 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aFk" = (
-/obj/disposalpipe/segment/brig,
 /obj/cable{
 	icon_state = "1-8"
 	},
 /obj/stool,
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aFl" = (
@@ -8701,6 +8696,9 @@
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -8709,18 +8707,27 @@
 /obj/machinery/light/emergency{
 	dir = 1
 	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
 /area/station/hallway/primary/east)
 "aGe" = (
-/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "aGf" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
 /turf/simulated/floor/yellow/corner{
 	dir = 1
 	},
@@ -8763,8 +8770,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aGu" = (
-/obj/disposalpipe/junction{
-	icon_state = "pipe-j2"
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -8852,16 +8860,16 @@
 	},
 /area/station/security/main)
 "aGE" = (
-/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/main)
 "aGF" = (
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -8883,12 +8891,12 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "aGK" = (
+/obj/mapping_helper/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/security/secwing)
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/info)
 "aGM" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
@@ -8954,9 +8962,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aHj" = (
-/obj/disposalpipe/junction{
-	dir = 8
+/obj/disposalpipe/segment{
+	dir = 4
 	},
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aHl" = (
@@ -8977,16 +8986,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/light,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
-"aHp" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/switch_junction{
 	dir = 4;
 	mail_tag = "detective";
@@ -8994,6 +8994,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"aHp" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "aHq" = (
 /obj/storage/closet/wardrobe/pride,
 /turf/simulated/floor/neutral/side{
@@ -9015,6 +9022,10 @@
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
@@ -9032,6 +9043,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aHA" = (
@@ -9082,12 +9094,12 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "aHI" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -9102,10 +9114,6 @@
 	},
 /area/station/security/main)
 "aHN" = (
-/obj/disposalpipe/segment/ejection{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
@@ -9162,10 +9170,6 @@
 	},
 /area/station/security/secwing)
 "aHT" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/table/auto,
 /obj/machinery/recharger{
 	pixel_x = -5;
@@ -9185,7 +9189,8 @@
 /area/station/security/secwing)
 "aHV" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -9369,6 +9374,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/navbeacon/tour/cog1/tour1,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "aIu" = (
@@ -9388,8 +9394,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/neutral/corner,
 /area/station/hallway/primary/east)
@@ -9397,18 +9405,20 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/light/emergency,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/east)
 "aIB" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/east)
@@ -9421,10 +9431,6 @@
 	dir = 9;
 	name = "autoname - SS13";
 	tag = ""
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -9516,11 +9522,20 @@
 	pixel_y = -24
 	},
 /obj/decal/stripe_caution,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aIV" = (
 /obj/machinery/light,
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment/morgue{
+	dir = 8;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aIW" = (
@@ -9564,19 +9579,23 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "aJg" = (
-/obj/disposalpipe/segment,
-/obj/disposalpipe/segment/transport{
-	dir = 4
+/obj/disposalpipe/switch_junction{
+	dir = 1;
+	icon_state = "pipe-sj2";
+	mail_tag = "kitchen";
+	name = "kitchen mail router"
 	},
-/turf/simulated/floor,
-/area/station/security/main)
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "aJh" = (
-/obj/disposalpipe/segment/transport{
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/purple/side{
 	dir = 4
 	},
-/obj/disposalpipe/segment/brig,
-/turf/simulated/floor,
-/area/station/security/main)
+/area/station/science/lobby)
 "aJi" = (
 /obj/disposalpipe/segment/transport{
 	icon_state = "pipe-c"
@@ -9726,6 +9745,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/stairs{
 	icon_state = "stairs_middle"
 	},
@@ -9749,6 +9769,7 @@
 	icon_state = "0-2"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue/side,
 /area/station/medical/medbooth)
 "aJK" = (
@@ -9802,6 +9823,7 @@
 /obj/window/reinforced{
 	dir = 4
 	},
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/blue/side,
 /area/station/medical/medbooth)
 "aJO" = (
@@ -9822,6 +9844,9 @@
 /area/station/hallway/primary/east)
 "aJQ" = (
 /obj/machinery/door/firedoor/pyro,
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aJT" = (
@@ -9835,12 +9860,11 @@
 /turf/simulated/floor/carpet,
 /area/station/chapel/sanctuary)
 "aJV" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/carpet{
-	dir = 8;
-	icon_state = "fred1"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/area/station/chapel/sanctuary)
+/turf/simulated/floor/grime,
+/area/station/hallway/primary/east)
 "aJW" = (
 /turf/simulated/floor/carpet{
 	dir = 4;
@@ -9895,8 +9919,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/item/cigbutt,
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aKg" = (
@@ -9961,9 +9988,14 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "aKo" = (
-/obj/disposalpipe/segment/brig,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
-/area/station/security/main)
+/area/station/hallway/primary/east)
 "aKp" = (
 /obj/cable,
 /obj/cable{
@@ -10153,6 +10185,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fgreen2"
@@ -10205,12 +10238,12 @@
 	pixel_x = 1;
 	pixel_y = 3
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/bluewhite{
 	dir = 9
 	},
 /area/station/medical/medbooth)
 "aKT" = (
-/obj/disposalpipe/segment/mail,
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/med_data{
 	dir = 4
@@ -10337,6 +10370,9 @@
 /turf/simulated/floor/circuit,
 /area/station/bridge)
 "aLp" = (
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/red/corner,
 /area/station/hallway/primary/east)
 "aLq" = (
@@ -10430,17 +10466,10 @@
 "aLB" = (
 /obj/machinery/light,
 /obj/storage/secure/closet/brig,
-/obj/disposalpipe/segment/brig{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "aLD" = (
 /obj/machinery/disposal/brig,
-/obj/disposalpipe/trunk/brig{
-	dir = 8
-	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "aLE" = (
@@ -10569,6 +10598,10 @@
 /area/station/crew_quarters/cafeteria)
 "aMc" = (
 /obj/iv_stand,
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -10578,6 +10611,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbooth)
 "aMe" = (
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/white,
 /area/station/medical/medbooth)
 "aMg" = (
@@ -10588,7 +10622,6 @@
 	dir = 9
 	},
 /obj/cable,
-/obj/disposalpipe/segment/mail,
 /obj/machinery/power/apc{
 	areastring = "Bridge";
 	name = "Bridge APC";
@@ -10610,6 +10643,11 @@
 "aMl" = (
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c";
+	name = "factory pipe"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -10724,9 +10762,11 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aMC" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/supernorn,
-/area/station/security/beepsky)
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "aMD" = (
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -10857,6 +10897,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
 "aNf" = (
@@ -10888,30 +10929,28 @@
 	icon_state = "5-10"
 	},
 /obj/machinery/drainage,
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/white,
 /area/station/medical/medbooth)
 "aNk" = (
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/red/corner{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
 "aNl" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/stool,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fred2"
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/area/station/chapel/sanctuary)
 "aNm" = (
 /obj/disposalpipe/segment/morgue{
-	dir = 2;
-	icon_state = "pipe-c"
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
@@ -10944,6 +10983,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
@@ -10951,6 +10991,11 @@
 "aNr" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 1;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
@@ -10960,6 +11005,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 2;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
@@ -11083,6 +11133,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aNR" = (
@@ -11205,14 +11256,13 @@
 /turf/simulated/floor/plating,
 /area/station/security/beepsky)
 "aOc" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/junction{
+/obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/security/beepsky)
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/hangar/main)
 "aOd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -11331,6 +11381,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fred4"
@@ -11443,12 +11494,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
 "aON" = (
-/obj/machinery/atmospherics/pipe/simple{
+/obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge)
+/turf/simulated/floor/purple/corner{
+	dir = 1
+	},
+/area/station/science/lobby)
 "aOO" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
@@ -11667,6 +11720,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "fred1"
@@ -11723,7 +11777,9 @@
 "aPx" = (
 /obj/machinery/disposal/morgue,
 /obj/machinery/light,
-/obj/disposalpipe/trunk/morgue,
+/obj/disposalpipe/trunk/morgue{
+	dir = 1
+	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbooth)
 "aPy" = (
@@ -11774,6 +11830,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "aPD" = (
@@ -11823,16 +11882,11 @@
 	message = "1";
 	name = "mail chute-'Bridge'"
 	},
-/obj/disposalpipe/trunk/mail{
-	dir = 4
-	},
+/obj/disposalpipe/trunk/mail,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aPM" = (
 /obj/table/wood/round/auto,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/light/emergency{
 	dir = 1
 	},
@@ -11854,26 +11908,22 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aPO" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aPP" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge)
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/crew_quarters/supplylobby)
 "aPQ" = (
 /obj/table/wood/round/auto,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -11884,18 +11934,12 @@
 	pixel_x = 6
 	},
 /obj/machinery/atmospherics/pipe/simple,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/item/reagent_containers/food/drinks/bottle/wine,
 /turf/simulated/floor,
 /area/station/bridge)
 "aPR" = (
 /obj/stool/chair/couch{
 	dir = 8
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
 	},
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -11904,9 +11948,6 @@
 /area/station/bridge)
 "aPS" = (
 /obj/stool/chair/couch{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/machinery/ai_status_display{
@@ -11918,12 +11959,12 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
 "aPW" = (
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet/grime,
-/area/station/security/hos)
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "aPY" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -12089,6 +12130,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet{
 	icon_state = "fred4"
 	},
@@ -12118,27 +12160,28 @@
 /area/station/security/detectives_office)
 "aQB" = (
 /obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/security/detectives_office)
-"aQC" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/security/detectives_office)
-"aQD" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/detectives_office)
-"aQE" = (
-/obj/disposalpipe/segment/morgue,
-/turf/simulated/floor/grime,
+/turf/simulated/floor,
 /area/station/hallway/primary/east)
+"aQC" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/plating,
+/area/station/storage/warehouse)
+"aQD" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters)
+"aQE" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor/black,
+/area/station/medical/crematorium)
 "aQF" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/west)
@@ -12212,16 +12255,16 @@
 /turf/simulated/floor,
 /area/station/bridge)
 "aQT" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/hos)
-"aQU" = (
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/turf/simulated/floor,
+/area/station/security/main)
+"aQU" = (
 /obj/machinery/light_switch{
 	name = "S light switch";
 	pixel_y = -24
@@ -12263,12 +12306,9 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
 "aRd" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/juryroom)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "aRe" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
@@ -12305,8 +12345,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aRk" = (
-/obj/disposalpipe/segment/morgue,
 /obj/machinery/navbeacon/tour/cog1/tour2,
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
 "aRm" = (
@@ -12348,7 +12390,7 @@
 	icon_state = "1-2"
 	},
 /obj/landmark/gps_waypoint,
-/obj/disposalpipe/segment/produce{
+/obj/disposalpipe/segment/mail{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
@@ -12480,6 +12522,9 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "aRJ" = (
@@ -12503,11 +12548,13 @@
 	},
 /area/station/chapel/sanctuary)
 "aRN" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/carpet{
-	icon_state = "fred2"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/area/station/chapel/sanctuary)
+/turf/simulated/floor/neutral/side{
+	dir = 8
+	},
+/area/station/crew_quarters/market)
 "aRO" = (
 /turf/simulated/floor/carpet{
 	dir = 6;
@@ -12529,6 +12576,10 @@
 /area/station/bridge)
 "aRS" = (
 /obj/machinery/atmospherics/pipe/simple,
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aRT" = (
@@ -12538,9 +12589,10 @@
 	},
 /area/station/bridge)
 "aRU" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/hos)
+/obj/grille/steel,
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "aRV" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger{
@@ -12780,7 +12832,9 @@
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
 "aSA" = (
-/obj/disposalpipe/segment/morgue,
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aSB" = (
@@ -12836,6 +12890,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "fblue2"
@@ -12843,6 +12901,9 @@
 /area/station/bridge)
 "aSQ" = (
 /obj/machinery/light/emergency,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/stairs{
 	dir = 4;
 	icon_state = "Stairs2_wide"
@@ -12852,11 +12913,18 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 5
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/bridge)
 "aSS" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -12864,16 +12932,19 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/bridge)
 "aSU" = (
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/machinery/disposal,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
+	},
+/obj/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -12881,6 +12952,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor,
 /area/station/janitor/office)
 "aSW" = (
@@ -12909,6 +12981,9 @@
 /area/station/hallway/primary/central)
 "aSZ" = (
 /obj/critter/turtle/sylvester/HoS,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
 "aTc" = (
@@ -12948,6 +13023,10 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/plating/scorched,
 /area/station/hallway/primary/east)
 "aTh" = (
@@ -12956,17 +13035,19 @@
 	pixel_x = 24
 	},
 /obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 8;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
 "aTi" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/blue/checker,
+/area/station/medical/research)
 "aTm" = (
 /turf/simulated/wall/grass/leafy,
 /area/station/garden/owlery)
@@ -13005,6 +13086,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
 "aTv" = (
@@ -13060,18 +13142,18 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/junction{
-	icon_state = "pipe-j2"
-	},
 /obj/item/crowbar,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
 "aTD" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/switch_junction{
+	dir = 4;
+	mail_tag = "dispatch";
+	name = "dispatch mail router"
 	},
-/turf/simulated/floor/grime,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/specialroom/bar,
+/area/station/security/secwing)
 "aTE" = (
 /obj/machinery/traymachine/morgue,
 /turf/simulated/floor/black,
@@ -13094,17 +13176,14 @@
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aTI" = (
-/obj/disposalpipe/trunk/mail,
-/obj/machinery/disposal/mail{
-	mail_tag = "chapel";
-	mailgroup = "chaplain";
-	message = "1";
-	name = "mail chute-'Chapel'"
-	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "aTJ" = (
@@ -13113,6 +13192,12 @@
 "aTK" = (
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -13127,7 +13212,13 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/machinery/power/apc/autoname_east,
+/obj/disposalpipe/trunk/mail,
+/obj/machinery/disposal/mail{
+	mail_tag = "chapel";
+	mailgroup = "chaplain";
+	message = "1";
+	name = "mail chute-'Chapel'"
+	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "aTM" = (
@@ -13138,7 +13229,6 @@
 /obj/window/reinforced{
 	dir = 1
 	},
-/obj/disposalpipe/segment/mail,
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
 	dir = 4
@@ -13486,6 +13576,7 @@
 	},
 /area/station/crew_quarters/jazz)
 "aUG" = (
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fred6"
@@ -13528,11 +13619,12 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aUO" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbooth)
 "aUP" = (
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
@@ -13548,16 +13640,20 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/crematorium)
 "aUT" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
-/area/station/chapel/office)
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/neutral/side,
+/area/station/hallway/primary/east)
 "aUU" = (
 /obj/stool,
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -13569,7 +13665,8 @@
 	icon_state = "1-4"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -13729,7 +13826,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "2-8"
 	},
@@ -13799,11 +13895,11 @@
 	},
 /area/station/crew_quarters/courtroom)
 "aVD" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor/grey/side{
-	dir = 1
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/crew_quarters/courtroom)
+/turf/simulated/floor/white,
+/area/station/science/artifact)
 "aVE" = (
 /obj/machinery/light/emergency{
 	dir = 4
@@ -13979,11 +14075,19 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/personal,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aWf" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -14014,6 +14118,7 @@
 /area/station/crew_quarters/pool)
 "aWn" = (
 /obj/disposalpipe/junction{
+	icon_state = "pipe-j2";
 	name = "morgue pipe"
 	},
 /turf/simulated/floor/black,
@@ -14032,6 +14137,10 @@
 	pixel_x = 12;
 	pixel_y = 5
 	},
+/obj/disposalpipe/segment/morgue{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fred2"
@@ -14042,6 +14151,9 @@
 /obj/item/reagent_containers/glass/bottle/holywater{
 	pixel_x = 7;
 	pixel_y = 10
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -14102,7 +14214,6 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred2"
@@ -14152,11 +14263,6 @@
 /area/station/bridge)
 "aWB" = (
 /obj/decal/cleanable/cobweb2,
-/obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c";
-	name = "crematorium pipe"
-	},
 /obj/machinery/fluid_canister,
 /obj/machinery/power/apc{
 	areastring = "Detective's Office";
@@ -14166,6 +14272,10 @@
 	},
 /obj/cable{
 	icon_state = "0-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -14205,7 +14315,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/bridge)
 "aWG" = (
@@ -14275,7 +14384,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "aWQ" = (
-/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "2-8"
 	},
@@ -14404,9 +14512,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "aXl" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/jazz)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "aXn" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -14422,10 +14530,10 @@
 /turf/simulated/floor/neutral/side,
 /area/station/crew_quarters/locker)
 "aXp" = (
-/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/junction,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aXq" = (
@@ -14523,18 +14631,15 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aXz" = (
+/obj/decal/cleanable/dirt,
 /obj/disposalpipe/segment/morgue{
-	dir = 4;
+	dir = 8;
+	icon_state = "pipe-c";
 	name = "crematorium pipe"
 	},
-/obj/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aXA" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "crematorium pipe"
-	},
 /obj/table/wood/auto,
 /obj/item/reagent_containers/food/drinks/bottle/bojackson,
 /obj/item/device/light/zippo{
@@ -14559,11 +14664,6 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aXB" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 2;
-	icon_state = "pipe-c";
-	name = "crematorium pipe"
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -14579,10 +14679,11 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/east)
 "aXG" = (
-/obj/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/blind_switch/area/west,
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aXH" = (
@@ -14611,13 +14712,29 @@
 	pixel_x = 7;
 	pixel_y = 11
 	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aXJ" = (
 /obj/mapping_helper/wingrille_spawn/auto,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/crematorium)
 "aXK" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred2"
@@ -14645,6 +14762,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/wall/false_wall,
 /area/station/chapel/sanctuary)
 "aXP" = (
@@ -14763,12 +14881,13 @@
 	},
 /area/station/crew_quarters/courtroom)
 "aYg" = (
-/obj/disposalpipe/segment,
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/courtroom)
+/turf/simulated/floor/purple/side{
+	dir = 1
+	},
+/area/station/science/lobby)
 "aYh" = (
 /obj/landmark/halloween,
 /obj/disposalpipe/segment/transport,
@@ -14874,9 +14993,6 @@
 /obj/item/storage/secure/ssafe{
 	pixel_y = -30
 	},
-/obj/disposalpipe/segment/morgue{
-	name = "crematorium pipe"
-	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aYG" = (
@@ -14940,8 +15056,7 @@
 	name = "Crematorium Outlet"
 	},
 /obj/disposalpipe/trunk/morgue{
-	dir = 2;
-	name = "crematorium pipe"
+	dir = 1
 	},
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
@@ -15019,6 +15134,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aYQ" = (
@@ -15094,7 +15210,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -15207,18 +15322,14 @@
 	},
 /area/station/crew_quarters/jazz)
 "aZx" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "fred6"
-	},
-/area/station/crew_quarters/jazz)
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "aZy" = (
 /obj/disposalpipe/segment{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
@@ -15230,22 +15341,28 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
 "aZA" = (
-/obj/disposalpipe/segment/morgue{
-	name = "crematorium pipe"
+/obj/machinery/light,
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/security/detectives_office)
+/turf/simulated/floor/blue/side{
+	dir = 0
+	},
+/area/station/hallway/primary/south)
 "aZC" = (
 /obj/decal/poster/wallsign/biohazard,
 /obj/disposalpipe/segment/morgue,
-/turf/simulated/wall/auto/supernorn,
+/obj/mapping_helper/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
 /area/station/medical/crematorium)
 "aZD" = (
-/obj/disposalpipe/segment/morgue{
-	name = "crematorium pipe"
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/crematorium)
+/area/space)
 "aZE" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/chapel/office)
@@ -15254,10 +15371,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "aZG" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "crematorium pipe"
-	},
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
@@ -15265,17 +15378,20 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment,
-/obj/disposalpipe/segment/morgue{
+/obj/disposalpipe/junction{
 	dir = 4;
-	name = "crematorium pipe"
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aZI" = (
-/obj/disposalpipe/segment/mail,
-/obj/decal/cleanable/rust,
-/turf/simulated/wall/auto/supernorn,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
 /area/station/chapel/sanctuary)
 "aZJ" = (
 /obj/decal/cleanable/rust,
@@ -15294,6 +15410,9 @@
 	},
 /obj/mapping_helper/access/telesci,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "aZM" = (
@@ -15396,7 +15515,6 @@
 /turf/simulated/floor/grey/side,
 /area/station/crew_quarters/courtroom)
 "bae" = (
-/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -15458,26 +15576,28 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bat" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "crematorium pipe"
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
 "bau" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "crematorium pipe"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/east)
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/science/lobby)
 "bav" = (
 /obj/cable{
 	icon_state = "0-2"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "crematorium pipe"
 	},
 /obj/machinery/power/apc{
 	areastring = "Crematorium";
@@ -15485,20 +15605,23 @@
 	name = "Crematorium APC";
 	pixel_y = 24
 	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "baw" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "crematorium pipe"
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bay" = (
 /obj/disposalpipe/segment/morgue{
-	dir = 8;
-	icon_state = "pipe-c";
-	name = "crematorium pipe"
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -15519,6 +15642,10 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple,
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "baF" = (
@@ -15534,7 +15661,6 @@
 /area/station/maintenance/east)
 "baG" = (
 /obj/decal/cleanable/dirt,
-/obj/disposalpipe/segment/mail,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-8"
@@ -15639,7 +15765,8 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
@@ -15649,10 +15776,6 @@
 	dir = 9;
 	name = "autoname - SS13";
 	tag = ""
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /obj/stool/bed,
 /obj/item/sticker/ribbon/first_place{
@@ -15695,15 +15818,14 @@
 	},
 /area/station/engine/elect)
 "bbi" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/light/emergency{
+	dir = 4
 	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/purple/side{
+	dir = 4
 	},
-/turf/simulated/floor/grime,
-/area/station/hallway/primary/east)
+/area/station/science/lobby)
 "bbk" = (
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -15781,7 +15903,6 @@
 /turf/simulated/floor,
 /area/station/engine/substation/pylon)
 "bbv" = (
-/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -15789,19 +15910,20 @@
 /turf/simulated/floor/plating,
 /area/station/engine/substation/pylon)
 "bbx" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/sanctuary)
 "bby" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/grime,
-/area/station/maintenance/east)
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/bridge)
 "bbz" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -15831,18 +15953,21 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bbE" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/grime,
-/area/station/maintenance/east)
+/obj/disposalpipe/switch_junction{
+	dir = 1;
+	icon_state = "pipe-sj2";
+	mail_tag = "bridge";
+	name = "bridge mail router"
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
 "bbF" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/east)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/specialroom/bar,
+/area/station/security/secwing)
 "bbH" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -15854,7 +15979,6 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bbJ" = (
@@ -15923,15 +16047,12 @@
 /area/station/crew_quarters/heads)
 "bbU" = (
 /obj/disposalpipe/segment/mail{
-	dir = 1;
+	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/turf/simulated/floor,
+/area/station/security/main)
 "bbW" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
@@ -15946,10 +16067,6 @@
 	},
 /area/station/crew_quarters/courtroom)
 "bbY" = (
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
@@ -16021,15 +16138,16 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
 "bch" = (
-/obj/disposalpipe/segment,
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/segment/transport,
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/turf/simulated/floor,
+/area/station/crew_quarters/market)
 "bci" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -16053,6 +16171,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bcn" = (
@@ -16096,27 +16215,18 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
 "bcx" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/pylon)
 "bcy" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/junction{
+	icon_state = "pipe-j2"
 	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
 "bcA" = (
@@ -16126,8 +16236,8 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
@@ -16135,17 +16245,19 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
 "bcC" = (
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
@@ -16158,10 +16270,6 @@
 /area/station/maintenance/east)
 "bcE" = (
 /obj/storage/cart/trash,
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
 "bcF" = (
@@ -16183,10 +16291,6 @@
 /turf/simulated/floor/stairs,
 /area/station/maintenance/east)
 "bcJ" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4
 	},
@@ -16196,18 +16300,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bcL" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bcM" = (
@@ -16252,7 +16349,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -16312,6 +16408,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fgreen2"
@@ -16320,6 +16420,9 @@
 "bdb" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 5;
@@ -16333,6 +16436,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bdd" = (
@@ -16340,13 +16446,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bdf" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -16354,6 +16459,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_south,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint)
 "bdg" = (
@@ -16444,18 +16552,15 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bdq" = (
 /obj/disposalpipe/segment{
-	dir = 4
+	dir = 8
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "bdr" = (
 /obj/grille/steel,
 /turf/simulated/floor/plating,
@@ -16477,10 +16582,6 @@
 /area/station/engine/substation/pylon)
 "bdx" = (
 /obj/machinery/vending/cigarette,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
 "bdy" = (
@@ -16493,24 +16594,22 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
 "bdz" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bdA" = (
-/obj/disposalpipe/segment{
-	dir = 2;
+/obj/disposalpipe/segment/mail{
+	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
@@ -16519,16 +16618,25 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
 "bdC" = (
 /obj/disposalpipe/segment/morgue,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bdD" = (
 /obj/storage/cart/trash,
 /obj/machinery/disposal/cart_port,
-/obj/disposalpipe/trunk,
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bdF" = (
@@ -16569,7 +16677,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/east)
 "bdO" = (
-/obj/disposalpipe/segment,
 /obj/reagent_dispensers/fueltank,
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -16723,6 +16830,7 @@
 "bem" = (
 /obj/machinery/navbeacon/tour/cog1/tour4,
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fred3"
@@ -16736,12 +16844,13 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "beo" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
@@ -16761,6 +16870,7 @@
 /area/space)
 "ber" = (
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/bridge)
 "bes" = (
@@ -16800,39 +16910,39 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bez" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/east)
+/obj/disposalpipe/segment,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "beA" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/disposalpipe/segment,
+/turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/east)
 "beB" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light/emergency{
 	dir = 8
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "beD" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
 /turf/simulated/floor/stairs{
 	dir = 8
 	},
 /area/station/janitor/office)
 "beG" = (
-/obj/disposalpipe/junction{
-	dir = 8
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/grime,
+/area/station/storage/warehouse)
 "beH" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -16840,8 +16950,9 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
@@ -16938,9 +17049,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/morgue,
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2";
+	name = "morgue pipe"
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
@@ -16948,16 +17060,17 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
 "beY" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/west)
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "beZ" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -17056,15 +17169,18 @@
 "bfr" = (
 /obj/grille/steel,
 /obj/disposalpipe/segment,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bfs" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/disposal)
 "bfv" = (
-/obj/disposalpipe/segment/morgue,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/disposal)
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "bfw" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -17072,6 +17188,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -17192,10 +17309,8 @@
 /area/station/crew_quarters/market)
 "bfU" = (
 /obj/machinery/disposal,
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/decal/stripe_caution,
+/obj/disposalpipe/trunk,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bfW" = (
@@ -17259,9 +17374,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bgc" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/east)
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/grime,
+/area/station/hallway/primary/east)
 "bgd" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -17329,6 +17447,7 @@
 /obj/stool/chair/red{
 	dir = 4
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "bgn" = (
@@ -17356,6 +17475,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_west,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bgq" = (
@@ -17372,6 +17492,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "bgt" = (
@@ -17403,6 +17524,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/purple/corner{
 	dir = 1
 	},
@@ -17594,18 +17716,22 @@
 	name = "W light switch";
 	pixel_x = -24
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "bhf" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/morgue{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "bhg" = (
-/obj/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	name = "morgue pipe"
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -17623,9 +17749,12 @@
 	},
 /area/station/janitor/office)
 "bhj" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/disposal)
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/hydroponics/lobby)
 "bhk" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/item/reagent_containers/food/snacks/chips,
@@ -17688,17 +17817,20 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bhv" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/east)
+/obj/disposalpipe/segment/food,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "bhw" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bhx" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/east)
+/obj/disposalpipe/segment/ejection,
+/obj/disposalpipe/segment/food{
+	dir = 4
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "bhy" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -17967,10 +18099,6 @@
 	location = "disposals";
 	name = "bot navigation beacon"
 	},
-/obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "bii" = (
@@ -17978,10 +18106,6 @@
 	dir = 4
 	},
 /obj/machinery/portable_reclaimer,
-/obj/disposalpipe/segment/morgue{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "bij" = (
@@ -17995,6 +18119,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor,
 /area/station/janitor/office)
 "bil" = (
@@ -18104,10 +18229,17 @@
 "biC" = (
 /obj/item/device/radio/intercom,
 /obj/decal/stripe_caution,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "biE" = (
 /obj/decal/stripe_caution,
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "biF" = (
@@ -18218,12 +18350,12 @@
 /turf/simulated/floor/grime,
 /area/station/routing/depot)
 "bjd" = (
-/obj/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -18254,6 +18386,10 @@
 	id = "garbage";
 	position = 1
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bjk" = (
@@ -18261,6 +18397,9 @@
 	id = "speedboost_crusher";
 	name = "Disposals Doors";
 	pixel_y = -24
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
@@ -18271,11 +18410,17 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "bjm" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
@@ -18283,7 +18428,10 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/morgue,
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "bjo" = (
@@ -18382,6 +18530,10 @@
 	tag = ""
 	},
 /obj/machinery/light/emergency,
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -18516,7 +18668,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/east)
 "bkd" = (
-/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "2-5"
 	},
@@ -18555,6 +18706,7 @@
 	},
 /obj/cable,
 /obj/mapping_helper/wingrille_spawn/auto,
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/plating,
 /area/station/janitor/office)
 "bkk" = (
@@ -18718,17 +18870,18 @@
 /turf/simulated/floor/sand,
 /area/station/chapel/sanctuary)
 "bkN" = (
-/obj/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/disposalpipe/segment/morgue{
 	dir = 4;
-	icon_state = "pipe-c"
+	name = "crematorium pipe"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/east)
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/sanctuary)
 "bkO" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
@@ -18833,7 +18986,6 @@
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "bls" = (
-/obj/disposalpipe/segment,
 /obj/machinery/cargo_router/Router6,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -18856,8 +19008,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/maintenance/disposal)
 "blw" = (
@@ -19348,8 +19500,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "bnr" = (
@@ -19773,11 +19925,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "boS" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/market)
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/testchamber)
 "boW" = (
 /obj/machinery/mass_driver{
 	drive_range = 15;
@@ -19839,11 +19995,15 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "bpn" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/east)
+/turf/simulated/floor,
+/area/station/science/lobby)
 "bpo" = (
 /obj/table/reinforced/auto,
 /obj/item/aiModule/removeCrew{
@@ -19864,9 +20024,6 @@
 "bps" = (
 /obj/cable{
 	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -20047,6 +20204,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "bpU" = (
@@ -20245,7 +20403,8 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
@@ -20257,9 +20416,6 @@
 	tag = ""
 	},
 /obj/storage/closet/law,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bqH" = (
@@ -20321,6 +20477,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "brb" = (
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "brc" = (
@@ -20404,7 +20561,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "brL" = (
@@ -20447,12 +20603,10 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/grille/catwalk{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -20473,10 +20627,14 @@
 /area/station/crew_quarters/info)
 "brS" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -20485,7 +20643,13 @@
 /area/station/crew_quarters/info)
 "brU" = (
 /obj/stool,
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/switch_junction{
+	desc = "An underfloor mail pipe.";
+	dir = 1;
+	icon_state = "pipe-sj2";
+	mail_tag = "info";
+	name = "info mail router"
+	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -20564,9 +20728,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bsA" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/table/wood/auto,
 /obj/decal/cleanable/desk_clutter{
 	pixel_y = 1
@@ -20594,7 +20755,10 @@
 /area/space)
 "bsC" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet,
 /area/station/crew_quarters/info)
@@ -20627,11 +20791,8 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bsJ" = (
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bsN" = (
@@ -20741,7 +20902,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/maintenance/east)
@@ -20771,7 +20931,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
@@ -21639,24 +21798,24 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
 "bxK" = (
-/obj/grille/catwalk{
-	dir = 5
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
+/obj/grille/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
 	},
 /area/space)
 "bxM" = (
-/obj/grille/catwalk,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
+/obj/grille/catwalk{
+	dir = 4
+	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "bxP" = (
@@ -21997,6 +22156,10 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "bzl" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/stairs{
 	dir = 4
 	},
@@ -22005,10 +22168,16 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hangar/main)
 "bzo" = (
-/obj/disposalpipe/segment,
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/yellow/corner,
 /area/station/hangar/main)
 "bzp" = (
@@ -22018,7 +22187,6 @@
 	},
 /area/station/hangar/main)
 "bzq" = (
-/obj/disposalpipe/segment/morgue,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -22164,16 +22332,13 @@
 /area/station/hangar/main)
 "bAi" = (
 /obj/machinery/disposal,
-/obj/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/hangar/main)
 "bAj" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	name = "VACUUM AREA";
@@ -22182,26 +22347,17 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/main)
 "bAk" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/storage/closet/welding_supply,
 /turf/simulated/floor/yellow/side{
 	dir = 10
 	},
 /area/station/hangar/main)
 "bAl" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/table/auto,
 /obj/item/storage/box/cablesbox,
 /turf/simulated/floor/yellow/side,
 /area/station/hangar/main)
 "bAm" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/light,
 /turf/simulated/floor/yellow/side,
@@ -22228,9 +22384,6 @@
 	pixel_y = 10
 	},
 /obj/machinery/power/apc/autoname_south,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable,
 /turf/simulated/floor/yellow/side,
 /area/station/hangar/main)
@@ -22481,9 +22634,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "bBK" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = 10
@@ -22573,8 +22723,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/storage/warehouse)
 "bBV" = (
@@ -22857,31 +23010,22 @@
 	},
 /area/station/storage/warehouse)
 "bDM" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/computer/barcode,
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/storage/warehouse)
 "bDN" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/lattice,
 /obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/disposalpipe/segment/morgue,
-/turf/simulated/floor/grime,
-/area/station/storage/warehouse)
-"bDO" = (
-/obj/disposalpipe/segment/mail{
-	dir = 2;
+	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/grime,
-/area/station/storage/warehouse)
+/turf/space,
+/area/space)
+"bDO" = (
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "bDP" = (
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
@@ -23005,7 +23149,6 @@
 	id = "speedboost_crusher";
 	name = "Disposals Door"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -23075,7 +23218,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "bEG" = (
@@ -23121,7 +23264,7 @@
 /obj/item/storage/box{
 	pixel_y = -1
 	},
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "bEH" = (
@@ -23342,9 +23485,12 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
@@ -23477,12 +23623,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering)
 "bGQ" = (
-/obj/disposalpipe/segment/morgue,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/storage/warehouse)
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/security/main)
 "bGR" = (
 /obj/item/tile/steel,
 /turf/simulated/floor/plating,
@@ -23656,15 +23802,21 @@
 /area/station/hallway/primary/south)
 "bIc" = (
 /obj/grille/steel,
-/obj/disposalpipe/segment/transport,
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "bId" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/south)
@@ -23775,9 +23927,12 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -23836,6 +23991,9 @@
 	dir = 8
 	},
 /obj/decal/stripe_caution,
+/obj/disposalpipe/segment/transport{
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bIX" = (
@@ -23897,6 +24055,7 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "bJb" = (
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/stairs,
 /area/station/hallway/primary/south)
 "bJc" = (
@@ -23984,10 +24143,6 @@
 /area/station/engine/engineering)
 "bJt" = (
 /obj/table/auto,
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/item/paper/blueprint/chart/system,
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -24088,6 +24243,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bJK" = (
@@ -24183,6 +24339,12 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/science/teleporter)
+"bKd" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/chapel/office)
 "bKe" = (
 /obj/rack,
 /obj/item/device/light/flashlight{
@@ -24280,9 +24442,8 @@
 	},
 /area/station/science/teleporter)
 "bKm" = (
-/obj/disposalpipe/segment/transport,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/teleporter)
+/turf/simulated/floor,
+/area/station/science/lobby)
 "bKn" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/stairs,
@@ -24298,9 +24459,6 @@
 	desc = "Careless use of experimental teleportation technology may be hazardous to your health.";
 	name = "Molecular Integrity Hazard";
 	pixel_y = -4
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/teleporter)
@@ -24401,21 +24559,19 @@
 /area/station/storage/warehouse)
 "bKQ" = (
 /obj/item/instrument/harmonica,
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "bKR" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
+/turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "bKS" = (
 /obj/item/cable_coil/cut,
@@ -24438,7 +24594,6 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
 	},
@@ -24704,6 +24859,9 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bLI" = (
@@ -24759,6 +24917,10 @@
 "bMe" = (
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/ejection{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/red/side,
 /area/station/crew_quarters/supplylobby)
@@ -24833,13 +24995,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/switch_junction{
-	desc = "An underfloor mail pipe.";
-	dir = 2;
-	icon_state = "pipe-sj2";
-	mail_tag = "cargo";
-	name = "quartermasters mail router"
-	},
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 9
 	},
@@ -24853,6 +25008,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 9
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bMy" = (
@@ -25015,6 +25171,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 4
 	},
@@ -25037,6 +25196,9 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/telepad,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/engine{
 	allows_vehicles = 0
 	},
@@ -25058,6 +25220,9 @@
 "bNg" = (
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/junction{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -25263,6 +25428,10 @@
 /obj/machinery/light,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -25526,6 +25695,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 8
 	},
@@ -25887,35 +26057,35 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "bPI" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/science/teleporter)
+/turf/simulated/floor,
+/area/station/hangar/main)
 "bPJ" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/science/teleporter)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/heads)
 "bPK" = (
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/teleporter)
+/turf/simulated/floor/black,
+/area/station/medical/crematorium)
 "bPO" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/machinery/door/airlock/pyro/security{
+	aiControlDisabled = 1;
+	name = "Armory"
 	},
-/obj/disposalpipe/segment/transport,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/teleporter)
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/secscanner{
+	pixel_y = 10
+	},
+/obj/mapping_helper/access/armory,
+/obj/disposalpipe/segment/ejection,
+/turf/simulated/floor,
+/area/station/ai_monitored/armory)
 "bPP" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -25931,13 +26101,13 @@
 /area/station/hallway/primary/south)
 "bPS" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/science/bot_storage)
 "bPT" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -26258,7 +26428,6 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "bQZ" = (
-/obj/disposalpipe/segment/mail,
 /obj/table/auto,
 /obj/item/kitchen/food_box/sugar_box{
 	pixel_y = 10
@@ -26269,7 +26438,8 @@
 /area/station/science/lobby)
 "bRd" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -26279,20 +26449,21 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/segment/transport{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
 /area/station/science/lobby)
 "bRf" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -26304,23 +26475,21 @@
 	pixel_y = 24
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 5
 	},
 /area/station/science/lobby)
 "bRh" = (
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/simulated/floor,
 /area/station/science/lobby)
 "bRi" = (
 /obj/storage/closet/biohazard,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -26330,35 +26499,22 @@
 	pixel_y = 21
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bRk" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/disposalpipe/segment/transport,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lobby)
+/turf/simulated/floor/black,
+/area/station/medical/crematorium)
 "bRl" = (
-/obj/disposalpipe/switch_junction{
-	desc = "An underfloor mail pipe.";
-	dir = 1;
-	icon_state = "pipe-sj2";
-	mail_tag = "testchamber";
-	name = "test chamber mail router"
-	},
-/turf/simulated/floor/purple/side{
-	dir = 4
-	},
-/area/station/hallway/primary/south)
+/obj/mapping_helper/wingrille_spawn/auto,
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/plating,
+/area/station/chapel/sanctuary)
 "bRm" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -26366,9 +26522,6 @@
 "bRn" = (
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -26693,43 +26846,36 @@
 	location = "Research"
 	},
 /obj/decal/stripe_caution,
-/turf/simulated/floor,
-/area/station/science/lobby)
-"bSE" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor,
-/area/station/science/lobby)
-"bSF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
+"bSE" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/science/bot_storage)
+"bSF" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/market)
 "bSG" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor,
-/area/station/science/lobby)
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/black,
+/area/station/chapel/office)
 "bSH" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/landmark/halloween,
+/obj/disposalpipe/segment/transport,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -26760,7 +26906,8 @@
 	name = "bot navigation beacon"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -26768,8 +26915,12 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/switch_junction{
+	desc = "An underfloor mail pipe.";
+	dir = 4;
+	icon_state = "pipe-sj2";
+	mail_tag = "research";
+	name = "research mail router"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -26788,10 +26939,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/drainage,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/drainage,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "bSP" = (
@@ -26799,17 +26950,11 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "bSQ" = (
-/obj/disposalpipe/switch_junction{
-	desc = "An underfloor mail pipe.";
-	dir = 1;
-	icon_state = "pipe-sj2";
-	mail_tag = "chemistry";
-	name = "chemistry mail router"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/decal/stripe_caution,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bSR" = (
@@ -26827,21 +26972,21 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/navbeacon/tour/cog1/tour12,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/navbeacon/tour/cog1/tour12,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bST" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "2-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -26868,14 +27013,11 @@
 /turf/space,
 /area/space)
 "bSZ" = (
-/obj/disposalpipe/switch_junction{
-	desc = "An underfloor mail pipe.";
-	dir = 1;
-	icon_state = "pipe-sj2";
-	mail_tag = "research";
-	name = "research mail router"
-	},
 /obj/decal/stripe_caution,
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bTf" = (
@@ -27091,94 +27233,87 @@
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "bTW" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
 /area/station/science/lobby)
 "bTX" = (
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bTY" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bTZ" = (
-/obj/disposalpipe/junction{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/purple/corner,
 /area/station/science/lobby)
 "bUa" = (
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "bUb" = (
-/obj/disposalpipe/segment{
+/obj/machinery/light,
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/light,
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "bUd" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/switch_junction{
+	desc = "An underfloor mail pipe.";
+	dir = 1;
+	icon_state = "pipe-sj2";
+	mail_tag = "testchamber";
+	name = "test chamber mail router"
 	},
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "bUe" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/purple/side{
 	dir = 6
 	},
 /area/station/science/lobby)
 "bUf" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lobby)
+/turf/simulated/floor,
+/area/station/security/main)
 "bUg" = (
 /obj/rack,
 /obj/item/extinguisher,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bUh" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/shower,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -27186,9 +27321,6 @@
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bUi" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
 	},
@@ -27199,39 +27331,39 @@
 /area/station/science/lobby)
 "bUj" = (
 /obj/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/disposalpipe/segment/transport,
-/obj/decal/poster/wallsign/fire,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lobby)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "bUk" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "bUm" = (
-/obj/disposalpipe/segment{
+/obj/mapping_helper/wingrille_spawn/auto,
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/purple/side{
-	dir = 8
-	},
-/area/station/hallway/primary/south)
+/turf/simulated/floor/plating,
+/area/station/science/bot_storage)
 "bUo" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/airbridge)
 "bUp" = (
+/obj/machinery/conveyor/NS{
+	id = "cargo"
+	},
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment{
-	dir = 2;
+/obj/disposalpipe/segment/mail{
+	dir = 4;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/quartermaster/office)
 "bUq" = (
-/obj/disposalpipe/segment/mail,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -27448,7 +27580,10 @@
 	},
 /area/station/science/lobby)
 "bVp" = (
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bVq" = (
@@ -27459,10 +27594,10 @@
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bVr" = (
-/obj/disposalpipe/segment,
 /obj/machinery/light/emergency{
 	dir = 4
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
@@ -27482,9 +27617,12 @@
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "bVw" = (
-/obj/disposalpipe/segment/transport,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lobby)
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "bVx" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -27503,7 +27641,9 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bVE" = (
@@ -27511,8 +27651,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/purple/corner{
 	dir = 8
@@ -27561,11 +27700,15 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "2-8"
+	},
+/obj/disposalpipe/switch_junction{
+	desc = "An underfloor mail pipe.";
+	dir = 8;
+	icon_state = "pipe-sj2";
+	mail_tag = "genetics";
+	name = "genetics mail router"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -27575,6 +27718,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "bVN" = (
@@ -27821,10 +27965,12 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bWB" = (
-/obj/disposalpipe/segment,
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
@@ -27860,6 +28006,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "bWI" = (
@@ -27952,6 +28099,9 @@
 "bWX" = (
 /obj/machinery/vending/snack,
 /obj/decal/stripe_caution,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bWY" = (
@@ -27976,13 +28126,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bXb" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/landmark/halloween,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bXd" = (
@@ -28010,7 +28158,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/supplylobby)
 "bXi" = (
-/obj/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/outlet_injector/active,
 /turf/simulated/floor,
 /area/station/crew_quarters/supplylobby)
@@ -28139,7 +28286,7 @@
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "bXH" = (
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/purple/corner{
 	dir = 4
 	},
@@ -28160,6 +28307,13 @@
 	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/switch_junction{
+	desc = "An underfloor mail pipe.";
+	dir = 1;
+	icon_state = "pipe-sj2";
+	mail_tag = "chemistry";
+	name = "chemistry mail router"
 	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
@@ -28252,8 +28406,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bXZ" = (
-/obj/disposalpipe/segment/transport,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "bYa" = (
@@ -28262,7 +28418,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bYb" = (
-/obj/disposalpipe/segment,
 /turf/simulated/floor/blue/corner{
 	dir = 8
 	},
@@ -28299,13 +28454,17 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bYi" = (
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/blue/corner,
 /area/station/hallway/primary/south)
 "bYj" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/blue/side{
 	dir = 0
 	},
@@ -28317,19 +28476,27 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/blue/side{
 	dir = 0
 	},
 /area/station/hallway/primary/south)
 "bYl" = (
 /obj/machinery/light/emergency,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/blue/side{
 	dir = 0
 	},
 /area/station/hallway/primary/south)
 "bYm" = (
 /obj/machinery/light,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/blue/side{
 	dir = 0
 	},
@@ -28450,11 +28617,11 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/supplylobby)
 "bYE" = (
-/obj/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor,
 /area/station/crew_quarters/supplylobby)
 "bYF" = (
+/obj/disposalpipe/segment,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -28550,6 +28717,9 @@
 	pixel_y = 6
 	},
 /obj/item/pen,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "bZh" = (
@@ -28615,11 +28785,6 @@
 /turf/simulated/floor/yellow/corner,
 /area/station/hallway/primary/south)
 "bZq" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c";
-	name = "factory pipe"
-	},
 /obj/machinery/door_control{
 	name = "Kitchen Shutter Control";
 	pixel_x = -24;
@@ -28727,11 +28892,13 @@
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/south)
 "bZE" = (
-/obj/disposalpipe/segment/transport,
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/south)
+/obj/disposalpipe/segment/morgue{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "bZF" = (
-/obj/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 8;
 	tag = ""
@@ -28748,6 +28915,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
@@ -28788,6 +28956,9 @@
 /turf/simulated/floor/neutral/side,
 /area/station/crew_quarters/supplylobby)
 "bZT" = (
+/obj/disposalpipe/segment/ejection{
+	dir = 4
+	},
 /turf/simulated/floor/red/side,
 /area/station/crew_quarters/supplylobby)
 "bZU" = (
@@ -28797,18 +28968,18 @@
 	message = "Automated parole chute activated.";
 	name = "Automated Parole Chute"
 	},
-/obj/disposalpipe/trunk/ejection{
-	dir = 4
-	},
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/trunk/ejection{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/supplylobby)
 "bZV" = (
-/obj/disposalpipe/segment/ejection{
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/mining/staff_room)
+/turf/simulated/floor/white,
+/area/station/science/teleporter)
 "bZX" = (
 /obj/table/auto,
 /obj/item/storage/firstaid/regular,
@@ -28926,61 +29097,43 @@
 /turf/space,
 /area/space)
 "cav" = (
-/obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
 /area/station/science/lobby)
 "caw" = (
-/obj/disposalpipe/segment,
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
 /area/station/science/lobby)
 "cax" = (
 /obj/table/auto,
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
 /obj/machinery/computer/security/wooden_tv/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "cay" = (
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
 /obj/mapping_helper/wingrille_spawn/auto,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/station/science/bot_storage)
+/area/station/crew_quarters/kitchen)
 "caz" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/guardbot_dock,
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/decal/stripe_caution,
-/turf/simulated/floor,
-/area/station/science/bot_storage)
+/obj/stool,
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/black,
+/area/station/chapel/office)
 "caA" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
+/obj/disposalpipe/segment/morgue{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/science/bot_storage)
+/area/station/hallway/primary/east)
 "caB" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -28991,8 +29144,9 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
@@ -29000,7 +29154,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/transport{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -29009,7 +29163,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/transport{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -29020,37 +29174,49 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
 /obj/machinery/bot/guardbot,
 /obj/decal/stripe_caution,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "caF" = (
-/obj/disposalpipe/segment/transport{
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/supernorn,
+/turf/simulated/floor/plating,
 /area/station/science/bot_storage)
 "caG" = (
 /obj/lattice,
-/obj/disposalpipe/segment/transport{
-	dir = 4
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/space,
 /area/space)
 "caH" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/south)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/science/lobby)
 "caN" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
@@ -29066,6 +29232,10 @@
 	dir = 1;
 	name = "South Primary Hallway APC";
 	pixel_y = 24
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
@@ -29177,7 +29347,6 @@
 	},
 /obj/machinery/door/window/northright,
 /obj/machinery/atmospherics/pipe/simple,
-/obj/disposalpipe/segment,
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/crew_quarters/supplylobby)
@@ -29189,26 +29358,17 @@
 /obj/submachine/ATM{
 	pixel_x = 32
 	},
-/obj/disposalpipe/segment/ejection{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/crew_quarters/supplylobby)
 "cbq" = (
-/obj/disposalpipe/segment/ejection{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/checkpoint/cargo)
+/obj/disposalpipe/segment,
+/turf/simulated/floor/white,
+/area/station/science/artifact)
 "cbs" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg{
 	name = "bail payment device"
-	},
-/obj/disposalpipe/segment/ejection{
-	dir = 4
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/red,
@@ -29220,19 +29380,19 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/disposalpipe/segment/ejection{
-	dir = 4
-	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/cargo)
 "cbu" = (
-/obj/disposalpipe/segment/ejection{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/mining/staff_room)
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/market)
 "cbw" = (
 /turf/simulated/floor/yellow/corner,
 /area/station/mining/staff_room)
@@ -29424,10 +29584,9 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/lobby)
 "cbR" = (
-/obj/disposalpipe/segment,
-/obj/decal/poster/wallsign/medbay,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/medbay/lobby)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor,
+/area/station/security/main)
 "cbU" = (
 /obj/decal/poster/wallsign/medbay,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -29453,7 +29612,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "cbX" = (
@@ -29463,12 +29621,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "cbY" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/conveyor/WE{
+	name = "cargo belt - east";
+	operating = 1
 	},
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
+/area/station/maintenance/east)
 "cbZ" = (
 /obj/stool/chair{
 	dir = 8
@@ -29496,7 +29655,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -29581,13 +29739,19 @@
 /area/station/crew_quarters/supplylobby)
 "ccw" = (
 /obj/machinery/atmospherics/pipe/simple,
-/obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southeast)
 "ccx" = (
-/obj/disposalpipe/segment/ejection,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/southeast)
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/engine{
+	allows_vehicles = 0
+	},
+/area/station/science/teleporter)
 "ccy" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/checkpoint/cargo)
@@ -29765,12 +29929,11 @@
 /turf/simulated/floor/wood,
 /area/station/medical/medbay/lobby)
 "cdf" = (
-/obj/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
 /obj/machinery/light/emergency{
 	dir = 1
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 8
@@ -29795,6 +29958,7 @@
 	name = "Robotics APC";
 	pixel_x = 24
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "cdk" = (
@@ -29996,7 +30160,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/supplylobby)
 "cdL" = (
-/obj/disposalpipe/segment/ejection,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -30092,6 +30255,10 @@
 /area/station/science/artifact)
 "cej" = (
 /obj/reagent_dispensers/watertank/fountain,
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -30117,17 +30284,14 @@
 /turf/simulated/floor/wood,
 /area/station/medical/medbay/lobby)
 "ceq" = (
+/obj/machinery/atmospherics/pipe/simple,
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood,
-/area/station/medical/medbay/lobby)
-"cer" = (
-/obj/window/reinforced{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail{
+/turf/simulated/floor/grime,
+/area/station/maintenance/east)
+"cer" = (
+/obj/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -30139,12 +30303,11 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "cet" = (
-/obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/plating,
+/area/station/science/testchamber)
 "ceu" = (
 /obj/disposalpipe/segment/mail{
 	dir = 8;
@@ -30238,7 +30401,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/supernorn,
+/turf/simulated/floor,
 /area/station/hallway/primary/south)
 "ceN" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -30259,7 +30422,6 @@
 /area/station/maintenance/southeast)
 "ceW" = (
 /obj/machinery/atmospherics/pipe/simple,
-/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -30385,11 +30547,18 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "cfq" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
@@ -30400,6 +30569,10 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -30416,7 +30589,6 @@
 	location = "research";
 	name = "bot navigation beacon"
 	},
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/purple/corner{
 	dir = 8
 	},
@@ -30429,6 +30601,10 @@
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -30440,6 +30616,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -30447,6 +30626,9 @@
 "cfx" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -30460,16 +30642,22 @@
 	dir = 1;
 	pixel_y = 21
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
 /area/station/science/lobby)
 "cfz" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/purple/corner{
-	dir = 1
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/science/lobby)
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 4
+	},
+/area/station/chapel/sanctuary)
 "cfA" = (
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/wood,
@@ -30487,7 +30675,10 @@
 	},
 /area/station/medical/medbay/lobby)
 "cfD" = (
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "red2"
@@ -30495,6 +30686,9 @@
 /area/station/medical/medbay/lobby)
 "cfE" = (
 /obj/machinery/door/window/eastleft,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/medical/medbay/lobby)
 "cfF" = (
@@ -30559,20 +30753,18 @@
 /turf/simulated/floor/grime,
 /area/station/medical/robotics)
 "cfQ" = (
-/obj/disposalpipe/segment,
 /obj/machinery/light/emergency,
 /turf/simulated/floor/blue/side{
 	dir = 10
 	},
 /area/station/hallway/primary/south)
 "cfR" = (
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue/side{
 	dir = 0
 	},
 /area/station/hallway/primary/south)
 "cfS" = (
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -30714,9 +30906,11 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
 	},
-/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
@@ -30797,6 +30991,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "cgG" = (
@@ -30823,20 +31018,24 @@
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "cgI" = (
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "cgJ" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "cgK" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/purple/side{
 	dir = 10
 	},
@@ -31058,7 +31257,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "chv" = (
-/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -31068,7 +31266,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "chw" = (
-/obj/disposalpipe/segment/ejection,
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "chy" = (
@@ -31184,16 +31385,16 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/stairs,
 /area/station/science/lobby)
 "chS" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/gen_storage)
 "chT" = (
-/obj/disposalpipe/segment/transport,
-/turf/simulated/wall/auto/supernorn,
-/area/station/science/gen_storage)
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/plating,
+/area/station/storage/warehouse)
 "chU" = (
 /obj/stool/chair{
 	dir = 8
@@ -31217,7 +31418,6 @@
 	},
 /area/station/science/lobby)
 "chX" = (
-/obj/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -31321,10 +31521,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "ciq" = (
@@ -31420,12 +31617,10 @@
 	},
 /area/station/hallway/secondary/exit)
 "ciH" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/lobby)
+/obj/machinery/atmospherics/pipe/simple,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/black,
+/area/station/bridge)
 "ciI" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/tech)
@@ -31437,19 +31632,19 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southeast)
 "ciN" = (
-/obj/disposalpipe/segment/ejection{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/transport{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/science/testchamber)
 "ciO" = (
 /obj/machinery/floorflusher/minibrig,
 /obj/disposalpipe/trunk/ejection{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/grime,
 /area/station/security/checkpoint/cargo)
@@ -31482,6 +31677,10 @@
 /area/station/quartermaster/office)
 "ciT" = (
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 8
 	},
@@ -31501,6 +31700,7 @@
 	icon_state = "1-2"
 	},
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "ciX" = (
@@ -31535,6 +31735,10 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "cjd" = (
@@ -31561,7 +31765,6 @@
 "cje" = (
 /obj/storage/closet/emergency,
 /obj/decal/cleanable/cobweb,
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
 "cjf" = (
@@ -31736,11 +31939,15 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
+	},
+/obj/disposalpipe/switch_junction{
+	desc = "An underfloor mail pipe.";
+	dir = 2;
+	icon_state = "pipe-sj2";
+	mail_tag = "cargo";
+	name = "quartermasters mail router"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -31962,6 +32169,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/artifact)
 "ckt" = (
@@ -31977,6 +32185,7 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 6
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/science/artifact)
 "cku" = (
@@ -32021,19 +32230,22 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "cky" = (
 /obj/disposalpipe/segment{
-	dir = 4;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/science/gen_storage)
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "fred6"
+	},
+/area/station/crew_quarters/jazz)
 "ckC" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -32041,9 +32253,6 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
@@ -32054,9 +32263,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -32066,20 +32272,18 @@
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "ckF" = (
-/obj/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/purple/side{
+/obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/area/station/science/lobby)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "fred1"
+	},
+/area/station/chapel/sanctuary)
 "ckG" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -32436,6 +32640,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/science/artifact)
 "clR" = (
@@ -32461,12 +32666,17 @@
 /turf/simulated/floor,
 /area/station/science/artifact)
 "clU" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/supernorn,
-/area/station/science/gen_storage)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/science/lobby)
 "clV" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
 "clW" = (
@@ -32498,14 +32708,12 @@
 	},
 /area/station/science/lobby)
 "cma" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/purple/side{
-	dir = 4
-	},
-/area/station/science/lobby)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "cmb" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -32559,10 +32767,12 @@
 	},
 /area/station/medical/medbay/lobby)
 "cmi" = (
-/turf/simulated/floor/bluewhite{
-	dir = 1
+/obj/cable{
+	icon_state = "1-2"
 	},
-/area/station/medical/medbay/lobby)
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor,
+/area/station/science/lobby)
 "cmj" = (
 /obj/machinery/disposal/morgue,
 /obj/disposalpipe/trunk/morgue,
@@ -32879,6 +33089,7 @@
 	icon_state = "0-4"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "cmY" = (
@@ -32890,6 +33101,7 @@
 	},
 /obj/cable,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "cmZ" = (
@@ -32900,13 +33112,15 @@
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "cnb" = (
-/obj/disposalpipe/segment,
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/testchamber)
 "cnc" = (
 /obj/disposalpipe/segment/transport,
-/turf/simulated/wall/auto/supernorn,
-/area/station/science/chemistry)
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "cnd" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/chemistry)
@@ -32917,9 +33131,16 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/research)
 "cnh" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/chemistry)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/stripe_caution,
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "cnk" = (
 /obj/health_scanner/wall{
 	find_in_range = 0;
@@ -33094,6 +33315,7 @@
 /area/station/hangar/science)
 "cod" = (
 /obj/storage/closet/biohazard,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/testchamber)
 "coe" = (
@@ -33118,12 +33340,10 @@
 /area/station/science/testchamber)
 "cog" = (
 /obj/machinery/disposal,
-/obj/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
+/obj/disposalpipe/trunk,
 /turf/simulated/floor,
 /area/station/science/testchamber)
 "coh" = (
@@ -33135,26 +33355,16 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "coi" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "coj" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
@@ -33498,11 +33708,18 @@
 /turf/simulated/floor,
 /area/station/science/testchamber)
 "cph" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/science/testchamber)
 "cpj" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
+	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/science/testchamber)
@@ -33519,7 +33736,6 @@
 "cpm" = (
 /obj/storage/closet/fire,
 /obj/disposalpipe/segment/transport{
-	dir = 4;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
@@ -33591,14 +33807,14 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "cpA" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/disposalpipe/junction{
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -33639,9 +33855,6 @@
 /area/station/medical/medbay)
 "cpF" = (
 /obj/storage/closet/biohazard,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 0;
@@ -33771,6 +33984,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/disposalpipe/segment/morgue,
 /turf/space,
 /area/space)
 "cpU" = (
@@ -33873,6 +34087,9 @@
 "cqk" = (
 /obj/stool/chair/office,
 /obj/decal/tile_edge/stripe/extra_big,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/science/testchamber)
 "cql" = (
@@ -33881,11 +34098,17 @@
 	target_pressure = 250
 	},
 /obj/decal/tile_edge/stripe/extra_big,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/science/testchamber)
 "cqm" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/testchamber)
@@ -33941,6 +34164,10 @@
 /turf/simulated/floor/purplewhite,
 /area/station/science/chemistry)
 "cqy" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 6
 	},
@@ -34347,6 +34574,9 @@
 	icon_state = "1-8"
 	},
 /obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "cse" = (
@@ -34505,20 +34735,13 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 1
 	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
 /area/station/medical/medbay/cloner)
 "csL" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/bluewhite{
 	dir = 5
 	},
@@ -34533,9 +34756,6 @@
 	},
 /area/station/hallway/secondary/exit)
 "csU" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
@@ -34554,9 +34774,6 @@
 	},
 /area/station/science/chemistry)
 "csV" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/decal/poster/wallsign/poster_ptoe{
 	pixel_y = 32
 	},
@@ -35045,13 +35262,10 @@
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/cloner)
 "cur" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/stool/bench/red/auto,
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbay/cloner)
+/obj/grille/steel,
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "cus" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -35284,9 +35498,6 @@
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
 "cvg" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/table/wood/auto,
 /obj/item/paper_bin{
 	pixel_x = -4;
@@ -35317,7 +35528,6 @@
 	},
 /area/station/medical/medbay/surgery)
 "cvj" = (
-/obj/disposalpipe/segment,
 /obj/table/auto,
 /obj/item/clothing/glasses/spectro{
 	pixel_y = 6
@@ -35608,9 +35818,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/research)
+/obj/disposalpipe/segment,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "cwj" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -35619,6 +35829,7 @@
 /area/station/medical/research)
 "cwk" = (
 /obj/machinery/atmospherics/pipe/simple,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "cwl" = (
@@ -35629,16 +35840,17 @@
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
 "cwm" = (
-/obj/disposalpipe/junction{
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/grime,
+/area/station/storage/warehouse)
+"cwn" = (
+/obj/machinery/atmospherics/unary/outlet_injector/active{
 	dir = 1
 	},
-/turf/simulated/floor/blue/checker,
-/area/station/medical/research)
-"cwn" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/outlet_injector/active{
+/obj/disposalpipe/junction{
 	dir = 1
 	},
 /turf/simulated/floor/blue/checker,
@@ -35834,7 +36046,10 @@
 /area/station/medical/research)
 "cwU" = (
 /obj/landmark/gps_waypoint,
-/obj/disposalpipe/segment,
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
 "cwV" = (
@@ -36030,10 +36245,8 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "cxS" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/cloner)
 "cya" = (
@@ -36354,6 +36567,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/maint,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "czH" = (
@@ -37099,10 +37313,14 @@
 	},
 /area/station/science/testchamber)
 "cCf" = (
-/obj/disposalpipe/segment,
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/research)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
+/turf/simulated/floor/grime,
+/area/station/hallway/primary/east)
 "cCg" = (
 /obj/decal/poster/wallsign/stencil/right/s{
 	pixel_x = 21
@@ -37429,7 +37647,10 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 9
 	},
-/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/produce{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "cHR" = (
@@ -37492,6 +37713,7 @@
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
@@ -37554,14 +37776,10 @@
 	operating = 1
 	},
 /obj/strip_door,
-/obj/disposalpipe/switch_junction{
-	dir = 4;
-	mail_tag = "sortingroom";
-	name = "sorting room router"
-	},
 /obj/machinery/door/firedoor/pyro{
 	layer = 29.1
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/caution/westeast,
 /area/station/routing/sortingRoom)
 "cOb" = (
@@ -37577,7 +37795,6 @@
 	},
 /obj/mapping_helper/access/kitchen,
 /obj/mapping_helper/firedoor_spawn,
-/obj/disposalpipe/segment,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/bar)
 "cOy" = (
@@ -37586,16 +37803,16 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "cOI" = (
-/obj/disposalpipe/segment,
-/obj/grille/catwalk,
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "cPw" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "cPP" = (
@@ -37749,6 +37966,7 @@
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/maint,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "cUP" = (
@@ -37939,9 +38157,6 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "dcw" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/storage/secure/closet/brig_automatic/genpop_s,
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -37978,7 +38193,6 @@
 /area/station/maintenance/central)
 "ddy" = (
 /obj/machinery/door/airlock/pyro/glass,
-/obj/disposalpipe/segment/mail,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
@@ -38180,9 +38394,10 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/disposalpipe/switch_junction{
+	desc = "An underfloor mail pipe.";
+	mail_tag = "chapel";
+	name = "chapel mail router"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
@@ -38376,6 +38591,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/bluewhite{
 	dir = 5
 	},
@@ -38402,11 +38618,11 @@
 /turf/simulated/floor/plating/airless,
 /area/station/quartermaster/refinery)
 "dtA" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	pixel_y = 23
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -38685,6 +38901,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "dAV" = (
@@ -38729,18 +38946,10 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "dDl" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/grille/catwalk,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5
-	},
-/area/space)
+/obj/landmark/pest,
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/crew_quarters/supplylobby)
 "dEj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -38748,6 +38957,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/security/main)
 "dFg" = (
@@ -38862,10 +39072,6 @@
 /turf/simulated/floor/plating/jen,
 /area/station/engine/coldloop)
 "dIw" = (
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/binary/valve{
 	high_risk = 1;
 	name = "Chapel"
@@ -38911,10 +39117,6 @@
 /area/station/hydroponics/bay)
 "dJW" = (
 /mob/living/carbon/human/npc/monkey/krimpus,
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "dKw" = (
@@ -39041,6 +39243,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor,
 /area/station/security/main)
 "dPh" = (
@@ -39066,12 +39269,10 @@
 /turf/simulated/floor,
 /area/station/storage/hydroponics)
 "dQf" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/decal/cleanable/rust,
-/turf/simulated/wall/auto/supernorn,
-/area/station/routing/sortingRoom)
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/plating,
+/area/station/science/lobby)
 "dQh" = (
 /obj/storage/closet/welding_supply,
 /obj/machinery/light/small{
@@ -39147,7 +39348,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "dRM" = (
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -39228,6 +39428,9 @@
 "dSW" = (
 /obj/landmark/pest,
 /obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "dTr" = (
@@ -39272,6 +39475,7 @@
 	dir = 8;
 	pixel_x = 15
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "dUE" = (
@@ -39328,11 +39532,17 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/supplylobby)
 "dWk" = (
-/obj/disposalpipe/segment{
-	dir = 8
+/obj/cable{
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
+/obj/disposalpipe/switch_junction{
+	dir = 4;
+	icon_state = "pipe-sj2";
+	mail_tag = "crew";
+	name = "crew quarters mail router"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "dWp" = (
 /obj/machinery/door/poddoor/pyro/shutters{
 	dir = 4;
@@ -39346,6 +39556,12 @@
 	},
 /obj/disposalpipe/segment/transport,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "dWz" = (
@@ -39364,11 +39580,11 @@
 	name = "Brig Divider Shutters";
 	opacity = 0
 	},
-/obj/disposalpipe/segment/ejection,
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "dXq" = (
@@ -39387,10 +39603,10 @@
 	},
 /area/station/security/main)
 "dXC" = (
-/obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/glass/security/alt,
 /obj/mapping_helper/access/security,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/security/main)
 "dYm" = (
@@ -39419,9 +39635,7 @@
 /turf/space,
 /area/space)
 "dZb" = (
-/obj/disposalpipe/segment{
-	dir = 1
-	},
+/obj/disposalpipe/segment/produce,
 /turf/simulated/floor/grasstodirt{
 	icon_state = "dirt"
 	},
@@ -39434,6 +39648,7 @@
 	name = "Information Office"
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
 "eai" = (
@@ -39495,7 +39710,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "eeD" = (
-/obj/disposalpipe/segment/ejection,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -39600,6 +39814,7 @@
 /obj/mapping_helper/access/robotdepot,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "eiP" = (
@@ -39647,7 +39862,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm/west,
-/obj/disposalpipe/segment/produce,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -39662,6 +39876,9 @@
 	pixel_x = -20
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/security/secwing)
 "ekW" = (
@@ -39854,9 +40071,11 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "erD" = (
-/obj/disposalpipe/segment/food,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/food{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
@@ -39864,9 +40083,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/produce{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/yellow/corner{
 	dir = 8
@@ -39944,9 +40162,6 @@
 	},
 /obj/machinery/power/apc/autoname_west,
 /obj/decal/stripe_delivery,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "etV" = (
@@ -39956,6 +40171,9 @@
 	},
 /obj/mapping_helper/access/bar,
 /obj/mapping_helper/access/kitchen,
+/obj/disposalpipe/segment/food{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "eup" = (
@@ -40029,37 +40247,33 @@
 /turf/simulated/floor/airless/solar,
 /area/station/solar/west)
 "ewn" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c";
-	name = "factory pipe"
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/purple/side,
+/area/station/science/lobby)
 "ewr" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/grille/catwalk{
-	dir = 5
-	},
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
 	},
 /area/space)
 "exh" = (
-/obj/grille/catwalk{
-	dir = 5
-	},
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment,
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -40070,7 +40284,7 @@
 	name = "S light switch";
 	pixel_y = -24
 	},
-/obj/disposalpipe/segment/produce{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor/grime,
@@ -40121,11 +40335,11 @@
 /turf/simulated/floor,
 /area/station/engine/elect)
 "eyC" = (
-/obj/disposalpipe/segment/mail,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 15
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/bridge)
 "eyE" = (
@@ -40301,7 +40515,9 @@
 	mail_tag = "kitchen";
 	name = "mail chute-'Kitchen'"
 	},
-/obj/disposalpipe/trunk/mail,
+/obj/disposalpipe/trunk/mail{
+	dir = 4
+	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "eDu" = (
@@ -40357,9 +40573,6 @@
 /obj/decal/cleanable/dirt,
 /obj/decal/cleanable/ash,
 /obj/item/cigbutt,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "eFo" = (
@@ -40420,9 +40633,6 @@
 /obj/landmark/start/job/botanist,
 /obj/machinery/alarm{
 	pixel_y = 23
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
 	},
 /turf/simulated/floor/green/side{
 	dir = 1
@@ -40593,13 +40803,10 @@
 /turf/simulated/floor/plating,
 /area/station/engine/coldloop)
 "eML" = (
-/obj/machinery/conveyor/WE{
-	name = "cargo belt - east";
-	operating = 1
-	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/storage/closet/biohazard,
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/science/testchamber)
 "eNa" = (
 /obj/table/reinforced/auto,
 /obj/item/cigpacket{
@@ -40669,8 +40876,18 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"eRh" = (
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/sanctuary)
 "eRW" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -40865,7 +41082,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/table/auto,
 /obj/item/plate,
 /obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{
@@ -40930,9 +41146,6 @@
 	icon_state = "2-8"
 	},
 /obj/table/glass/auto,
-/obj/disposalpipe/segment{
-	dir = 1
-	},
 /obj/item/sheet/steel/fullstack,
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
@@ -41012,6 +41225,7 @@
 	dir = 1
 	},
 /obj/landmark/start/job/medical_doctor,
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -41045,13 +41259,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "fge" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	name = "factory pipe"
 	},
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -41203,6 +41415,9 @@
 /obj/item/reagent_containers/food/snacks/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "fmu" = (
@@ -41216,10 +41431,10 @@
 	},
 /area/station/chapel/sanctuary)
 "fmP" = (
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -41382,21 +41597,21 @@
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "fqc" = (
-/obj/disposalpipe/segment{
-	dir = 2;
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/grille/catwalk,
-/obj/cable/orange{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5
-	},
-/area/space)
+/turf/simulated/floor,
+/area/station/science/lobby)
 "fqw" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
@@ -41446,6 +41661,10 @@
 	},
 /turf/space,
 /area/space)
+"fsp" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor,
+/area/station/science/artifact)
 "fsz" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
@@ -41487,10 +41706,6 @@
 /area/station/engine/engineering)
 "fts" = (
 /obj/landmark/pest,
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "ftU" = (
@@ -41713,13 +41928,9 @@
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "fDN" = (
-/obj/machinery/disposal/brig,
-/obj/disposalpipe/trunk/brig{
-	dir = 4
-	},
-/obj/decal/stripe_delivery,
-/turf/simulated/floor,
-/area/station/security/main)
+/obj/disposalpipe/segment/food,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/bar)
 "fEo" = (
 /obj/grille/catwalk{
 	dir = 8
@@ -41762,9 +41973,6 @@
 /turf/simulated/floor,
 /area/station/engine/elect)
 "fFQ" = (
-/obj/disposalpipe/segment/ejection{
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "2-8"
 	},
@@ -41787,7 +41995,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/disposalpipe/junction,
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "fFY" = (
@@ -41988,14 +42196,17 @@
 /area/space)
 "fOw" = (
 /obj/table/wood/auto,
-/obj/item/camera{
-	pixel_x = 6;
-	pixel_y = 5
+/obj/machinery/networked/printer{
+	print_id = "Information"
 	},
-/obj/item/camera{
-	pixel_x = -3;
+/obj/item/item_box/postit{
+	pixel_x = 5;
 	pixel_y = 3
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
 "fPv" = (
@@ -42119,10 +42330,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "fSQ" = (
-/obj/grille/catwalk,
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "fTc" = (
@@ -42141,16 +42353,25 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment{
-	dir = 1
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
+"fUo" = (
+/obj/machinery/conveyor/WE{
+	id = "enginesupply"
+	},
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/plating,
+/area/station/storage/warehouse)
 "fUp" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
-/obj/disposalpipe/segment{
-	dir = 1
-	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
@@ -42160,7 +42381,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/mapping_helper/firedoor_spawn,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -42232,9 +42452,8 @@
 	dir = 4
 	},
 /obj/shrub,
-/obj/disposalpipe/segment/ejection{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -42482,6 +42701,9 @@
 	},
 /obj/mapping_helper/access/chapel_office,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "giH" = (
@@ -42526,14 +42748,14 @@
 	dir = 4;
 	name = "Research Sector"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/mapping_helper/access/research_foyer,
 /obj/mapping_helper/airlock/cycler{
 	cycle_id = "research";
 	enter_id = "inner";
 	name = "Research"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
@@ -42551,9 +42773,6 @@
 /area/station/medical/medbay)
 "glo" = (
 /obj/machinery/firealarm/north,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/table/auto,
 /obj/item/paper_bin{
 	pixel_x = 4;
@@ -42651,6 +42870,9 @@
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/access/chapel_office,
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "gpw" = (
@@ -42661,7 +42883,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "gpQ" = (
-/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/produce,
 /turf/simulated/floor/stairs{
 	dir = 1;
 	icon_state = "Stairs2_wide"
@@ -42698,10 +42920,6 @@
 "gqP" = (
 /obj/stool/chair/comfy/blue{
 	dir = 1
-	},
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/east)
@@ -42740,6 +42958,7 @@
 	name = "W light switch";
 	pixel_x = -24
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "gsj" = (
@@ -42828,6 +43047,7 @@
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
 "gDx" = (
@@ -42899,7 +43119,7 @@
 /turf/space,
 /area/space)
 "gFg" = (
-/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/produce,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -42985,8 +43205,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/mapping_helper/access/chemistry,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "gIq" = (
@@ -43011,6 +43231,7 @@
 	},
 /obj/mapping_helper/access/medical,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue/side,
 /area/station/medical/medbooth)
 "gIU" = (
@@ -43204,10 +43425,6 @@
 	},
 /area/station/engine/elect)
 "gNR" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/glass_recycler/chemistry,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/firealarm/north,
@@ -43264,15 +43481,9 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "gRd" = (
-/obj/grille/catwalk{
-	dir = 10
-	},
 /obj/cable/orange{
 	icon_state = "2-4"
 	},
@@ -43280,6 +43491,7 @@
 	dir = 4;
 	name = "brig pipe"
 	},
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross"
@@ -43306,7 +43518,6 @@
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "gRz" = (
-/obj/disposalpipe/segment,
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
@@ -43318,7 +43529,6 @@
 /area/station/maintenance/east)
 "gUi" = (
 /obj/machinery/atmospherics/pipe/simple,
-/obj/disposalpipe/segment,
 /obj/machinery/light/emergency{
 	dir = 8;
 	pixel_x = -10
@@ -43406,9 +43616,6 @@
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment{
-	dir = 1
-	},
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
 "gXx" = (
@@ -43426,7 +43633,6 @@
 /area/station/engine/ptl)
 "gYc" = (
 /obj/machinery/firealarm/east,
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -43443,6 +43649,7 @@
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "gYS" = (
@@ -43523,7 +43730,6 @@
 /turf/simulated/floor,
 /area/station/hangar/engine)
 "hbw" = (
-/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -43541,12 +43747,12 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "hdf" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/mapping_helper/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/market)
+/turf/simulated/floor,
+/area/station/hydroponics/lobby)
 "hdS" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -43554,6 +43760,9 @@
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
+	},
+/obj/disposalpipe/segment{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
@@ -43600,9 +43809,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/device/prisoner_scanner,
-/obj/disposalpipe/segment/brig{
-	dir = 4
-	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "hfr" = (
@@ -43846,7 +44052,6 @@
 	dir = 8;
 	tag = "icon-xtra_bigstripe-edge (WEST)"
 	},
-/obj/disposalpipe/segment/produce,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -43864,10 +44069,10 @@
 	},
 /area/station/quartermaster/refinery)
 "hra" = (
-/obj/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/security/main)
 "hsl" = (
@@ -44003,9 +44208,6 @@
 /turf/simulated/floor/plating/scorched,
 /area/station/crew_quarters/clown)
 "hxp" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -44023,7 +44225,6 @@
 "hxR" = (
 /obj/storage/closet/emergency,
 /obj/machinery/atmospherics/pipe/simple,
-/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -44319,10 +44520,6 @@
 	},
 /area/station/hydroponics/bay)
 "hIt" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/item/device/radio/intercom/security{
 	dir = 8
 	},
@@ -44427,9 +44624,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment{
-	dir = 1
-	},
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
 "hLn" = (
@@ -44508,6 +44702,10 @@
 "hOx" = (
 /obj/item/device/radio/intercom/engineering{
 	dir = 1
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/bridge)
@@ -44723,14 +44921,15 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
 	},
 /obj/landmark/start/job/scientist,
+/obj/disposalpipe/segment/transport{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -44831,7 +45030,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/stairs{
 	icon_state = "Stairs2_wide"
 	},
@@ -44876,16 +45075,13 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "iel" = (
-/obj/grille/catwalk{
-	dir = 9
-	},
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/disposalpipe/junction{
+	dir = 1
 	},
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -44909,9 +45105,17 @@
 /turf/simulated/floor/green,
 /area/station/turret_protected/Zeta)
 "ieU" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/guardbot_dock,
+/obj/decal/stripe_caution,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/science/bot_storage)
 "ifi" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -45075,9 +45279,6 @@
 /area/station/medical/medbay)
 "ikr" = (
 /obj/decal/cleanable/dirt,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "ikt" = (
@@ -45126,12 +45327,15 @@
 /turf/space,
 /area/space)
 "inc" = (
-/obj/disposalpipe/segment/mail,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
@@ -45452,11 +45656,9 @@
 /obj/item/device/radio/intercom/medical{
 	dir = 1
 	},
-/obj/disposalpipe/switch_junction{
-	dir = 4;
-	icon_state = "pipe-sj2";
-	mail_tag = "kitchen";
-	name = "kitchen mail router"
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -45618,6 +45820,17 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
+"iKM" = (
+/obj/machinery/conveyor/EW{
+	name = "cargo belt - west";
+	operating = 1
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "iLY" = (
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/carpet{
@@ -45734,9 +45947,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/ejection{
-	icon_state = "pipe-c"
-	},
 /obj/landmark/start/job/security_assistant,
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -45758,7 +45968,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/ejection{
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -45880,6 +46090,7 @@
 /obj/decal/tile_edge/stripe/corner/big2{
 	dir = 6
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "iWp" = (
@@ -45943,9 +46154,6 @@
 	},
 /area/station/science/chemistry)
 "iYS" = (
-/obj/disposalpipe/segment/produce{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Biodome"
@@ -45976,13 +46184,15 @@
 	},
 /area/space)
 "jaV" = (
-/obj/machinery/conveyor/EW{
-	name = "cargo belt - west";
-	operating = 1
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/hydroponics/lobby)
 "jbi" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/engineering/ce)
@@ -46120,6 +46330,9 @@
 /obj/railing/orange/reinforced{
 	dir = 1
 	},
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
@@ -46199,7 +46412,6 @@
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "jme" = (
-/obj/disposalpipe/segment/morgue,
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -46373,6 +46585,7 @@
 	},
 /obj/cable,
 /obj/machinery/power/apc/autoname_east,
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "jsC" = (
@@ -46383,12 +46596,13 @@
 /turf/simulated/floor/black,
 /area/station/engine/coldloop)
 "jsQ" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/routing/sortingRoom)
+/turf/simulated/floor/blue/side{
+	dir = 0
+	},
+/area/station/hallway/primary/south)
 "jtV" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -46400,6 +46614,9 @@
 /area/station/routing/medsci)
 "jtW" = (
 /obj/landmark/pest,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "juv" = (
@@ -46438,7 +46655,8 @@
 "jwh" = (
 /obj/landmark/start/job/chef,
 /obj/disposalpipe/segment{
-	dir = 8
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -46488,12 +46706,11 @@
 	name = "S light switch";
 	pixel_y = -24
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -46528,10 +46745,7 @@
 	pixel_x = 2;
 	pixel_y = 1
 	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -46983,6 +47197,9 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/maint,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "jRr" = (
@@ -47011,6 +47228,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/purple/side,
 /area/station/janitor/office)
 "jSE" = (
@@ -47045,7 +47263,6 @@
 	persistent_id = "bar";
 	pixel_x = 32
 	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "jTA" = (
@@ -47096,7 +47313,7 @@
 	name = "cargo belt - east";
 	operating = 1
 	},
-/obj/disposalpipe/segment/morgue,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "jVA" = (
@@ -47520,12 +47737,11 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "kkk" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/security/main)
+/turf/simulated/floor/black,
+/area/station/bridge)
 "kkz" = (
 /obj/machinery/mass_driver{
 	dir = 4;
@@ -47551,6 +47767,9 @@
 /area/station/medical/medbay)
 "knf" = (
 /obj/mapping_helper/wingrille_spawn/auto,
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "knL" = (
@@ -47572,6 +47791,9 @@
 /area/station/science/lab)
 "koE" = (
 /obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "koL" = (
@@ -47610,6 +47832,7 @@
 /area/station/security/detectives_office)
 "kpq" = (
 /obj/landmark/pest,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -47625,6 +47848,10 @@
 "kpY" = (
 /obj/item/device/radio/intercom/engineering{
 	dir = 1
+	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/science/lobby)
@@ -47653,6 +47880,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "kqA" = (
@@ -47678,6 +47906,7 @@
 /obj/cable{
 	icon_state = "1-10"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -47825,7 +48054,6 @@
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/south)
 "kwa" = (
-/obj/disposalpipe/segment/ejection,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -47867,9 +48095,8 @@
 /area/station/medical/medbay)
 "kxF" = (
 /obj/item/swingsignfolded,
-/obj/disposalpipe/segment/produce{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
@@ -47884,14 +48111,13 @@
 	name = "Mail Sorting Room"
 	},
 /obj/mapping_helper/access/maint,
-/obj/disposalpipe/switch_junction{
-	dir = 2;
-	name = "undeliverable mail router"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/routing/sortingRoom)
 "kyx" = (
@@ -47899,6 +48125,9 @@
 	icon_state = "1-2"
 	},
 /obj/landmark/start/job/scientist,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "kyM" = (
@@ -47915,6 +48144,9 @@
 "kzw" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
@@ -48073,6 +48305,7 @@
 /obj/stool/chair/purple{
 	dir = 8
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "kIr" = (
@@ -48167,7 +48400,10 @@
 	},
 /area/mining/magnet)
 "kLp" = (
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
@@ -48239,10 +48475,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/disposalpipe/segment/transport,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Research Sector"
@@ -48253,10 +48485,12 @@
 	enter_id = "outer";
 	name = "Research"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "kOI" = (
-/obj/disposalpipe/segment,
 /obj/machinery/conveyor/NS{
 	name = "cargo belt - south";
 	operating = 1
@@ -48364,7 +48598,6 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/red/corner,
 /area/station/security/main)
 "kVv" = (
@@ -48481,14 +48714,11 @@
 /area/station/medical/medbay)
 "kZy" = (
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
-/area/station/security/main)
+/area/station/bridge)
 "kZW" = (
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/wood{
@@ -48642,6 +48872,8 @@
 	},
 /obj/mapping_helper/access/crematorium,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "ljb" = (
@@ -48690,19 +48922,17 @@
 	name = "Chaplain's Office"
 	},
 /obj/mapping_helper/access/chapel_office,
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "lkX" = (
-/obj/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
+/obj/machinery/conveyor/EW{
+	name = "cargo belt - west";
+	operating = 1
 	},
-/obj/disposalpipe/segment,
-/obj/grille/catwalk,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5
-	},
-/area/space)
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "llo" = (
 /mob/living/carbon/human/npc/monkey,
 /turf/simulated/floor/grass{
@@ -48808,15 +49038,15 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
 "lrG" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Ranch"
 	},
 /obj/mapping_helper/access/rancher,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
 /turf/simulated/floor/green,
 /area/station/ranch)
 "lsz" = (
@@ -48908,6 +49138,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/crew_quarters/cafeteria)
 "lww" = (
@@ -48926,6 +49157,9 @@
 "lxQ" = (
 /obj/item/device/radio/intercom/security{
 	dir = 8
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -49165,12 +49399,10 @@
 	icon_state = "1-2"
 	},
 /obj/landmark/halloween,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/decal/tile_edge/stripe/corner/big2{
 	dir = 5
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "lJf" = (
@@ -49216,11 +49448,11 @@
 	name = "Brig Divider Shutters";
 	opacity = 0
 	},
-/obj/disposalpipe/segment/brig,
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "lKY" = (
@@ -49259,6 +49491,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/bar)
 "lMq" = (
@@ -49290,9 +49525,12 @@
 /area/station/routing/catering)
 "lQi" = (
 /obj/landmark/pest,
-/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
@@ -49441,6 +49679,9 @@
 /obj/mapping_helper/access/artlab,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/science/artifact)
 "lVE" = (
@@ -49507,6 +49748,7 @@
 	dir = 4
 	},
 /obj/decal/stripe_caution,
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/security/main)
 "lYi" = (
@@ -49574,12 +49816,15 @@
 	},
 /area/station/hallway/primary/south)
 "maI" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "fred2"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/chapel/sanctuary)
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/science/lobby)
 "maK" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -49848,6 +50093,10 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "moc" = (
@@ -49884,6 +50133,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
@@ -49895,10 +50145,9 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/junction{
+	icon_state = "pipe-j2"
 	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "mpC" = (
@@ -49941,10 +50190,6 @@
 "mrO" = (
 /obj/machinery/power/terminal{
 	dir = 1
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
 	},
 /obj/cable/orange{
 	icon_state = "0-2"
@@ -50009,7 +50254,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/mapping_helper/firedoor_spawn,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -50062,19 +50306,19 @@
 	},
 /area/station/science/testchamber)
 "mva" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/table/wood/auto,
-/obj/machinery/networked/printer{
-	print_id = "Information"
+/obj/machinery/firealarm/north,
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/obj/item/item_box/postit{
-	pixel_x = 5;
+/obj/item/camera{
+	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/machinery/firealarm/north,
+/obj/item/camera{
+	pixel_x = 6;
+	pixel_y = 5
+	},
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "fred2"
@@ -50129,10 +50373,10 @@
 /turf/simulated/floor/plating,
 /area/station/medical/staff)
 "mwX" = (
-/obj/disposalpipe/segment/ejection,
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "mwY" = (
@@ -50187,6 +50431,9 @@
 "myZ" = (
 /obj/item/device/radio/intercom/engineering{
 	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/crew_quarters/info)
@@ -50244,8 +50491,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/mapping_helper/access/maint,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/maintenance/disposal)
 "mBH" = (
@@ -50282,8 +50529,8 @@
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
 "mCv" = (
-/obj/disposalpipe/segment,
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/security/main)
 "mCK" = (
@@ -50387,11 +50634,16 @@
 	enter_id = "side";
 	name = "Security"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/security/secwing)
 "mFI" = (
 /obj/item/device/radio/beacon,
 /obj/landmark/pest,
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/carpet{
 	icon_state = "fred3"
 	},
@@ -50455,7 +50707,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
@@ -50575,12 +50826,14 @@
 /turf/simulated/floor,
 /area/station/routing/engine)
 "mPc" = (
-/obj/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
 "mPo" = (
 /obj/cable,
 /obj/cable{
@@ -50647,9 +50900,6 @@
 /area/station/crew_quarters/bar)
 "mRk" = (
 /obj/machinery/disposal,
-/obj/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/machinery/door_control{
 	id = "chemistry";
 	name = "Safety Shutters";
@@ -50658,12 +50908,12 @@
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
+/obj/disposalpipe/trunk,
 /turf/simulated/floor/purplewhite{
 	dir = 5
 	},
 /area/station/science/chemistry)
 "mRm" = (
-/obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/sortingRoom)
 "mRx" = (
@@ -50741,11 +50991,10 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/brig,
-/obj/disposalpipe/segment/ejection{
-	dir = 4
-	},
 /mob/living/carbon/human/npc/monkey/stirstir,
+/obj/disposalpipe/junction{
+	name = "ejection pipe"
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "mUB" = (
@@ -50764,12 +51013,12 @@
 	},
 /area/station/storage/primary)
 "mVI" = (
-/obj/disposalpipe/segment/mail{
-	dir = 2;
+/obj/disposalpipe/segment{
+	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/routing/sortingRoom)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "mVQ" = (
 /obj/landmark/pest,
 /turf/simulated/floor/blue,
@@ -50851,6 +51100,11 @@
 "mXu" = (
 /obj/item/device/radio/intercom/security{
 	dir = 4
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -51042,6 +51296,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/security/main)
 "nhQ" = (
@@ -51252,7 +51507,6 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "nph" = (
-/obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
 	icon_state = "1-2"
@@ -51311,13 +51565,12 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "nqI" = (
-/obj/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
 /obj/machinery/light/emergency{
 	dir = 8;
 	pixel_x = -10
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -51386,9 +51639,6 @@
 /area/station/engine/gas)
 "nts" = (
 /obj/stool/chair/comfy,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/landmark/start/job/head_of_security,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
@@ -51422,6 +51672,13 @@
 	icon_state = "7"
 	},
 /area/shuttle/arrival/station)
+"nvG" = (
+/obj/disposalpipe/segment/morgue,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "nwo" = (
 /obj/machinery/door/airlock/pyro/glass/security/alt{
 	dir = 4
@@ -51563,10 +51820,11 @@
 /turf/simulated/floor/airless/solar,
 /area/station/solar/north)
 "nzS" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/firealarm/south,
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "nzX" = (
@@ -51583,7 +51841,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "nAl" = (
-/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/stairs{
 	icon_state = "Stairs_wide"
 	},
@@ -51617,9 +51875,9 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay)
 "nBf" = (
-/obj/disposalpipe/segment/mail,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "nBp" = (
@@ -51634,9 +51892,6 @@
 	},
 /obj/cable/orange{
 	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -51731,20 +51986,23 @@
 	},
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "nHP" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/decal/stripe_caution,
+/obj/disposalpipe/switch_junction{
+	dir = 2;
+	name = "undeliverable mail router"
+	},
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "nHW" = (
@@ -51857,12 +52115,11 @@
 /turf/simulated/floor/yellow/side,
 /area/station/storage/primary)
 "nNK" = (
-/obj/disposalpipe/segment/produce{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/produce{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
@@ -51872,9 +52129,6 @@
 	},
 /obj/cable{
 	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
@@ -51929,7 +52183,6 @@
 /area/station/ai_monitored/armory)
 "nQn" = (
 /obj/storage/secure/closet/fridge/kitchen,
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "nQR" = (
@@ -51974,7 +52227,6 @@
 /turf/simulated/floor,
 /area/station/bridge)
 "nRg" = (
-/obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Electrical Substation"
 	},
@@ -52031,12 +52283,11 @@
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "nSB" = (
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/item/device/radio/intercom/medical{
 	dir = 1
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/blue/side{
 	dir = 0
@@ -52181,10 +52432,13 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "oaO" = (
-/obj/disposalpipe/segment/mail,
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
@@ -52224,12 +52478,15 @@
 	},
 /area/station/mining/staff_room)
 "obY" = (
-/obj/disposalpipe/segment/produce,
 /obj/cable{
 	icon_state = "2-4"
 	},
 /obj/railing/orange/reinforced{
 	dir = 8
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
@@ -52249,6 +52506,10 @@
 	},
 /obj/machinery/light{
 	tag = ""
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
@@ -52294,14 +52555,13 @@
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "ofw" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 1
+/obj/disposalpipe/segment/morgue{
+	dir = 2;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/east)
@@ -52443,20 +52703,22 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/engine)
 "okK" = (
-/obj/disposalpipe/switch_junction{
-	dir = 1;
-	icon_state = "pipe-sj2";
-	mail_tag = "bridge";
-	name = "bridge mail router"
-	},
 /obj/item/device/radio/intercom/AI{
 	broadcasting = 0
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/bridge)
 "okN" = (
 /obj/machinery/light/emergency,
 /obj/machinery/firealarm/east,
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/blue/side{
 	dir = 6
 	},
@@ -52513,18 +52775,20 @@
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "omr" = (
-/obj/disposalpipe/segment/brig,
 /obj/vehicle/segway,
 /obj/decal/stripe_caution,
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor,
 /area/station/security/main)
 "omw" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor,
-/area/station/hydroponics/lobby)
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/sanctuary)
 "omx" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -52686,10 +52950,8 @@
 	},
 /area/station/solar/north)
 "otx" = (
-/obj/disposalpipe/switch_junction{
-	desc = "An underfloor mail pipe.";
-	mail_tag = "chapel";
-	name = "chapel mail router"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
@@ -52769,17 +53031,16 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/medlab,
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/medical/research)
 "owS" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/grille/catwalk,
 /obj/cable/orange{
 	icon_state = "1-8"
 	},
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
@@ -52794,12 +53055,12 @@
 	},
 /area/station/hydroponics/bay)
 "oyc" = (
-/obj/disposalpipe/segment/produce{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
+	},
+/obj/disposalpipe/segment/produce{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
@@ -52852,6 +53113,13 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/science/lab)
+"oBF" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "oCb" = (
 /obj/machinery/bot/medbot/no_camera,
 /obj/item/device/radio/intercom/security{
@@ -52882,7 +53150,6 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/south,
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/carpet{
 	dir = 10;
 	icon_state = "fred2"
@@ -52897,11 +53164,14 @@
 	},
 /obj/mapping_helper/access/rancher,
 /obj/mapping_helper/firedoor_spawn,
-/obj/disposalpipe/segment/produce,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/green,
 /area/station/ranch)
 "oDm" = (
 /obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -52989,9 +53259,12 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
@@ -53127,10 +53400,10 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/grille/catwalk,
 /obj/cable/orange{
 	icon_state = "1-8"
 	},
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
@@ -53251,10 +53524,6 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/disposalpipe/segment/transport{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
@@ -53322,13 +53591,10 @@
 /turf/simulated/floor/grime,
 /area/station/storage/hydroponics)
 "oUZ" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "oVe" = (
@@ -53581,9 +53847,6 @@
 	dir = 4;
 	name = "Biodome"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/mapping_helper/access/hydro,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/green,
@@ -53667,6 +53930,7 @@
 	dir = 4;
 	pixel_x = -15
 	},
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "pfM" = (
@@ -53678,20 +53942,19 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "pgo" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/stool,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/carpet{
+	icon_state = "fred2"
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/area/station/chapel/sanctuary)
 "pgN" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -53796,6 +54059,11 @@
 	dir = 1
 	},
 /obj/landmark/start/job/chaplain,
+/obj/disposalpipe/segment/morgue{
+	dir = 8;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred1"
@@ -53880,13 +54148,11 @@
 /turf/simulated/floor/grime,
 /area/station/storage/hydroponics)
 "pky" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c";
-	name = "factory pipe"
+/obj/disposalpipe/segment,
+/turf/simulated/floor/neutral/side{
+	dir = 5
 	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
+/area/station/crew_quarters/supplylobby)
 "pkH" = (
 /obj/machinery/disposal/mail/small/autoname/mechanics/south,
 /obj/disposalpipe/trunk/mail{
@@ -53908,14 +54174,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "plF" = (
 /obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/table/auto,
@@ -53967,10 +54230,6 @@
 	pixel_y = 10
 	},
 /obj/machinery/firealarm/south,
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},
@@ -54046,8 +54305,7 @@
 /area/station/maintenance/northeast)
 "prD" = (
 /obj/landmark/pest,
-/obj/disposalpipe/segment{
-	dir = 4;
+/obj/disposalpipe/segment/food{
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
@@ -54104,16 +54362,9 @@
 /turf/simulated/floor/grime,
 /area/station/storage/hydroponics)
 "pwv" = (
-/obj/disposalpipe/switch_junction{
-	desc = "An underfloor mail pipe.";
-	dir = 1;
-	icon_state = "pipe-sj2";
-	mail_tag = "info";
-	name = "info mail router"
-	},
-/obj/mapping_helper/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/market)
+/obj/disposalpipe/segment,
+/turf/simulated/floor/neutral/side,
+/area/station/crew_quarters/supplylobby)
 "pwx" = (
 /obj/storage/secure/closet/command/captain,
 /obj/cable{
@@ -54125,17 +54376,14 @@
 	},
 /area/station/crew_quarters/captain)
 "pwI" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
-	dir = 1
+	dir = 8
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
 "pwM" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/cable{
@@ -54207,7 +54455,6 @@
 /area/station/science/lab)
 "pyP" = (
 /obj/machinery/door/airlock/pyro/glass,
-/obj/disposalpipe/segment/mail,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
@@ -54227,16 +54474,14 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "pzD" = (
-/obj/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2";
-	name = "ejection pipe"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/ejection{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -54466,6 +54711,7 @@
 	dir = 4;
 	pixel_x = -15
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "pKu" = (
@@ -54591,7 +54837,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 2;
+	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
@@ -54667,10 +54913,6 @@
 /area/station/hangar/qm)
 "pUk" = (
 /obj/machinery/door/airlock/pyro/maintenance,
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -54706,12 +54948,15 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "pVn" = (
-/obj/landmark/pest,
-/obj/disposalpipe/segment/produce{
+/obj/machinery/conveyor/EW{
+	name = "cargo belt - west";
+	operating = 1
+	},
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "pVp" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -54802,6 +55047,7 @@
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "pYK" = (
@@ -54833,7 +55079,6 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "qci" = (
-/obj/disposalpipe/segment/ejection,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -54922,12 +55167,16 @@
 /obj/mapping_helper/access/security,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment/ejection{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/routing/security)
 "qfa" = (
 /obj/item/device/radio/intercom/catering{
 	dir = 8
 	},
+/obj/disposalpipe/segment/food,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "qfY" = (
@@ -54993,8 +55242,9 @@
 	},
 /area/station/hallway/primary/south)
 "qgA" = (
-/obj/disposalpipe/segment,
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/switch_junction{
+	mail_tag = "security";
+	name = "security mail router";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -55032,11 +55282,10 @@
 	},
 /area/station/mining/staff_room)
 "qhP" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
+/obj/stool,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/carpet,
+/area/station/chapel/sanctuary)
 "qiY" = (
 /obj/machinery/disposal/mail{
 	mail_tag = "brig";
@@ -55075,6 +55324,10 @@
 /area/station/routing/depot)
 "qkq" = (
 /obj/machinery/light/small/floor/warm,
+/obj/disposalpipe/junction{
+	name = "produce pipe";
+	dir = 8
+	},
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
 "qkY" = (
@@ -55082,7 +55335,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/produce,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "qlP" = (
@@ -55301,7 +55554,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "qva" = (
@@ -55358,10 +55610,10 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/disposalpipe/segment/ejection{
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "qwc" = (
@@ -55520,12 +55772,10 @@
 /turf/simulated/floor,
 /area/station/hangar/engine)
 "qzs" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -55643,7 +55893,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
@@ -55668,8 +55918,8 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 1
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
@@ -55817,9 +56067,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "qIW" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/firealarm/north,
 /obj/vehicle/segway,
 /turf/simulated/floor/black,
@@ -55833,6 +56080,9 @@
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/access/janitor,
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
 /turf/simulated/floor/grime,
 /area/station/janitor/office)
 "qJw" = (
@@ -55922,6 +56172,9 @@
 "qLE" = (
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 8
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -56058,8 +56311,7 @@
 "qPC" = (
 /obj/item/device/radio/intercom/engineering,
 /obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -56121,6 +56373,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "qQQ" = (
@@ -56176,7 +56432,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/table/auto,
 /obj/item/clothing/head/helmet/space/santahat,
 /turf/simulated/floor/black,
@@ -56191,6 +56446,10 @@
 	},
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
@@ -56316,6 +56575,9 @@
 /area/space)
 "qYP" = (
 /obj/landmark/pest,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "qYQ" = (
@@ -56343,12 +56605,14 @@
 /turf/simulated/floor/plating,
 /area/station/hangar/sec)
 "qZf" = (
-/obj/grille/catwalk{
-	dir = 6
-	},
 /obj/cable/orange{
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
@@ -56358,9 +56622,11 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria)
 "rcX" = (
-/obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment/produce{
-	dir = 4
+/obj/disposalpipe/switch_junction{
+	dir = 2;
+	icon_state = "pipe-sj2";
+	mail_tag = "hydroponics";
+	name = "hydroponics mail router"
 	},
 /turf/simulated/floor/green/side{
 	dir = 4
@@ -56403,11 +56669,10 @@
 /turf/simulated/floor/plating,
 /area/station/engine/power)
 "reg" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/routing/sortingRoom)
+/obj/mapping_helper/wingrille_spawn/auto,
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "rfl" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/security_horizontal/vertical,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -56423,6 +56688,10 @@
 	dir = 4
 	},
 /obj/landmark/kudzu,
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "rii" = (
@@ -56447,6 +56716,7 @@
 	icon_state = "0-2"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/plating,
 /area/station/routing/security)
 "rjI" = (
@@ -56480,6 +56750,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/security,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "rlw" = (
@@ -56548,6 +56819,7 @@
 	},
 /obj/item/storage/box/donkpocket_kit,
 /obj/machinery/door/firedoor/pyro,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "rqv" = (
@@ -56651,6 +56923,7 @@
 /area/station/solar/north)
 "rwf" = (
 /obj/machinery/atmospherics/pipe/simple,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue/checker,
 /area/station/medical/research)
 "rwL" = (
@@ -56765,10 +57038,7 @@
 /area/station/hallway/secondary/exit)
 "rBN" = (
 /obj/landmark/pest,
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
 "rDe" = (
@@ -56810,11 +57080,11 @@
 	},
 /area/station/engine/hotloop)
 "rDH" = (
-/obj/disposalpipe/segment,
 /obj/machinery/light_switch{
 	name = "W light switch";
 	pixel_x = -24
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/security/main)
 "rDU" = (
@@ -56907,11 +57177,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "rGl" = (
-/obj/disposalpipe/segment,
-/obj/grille/catwalk,
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -57018,9 +57287,6 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "rLh" = (
-/obj/disposalpipe/segment{
-	dir = 1
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -57134,7 +57400,7 @@
 /obj/railing/orange/reinforced{
 	dir = 1
 	},
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/produce{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
@@ -57143,16 +57409,12 @@
 	},
 /area/station/ranch)
 "rOj" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
 	},
-/obj/grille/catwalk,
-/obj/disposalpipe/junction/left/north,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
-/area/space)
+/turf/simulated/floor/black,
+/area/station/chapel/office)
 "rOJ" = (
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/blue/checker,
@@ -57168,10 +57430,10 @@
 	icon_state = "bdoor_pyro";
 	name = "rusted airlock"
 	},
-/obj/disposalpipe/segment/mail{
+/obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
 "rPq" = (
@@ -57192,9 +57454,6 @@
 "rQa" = (
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -57315,10 +57574,8 @@
 /turf/space,
 /area/space)
 "rVU" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
 /obj/disposalpipe/segment/bent/west,
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
@@ -57355,7 +57612,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm/east,
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/security/main)
 "rXO" = (
@@ -57399,18 +57656,11 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "rYo" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/mapping_helper/firedoor_spawn,
-/obj/decal/stripe_caution,
-/turf/simulated/floor,
-/area/station/crew_quarters/market)
+/turf/simulated/floor/grime,
+/area/station/maintenance/east)
 "rYw" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8;
@@ -57422,10 +57672,6 @@
 /obj/landmark/start/job/rancher,
 /obj/railing/orange/reinforced{
 	dir = 8
-	},
-/obj/disposalpipe/segment/produce{
-	dir = 4;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
@@ -57579,6 +57825,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
@@ -57594,9 +57841,11 @@
 /turf/simulated/floor/grime,
 /area/station/security/checkpoint/cargo)
 "sdX" = (
-/obj/disposalpipe/segment/transport,
 /obj/item/device/radio/intercom/security{
 	dir = 1
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/red/side,
 /area/station/science/lobby)
@@ -57605,7 +57854,7 @@
 	dir = 8
 	},
 /obj/railing/orange/reinforced,
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/produce{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
@@ -57653,6 +57902,7 @@
 	dir = 8;
 	tag = ""
 	},
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/stairs{
 	dir = 1;
 	icon_state = "Stairs2_wide"
@@ -57662,7 +57912,6 @@
 /obj/machinery/conveyor/WE{
 	id = "enginesupply"
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -57889,10 +58138,6 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/morgue{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/item/device/radio/intercom/cargo,
 /turf/simulated/floor,
 /area/station/maintenance/east)
@@ -58100,18 +58345,16 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/security,
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor,
 /area/station/security/checkpoint/cargo)
 "szn" = (
-/obj/disposalpipe/segment/produce{
-	dir = 4
-	},
-/obj/disposalpipe/segment/produce{
-	dir = 4
-	},
 /obj/item/satchel/hydro{
 	pixel_x = -7;
 	pixel_y = 2
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/grime,
 /area/station/hallway/primary/east)
@@ -58187,7 +58430,6 @@
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "sCY" = (
-/obj/disposalpipe/segment/food,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-2"
@@ -58195,9 +58437,14 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "sDi" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/east)
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 4
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/bridge)
 "sDK" = (
 /obj/item/device/radio/intercom/brig{
 	dir = 4
@@ -58281,11 +58528,11 @@
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "sGG" = (
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/security/main)
 "sGL" = (
@@ -58392,9 +58639,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "sKs" = (
-/obj/disposalpipe/segment{
-	dir = 1
-	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
@@ -58608,13 +58853,10 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/supplylobby)
 "sQL" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "sRd" = (
@@ -58633,6 +58875,9 @@
 "sRY" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
@@ -58721,16 +58966,12 @@
 	},
 /area/station/science/chemistry)
 "sVM" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
 "sVW" = (
@@ -58774,13 +59015,11 @@
 /turf/simulated/floor,
 /area/station/routing/sortingRoom)
 "tag" = (
-/obj/disposalpipe/segment,
-/obj/machinery/conveyor/EW{
-	name = "cargo belt - west";
-	operating = 1
+/obj/disposalpipe/junction{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "tap" = (
 /obj/landmark/pest,
 /obj/cable{
@@ -58906,6 +59145,9 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/rancher,
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/ranch)
 "tht" = (
@@ -59053,6 +59295,7 @@
 	},
 /obj/mapping_helper/access/heads,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "toe" = (
@@ -59067,6 +59310,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "toP" = (
@@ -59095,6 +59339,9 @@
 	icon_state = "1-8"
 	},
 /obj/stool,
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "tpT" = (
@@ -59102,8 +59349,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
@@ -59111,22 +59357,23 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/switch_junction{
-	dir = 4;
-	mail_tag = "security";
-	name = "security mail router"
-	},
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "tqc" = (
-/obj/disposalpipe/segment/ejection{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2";
+	name = "ejection pipe"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -59190,6 +59437,10 @@
 	dir = 8;
 	pixel_x = -10
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "tsL" = (
@@ -59235,10 +59486,6 @@
 	},
 /area/space)
 "tuj" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/light_switch{
 	name = "E light switch";
 	pixel_x = 24
@@ -59249,16 +59496,10 @@
 	},
 /area/station/medical/medbay/cloner)
 "tuK" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/grille/catwalk{
-	dir = 10
-	},
 /obj/cable/orange{
 	icon_state = "2-4"
 	},
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
@@ -59483,16 +59724,18 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "tEf" = (
-/obj/disposalpipe/segment,
-/obj/mapping_helper/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/courtroom)
+/obj/disposalpipe/segment/morgue,
+/turf/simulated/floor/grime,
+/area/station/maintenance/east)
 "tEn" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/maint,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "tFP" = (
@@ -59514,13 +59757,11 @@
 /obj/machinery/door_timer/genpop_n{
 	pixel_x = 24
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/security/main)
 "tGq" = (
 /obj/landmark/pest,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "tGA" = (
@@ -59606,7 +59847,6 @@
 /obj/window/reinforced{
 	dir = 8
 	},
-/obj/disposalpipe/segment,
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -59639,9 +59879,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/mapping_helper/access/maint,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "tLR" = (
@@ -59783,9 +60023,6 @@
 /obj/machinery/light_switch{
 	name = "S light switch";
 	pixel_y = -24
-	},
-/obj/disposalpipe/segment{
-	dir = 8
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -59985,15 +60222,12 @@
 	},
 /area/station/medical/medbay/surgery)
 "tWW" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
-/obj/disposalpipe/segment/transport,
-/obj/mapping_helper/firedoor_spawn,
-/obj/decal/stripe_caution,
 /turf/simulated/floor,
-/area/station/crew_quarters/market)
+/area/station/hallway/primary/east)
 "tXn" = (
 /obj/cable/orange{
 	icon_state = "4-8"
@@ -60139,11 +60373,11 @@
 /turf/simulated/floor/carpet/blue/fancy/narrow/east,
 /area/station/medical/staff)
 "ubA" = (
-/obj/disposalpipe/segment/brig,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "ubQ" = (
@@ -60181,12 +60415,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm/north,
-/obj/disposalpipe/switch_junction{
-	desc = "An underfloor mail pipe.";
-	dir = 8;
-	icon_state = "pipe-sj2";
-	mail_tag = "genetics";
-	name = "genetics mail router"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -60255,8 +60485,8 @@
 /turf/simulated/floor/airless/damaged5,
 /area/station/wreckage)
 "ufo" = (
-/obj/disposalpipe/segment/transport,
 /obj/storage/closet/biohazard,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "ufy" = (
@@ -60343,16 +60573,14 @@
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/AIbaseoutside)
 "ujF" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/grille/catwalk{
-	dir = 9
-	},
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -60471,13 +60699,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "ulq" = (
-/obj/mapping_helper/wingrille_spawn/auto,
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/hydroponics/lobby)
+/obj/disposalpipe/segment,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/baroffice)
 "ulC" = (
 /obj/grille/steel,
 /obj/lattice{
@@ -60613,9 +60837,6 @@
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment{
-	dir = 1
-	},
 /obj/random_item_spawner/med_kit,
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
@@ -60681,6 +60902,7 @@
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/access/maint,
+/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor,
 /area/station/maintenance/disposal)
 "usN" = (
@@ -61014,9 +61236,6 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice)
 "uDl" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/navbeacon/tour/cog1/tour3,
 /obj/cable{
 	icon_state = "4-8"
@@ -61066,10 +61285,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "uEJ" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/grille/catwalk{
 	dir = 6
 	},
@@ -61236,7 +61451,6 @@
 	},
 /area/station/medical/medbay)
 "uLz" = (
-/obj/disposalpipe/segment/ejection,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -61354,11 +61568,12 @@
 /turf/simulated/floor/yellow/side,
 /area/station/storage/primary)
 "uRR" = (
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/medbooth)
+/turf/simulated/floor,
+/area/station/science/lobby)
 "uSJ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -61403,9 +61618,6 @@
 	})
 "uUC" = (
 /obj/machinery/door/airlock/pyro/glass/security/alt,
-/obj/disposalpipe/segment/ejection{
-	dir = 4
-	},
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
@@ -61414,6 +61626,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/security,
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "uUL" = (
@@ -61505,9 +61718,10 @@
 /area/station/science/lobby)
 "uZB" = (
 /obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c";
-	name = "factory pipe"
+	dir = 4
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
@@ -61540,6 +61754,10 @@
 	},
 /obj/machinery/door_timer/genpop_s{
 	pixel_x = 24
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -61653,6 +61871,9 @@
 /area/station/medical/robotics)
 "veJ" = (
 /mob/living/critter/small_animal/boogiebot,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "fred4"
@@ -61666,6 +61887,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/medlab,
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/medical/research)
 "vfi" = (
@@ -61719,7 +61941,10 @@
 	name = "cargo belt - west";
 	operating = 1
 	},
-/obj/disposalpipe/segment/morgue,
+/obj/disposalpipe/switch_junction{
+	mail_tag = "sortingroom";
+	name = "sorting room router"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "vhk" = (
@@ -61744,6 +61969,9 @@
 	dir = 4
 	},
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/science/chemistry)
 "vhW" = (
@@ -61957,6 +62185,9 @@
 	},
 /obj/mapping_helper/access/heads,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "vqd" = (
@@ -61998,7 +62229,8 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -62038,9 +62270,6 @@
 	},
 /area/station/crew_quarters/captain)
 "vuN" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
 "vuZ" = (
@@ -62107,7 +62336,6 @@
 	},
 /area/station/crew_quarters/market)
 "vyW" = (
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "fred1"
@@ -62175,12 +62403,16 @@
 /turf/simulated/floor/carpet/blue/fancy/edge,
 /area/station/medical/medbay/psychiatrist)
 "vCP" = (
-/obj/disposalpipe/segment/ejection,
-/obj/cable{
-	icon_state = "1-2"
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor,
-/area/station/security/main)
+/obj/disposalpipe/segment/transport{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/space,
+/area/space)
 "vDQ" = (
 /obj/machinery/conveyor/WE{
 	name = "cargo belt - east";
@@ -62214,11 +62446,11 @@
 /area/station/engine/power)
 "vGo" = (
 /obj/disposalpipe/segment{
-	dir = 1;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/southeast)
+/turf/simulated/floor,
+/area/station/science/lobby)
 "vGs" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -62329,9 +62561,6 @@
 "vKV" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/glass_recycler/bar,
-/obj/disposalpipe/segment/food{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
 	},
@@ -62369,12 +62598,12 @@
 /area/station/routing/airbridge)
 "vNW" = (
 /obj/machinery/door/airlock/pyro/glass/security/alt,
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/access/security,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/security/main)
 "vNX" = (
@@ -62497,6 +62726,15 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/medical/dome)
+"vQq" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
 "vRd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -62829,15 +63067,13 @@
 /area/station/turret_protected/armory_outside)
 "whg" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/produce{
-	dir = 1;
+/obj/disposalpipe/segment{
+	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
+/turf/simulated/floor,
 /area/station/hallway/primary/east)
 "whr" = (
 /obj/tug_cart,
@@ -63003,10 +63239,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/door/airlock/pyro/glass/security{
 	dir = 4
 	},
@@ -63155,12 +63387,10 @@
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Teleporter Control Room"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/mapping_helper/access/telesci,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
 /area/station/science/teleporter)
 "wuJ" = (
@@ -63221,10 +63451,6 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "wvf" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/decal/cleanable/rust,
 /turf/simulated/wall/auto/supernorn,
 /area/station/routing/sortingRoom)
@@ -63257,9 +63483,6 @@
 /area/station/crew_quarters/barber_shop)
 "wwE" = (
 /obj/landmark/halloween,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -63390,6 +63613,7 @@
 	dir = 8;
 	pixel_x = -10
 	},
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
 "wAC" = (
@@ -63483,6 +63707,10 @@
 	},
 /obj/mapping_helper/access/forensics,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/grime,
 /area/station/security/detectives_office)
 "wDL" = (
@@ -63684,6 +63912,7 @@
 	dir = 4;
 	pixel_x = -15
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "wNC" = (
@@ -63744,7 +63973,7 @@
 /area/station/turret_protected/ai_upload)
 "wPN" = (
 /obj/machinery/light,
-/obj/disposalpipe/segment/produce{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor/grime,
@@ -63853,9 +64082,7 @@
 /turf/simulated/floor/airless/solar,
 /area/station/solar/south)
 "wRX" = (
-/obj/disposalpipe/segment{
-	dir = 1
-	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
@@ -63873,17 +64100,12 @@
 /turf/simulated/floor/specialroom/bar/edge,
 /area/station/crew_quarters/bar)
 "wSZ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/switch_junction{
+/obj/disposalpipe/segment/mail{
 	dir = 4;
-	icon_state = "pipe-sj2";
-	mail_tag = "hydroponics";
-	name = "hydroponics mail router"
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "wTs" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -63933,9 +64155,11 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/east)
 "wVZ" = (
@@ -64201,12 +64425,14 @@
 	},
 /area/station/engine/engineering)
 "xhn" = (
-/obj/disposalpipe/segment{
-	dir = 8;
+/obj/stool/chair/office,
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/disposalpipe/segment/mail{
+	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/east)
+/area/station/science/testchamber)
 "xhr" = (
 /obj/decal/cleanable/dirt,
 /obj/landmark/start/job/clown,
@@ -64311,12 +64537,13 @@
 /turf/simulated/floor/grime,
 /area/station/storage/hydroponics)
 "xmb" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
+	},
+/obj/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/supplylobby)
@@ -64359,6 +64586,7 @@
 /area/station/routing/eva)
 "xnp" = (
 /obj/machinery/vending/snack,
+/obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/red/corner{
 	dir = 1
 	},
@@ -64397,12 +64625,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "xra" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/stool/chair/red,
 /obj/machinery/firealarm/north,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/security/main)
 "xrq" = (
@@ -64468,7 +64695,6 @@
 	dir = 4
 	},
 /obj/landmark/gps_waypoint,
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred1"
@@ -64483,10 +64709,7 @@
 /obj/mapping_helper/access/kitchen,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
-/obj/disposalpipe/segment/produce{
-	dir = 4
-	},
-/obj/disposalpipe/segment/produce{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -64864,14 +65087,16 @@
 /area/station/engine/ptl)
 "xNP" = (
 /obj/machinery/atmospherics/binary/valve,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/science/testchamber)
 "xNY" = (
 /obj/landmark/antagonist/blob,
-/obj/disposalpipe/segment/morgue,
 /obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "crematorium pipe"
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -64930,13 +65155,10 @@
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/psychiatrist)
 "xQB" = (
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/neutral/corner,
 /area/station/hallway/primary/east)
 "xQI" = (
@@ -65017,6 +65239,10 @@
 	},
 /obj/cable{
 	icon_state = "2-8"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 9
@@ -65120,6 +65346,7 @@
 /obj/table/wood/auto,
 /obj/item/boardgame/chess,
 /obj/item/decoration/ashtray,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet,
 /area/station/crew_quarters/jazz)
 "xYQ" = (
@@ -65481,7 +65708,6 @@
 	dir = 8;
 	tag = ""
 	},
-/obj/disposalpipe/segment/mail,
 /obj/table/auto,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
@@ -65492,6 +65718,8 @@
 /obj/machinery/light/emergency{
 	dir = 4
 	},
+/obj/machinery/disposal/brig,
+/obj/decal/stripe_delivery,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -90425,7 +90653,7 @@ aMw
 aNF
 aOK
 aPL
-aRS
+ciH
 aRS
 aSN
 aTV
@@ -90728,7 +90956,7 @@ aNG
 aKd
 aPM
 aQN
-aQN
+kkk
 aSO
 aTW
 aVl
@@ -91030,7 +91258,7 @@ aNH
 aKc
 aPN
 aQN
-aQN
+kkk
 aSO
 aTW
 aVm
@@ -91331,8 +91559,8 @@ mmZ
 aNI
 tnF
 aPO
-aZO
-aZO
+aPO
+bbE
 aSP
 aTX
 aVn
@@ -91629,10 +91857,10 @@ aHl
 aID
 aKd
 aLm
-aMA
+mPc
 sNo
 aKd
-aPP
+aKd
 aQP
 aRT
 aSQ
@@ -91931,7 +92159,7 @@ rnn
 xiS
 aKd
 kFQ
-aMA
+mPc
 kuI
 aNF
 aPQ
@@ -92233,13 +92461,13 @@ aDs
 aIF
 aKd
 aLo
-aMA
+mPc
 pic
 aOM
 aPR
 aQR
 aQR
-aSS
+sDi
 aUa
 aVq
 aQR
@@ -92542,12 +92770,12 @@ aPS
 aQR
 aQR
 aSS
-aQR
-aVq
+aQS
+kZy
 ber
-aQR
-aQR
-aQR
+aQS
+aQS
+aQS
 hOx
 aKd
 aaG
@@ -92839,12 +93067,12 @@ aIW
 aJO
 aKe
 aMh
-aON
+aOM
 okK
 eyC
-aQS
+bby
 aST
-aQS
+aQR
 aVr
 aWF
 aWF
@@ -93143,8 +93371,8 @@ aMD
 aMD
 aOO
 svA
-aQT
-aRU
+aME
+aME
 aSU
 aUb
 aVs
@@ -93444,7 +93672,7 @@ wCn
 aME
 sgg
 slQ
-aPV
+aQV
 aQU
 aME
 aOM
@@ -93518,11 +93746,11 @@ cgF
 cgI
 pJN
 cks
-ccU
+fsp
 cmX
 cod
-cph
-cqk
+aDI
+xhn
 lHL
 csl
 csm
@@ -93747,7 +93975,7 @@ aME
 pjn
 gtK
 aSZ
-aQV
+aPV
 aRV
 aOM
 aUc
@@ -93815,15 +94043,15 @@ qDB
 bHW
 ccT
 ceh
-cfq
+avw
 cgG
 kTI
 cjc
 ckt
 clQ
 cmY
-cod
-cph
+eML
+aBD
 cqk
 lHL
 csm
@@ -94048,7 +94276,7 @@ aLq
 aME
 lWG
 aOR
-aPV
+aQV
 nts
 ftg
 aOM
@@ -94059,7 +94287,7 @@ aYb
 aKd
 aZS
 bbb
-bbT
+bPJ
 bda
 bdZ
 cWB
@@ -94117,7 +94345,7 @@ dkG
 bHW
 ccU
 ceh
-cfq
+avw
 cgH
 mzh
 cfq
@@ -94350,7 +94578,7 @@ aLq
 aME
 aNR
 aOS
-aPW
+aQV
 hIt
 aRX
 aOM
@@ -94361,7 +94589,7 @@ aYc
 aKd
 gmw
 bbc
-bbU
+bbT
 bdb
 bea
 cuB
@@ -94420,9 +94648,9 @@ bHW
 ccV
 ceg
 csd
-cgI
-cgI
-cfq
+awZ
+cbq
+aph
 ckv
 xBH
 ccX
@@ -94721,8 +94949,8 @@ caq
 bHW
 ydn
 eup
-cfq
-cgI
+avw
+aVD
 chQ
 cjd
 ckw
@@ -95032,7 +95260,7 @@ ccX
 ccX
 coh
 cpk
-cpk
+cet
 cro
 crj
 ctb
@@ -95267,7 +95495,7 @@ aUk
 eVK
 aZV
 aZQ
-aDV
+aZQ
 nHm
 aZQ
 aaG
@@ -95328,13 +95556,13 @@ cej
 cft
 cgK
 chR
-bVq
+cmi
 ckx
-bVq
+cmi
 gIi
 coi
-cpl
-cpl
+ciN
+boS
 crp
 oel
 cpl
@@ -95627,12 +95855,12 @@ bXA
 bXA
 ccZ
 dSW
-bSE
+bWz
 nSB
 chS
 chS
-cky
-clU
+chS
+chS
 cnb
 coj
 cpm
@@ -95831,7 +96059,7 @@ adE
 adE
 adE
 ajj
-ffc
+bPO
 dPe
 sfv
 xnp
@@ -95928,14 +96156,14 @@ bZf
 cas
 cbI
 cda
-cbI
+caH
 cfu
 sdX
-chT
+chS
 cje
 sVM
 clV
-cnc
+cnd
 auP
 oSg
 cnd
@@ -96136,28 +96364,28 @@ fFQ
 ajq
 qci
 kwa
-vCP
+aJd
 pzD
-kkk
-aHH
-aHH
-aHH
-aGe
+aHB
+aHB
+aHB
+bbU
+aAe
 hra
-aHH
-aHH
-aHH
-aHH
+cbR
+cbR
+cbR
+bUf
 qgA
 rDH
-aHH
+cbR
 nAl
 mCv
 dXC
 aGE
 aGe
-aJg
-aKk
+aJf
+aKl
 aLw
 aMJ
 aNV
@@ -96441,25 +96669,25 @@ stQ
 aHB
 fdb
 vrP
-aJd
+bGQ
 dEj
-aJd
+aQT
 tFP
 lXN
 nho
 aCT
-aJd
-aJd
+bGQ
+aQT
 tpY
 rXb
-kZy
+nho
 iaP
 sGG
 vNW
 aGF
 aHI
-aJf
-aKl
+aDV
+aKk
 aLx
 lYi
 aNW
@@ -96750,7 +96978,7 @@ aho
 dON
 asX
 yjq
-fDN
+aJj
 vaa
 pgN
 aho
@@ -96827,8 +97055,8 @@ bIP
 gck
 bSD
 bTW
-bVo
-bWy
+aON
+bau
 bXE
 vbI
 cau
@@ -97043,7 +97271,7 @@ acV
 awK
 awK
 fRJ
-avd
+iSL
 dtM
 aho
 aGJ
@@ -97055,7 +97283,7 @@ qKH
 avt
 aho
 wqf
-azM
+aho
 ahn
 aho
 ail
@@ -97125,15 +97353,15 @@ jRr
 bLr
 bLr
 sGk
-bPI
+bIQ
 bQZ
-bSE
-bTX
-bVp
-bWz
+bWx
+bKm
+bRh
+fqc
 kHj
-vbI
-cau
+dQf
+vCP
 adC
 aag
 vbI
@@ -97345,7 +97573,7 @@ acV
 ahm
 awK
 fRJ
-avd
+iSL
 iQw
 aho
 anH
@@ -97357,15 +97585,15 @@ aum
 avu
 aho
 ayr
-azN
+aho
 aho
 aho
 aEa
 aFj
 aho
 kwp
-aJf
-aHB
+aJi
+aJe
 aLA
 awM
 rwX
@@ -97427,15 +97655,15 @@ bKe
 bLr
 pjv
 bOu
-bPJ
+bIQ
 uYN
-bSF
+bWy
 bTY
-bVq
+clU
 bWA
 bXG
 bVj
-cat
+vbI
 vbI
 vbI
 bVj
@@ -97647,15 +97875,15 @@ agD
 wfU
 awK
 evc
-avd
+iSL
 ofy
 aho
 eyb
-aoT
+azS
 aqn
 axY
 ata
-aun
+bhx
 avv
 lKp
 mUq
@@ -97666,8 +97894,8 @@ aEb
 aFk
 ubA
 omr
-aJh
-aKo
+aJj
+aJf
 aLB
 awM
 aOa
@@ -97729,19 +97957,19 @@ bKf
 bLr
 bLr
 cSN
-bPJ
+bIQ
 bJt
-bSG
+bWx
 bTX
-bVp
-bVp
+vGo
+uRR
 bXH
-bXA
 cav
-bXA
-bXA
-bXA
-cfz
+cav
+cav
+cav
+cav
+bVo
 bVp
 chW
 lyD
@@ -97955,21 +98183,21 @@ ahs
 anJ
 aoU
 aqo
-arK
-aqo
+aCH
+aCH
 auo
-avw
+aCH
 dWU
-arK
-azP
-aqo
-aqo
+aCH
+aBv
+aoV
+aoV
 alr
-aqo
+aoV
 uLz
 aHN
-aJi
-aJe
+aJk
+aJf
 hfb
 awM
 aOa
@@ -98031,24 +98259,24 @@ bKg
 bLs
 bMU
 bOw
-bPJ
+bIQ
 hYn
 bSH
 bTZ
-bVr
+bbi
+arK
 bWB
-bWB
-bWB
+alK
 caw
-bWB
+caw
 bVr
-bWB
-bWB
-bWB
+caw
+caw
+aJh
 chX
 bWB
-ckF
-cma
+bWB
+bWB
 cjC
 cor
 cpu
@@ -98256,12 +98484,12 @@ alA
 ahs
 amV
 aoV
-aoV
+aoT
 aoV
 hjA
 aun
 avx
-awS
+aho
 ayt
 azQ
 aBv
@@ -98270,7 +98498,7 @@ bTJ
 anK
 aGJ
 iSt
-aJj
+aJk
 aJf
 aLD
 awM
@@ -98333,8 +98561,8 @@ bIQ
 bIQ
 qqS
 bOx
-bPJ
-bRd
+bIQ
+aYg
 bWx
 bUa
 hVP
@@ -98350,8 +98578,8 @@ vbI
 vbI
 vbI
 vbI
-ciH
-cnh
+bVj
+cne
 gNR
 cpu
 cqv
@@ -98569,8 +98797,8 @@ azR
 aBw
 aCH
 amy
-aCH
-azM
+aoV
+aho
 aHP
 aJk
 aJf
@@ -98642,8 +98870,8 @@ bUb
 bVj
 cdb
 cdb
+bUm
 bZh
-cay
 cdb
 cdb
 aap
@@ -98867,38 +99095,38 @@ auX
 ioj
 aho
 ayv
-azS
+aoV
 qiY
 anK
 amR
 aFl
-azN
+aho
 aHQ
 dSC
 aKp
 sNI
 ayy
-aOc
-aMC
+aOa
+aOh
 gRz
-aRd
-aRd
-aRd
-tEf
-aVD
+aRc
+aRc
+aRc
+aSe
+aTc
 aWQ
-aYg
-aYg
+aVy
+aVy
 bae
 nph
-bch
+bfh
 bcP
 bdO
-beY
+aQF
 bfU
 dUB
 toM
-bgL
+bSF
 bgL
 bgL
 bgL
@@ -98935,17 +99163,17 @@ aah
 bIP
 bTi
 bLu
-bLu
+bZV
 bOz
 bKq
 bRd
-bWx
-bUa
+bpn
+ewn
 mRx
 bWE
 bXI
+ieU
 bZi
-caz
 cbK
 cdb
 aaG
@@ -99174,7 +99402,7 @@ aho
 aCI
 aEd
 aFm
-azN
+aho
 aHR
 aJm
 aKq
@@ -99239,15 +99467,15 @@ hto
 bLv
 kyx
 byR
-bPJ
+bIQ
 dtA
-bWx
+maI
 nzS
 bVj
 bWF
 eCS
+bPS
 eCS
-caA
 cbL
 cdb
 aap
@@ -99471,12 +99699,12 @@ aus
 ail
 aho
 aho
-awV
+awT
 awT
 aCJ
 aEe
 aFn
-awV
+awT
 aHS
 aJn
 aKr
@@ -99525,7 +99753,7 @@ bvG
 bwx
 bxo
 bxo
-bxo
+aOc
 bAk
 btf
 aaG
@@ -99539,9 +99767,9 @@ aah
 bIP
 bKk
 bTi
-bLu
+bZV
 bVs
-bPJ
+bIQ
 bRf
 bSK
 bUd
@@ -99778,7 +100006,7 @@ aBy
 aCK
 amS
 aFo
-aGK
+ayy
 aHT
 aJm
 aKs
@@ -99804,7 +100032,7 @@ bfh
 bgh
 bfh
 bhW
-aRh
+aMC
 aQF
 bkr
 bla
@@ -99827,7 +100055,7 @@ bvH
 bwy
 bwB
 bwB
-bwB
+bPI
 bAl
 cuu
 aaG
@@ -99843,7 +100071,7 @@ bKl
 bLx
 bMY
 bOC
-bPJ
+bIQ
 bRg
 bSL
 bUe
@@ -100074,8 +100302,8 @@ atd
 auu
 avB
 pUk
-ayx
-azV
+ajV
+ajV
 ajV
 ajV
 anM
@@ -100106,7 +100334,7 @@ bfk
 ujK
 bfk
 bhX
-aRh
+aMC
 aQF
 iZC
 bla
@@ -100129,7 +100357,7 @@ bvI
 bwz
 bxp
 bwB
-bwB
+bPI
 bAm
 cvs
 aaG
@@ -100145,10 +100373,10 @@ bIP
 ami
 aZL
 bIP
-bPK
-bRh
+bIP
+bVj
 gjN
-bUf
+bVj
 bVj
 bWI
 sGz
@@ -100166,7 +100394,7 @@ cmd
 dmk
 cox
 cpy
-cqB
+bdq
 cqB
 cqB
 cqB
@@ -100375,13 +100603,13 @@ alF
 alF
 auv
 apc
-awV
+awT
 awT
 azW
 aBz
 aCL
-aBz
-aBz
+aTD
+bbF
 mEV
 aHV
 aWg
@@ -100408,7 +100636,7 @@ aQF
 aQF
 aQF
 bcN
-aRh
+aMC
 aQF
 bgN
 bkZ
@@ -100445,9 +100673,9 @@ aah
 adC
 bIP
 bLz
-bNa
+ccx
 bNc
-bPK
+bIP
 cpF
 bSN
 bUg
@@ -100468,7 +100696,7 @@ cme
 cnk
 coy
 cpz
-cqB
+bdq
 cqB
 cqB
 dNX
@@ -100682,7 +100910,7 @@ ayy
 kNQ
 aBz
 aBz
-aBz
+azN
 aFq
 dAe
 aHW
@@ -100710,7 +100938,7 @@ adC
 adC
 aQF
 bcN
-aRh
+aMC
 aQF
 gpw
 bla
@@ -100726,7 +100954,7 @@ bqA
 dZu
 brS
 bsC
-btk
+aEl
 myZ
 brd
 kAq
@@ -100749,14 +100977,14 @@ bIP
 bLA
 bNb
 bNa
-bPK
+bIP
 bRj
 bSO
 bUh
 bVj
 bWD
 bWD
-bWD
+bSE
 caF
 bWD
 bWD
@@ -100770,7 +100998,7 @@ bVR
 cnl
 coz
 cpA
-cqB
+bVw
 cqB
 cqB
 cqB
@@ -100984,7 +101212,7 @@ ayy
 azY
 aBA
 aCM
-aBz
+azN
 aFr
 yhj
 aHX
@@ -101012,7 +101240,7 @@ aaw
 aaw
 aQF
 bcN
-aRh
+aMC
 aQF
 bkt
 bla
@@ -101049,20 +101277,20 @@ bEU
 bEU
 bIP
 bOD
-bNc
+aCU
 bOD
-bPK
+bIP
 bRi
 bSN
 bUi
 bVj
-aap
-aap
-aap
+bDN
+bxh
+bxh
 caG
 cbQ
 cdc
-ceq
+chZ
 cfD
 cgW
 cib
@@ -101326,9 +101554,9 @@ bgL
 pIN
 bfS
 bfS
-boS
+bfS
 brd
-brg
+aGK
 brg
 brd
 brd
@@ -101349,19 +101577,19 @@ bCZ
 bCZ
 bFW
 bIc
-bKm
+bIP
 fQF
 dWp
 fQF
-bPO
-bRk
+bIP
+bVj
 kNZ
-bUj
-bVw
+cbH
+bVj
 bXZ
-bXZ
-bZE
-ceJ
+sDQ
+bLG
+bLG
 cbQ
 cdd
 cer
@@ -101583,7 +101811,7 @@ anQ
 anQ
 anQ
 anQ
-awZ
+anQ
 ath
 ath
 ath
@@ -101628,9 +101856,9 @@ bgL
 bpg
 bpz
 bqa
-hdf
+bfN
 ebf
-blG
+aRN
 blG
 blG
 blG
@@ -101658,7 +101886,7 @@ bOE
 bPP
 bRm
 bSR
-bUm
+bRm
 wQB
 bWX
 bYa
@@ -101666,8 +101894,8 @@ bLG
 cfJ
 cbQ
 leZ
-ces
 cev
+ces
 cev
 cev
 cev
@@ -101890,7 +102118,7 @@ kZW
 azZ
 bUk
 aCO
-aEh
+aEv
 aFu
 aEh
 aEh
@@ -101919,7 +102147,7 @@ aLN
 aLN
 bhz
 aLN
-aLN
+cnc
 edG
 bzr
 bzr
@@ -101930,9 +102158,9 @@ bzr
 bzr
 bzr
 bzr
-tWW
+edG
 bzr
-bzr
+bch
 bzr
 bzr
 bzr
@@ -101954,23 +102182,23 @@ adC
 noo
 bIW
 bJb
+oBF
+ceJ
 bKp
 bLO
-bKp
-bPR
-bPR
+bLO
 bSS
-bWU
 bLO
-bWY
+bYh
+akF
 bYb
 bZF
 cfQ
-cbR
+cbU
 cdf
-cet
-cfF
-cfF
+cev
+ces
+mVI
 cfF
 cfF
 cfF
@@ -102232,9 +102460,9 @@ boC
 bxu
 bxu
 bxu
-rYo
+dqE
 bxu
-bxu
+cbu
 bxu
 bxu
 bxu
@@ -102259,20 +102487,20 @@ bJc
 bKC
 bNe
 bKC
-bPS
+bNe
 bRn
 bST
-bUp
+bNe
 bVD
-bWZ
-bYh
-bZG
+bLO
+bWY
+pOl
 cfR
 nBf
-cmh
-ceu
-cev
-cev
+axQ
+cfF
+cwi
+bUj
 dnI
 cjq
 cev
@@ -102489,7 +102717,7 @@ nkq
 wNC
 nQR
 wwz
-axc
+avF
 avF
 aAb
 bUk
@@ -102534,7 +102762,7 @@ blH
 blH
 blH
 pJv
-pwv
+bfN
 brj
 brU
 bsE
@@ -102561,19 +102789,19 @@ bKn
 bLD
 bNh
 bLD
-bRl
+bLD
 bSQ
 bSZ
 bUq
 bVE
+bLO
 bWU
-bPR
 bLO
 bYj
 cPw
-cmi
-cev
-cev
+cmh
+aRd
+ceu
 cev
 cev
 cjr
@@ -102796,7 +103024,7 @@ avF
 aAc
 bUk
 aCR
-aEh
+aEv
 aFw
 aGR
 aIb
@@ -102868,7 +103096,7 @@ vYJ
 qeD
 bUo
 bVF
-bXa
+bZG
 bYi
 bZH
 okN
@@ -103093,12 +103321,12 @@ anQ
 anQ
 auy
 xLf
-axc
+avF
 avF
 aAd
 bUk
 aCR
-aEh
+aEv
 aFx
 aGS
 xaa
@@ -103170,8 +103398,8 @@ bRp
 bPU
 cBt
 bVH
-bWU
-bYj
+bLO
+jsQ
 bLG
 bLG
 cbQ
@@ -103400,7 +103628,7 @@ ayA
 anQ
 ath
 srh
-aEh
+aEv
 aFy
 xaa
 xaa
@@ -103472,8 +103700,8 @@ bRq
 bPU
 cCg
 bVH
-bWU
-bYj
+bLO
+jsQ
 bZI
 ubf
 caW
@@ -103687,22 +103915,22 @@ agK
 acz
 ugH
 ajE
-akF
-alK
+acz
+acz
 pyP
-aph
-aph
-aph
-aph
+avK
+avK
+avK
+avK
 ati
 auC
 dRM
-aAe
+aXj
 aXj
 aqw
 aBF
 aCR
-aEh
+aEv
 aFy
 xaa
 aap
@@ -103774,8 +104002,8 @@ bRr
 bSV
 cCi
 bVH
-bWU
-bYj
+bLO
+jsQ
 bLG
 ahf
 usA
@@ -103990,7 +104218,7 @@ ahD
 afd
 ajF
 akG
-afd
+aQD
 pXN
 anX
 anX
@@ -104004,7 +104232,7 @@ anX
 anX
 gYw
 akl
-aEk
+dWk
 aFy
 xaa
 aaG
@@ -104077,9 +104305,9 @@ bSW
 bNi
 bVI
 bXb
-bUL
+cnh
 czF
-bMg
+cii
 cbV
 cbQ
 cbQ
@@ -104301,12 +104529,12 @@ api
 awA
 axg
 ayC
-aBD
+aBH
 avK
 aZF
 aBF
 aCW
-aWT
+aEm
 aFy
 xaa
 aaG
@@ -104378,15 +104606,15 @@ bNi
 jqS
 bNi
 ucg
-bXa
+bLO
 bYk
-caH
+bLG
 caN
 cbW
-cbY
+chb
 ccd
 cfS
-cii
+bMg
 cih
 cih
 cih
@@ -104603,12 +104831,12 @@ anZ
 anZ
 axh
 axg
-aBG
-aph
-aph
+aBH
+avK
+avK
 ddy
-aCU
-aEl
+aCR
+aEm
 aFy
 xaa
 aaG
@@ -104680,14 +104908,14 @@ hLZ
 jqS
 bNi
 jyp
-bWU
+bLO
 bYl
 bLG
 caO
-ahd
-ahd
+caR
+caR
 cdj
-ahd
+caR
 cip
 cjE
 cjE
@@ -104982,7 +105210,7 @@ obL
 bNi
 bNi
 bVH
-bWU
+bLO
 bYm
 bLG
 caP
@@ -105004,8 +105232,8 @@ csD
 cya
 cyH
 cyH
-cyH
 cwg
+cwP
 tWR
 dvC
 ktW
@@ -105284,8 +105512,8 @@ obL
 bNi
 huk
 bVN
-bWU
-bYj
+bLO
+jsQ
 bLG
 caP
 cca
@@ -105586,8 +105814,8 @@ vNU
 bUo
 bUs
 bVO
-bWU
-bYj
+bLO
+jsQ
 bLG
 caP
 cca
@@ -105609,7 +105837,7 @@ cvG
 cvG
 cng
 owI
-cwi
+ctD
 ctD
 ctD
 ctD
@@ -105888,8 +106116,8 @@ adC
 bEU
 bUt
 bVO
-bWU
-bYj
+bLO
+jsQ
 wqy
 caP
 cca
@@ -105910,8 +106138,8 @@ csG
 jOa
 hix
 ctD
-cuo
-cwj
+cwl
+aTi
 cuo
 cuo
 vql
@@ -106190,8 +106418,8 @@ aaw
 bEU
 bUu
 bVO
-bWU
-bYm
+bWY
+aZA
 wqy
 ceA
 ccb
@@ -106814,10 +107042,10 @@ cqQ
 crU
 csJ
 cGa
-cur
-cCf
+cup
+ctD
 cvj
-cwm
+cuo
 cwU
 mMJ
 sNr
@@ -107120,7 +107348,7 @@ cxS
 vfb
 rwf
 cwn
-cuo
+aqR
 sSa
 gbe
 wtE
@@ -113368,7 +113596,7 @@ tks
 vaq
 qKo
 ghZ
-aFO
+tag
 aIt
 aJG
 aKN
@@ -113396,14 +113624,14 @@ cOI
 ujF
 exh
 fSQ
-fSQ
-fSQ
-fSQ
-fSQ
+qYs
+qYs
+qYs
+qYs
 qZf
 bfi
 gRd
-qYs
+fSQ
 qYs
 ezq
 qnb
@@ -113686,23 +113914,23 @@ aUH
 aWa
 aXu
 veJ
-aZx
-aXl
+aYA
+aSq
 bbv
 bcx
 bdw
-fqc
+gJi
 rGl
 owS
 aap
-bwg
+qzs
 aUg
 aaq
 aaq
 aaq
 aaq
 aaq
-gJi
+axc
 iel
 oOY
 aaq
@@ -113962,10 +114190,10 @@ aop
 apw
 aqQ
 asj
-aqP
-qfa
-aqP
 mYQ
+qfa
+bhv
+bhv
 lem
 jdp
 asl
@@ -113987,7 +114215,7 @@ aTw
 aUE
 aUH
 aXv
-aYA
+cky
 aZy
 aSq
 bbs
@@ -113997,7 +114225,7 @@ aaq
 aaq
 aaq
 aap
-bwg
+qzs
 aUh
 adC
 adC
@@ -114005,7 +114233,7 @@ adC
 adC
 adC
 aag
-bwg
+qzs
 aaG
 adC
 adC
@@ -114299,7 +114527,7 @@ adC
 adC
 adC
 aag
-bwg
+qzs
 aUh
 adC
 adC
@@ -114307,7 +114535,7 @@ adC
 adC
 adC
 aag
-bwg
+qzs
 aaG
 adC
 adC
@@ -114564,12 +114792,12 @@ ame
 amY
 aoq
 apD
-aqR
+wVZ
 sCY
 erD
 auO
 ask
-ayR
+asl
 asl
 asl
 aBU
@@ -114601,7 +114829,7 @@ adC
 adC
 adC
 aag
-bwg
+qzs
 aUh
 adC
 adC
@@ -114609,7 +114837,7 @@ adC
 adC
 adC
 aag
-bwg
+qzs
 aaG
 adC
 adC
@@ -114867,8 +115095,8 @@ alg
 alg
 prD
 cOx
-iNm
-iNm
+fDN
+ayR
 jTk
 lQi
 iNm
@@ -114911,7 +115139,7 @@ aal
 adC
 aal
 aag
-bwg
+qzs
 aaG
 adC
 adC
@@ -115213,7 +115441,7 @@ bgV
 blZ
 bdN
 aap
-bwg
+qzs
 aap
 azt
 adC
@@ -115469,7 +115697,7 @@ alg
 kxP
 jiB
 jiB
-pky
+alg
 bZq
 lel
 wVZ
@@ -115515,7 +115743,7 @@ aYQ
 bma
 bdN
 aap
-dDl
+qgr
 eCa
 aaG
 adC
@@ -115772,23 +116000,23 @@ spb
 alg
 alg
 alg
-dWk
+alg
 aso
 atC
 mlb
-wZm
+pwI
 sqG
 ayT
 aAw
 aBW
 aDh
 bjh
-ttG
-xhn
-aHp
+bUx
+bVV
+bVG
 aJK
 aKT
-aMd
+aUO
 aMd
 aOy
 aPw
@@ -115797,8 +116025,8 @@ aRz
 aSu
 mDT
 koU
-aSt
 aXy
+aSt
 aYD
 aQy
 baM
@@ -116075,9 +116303,9 @@ jiB
 vuZ
 alg
 jwh
-alg
+bez
 rqj
-auR
+ulq
 qQK
 uQK
 ppQ
@@ -116085,16 +116313,16 @@ aAx
 aBX
 aDi
 bjh
-aDC
-bNf
-bVG
+vQq
+nvG
+azV
 aJL
 ffm
 aMe
 aNi
 aMe
 aPx
-aQB
+aRD
 nyV
 aSv
 aTz
@@ -116396,13 +116624,13 @@ kqC
 jAI
 wIz
 aPy
-aQC
+aRD
 aRB
 aSw
 aSt
 aUM
 aWf
-aXy
+aSt
 aYE
 aRD
 aYQ
@@ -116415,18 +116643,18 @@ pcs
 bdN
 pVp
 bkc
-bkN
+bdN
 bls
 kOI
 tJc
-bhv
-tag
-sDi
-lkX
+aYQ
+piR
+bdN
+qgr
 bxE
 bxE
 bxE
-rOj
+eCa
 aap
 aaw
 ylM
@@ -116695,10 +116923,10 @@ iCH
 aKR
 aKR
 aKR
-uRR
 aMg
 aMg
-aQD
+aMg
+aQy
 aRC
 aSx
 aTA
@@ -116706,7 +116934,7 @@ aUN
 ben
 aXB
 aYF
-aZA
+aRD
 aWB
 dAz
 bcl
@@ -116978,7 +117206,7 @@ aiZ
 aiZ
 aiZ
 aiY
-aiY
+cay
 aiZ
 vmK
 aiZ
@@ -116992,15 +117220,15 @@ iEN
 aDl
 bjh
 qDc
-bNf
-bVG
+bVV
+gro
 bNf
 pze
 bHZ
 etO
 aOB
 aye
-aQD
+aQy
 aRD
 aSy
 aTB
@@ -117012,7 +117240,7 @@ aQy
 aZG
 bHZ
 tTL
-bdq
+bHZ
 bHZ
 bgb
 itK
@@ -117302,7 +117530,7 @@ aJP
 fFV
 aKX
 aMR
-aNl
+aWi
 aMR
 aRj
 aSz
@@ -117312,21 +117540,21 @@ aTC
 aWi
 aMR
 aZH
-bbi
+wWK
 bcv
 bdx
-bez
-bgc
-bgc
-bhx
-bhx
-bhx
-bgc
+bHZ
+bdN
+bdN
+aYQ
+aYQ
+aYQ
+bdN
 bEp
-bhj
-eML
-bhx
-jaV
+bdK
+fBe
+aYQ
+piR
 wvf
 scX
 onF
@@ -117584,7 +117812,7 @@ xwN
 ane
 xgn
 apK
-apK
+bfv
 apK
 apK
 apK
@@ -117595,22 +117823,22 @@ mWd
 mgC
 jKa
 ayT
-bUx
-bVV
-bVG
+ahM
 bNf
-bNf
+aKo
+aQB
+aSA
 aJQ
 aLp
 lxQ
 aNk
 aNm
-aQE
+aNm
 aRk
 aSA
 aSA
 aTh
-aTD
+arq
 qJX
 arq
 bat
@@ -117629,7 +117857,7 @@ bdK
 fBe
 aYQ
 piR
-reg
+mRm
 wjO
 hBx
 jgn
@@ -117885,21 +118113,21 @@ aie
 amj
 lED
 ihy
-apK
-apK
-apK
-apK
-apK
-apK
+aPW
+aJg
+aXl
+aXl
+aXl
+aXl
 ocU
 ayT
 ayT
 ayT
 ayT
 ayU
-bUx
-bVV
-bVG
+ahM
+giH
+whg
 aIU
 bHZ
 bLI
@@ -117911,15 +118139,15 @@ bLI
 bHZ
 bLI
 bLI
-aTi
-aUO
 bLI
 bLI
-bau
+bLI
+bLI
+bLI
 bLI
 rOP
-bdq
-bdq
+bHZ
+bHZ
 bfs
 bfs
 bfs
@@ -117931,7 +118159,7 @@ bdK
 fBe
 aYQ
 piR
-reg
+mRm
 eeS
 mhk
 skM
@@ -118218,21 +118446,21 @@ aXG
 aYI
 aSB
 bav
-bbH
+bdp
 bcA
 bdz
 beB
-bfF
+ayx
 bgp
 bhd
-beI
+awS
 bjj
 bfF
 dWz
 bdK
 fBe
 aYQ
-piR
+iKM
 cOa
 kPj
 fRP
@@ -118516,14 +118744,14 @@ aSB
 aTF
 aUP
 beo
-aUP
-aUP
+bRk
+aQE
 lij
 baw
-baM
+wSZ
 bcB
 bdA
-beG
+baM
 bfF
 bgq
 hvF
@@ -118534,8 +118762,8 @@ wdQ
 bdK
 fBe
 aYQ
-piR
-dQf
+pVn
+wvf
 mAT
 gaM
 lQD
@@ -118803,8 +119031,8 @@ tbE
 tbE
 tbE
 aqY
-bUx
-bVV
+ahM
+tWW
 wVp
 cLi
 gse
@@ -118822,7 +119050,7 @@ aXH
 aXH
 aZC
 xNY
-bbx
+bbB
 bcC
 bdB
 beH
@@ -118836,13 +119064,13 @@ qat
 bdK
 fBe
 aYQ
-piR
-reg
+pVn
+mRm
 hlm
 sYg
 hXA
 geR
-blE
+aZD
 aap
 hBe
 adC
@@ -119093,7 +119321,7 @@ aie
 amj
 ttQ
 tpp
-pVn
+qYP
 pYK
 asv
 atI
@@ -119110,7 +119338,7 @@ bVV
 aIB
 aXQ
 aRG
-aMm
+beY
 aNp
 aHs
 mEg
@@ -119119,16 +119347,16 @@ bnp
 aSB
 tXQ
 vwW
-aUP
+bPK
 aXI
 aYJ
-aZD
+aSB
 bay
-bby
 bcD
+tEf
 bdC
 beW
-bfv
+bdK
 jme
 bhg
 bih
@@ -119138,13 +119366,13 @@ fVm
 bdK
 fBe
 aYQ
-piR
-mVI
+pVn
+mRm
 kxW
 mRm
-jsQ
 geR
-blE
+geR
+aZD
 aap
 aaG
 adC
@@ -119407,14 +119635,14 @@ taD
 aqY
 aqY
 aqY
-giH
+caA
 aHj
-aIB
-aXQ
-aLa
-aHs
+aUT
+bRl
+cfz
+aZI
 aNq
-aMm
+bZE
 mEg
 mEg
 aGo
@@ -119426,7 +119654,7 @@ aXJ
 aSB
 aSC
 baz
-bbz
+rYo
 bcE
 bdD
 beX
@@ -119444,7 +119672,7 @@ vhc
 tLi
 nHP
 tse
-bpn
+bdN
 aaw
 hNc
 kTT
@@ -119696,7 +119924,7 @@ aie
 aie
 aie
 kVG
-arq
+arc
 szn
 pYK
 asw
@@ -119709,22 +119937,22 @@ aqY
 aqY
 aDw
 aER
+bNf
 bVV
-ewn
 ofw
 fUp
 qDq
 uZB
 aNr
-aOF
+azM
 aPB
 aQG
 aRF
 aSD
 aTI
-aUT
 aTJ
-aTJ
+bKd
+rOj
 aYU
 aSD
 baA
@@ -119745,7 +119973,7 @@ aYQ
 piR
 bov
 bps
-brb
+awV
 bsJ
 btp
 btp
@@ -119761,16 +119989,16 @@ btO
 btO
 btO
 bAT
-bAT
-bAT
+azP
+uhZ
 bDM
 bDP
-bDP
-bFV
-bFV
-rTp
-bFV
-bGc
+beG
+chT
+chT
+fUo
+chT
+cwm
 bKQ
 bPg
 vIt
@@ -119998,8 +120226,8 @@ aie
 aie
 apR
 jbZ
-arq
 arc
+aJV
 pYK
 pYK
 pYK
@@ -120009,7 +120237,7 @@ axC
 tVl
 xjn
 aqZ
-bUx
+ttG
 sQL
 xQB
 inc
@@ -120017,14 +120245,14 @@ aIC
 aGo
 aLc
 oQT
-aNq
-aMm
-aOF
-aMm
-aRG
+bkN
+aHp
+eRh
+bDO
+atX
 lkL
-aTJ
-aUU
+bSG
+caz
 aWp
 aXK
 aYL
@@ -120065,15 +120293,15 @@ bxM
 mIC
 bBU
 muc
-bDN
 bEF
 bEF
-bGb
-bGQ
-sfA
-bGQ
-bzq
 bKR
+bGb
+bMq
+sfA
+bMq
+bzq
+bMq
 bMq
 bMq
 bPh
@@ -120300,8 +120528,8 @@ aie
 aie
 aie
 kVG
-arq
 arc
+aJV
 aqZ
 asz
 atK
@@ -120312,7 +120540,7 @@ hRG
 aAH
 aqZ
 qPC
-pwI
+gro
 gqP
 aGo
 aGo
@@ -120320,9 +120548,9 @@ aGo
 aUr
 kiL
 aNs
-aMl
+bbx
 aPC
-aMl
+bbx
 aRH
 gpc
 aTK
@@ -120342,32 +120570,32 @@ aSV
 bik
 jSg
 bkj
-iEe
-bjx
-fBe
-bcF
-piR
-bVx
+azk
+aRU
+cbY
+cur
+lkX
+reg
 bpS
 brb
-sdx
-sdx
-sdx
-aaq
-aap
-aaq
-aaq
-aaq
-aaq
-aaq
-aap
-aaq
-aaq
+aZx
+aZx
+aZx
+eDF
+lXc
+eDF
+eDF
+eDF
+eDF
+eDF
+lXc
+eDF
+eDF
 cpT
-uhZ
-uhZ
-uhZ
-bDO
+aQC
+aQC
+aQC
+bPg
 bEG
 oaO
 tpT
@@ -120602,8 +120830,8 @@ aie
 aie
 aie
 kVG
-arq
 arc
+aJV
 aqZ
 asA
 dad
@@ -120686,10 +120914,10 @@ bzY
 bzY
 bzY
 xmb
-rwL
-bYB
-bZO
-bSd
+dDl
+aPP
+pwv
+pky
 bYF
 kpq
 cUv
@@ -120904,8 +121132,8 @@ emU
 apP
 apS
 kVG
-arq
 arc
+aJV
 ara
 nqq
 atM
@@ -120916,7 +121144,7 @@ atM
 aAJ
 aqZ
 aDC
-pgo
+gro
 skn
 bew
 aIK
@@ -121206,8 +121434,8 @@ ajc
 kVG
 kVG
 kVG
-arq
 arc
+aJV
 ara
 asC
 atM
@@ -121218,7 +121446,7 @@ atM
 aAK
 aqZ
 ktu
-pgo
+gro
 eVe
 bex
 bfo
@@ -121283,7 +121511,7 @@ bII
 bJI
 bKU
 bMu
-sPu
+bUp
 tCI
 sPu
 bSa
@@ -121297,7 +121525,7 @@ cbn
 ceU
 ceU
 ceU
-cgf
+aBG
 chr
 vYg
 ciL
@@ -121508,7 +121736,7 @@ akf
 alk
 ubQ
 kCR
-arq
+arc
 exA
 aqZ
 asD
@@ -121539,8 +121767,8 @@ aWt
 aGo
 bgO
 aWk
-baA
-bbB
+bbz
+bdA
 bcG
 bdI
 bgj
@@ -121601,8 +121829,8 @@ hxR
 ceW
 cgp
 chv
-ieU
-vGo
+ckb
+ciL
 ciL
 xKS
 ciL
@@ -121810,7 +122038,7 @@ akf
 arq
 arq
 arq
-arq
+arc
 wPN
 aqZ
 aqZ
@@ -121822,7 +122050,7 @@ azc
 aAM
 aCi
 aDC
-pgo
+gro
 aXQ
 aXQ
 aIN
@@ -121841,8 +122069,8 @@ aGo
 aGo
 hNK
 aYH
+ceq
 baC
-bbE
 bcH
 dqA
 beI
@@ -121898,12 +122126,12 @@ bUU
 bUU
 bZO
 cbp
-ccx
+ceU
 cdL
-chw
+ckb
 chw
 mwX
-ciN
+oUZ
 oUZ
 xVZ
 qyS
@@ -122112,16 +122340,16 @@ jrT
 alm
 wWK
 wWK
-wWK
+cCf
 erT
 asM
 ejG
-aDI
+ayd
 ayf
 azv
-aDI
-aDI
-whg
+ayd
+ayd
+ayd
 ayd
 aDD
 uDl
@@ -122144,7 +122372,7 @@ aTM
 aXE
 aYO
 jRg
-bbF
+aYQ
 tii
 bdK
 bdI
@@ -122199,13 +122427,13 @@ bUU
 bUU
 bUU
 bZS
-cbq
 ccy
 ccy
 ccy
 ccy
 ccy
-cbq
+ccy
+ccy
 ccy
 ccy
 ccy
@@ -122414,8 +122642,8 @@ hgm
 aln
 arq
 arq
-arq
-arq
+arc
+bgc
 asN
 azx
 azx
@@ -122443,7 +122671,7 @@ lcI
 dlj
 bcg
 aXN
-bbH
+cma
 aYP
 baE
 dIw
@@ -122728,7 +122956,7 @@ azd
 aAN
 aCj
 aDJ
-wSZ
+bVG
 aXQ
 aHr
 aIP
@@ -123033,22 +123261,22 @@ aDK
 vxJ
 isN
 kLp
-maI
-aJV
-aJV
+aLe
+aLf
+aLf
 vyW
 xtf
 vyW
-aJV
-aJV
-aRN
+aLf
+aLf
+aPE
 otx
 aTO
 aWw
 aWw
 aWw
 oCM
-aZI
+aZJ
 baG
 bbI
 bcL
@@ -123328,23 +123556,23 @@ avy
 amD
 awt
 axK
-omw
+azf
 aAP
-ulq
+axI
 aDL
 gro
 aGo
 aHu
-aIP
-aJU
-aJU
-aJU
-aNy
-aJU
-aJU
-aJU
-aRM
-aOF
+aNl
+qhP
+qhP
+qhP
+ckF
+qhP
+qhP
+qhP
+pgo
+omw
 aTP
 iqw
 xfX
@@ -123407,7 +123635,7 @@ hva
 ihI
 bIf
 bZU
-cbq
+ccy
 ccy
 ccy
 ccy
@@ -123629,8 +123857,8 @@ awI
 atR
 amD
 eGt
-axL
-azf
+bhj
+hdf
 aAQ
 aoE
 lvm
@@ -123708,8 +123936,8 @@ bUZ
 bUZ
 bUZ
 noq
-bZV
-cbu
+bUZ
+bUZ
 ccC
 qJF
 cfc
@@ -124536,7 +124764,7 @@ atU
 amD
 awx
 axO
-azi
+jaV
 snW
 mEL
 rMG
@@ -124837,7 +125065,7 @@ fTr
 dnB
 atW
 awy
-axO
+axL
 azi
 aAU
 auq
@@ -125133,7 +125361,7 @@ atW
 tSN
 awI
 awI
-atX
+jiQ
 hpR
 azp
 awI
@@ -125435,14 +125663,14 @@ atW
 mDJ
 awI
 awI
-atX
+jiQ
 eFQ
 awI
 fSd
 atW
 dSo
-axQ
-azk
+awG
+azn
 kXj
 auq
 wqg
@@ -125737,13 +125965,13 @@ tqZ
 mwY
 awI
 awI
-atX
+jiQ
 hpR
 mDJ
 awI
 apY
 suj
-axQ
+awG
 azn
 aAW
 kVJ
@@ -126045,7 +126273,7 @@ sem
 awI
 atW
 awC
-axQ
+awG
 azn
 aAX
 auq
@@ -126347,8 +126575,8 @@ asK
 azs
 atW
 dsG
-axQ
-azk
+awG
+azn
 aAY
 auq
 wfn
@@ -126952,7 +127180,7 @@ vdC
 nhn
 awF
 azz
-qhP
+awG
 tyN
 nhn
 vdC
@@ -127254,7 +127482,7 @@ atZ
 avj
 juE
 oyc
-mPc
+awG
 qUI
 avj
 xdC

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -2831,13 +2831,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/fancy_beer,
 /turf/simulated/floor/purple,
 /area/station/crew_quarters/quartersA)
-"akF" = (
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "akG" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -3126,15 +3119,6 @@
 /obj/machinery/vending/cards,
 /turf/simulated/floor/purple/side,
 /area/station/crew_quarters/quarters)
-"alK" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/purple/side{
-	dir = 4
-	},
-/area/station/science/lobby)
 "alL" = (
 /obj/machinery/light_switch{
 	name = "S light switch";
@@ -19891,9 +19875,9 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "boW" = (
@@ -19960,9 +19944,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/switch_junction/right/west{
+	mail_tag = "place";
+	name = "research router"
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -22976,14 +22960,6 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/storage/warehouse)
-"bDN" = (
-/obj/lattice,
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/space,
-/area/space)
 "bDO" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/specialroom/chapel,
@@ -26061,15 +26037,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"bPS" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/science/bot_storage)
 "bPT" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -26399,10 +26366,6 @@
 	},
 /area/station/science/lobby)
 "bRd" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -26424,9 +26387,6 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -26435,10 +26395,6 @@
 /obj/machinery/light_switch{
 	name = "N light switch";
 	pixel_y = 24
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 5
@@ -26814,10 +26770,6 @@
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
-"bSE" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/science/bot_storage)
 "bSF" = (
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -26867,9 +26819,9 @@
 	location = "depot";
 	name = "bot navigation beacon"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/disposalpipe/switch_junction/right/west{
+	mail_tag = "chemistry";
+	name = "chemistry router"
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -26877,12 +26829,8 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/switch_junction{
-	desc = "An underfloor mail pipe.";
-	dir = 4;
-	icon_state = "pipe-sj2";
-	mail_tag = "research";
-	name = "research mail router"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -26976,9 +26924,9 @@
 /area/space)
 "bSZ" = (
 /obj/decal/stripe_caution,
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/disposalpipe/switch_junction/right/north{
+	mail_tag = "research","chemistry","test_chamber";
+	name = "research dept router"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -27206,12 +27154,6 @@
 	dir = 8
 	},
 /area/station/science/lobby)
-"bTX" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/science/lobby)
 "bTY" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -27223,36 +27165,21 @@
 /turf/simulated/floor,
 /area/station/science/lobby)
 "bTZ" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/purple/corner,
 /area/station/science/lobby)
 "bUa" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "bUb" = (
 /obj/machinery/light,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "bUd" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/switch_junction{
-	desc = "An underfloor mail pipe.";
-	dir = 1;
-	icon_state = "pipe-sj2";
-	mail_tag = "testchamber";
-	name = "test chamber mail router"
-	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "bUe" = (
@@ -27302,13 +27229,6 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
-"bUm" = (
-/obj/mapping_helper/wingrille_spawn/auto,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/science/bot_storage)
 "bUo" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/airbridge)
@@ -27329,6 +27249,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
@@ -27585,6 +27506,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "bVx" = (
@@ -27605,9 +27527,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bVE" = (
@@ -27615,7 +27534,8 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/purple/corner{
 	dir = 8
@@ -28063,9 +27983,6 @@
 "bWX" = (
 /obj/machinery/vending/snack,
 /obj/decal/stripe_caution,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bWY" = (
@@ -28272,12 +28189,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/switch_junction{
-	desc = "An underfloor mail pipe.";
-	dir = 1;
-	icon_state = "pipe-sj2";
-	mail_tag = "chemistry";
-	name = "chemistry mail router"
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
@@ -28369,13 +28283,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"bXZ" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/south)
 "bYa" = (
 /obj/machinery/vending/cola/red,
 /obj/decal/stripe_caution,
@@ -28410,13 +28317,6 @@
 "bYe" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/toilets)
-"bYh" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "bYi" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
@@ -29108,27 +29008,17 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "caC" = (
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "caD" = (
 /obj/cable{
 	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
@@ -29140,26 +29030,8 @@
 /obj/machinery/guardbot_dock,
 /obj/machinery/bot/guardbot,
 /obj/decal/stripe_caution,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
-"caF" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/science/bot_storage)
-"caG" = (
-/obj/lattice,
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/space,
-/area/space)
 "caH" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -31596,15 +31468,14 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southeast)
 "ciN" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 1;
+/obj/disposalpipe/segment/mail{
+	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/station/science/testchamber)
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/station/science/lobby)
 "ciO" = (
 /obj/machinery/floorflusher/minibrig,
 /obj/disposalpipe/trunk/ejection{
@@ -33329,9 +33200,6 @@
 /area/station/science/testchamber)
 "coj" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "col" = (
@@ -33690,18 +33558,21 @@
 /turf/simulated/floor,
 /area/station/science/testchamber)
 "cpk" = (
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "cpl" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "cpm" = (
 /obj/storage/closet/fire,
-/obj/disposalpipe/segment/transport,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -34093,7 +33964,7 @@
 /turf/simulated/floor,
 /area/station/science/testchamber)
 "cqn" = (
-/obj/disposalpipe/segment/transport,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "cqo" = (
@@ -34394,20 +34265,17 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment/transport{
-	dir = 4
+/obj/disposalpipe/junction{
+	name = "transport pipe"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "crq" = (
-/obj/disposalpipe/junction{
-	name = "transport pipe"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/storage/closet/biohazard,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "crr" = (
@@ -35092,12 +34960,12 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/transport{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
@@ -35105,11 +34973,8 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/disposalpipe/segment/transport{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/power/apc/autoname_east,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "ctV" = (
@@ -35403,12 +35268,11 @@
 	name = "Test Chamber Shutter Control";
 	pixel_y = -23
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
@@ -38607,9 +38471,6 @@
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -40244,13 +40105,6 @@
 /obj/machinery/power/solar/west,
 /turf/simulated/floor/airless/solar,
 /area/station/solar/west)
-"ewn" = (
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/purple/side,
-/area/station/science/lobby)
 "ewr" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/disposalpipe/segment{
@@ -40678,6 +40532,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/north)
+"eIj" = (
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/science/lobby)
 "eIp" = (
 /obj/machinery/vehicle/pod_smooth/light,
 /turf/simulated/floor/shuttlebay,
@@ -45101,18 +44962,6 @@
 	},
 /turf/simulated/floor/green,
 /area/station/turret_protected/Zeta)
-"ieU" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/guardbot_dock,
-/obj/decal/stripe_caution,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/science/bot_storage)
 "ifi" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -46979,6 +46828,15 @@
 /area/station/hangar/catering{
 	name = "Catering Hangar"
 	})
+"jKJ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/science/bot_storage)
 "jKQ" = (
 /obj/machinery/firealarm/south,
 /obj/cable{
@@ -49568,6 +49426,13 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/fitness)
+"lRT" = (
+/obj/mapping_helper/wingrille_spawn/auto,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/science/bot_storage)
 "lSC" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -49807,16 +49672,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"maI" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/science/lobby)
 "maK" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -51813,10 +51668,6 @@
 /area/station/solar/north)
 "nzS" = (
 /obj/machinery/firealarm/south,
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/purple/side,
 /area/station/science/lobby)
 "nzX" = (
@@ -52543,7 +52394,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm/west,
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "ofw" = (
@@ -60486,7 +60337,10 @@
 /area/station/wreckage)
 "ufo" = (
 /obj/storage/closet/biohazard,
-/obj/disposalpipe/segment/transport,
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "ufy" = (
@@ -62530,6 +62384,18 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/bridge)
+"vJR" = (
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/guardbot_dock,
+/obj/decal/stripe_caution,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/science/bot_storage)
 "vKj" = (
 /obj/cable/yellow,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -95546,7 +95412,7 @@ cmi
 ckx
 cmi
 gIi
-ciN
+cpl
 bVw
 boS
 crp
@@ -97945,8 +97811,8 @@ bLr
 cSN
 bIQ
 bJt
-bWx
-bTX
+bpn
+eIj
 vGo
 uRR
 bXH
@@ -98252,7 +98118,7 @@ bTZ
 bbi
 arK
 bWB
-alK
+ciN
 caw
 caw
 bVr
@@ -98856,7 +98722,7 @@ bUb
 bVj
 cdb
 cdb
-bUm
+lRT
 bZh
 cdb
 cdb
@@ -99153,12 +99019,12 @@ bZV
 bOz
 bKq
 bRd
-bpn
-ewn
+bWx
+bUa
 mRx
 bWE
 bXI
-ieU
+vJR
 bZi
 cbK
 cdb
@@ -99455,12 +99321,12 @@ kyx
 byR
 bIQ
 dtA
-maI
+bWx
 nzS
 bVj
 bWF
 eCS
-bPS
+jKJ
 eCS
 cbL
 cdb
@@ -100970,8 +100836,8 @@ bUh
 bVj
 bWD
 bWD
-bSE
-caF
+bWD
+bWD
 bWD
 bWD
 cCl
@@ -101270,10 +101136,10 @@ bRi
 bSN
 bUi
 bVj
-bDN
-bxh
-bxh
-caG
+aap
+aap
+aap
+aap
 cbQ
 cdc
 chZ
@@ -101572,7 +101438,7 @@ bVj
 kNZ
 cbH
 bVj
-bXZ
+sDQ
 sDQ
 bLG
 bLG
@@ -102175,8 +102041,8 @@ bLO
 bLO
 bSS
 bLO
-bYh
-akF
+bLO
+bLO
 bYb
 bZF
 cfQ

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -5909,10 +5909,6 @@
 "awM" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/main)
-"awN" = (
-/obj/disposalpipe/segment/transport,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/main)
 "awQ" = (
 /obj/machinery/conveyor/EW{
 	id = "ghostdrone"
@@ -7223,7 +7219,6 @@
 /area/station/security/main)
 "aBs" = (
 /obj/grille/steel,
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "aBu" = (
@@ -8085,13 +8080,6 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/security/main)
-"aDV" = (
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/security/main)
 "aEa" = (
 /obj/table/reinforced/auto,
 /obj/machinery/power/data_terminal,
@@ -8833,7 +8821,6 @@
 	name = "N light switch";
 	pixel_y = 24
 	},
-/obj/disposalpipe/segment/transport,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -9083,7 +9070,6 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/disposalpipe/segment/transport,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -9565,16 +9551,10 @@
 	},
 /turf/simulated/floor,
 /area/station/security/main)
-"aJe" = (
-/obj/disposalpipe/segment/transport{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/security/main)
 "aJf" = (
 /obj/disposalpipe/segment/transport{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -9596,12 +9576,6 @@
 	dir = 4
 	},
 /area/station/science/lobby)
-"aJi" = (
-/obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/security/main)
 "aJj" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 1;
@@ -10473,16 +10447,16 @@
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "aLE" = (
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/scanner{
-	bank_id = "security"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/light_switch{
 	name = "S light switch";
 	pixel_y = -24
+	},
+/obj/decal/stripe_delivery,
+/obj/disposalpipe/trunk/transport{
+	dir = 1
+	},
+/obj/machinery/disposal{
+	name = "Test Chamber Chute"
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
@@ -10798,12 +10772,6 @@
 	dir = 1;
 	icon_state = "fred1"
 	},
-/area/station/security/main)
-"aMM" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/supernorn,
 /area/station/security/main)
 "aMO" = (
 /obj/decal/poster/wallsign/security,
@@ -40589,13 +40557,13 @@
 /turf/space,
 /area/space)
 "eEI" = (
-/obj/machinery/disposal{
-	name = "Test Chamber Chute"
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/scanner{
+	bank_id = "security"
 	},
-/obj/disposalpipe/trunk/transport{
-	dir = 1
+/obj/cable{
+	icon_state = "0-8"
 	},
-/obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/security/main)
 "eEN" = (
@@ -45184,11 +45152,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"igs" = (
-/obj/disposalpipe/segment/transport,
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/security/main)
 "ihy" = (
 /obj/disposalpipe/segment/produce{
 	dir = 4
@@ -45875,9 +45838,6 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "iMW" = (
-/obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "iNm" = (
@@ -46270,10 +46230,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/bar)
 "jeh" = (
-/obj/disposalpipe/segment/transport{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/red/corner,
 /area/station/security/main)
 "jeE" = (
@@ -57333,6 +57289,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/engine/inner)
 "rLp" = (
@@ -62821,6 +62778,9 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
 /area/station/security/main)
 "vVq" = (
@@ -63550,7 +63510,6 @@
 	dir = 4;
 	name = "Interrogation Room"
 	},
-/obj/disposalpipe/segment/transport,
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/security,
 /turf/simulated/floor/black,
@@ -95796,18 +95755,18 @@ lww
 iik
 eAM
 iMW
-igs
-igs
-awN
+lww
+lww
+awK
 wxx
-awN
+awK
 aBs
-awN
-awN
-awN
+awK
+awK
+awK
 aGC
 aHG
-aJe
+aHB
 aKi
 aLu
 uzM
@@ -96109,7 +96068,7 @@ vOp
 dJo
 aGD
 avd
-aJf
+aHB
 usN
 aLv
 aGp
@@ -96411,7 +96370,7 @@ mCv
 dXC
 aGE
 aGe
-aJf
+aHB
 aKl
 aLw
 aMJ
@@ -96713,7 +96672,7 @@ sGG
 vNW
 aGF
 aHI
-aDV
+aHH
 aKk
 aLx
 lYi
@@ -97015,7 +96974,7 @@ ohW
 dJo
 aGG
 bhZ
-aJf
+aHB
 aKm
 fkj
 fkj
@@ -97317,7 +97276,7 @@ ail
 aho
 aho
 aHK
-aJf
+aHB
 aKn
 aLz
 pHc
@@ -97619,8 +97578,8 @@ aEa
 aFj
 aho
 kwp
-aJi
-aJe
+aHB
+aHB
 aLA
 awM
 rwX
@@ -97922,7 +97881,7 @@ aFk
 ubA
 omr
 aJj
-aJf
+aHB
 aLB
 awM
 aOa
@@ -98224,7 +98183,7 @@ aoV
 uLz
 aHN
 aJk
-aJf
+aHB
 hfb
 awM
 aOa
@@ -98526,7 +98485,7 @@ anK
 aGJ
 iSt
 aJk
-aJf
+aHB
 aLD
 awM
 aOa
@@ -98830,7 +98789,7 @@ aHP
 aJk
 aJf
 aLE
-aMM
+awM
 aOb
 aOh
 aQg


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

I enjoy plumbing... This re-routes most pipes on Cogmap 1 that go through walls or otherwise can go under a door instead of a window etc.

Points of note:

- Table, window and chemvendor budged in medsci for space.
- Pipes route through artsci now, possibly too frequently damaged?
- Window and blinds added to the crematorium.

I believe I've tested most chutes, it all seems fine.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Pipes are much easier to repair when they're not underneath walls. 



