### PR TITLE
Fix artifact pitchers using reagent overlays

### DIFF
--- a/code/obj/artifacts/artifact_items/pitcher.dm
+++ b/code/obj/artifacts/artifact_items/pitcher.dm
@@ -15,6 +15,8 @@
 		SPAWN(0)
 			src.ArtifactSetup()
 
+		src.RemoveComponentsOfType(/datum/component/reagent_overlay)
+
 		if (prob(15))
 			src.reagents.inert = TRUE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove the reagent overlay component from artifact pitchers on spawn

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #20017
Fix #19995

