### PR TITLE
Ant-proofs chairs and racks

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -48,7 +48,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 			return TRUE // there are no ants in deep space...
 		if (locate(/obj/table) in src.loc) // locate is faster than typechecking each movable
 			return TRUE
-		if (locate(/obj/chair) in src.loc)
+		if (locate(/obj/item/chair) in src.loc)
 			return TRUE
 		if (locate(/obj/rack) in src.loc)
 			return TRUE

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -48,6 +48,10 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 			return TRUE // there are no ants in deep space...
 		if (locate(/obj/table) in src.loc) // locate is faster than typechecking each movable
 			return TRUE
+		if (locate(/obj/chair) in src.loc)
+			return TRUE
+		if (locate(/obj/rack) in src.loc)
+			return TRUE
 		if (locate(/obj/surgery_tray) in src.loc) // includes kitchen islands
 			return TRUE
 		if (locate(/obj/storage/secure/closet/fridge) in src.loc) // includes fridges


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[CATERING] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This adds chairs and racks to the ant_safe proc.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #20021 (for the most part hopefully), also stops ants from eating food on chairs which  fixes oshan's detective popcorn spawning with ants roundstart.


