### PR TITLE
Changes the direction of certain noticeboards where applicable

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -283,7 +283,8 @@
 	name = "Detective's Office persistent notice board";
 	persistent_id = "detectives office";
 	pixel_x = 32;
-	pixel_y = 2
+	pixel_y = 2;
+	dir = 4
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -3523,7 +3524,8 @@
 	name = "Brig persistent notice board";
 	persistent_id = "brig";
 	pixel_x = -32;
-	pixel_y = 0
+	pixel_y = 0;
+	dir = 8
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -5831,7 +5833,8 @@
 	name = "Mechanics Workshop persistent notice board";
 	persistent_id = "mechanics";
 	pixel_x = 32;
-	pixel_y = 0
+	pixel_y = 0;
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 5
@@ -10834,7 +10837,8 @@
 	name = "Crew Quarters persistent notice board";
 	persistent_id = "crew quarters";
 	pixel_x = 32;
-	pixel_y = 0
+	pixel_y = 0;
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
@@ -11268,7 +11272,8 @@
 	name = "Botany persistent notice board";
 	persistent_id = "botany";
 	pixel_x = 32;
-	pixel_y = 0
+	pixel_y = 0;
+	dir = 4
 	},
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -32427,7 +32427,8 @@
 	name = "Botany persistent notice board";
 	persistent_id = "botany";
 	pixel_x = 32;
-	pixel_y = 0
+	pixel_y = 0;
+	dir = 4
 	},
 /obj/submachine/seed_manipulator{
 	dir = 8

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -13523,7 +13523,8 @@
 	name = "Detective's Office persistent notice board";
 	persistent_id = "detectives office";
 	pixel_x = 32;
-	pixel_y = 2
+	pixel_y = 2;
+	dir = 4
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -16922,7 +16923,8 @@
 	name = "Customs persistent notice board";
 	persistent_id = "customs";
 	pixel_x = -32;
-	pixel_y = 2
+	pixel_y = 2;
+	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint)

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -4462,7 +4462,8 @@
 	name = "Crew Quarters persistent notice board";
 	persistent_id = "crew quarters";
 	pixel_x = 32;
-	pixel_y = 0
+	pixel_y = 0;
+	dir = 4
 	},
 /turf/simulated/floor/stairs/wide/other,
 /area/station/hangar/arrivals)
@@ -12823,12 +12824,12 @@
 /area/station/chapel/sanctuary)
 "dMJ" = (
 /obj/table/round/auto,
-/obj/machinery/light_switch/auto,
 /obj/noticeboard/persistent{
 	name = "Cargo persistent notice board";
 	persistent_id = "cargo";
 	pixel_x = 32;
-	pixel_y = 0
+	pixel_y = 0;
+	dir = 4
 	},
 /obj/item/kitchen/food_box/sugar_box{
 	pixel_y = 16
@@ -52718,7 +52719,8 @@
 	name = "Engineering persistent notice board";
 	persistent_id = "engineering";
 	pixel_x = -32;
-	pixel_y = 0
+	pixel_y = 0;
+	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/breakroom)
@@ -55118,7 +55120,8 @@
 	name = "Mechanics Workshop persistent notice board";
 	persistent_id = "mechanics";
 	pixel_x = 32;
-	pixel_y = 0
+	pixel_y = 0;
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -44323,7 +44323,8 @@
 	name = "Chapel persistent notice board";
 	persistent_id = "chapel";
 	pixel_x = 32;
-	pixel_y = 0
+	pixel_y = 0;
+	dir = 4
 	},
 /turf/simulated/floor/wood/two,
 /area/station/chapel/sanctuary)
@@ -49258,7 +49259,8 @@
 	name = "Brig persistent notice board";
 	persistent_id = "brig";
 	pixel_x = 32;
-	pixel_y = 0
+	dir = 4;
+	pixel_y = 4
 	},
 /obj/machinery/vending/snack{
 	credit = 50


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the direction of certain noticeboards so they use the new directional sprite. Hopefully this keeps any papers currently on the board. 😓 

![image](https://github.com/user-attachments/assets/c8f2f3fd-f95f-46f2-8c16-7b19490f4477)

Maps that had changes were:
- Atlas (Detective's office, Brig, Mechanics, Crew Quarters, and Botany)
- Clarion (Botany)
- Cogmap (Detective's office, Customs office)
- Donut3 (Crew Quarters, Cargo, Engineering, Mechanics)
- Kondaru (Chapel, Brig)



(Also removed a single extra light switch in donut3 cargo because it was on the same tile and didn't seem to be important, let me know if that was not the case.)
![image](https://github.com/user-attachments/assets/be77e39a-2b4c-4c26-8b3a-23af19d04c51)
The lightswitch in question ^

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The sprites exist now, just needed to change the dir of some noticeboards 👍 