### PR TITLE
Fix Clarion Engine plant

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -746,7 +746,7 @@ var/global/list/mapNames = list(
 	valid_nuke_targets = list("the main security room" = list(/area/station/security/main),
 		"the central research sector hub" = list(/area/station/science/lobby),
 		"the quartermaster's office" = list(/area/station/quartermaster/office),
-		"the thermo-electric generator room" = list(/area/station/engine/core),
+		"the nuclear reactor room" = list(/area/station/engine/core/nuclear),
 		"the medbay" = list(/area/station/medical/medbay, /area/station/medical/medbay/lobby),
 		"the bar" = list(/area/station/crew_quarters/bar),
 		//"the EVA storage" = list(/area/station/ai_monitored/storage/eva),


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Clarion engineering plant is "thermo electric generator room" engine/core area, none of these exist on clarion but the map pointer still shows the "nuclear reactor room" engine/core/nuclear area, nukies cant plant there. Fixes that


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix = good