### PR TITLE
Fix first aid kits only accepting pill bottles

### DIFF
--- a/code/obj/item/storage/med_chem.dm
+++ b/code/obj/item/storage/med_chem.dm
@@ -9,6 +9,7 @@
 	can_hold = list(/obj/item/storage/pill_bottle)
 	throw_range = 8
 	max_wclass = W_CLASS_TINY
+	check_wclass = TRUE
 	var/list/kit_styles = null
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
check_wclass allows items not on the can_hold list but in/under the max_wclass to fit in the first aid box, like health scanners, pills, patches, etc. everything you would expect.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
first aid kits only accept pill bottles :C

Fix #20035