### PR TITLE
Re-locates most contraband lockers 

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -12651,7 +12651,6 @@
 /area/space)
 "bJh" = (
 /obj/storage/secure/closet/security/equipment,
-/obj/machinery/light_switch/west,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -12688,12 +12687,12 @@
 	dir = 4;
 	pixel_x = -32
 	},
-/obj/storage/secure/closet/brig,
 /obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /obj/machinery/light_switch/south,
+/obj/storage/closet/wardrobe/orange,
 /turf/simulated/floor/red/side{
 	dir = 10
 	},
@@ -17141,7 +17140,7 @@
 	},
 /area/station/solar/east)
 "eES" = (
-/obj/storage/secure/closet/brig,
+/obj/machinery/flasher/portable,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -39104,7 +39103,10 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "uWQ" = (
-/obj/machinery/flasher/portable,
+/obj/storage/secure/closet/brig,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -39888,6 +39890,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/red/side{
 	dir = 10
 	},
@@ -42207,7 +42210,6 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/storage/closet/wardrobe/orange,
 /turf/simulated/floor/red/side{
 	dir = 9
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -10424,12 +10424,10 @@
 /area/station/security/main)
 "aLA" = (
 /obj/machinery/light/emergency,
-/obj/storage/secure/closet/brig,
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "aLB" = (
 /obj/machinery/light,
-/obj/storage/secure/closet/brig,
 /obj/disposalpipe/segment/brig{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -39990,9 +39988,6 @@
 	desc = "A crate of confiscated items.";
 	name = "Contraband"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/item/item_box/no{
 	pixel_x = 8;
 	pixel_y = -5
@@ -51172,6 +51167,15 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters)
+"nlh" = (
+/obj/storage/secure/closet/brig,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/main)
 "nna" = (
 /obj/storage/crate/rcd,
 /obj/machinery/light{
@@ -97355,7 +97359,7 @@ afN
 acV
 ahm
 awK
-fRJ
+nlh
 avd
 iQw
 aho

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -22388,8 +22388,7 @@
 /area/station/routing/security)
 "bqC" = (
 /obj/disposalpipe/segment/mail/vertical,
-/obj/table/reinforced/auto,
-/obj/item/hand_labeler,
+/obj/storage/secure/closet/brig,
 /turf/simulated/floor/grime,
 /area/station/routing/security)
 "bqD" = (
@@ -22397,8 +22396,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/vehicle/segway,
-/obj/decal/stripe_caution,
+/obj/storage/secure/closet/brig,
 /turf/simulated/floor,
 /area/station/routing/security)
 "bqE" = (
@@ -58056,7 +58054,8 @@
 /turf/simulated/floor/orangeblack,
 /area/station/maintenance/central)
 "giI" = (
-/obj/storage/secure/closet/brig,
+/obj/vehicle/segway,
+/obj/decal/stripe_caution,
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "gke" = (
@@ -61424,6 +61423,8 @@
 	})
 "jwl" = (
 /obj/machinery/firealarm/west,
+/obj/table/reinforced/auto,
+/obj/item/hand_labeler,
 /turf/simulated/floor/caution/south,
 /area/station/routing/security)
 "jwG" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -23724,9 +23724,6 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "gzM" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/storage/cart/forensic/bomb_disposal,
 /turf/simulated/floor/grime,
 /area/station/security/equipment)
@@ -29528,6 +29525,9 @@
 /area/station/engine/inner)
 "kvs" = (
 /obj/storage/secure/closet/brig,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/security/equipment)
 "kvu" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -11048,7 +11048,6 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/white,
 /area/station/security/main)
 "diK" = (
@@ -25988,7 +25987,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "hMf" = (
-/obj/storage/secure/closet/brig,
+/obj/storage/closet/wardrobe/orange,
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -33413,8 +33412,10 @@
 	},
 /area/station/science/lobby)
 "kat" = (
-/obj/storage/closet/wardrobe/orange,
-/obj/machinery/light_switch/west,
+/obj/storage/secure/closet/brig,
+/obj/machinery/light/incandescent/warm{
+	dir = 8
+	},
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -80065,6 +80066,7 @@
 /obj/machinery/light/incandescent/warm{
 	dir = 1
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/white,
 /area/station/security/main)
 "xYz" = (
@@ -103750,9 +103752,9 @@ jhw
 ilj
 jhw
 kat
-fOF
-hMf
 lOG
+hMf
+fOF
 rag
 ieY
 rce

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -36215,12 +36215,8 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/computer3/generic/secure_data{
-	dir = 4;
-	tag = ""
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable,
+/obj/storage/secure/crate/weapon/confiscated_items,
+/obj/machinery/light_switch/south,
 /turf/simulated/floor/red/side,
 /area/station/security/secwing)
 "gxC" = (
@@ -47173,9 +47169,14 @@
 /area/research_outpost/indigo_rye)
 "ozl" = (
 /obj/machinery/light/emergency,
-/obj/storage/secure/crate/weapon/confiscated_items,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/secwing)
@@ -49484,9 +49485,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "qkd" = (
-/obj/stool/chair/red{
-	dir = 8
-	},
+/obj/machinery/light,
+/obj/storage/secure/closet/brig,
 /turf/simulated/floor/red/side,
 /area/station/security/secwing)
 "qkS" = (
@@ -52220,7 +52220,14 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_south)
 "shZ" = (
-/obj/storage/secure/closet/brig,
+/obj/machinery/computer3/generic/secure_data{
+	dir = 4;
+	tag = ""
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/red/side,
 /area/station/security/secwing)
 "sje" = (
@@ -53463,15 +53470,6 @@
 /obj/machinery/launcher_loader/east,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/inner/east)
-"tdg" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/security/secwing)
 "tdy" = (
 /obj/disposaloutlet/south,
 /obj/disposalpipe/trunk/west,
@@ -116807,7 +116805,7 @@ dha
 tiv
 wVg
 qVZ
-shZ
+raX
 qGc
 xpj
 ftT
@@ -119525,7 +119523,7 @@ bTp
 mnO
 xDR
 gwU
-raX
+shZ
 kqg
 uEv
 cbZ
@@ -120128,7 +120126,7 @@ bRW
 gmO
 mnO
 bVP
-tdg
+wjC
 gxk
 vTU
 szp

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -4972,7 +4972,7 @@
 	},
 /area/listeningpost)
 "clb" = (
-/obj/storage/secure/closet/brig,
+/obj/storage/closet/wardrobe/orange,
 /turf/simulated/floor/redblack,
 /area/station/security/main)
 "cle" = (
@@ -8422,7 +8422,11 @@
 /turf/space/fluid/acid/clear,
 /area/shuttle/arrival/station)
 "dOM" = (
-/obj/storage/closet/wardrobe/orange,
+/obj/storage/secure/crate/gear{
+	desc = "A secure crate for transferring contraband, and definitely not people.";
+	name = "Secure Transfer Crate";
+	req_access_txt = "1"
+	},
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -26125,6 +26129,10 @@
 	pixel_x = 10;
 	tag = ""
 	},
+/obj/item/device/radio/intercom/security{
+	dir = 8
+	},
+/obj/storage/secure/closet/brig,
 /turf/simulated/floor/redblack{
 	dir = 6
 	},
@@ -29266,6 +29274,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/black,
 /area/station/security/brig)
 "mif" = (
@@ -40960,13 +40969,9 @@
 /turf/simulated/floor/industrial,
 /area/ghostdrone_factory)
 "rwt" = (
-/obj/storage/secure/crate/gear{
-	desc = "A secure crate for transferring contraband, and definitely not people.";
-	name = "Secure Transfer Crate";
-	req_access_txt = "1"
-	},
-/obj/item/device/radio/intercom/security{
-	dir = 8
+/obj/storage/secure/closet/brig,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -49352,11 +49357,6 @@
 "vef" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 2
-	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
 	},
 /obj/cable{
 	icon_state = "1-2"

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -27495,6 +27495,9 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
 "bVi" = (
+/obj/machinery/light_switch/east{
+	pixel_y = -4
+	},
 /turf/simulated/floor/red/side{
 	dir = 9
 	},

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -32849,7 +32849,6 @@
 /area/station/science/bot_storage)
 "bFM" = (
 /obj/machinery/light,
-/obj/storage/secure/closet/brig,
 /obj/disposalpipe/segment/brig{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -33018,7 +33017,6 @@
 /area/station/crew_quarters/quarters)
 "bGn" = (
 /obj/machinery/light/emergency,
-/obj/storage/secure/closet/brig,
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "bGo" = (
@@ -44271,9 +44269,6 @@
 /obj/storage/crate{
 	desc = "A crate of confiscated items.";
 	name = "Contraband"
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /obj/item/item_box/no{
 	pixel_x = -8;
@@ -58794,6 +58789,15 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
+"lie" = (
+/obj/storage/secure/closet/brig,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/main)
 "ljx" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 2;
@@ -124926,7 +124930,7 @@ axX
 cAL
 niB
 cAR
-cfg
+lie
 avD
 bTX
 cAM


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME-OBJECTS] [QoL] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR does three things:

- If a map has contraband lockers in its security department's main room or similar, removes them and places them in the back.
- If a map only has one locker, add another. (Clarion didn't have space...)
- If there's no light tubes/bulbs above one of the lockers, add one. If there's no switch in the room add one.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I believe contraband lockers should be located in the back of a security department if possible, as stealing back lost loot should be encouraged. I also think adding a light tube above them makes that form of breaking lockers more obvious.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CalliopeSoups
(+)Contraband lockers have been re-located to the back rooms of most security departments. This is sure to deter theft as nobody goes back there!
