### PR TITLE
Fixes cyborgs from stutter when closed in a door.

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -923,7 +923,7 @@
 
 	last_words = message
 
-	if (src.stuttering)
+	if (src.stuttering && !isrobot(src))
 		message = stutter(message)
 
 	if (src.get_brain_damage() >= 60)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pull request stops cyborgs from stuttering when a closed in a door.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cyborgs would previously stutter. This change makes it to where before making someone stutter it checks if the player is a cyborg. (Fixes #19944)

