### PR TITLE
Slight documentation addition, proc name change for code clarity

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -249,14 +249,16 @@
 		if (!obj_turf)
 			return FALSE
 		for (var/obj/O in obj_turf)
-			if (src.constructible_check(O))
+			if (src.should_ignore_dense_check(O))
 				continue
 			if (O.density)
 				boutput(owner, SPAN_ALERT("You try to build \the [obj_name], but there's \the [O] in the way!"))
 				return TRUE
 		return FALSE
 
-	proc/constructible_check(var/obj/O)
+	/// Check if the object is one of a dense object which is an exception to most others -- and should be allowed to have
+	/// several of its own instances on a tile. Girders, thin windows, and railings are all examples of this.
+	proc/should_ignore_dense_check(var/obj/O)
 		// girder for soul, window for thindow (fuck thindow) <- ((I have no idea what this means))
 		return istype(O, /obj/structure/girder) || istype(O, /obj/window) || istype(O, /obj/railing)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Someone was musing about a weird comment (which I recognized as partly my own) and it turns out that the new proc which was extracted from the boolean check previously within has_dense_object() is a bit hard to understand the purpose of.

This just adds a small doc comment and proc name change to make it clearer on what exactly the purpose and function of that proc is -- constructible_check() is ambiguous, but should_ignore_dense_check() adequately explains that the code returns true for these objects _because_ they are exempt to the density check.

The previous comment is still funny, so I left it in there since there's no harm to keeping it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Improves readability of code.

