### PR TITLE
Fix old newspaper set not giving correct amount of newspapers

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -2004,8 +2004,7 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 	desc = "A bunch of old newspapers that we wanted to get rid of. Please take them off our hands."
 	cost = PAY_TRADESMAN
 	containername = "Newspaper Crate"
-	contains = list(/obj/item/paper/newspaper/rolled)
-	amount = 8
+	contains = list(/obj/item/paper/newspaper/rolled = 8)
 	containertype = /obj/storage/crate/packing
 
 /datum/supply_packs/electricguitar


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
For cargo supply packs, `amount` is for stacks of stuff, instead make the contents include eight separate newspapers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #20055