### PR TITLE
Terrainify Re-Entry

### DIFF
--- a/code/modules/admin/terrainify.dm
+++ b/code/modules/admin/terrainify.dm
@@ -260,7 +260,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 				var/mob/player_mob = C.mob
 				if(istype(player_mob) && player_mob.z == Z_LEVEL_STATION)
 					SPAWN(0)
-						shake_camera(player_mob, 20 SECONDS, rand(55,85))
+						shake_camera(player_mob, 20 SECONDS, rand(20,40))
 					player_mob.changeStatus("knockdown", 2 SECONDS)
 
 		return
@@ -274,7 +274,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 				var/mob/player_mob = C.mob
 				if(istype(player_mob) && player_mob.z == Z_LEVEL_STATION)
 					SPAWN(0)
-						shake_camera(player_mob, 5 SECONDS, rand(55,85))
+						shake_camera(player_mob, 4 SECONDS, rand(55,85))
 					player_mob.changeStatus("knockdown", 5 SECONDS)
 
 		REMOVE_PARALLAX_RENDER_SOURCE_FROM_GROUP(Z_LEVEL_STATION, list(/atom/movable/screen/parallax_render_source/foreground/embers/atmosphere_entry, /atom/movable/screen/parallax_render_source/foreground/snow/atmosphere_entry), 10 SECONDS)

--- a/code/modules/admin/terrainify.dm
+++ b/code/modules/admin/terrainify.dm
@@ -193,6 +193,16 @@ var/datum/station_zlevel_repair/station_repair = new
 			ST.update_nearby_tiles(need_rebuild=TRUE)
 			LAGCHECK(LAG_MED)
 
+/atom/movable/screen/parallax_render_source/foreground/embers/atmosphere_entry
+	color = list(
+		1, 0, 0, -0.1,
+		0, 1, 0, -0.1,
+		0, 0, 1, -0.1,
+		0, 0, 0, 1,
+		0, 0, 0, 0)
+
+/atom/movable/screen/parallax_render_source/foreground/snow/atmosphere_entry
+
 ABSTRACT_TYPE(/datum/terrainify)
 /datum/terrainify
 	var/name
@@ -202,6 +212,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 	var/static/datum/terrainify/terrainify_lock
 	var/allow_underwater = FALSE
 	var/syndi_camo_color = null
+	var/ambient_color
 
 	New()
 		..()
@@ -224,6 +235,50 @@ ABSTRACT_TYPE(/datum/terrainify)
 			.[option] = src.additional_options[option][1]
 		.["vehicle"] = TERRAINIFY_ALLOW_VEHCILES
 
+	proc/perform_terrainify(params, mob/user)
+		USR_ADMIN_ONLY
+		pre_convert(params, user)
+		convert_station_level(params, user)
+		post_convert(params, user)
+
+	proc/pre_convert(params, mob/user)
+		if(src.ambient_color)
+			if(params["Ambient Light Obj"])
+				station_repair.ambient_obj = station_repair.ambient_obj || new /obj/ambient
+				station_repair.ambient_obj.color = src.ambient_color
+			else
+				station_repair.ambient_light = new /image/ambient
+				station_repair.ambient_light.color = src.ambient_color
+
+
+		if(current_state >= GAME_STATE_PLAYING && params["Re-Entry"])
+			REMOVE_ALL_PARALLAX_RENDER_SOURCES_FROM_GROUP(Z_LEVEL_STATION)
+			var/list/parallax_layers = list(/atom/movable/screen/parallax_render_source/foreground/embers/atmosphere_entry, /atom/movable/screen/parallax_render_source/foreground/snow/atmosphere_entry)
+			ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, parallax_layers, 2 SECONDS)
+
+			for (var/client/C in clients)
+				var/mob/player_mob = C.mob
+				if(istype(player_mob) && player_mob.z == Z_LEVEL_STATION)
+					SPAWN(0)
+						shake_camera(player_mob, 20 SECONDS, rand(55,85))
+					player_mob.changeStatus("knockdown", 2 SECONDS)
+
+		return
+
+	proc/post_convert(params, mob/user)
+		if(params["Prefabs"])
+			place_prefabs(10)
+
+		if(current_state >= GAME_STATE_PLAYING && params["Re-Entry"])
+			for (var/client/C in clients)
+				var/mob/player_mob = C.mob
+				if(istype(player_mob) && player_mob.z == Z_LEVEL_STATION)
+					SPAWN(0)
+						shake_camera(player_mob, 5 SECONDS, rand(55,85))
+					player_mob.changeStatus("knockdown", 5 SECONDS)
+
+		REMOVE_PARALLAX_RENDER_SOURCE_FROM_GROUP(Z_LEVEL_STATION, list(/atom/movable/screen/parallax_render_source/foreground/embers/atmosphere_entry, /atom/movable/screen/parallax_render_source/foreground/snow/atmosphere_entry), 10 SECONDS)
+		return
 
 	proc/convert_station_level(params, mob/user)
 		USR_ADMIN_ONLY
@@ -343,14 +398,35 @@ ABSTRACT_TYPE(/datum/terrainify)
 					logTheThing(LOG_DEBUG, null, "Prefab Z1 placement #[n] [P.type] failed due to maximum tries [maxTries][P.required?" WARNING: REQUIRED FAILED":""].")
 			else break
 
-	proc/convert_turfs(list/turfs)
+	proc/convert_turfs(list/turfs, params)
 		station_repair.station_generator.generate_terrain(turfs, flags=MAPGEN_ALLOW_VEHICLES * station_repair.allows_vehicles)
+
+		for(var/turf/T as anything in turfs)
+			if(station_repair.ambient_light)
+				T.AddOverlays(station_repair.ambient_light, "ambient")
+			if(station_repair.ambient_obj)
+				T.vis_contents |= station_repair.ambient_obj
+			if(station_repair.weather_img)
+				T.AddOverlays(station_repair.weather_img, "weather")
+			if(station_repair.weather_effect)
+				var/obj/effects/E = locate(station_repair.weather_effect) in T
+				if(!E)
+					new station_repair.weather_effect(T)
+			T.ClearSpecificOverlays("foreground_parallax_occlusion_overlay")
+
+		if(params["Prefabs"])
+			place_prefabs(10)
+
+		station_repair.clean_up_station_level(params["vehicle"] & TERRAINIFY_VEHICLE_CARS, params["vehicle"] & TERRAINIFY_VEHICLE_FABS, season=params["Season"])
+
+		handle_mining(params, turfs)
 
 /datum/terrainify/desertify
 	name = "Desert Station"
 	desc = "Turn space into into a nice desert full of sand and stones."
 	additional_options = list("Mining"=list("None","Normal","Rich"))
-	additional_toggles = list("Ambient Light Obj"=TRUE, "Prefabs"=FALSE)
+	additional_toggles = list("Ambient Light Obj"=TRUE, "Prefabs"=FALSE, "Re-Entry"=FALSE)
+	ambient_color = "#cfcfcf"
 
 	New()
 		syndi_camo_color = list(nuke_op_color_matrix[1], "#efc998", nuke_op_color_matrix[3])
@@ -358,28 +434,13 @@ ABSTRACT_TYPE(/datum/terrainify)
 
 	convert_station_level(params, mob/user)
 		if(..())
-			var/const/ambient_light = "#cfcfcf"
 			station_repair.station_generator = new/datum/map_generator/desert_generator
-			if(params["Ambient Light Obj"])
-				station_repair.ambient_obj = station_repair.ambient_obj || new /obj/ambient
-				station_repair.ambient_obj.color = ambient_light
-			else
-				station_repair.ambient_light = new /image/ambient
-				station_repair.ambient_light.color = ambient_light
 			station_repair.default_air.temperature = 330
 
 			var/list/space = list()
 			for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
 				space += S
-			convert_turfs(space)
-			for (var/turf/S in space)
-				if(params["Ambient Light Obj"])
-					S.vis_contents |= station_repair.ambient_obj
-				else
-					S.AddOverlays(station_repair.ambient_light, "ambient")
-
-			station_repair.clean_up_station_level(params["vehicle"] & TERRAINIFY_VEHICLE_CARS, params["vehicle"] & TERRAINIFY_VEHICLE_FABS)
-			handle_mining(params, space)
+			convert_turfs(space, params)
 
 			log_terrainify(user, "turned space into a desert.")
 
@@ -387,26 +448,19 @@ ABSTRACT_TYPE(/datum/terrainify)
 	name = "Underground Station"
 	desc = "Turns space into a cave system"
 	additional_options = list("Mining"=list("None","Normal","Rich"), "Bioluminescent Algae Coverage"=list("None", "Normal", "Heavy", "Extreme", "All"))
-	additional_toggles = list("Ambient Light Obj"=TRUE, "Prefabs"=FALSE, "Asteroid"=FALSE)
+	additional_toggles = list("Ambient Light Obj"=TRUE, "Prefabs"=FALSE, "Asteroid"=FALSE, "Re-Entry"=FALSE)
+	ambient_color = "#222222"
 
 	New()
 		..()
 
 	convert_station_level(params, mob/user)
 		if(..())
-			var/const/ambient_light = "#222222"
 
 			if(params["Asteroid"])
 				station_repair.station_generator = new/datum/map_generator/cave_generator/asteroid
 			else
 				station_repair.station_generator = new/datum/map_generator/cave_generator
-
-			if(params["Ambient Light Obj"])
-				station_repair.ambient_obj = station_repair.ambient_obj || new /obj/ambient
-				station_repair.ambient_obj.color = ambient_light
-			else
-				station_repair.ambient_light = new /image/ambient
-				station_repair.ambient_light.color = ambient_light
 
 			var/algae_coverage = 0
 			switch(params["Bioluminescent Algae Coverage"])
@@ -438,18 +492,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 			var/list/space = list()
 			for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
 				space += S
-			convert_turfs(space)
-			for (var/turf/S in space)
-				if(params["Ambient Light Obj"])
-					S.vis_contents |= station_repair.ambient_obj
-				else
-					S.AddOverlays(station_repair.ambient_light, "ambient")
-
-			if(params["Prefabs"])
-				place_prefabs(10)
-
-			station_repair.clean_up_station_level(params["vehicle"] & TERRAINIFY_VEHICLE_CARS, params["vehicle"] & TERRAINIFY_VEHICLE_FABS)
-			handle_mining(params, space)
+			convert_turfs(space, params)
 
 			log_terrainify(user, "turned space into a caves.")
 
@@ -469,12 +512,9 @@ ABSTRACT_TYPE(/datum/terrainify)
 
 			log_terrainify( "turned space into an THE VOID.")
 
-
-
 /proc/generate_void(all_z_levels = FALSE)
 	station_repair.ambient_light = new /image/ambient
 	station_repair.ambient_light.color = rgb(6.9, 4.20, 6.9)
-
 	station_repair.station_generator = new/datum/map_generator/void_generator
 
 	var/list/space = list()
@@ -528,11 +568,12 @@ ABSTRACT_TYPE(/datum/terrainify)
 			station_repair.default_air.oxygen = 0
 			station_repair.default_air.temperature = 100
 
-			if(!params["Pitch Black"])
-				station_repair.ambient_light = new /image/ambient
+			if(params["Pitch Black"])
+				station_repair.ambient_light = null
 
 			station_repair.station_generator = new/datum/map_generator/icemoon_generator
 
+			// Path to market does not need to be cleared because it was converted to ice.  Abyss will screw up everything!
 			var/list/turf/traveling_crate_turfs = station_repair.get_turfs_to_fix()
 			for(var/turf/space/T in traveling_crate_turfs)
 				T.ReplaceWith(/turf/unsimulated/floor/arctic/snow/ice)
@@ -547,7 +588,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 			var/list/space = list()
 			for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
 				space += S
-			convert_turfs(space)
+			convert_turfs(space, params)
 			for (var/turf/S in space)
 				if(snow)
 					if(snow == "Yes")
@@ -558,9 +599,8 @@ ABSTRACT_TYPE(/datum/terrainify)
 					ambient_value = lerp(10,50,min(1-S.x/300,0.8))
 					station_repair.ambient_light.color = rgb(ambient_value,ambient_value+((rand()*1)),ambient_value+((rand()*1))) //randomly shift green&blue to reduce vertical banding
 					S.AddOverlays(station_repair.ambient_light, "ambient")
-			// Path to market does not need to be cleared because it was converted to ice.  Abyss will screw up everything!
+
 			REMOVE_ALL_PARALLAX_RENDER_SOURCES_FROM_GROUP(Z_LEVEL_STATION)
-			handle_mining(params, space)
 
 			log_terrainify(user, "turned space into an another outpost on Theta.")
 
@@ -595,13 +635,11 @@ ABSTRACT_TYPE(/datum/terrainify)
 			var/list/space = list()
 			for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
 				space += S
-			convert_turfs(space)
+			convert_turfs(space, params)
 
 			REMOVE_ALL_PARALLAX_RENDER_SOURCES_FROM_GROUP(Z_LEVEL_STATION)
 			var/list/parallax_layers = list(/atom/movable/screen/parallax_render_source/foreground/embers)
 			ADD_PARALLAX_RENDER_SOURCE_TO_GROUP(Z_LEVEL_STATION, parallax_layers, 0 SECONDS)
-
-			handle_mining(params, space)
 
 			log_terrainify(user, "turned space into an another outpost on Io.")
 
@@ -610,7 +648,8 @@ ABSTRACT_TYPE(/datum/terrainify)
 	name = "Swamp Station"
 	desc = "Turns space into a swamp"
 	additional_options = list("Rain"=list("No", "Yes", "Particles"), "Mining"=list("None","Normal","Rich"))
-	additional_toggles = list("Ambient Light Obj"=TRUE, "Prefabs"=FALSE)
+	additional_toggles = list("Ambient Light Obj"=TRUE, "Prefabs"=FALSE, "Re-Entry"=FALSE)
+	ambient_color = "#222222"
 
 	New()
 		syndi_camo_color = list(nuke_op_color_matrix[1], "#6f7026", nuke_op_color_matrix[3])
@@ -618,7 +657,6 @@ ABSTRACT_TYPE(/datum/terrainify)
 
 	convert_station_level(params, mob/user)
 		if(..())
-			var/const/ambient_light = "#222222"
 			var/rain = params["Rain"]
 			rain = (rain == "No") ? null : rain
 
@@ -631,37 +669,22 @@ ABSTRACT_TYPE(/datum/terrainify)
 			else if(rain)
 				station_repair.weather_effect = /obj/effects/precipitation/rain/sideways/tile
 
-
-			if(params["Ambient Light Obj"])
-				station_repair.ambient_obj = station_repair.ambient_obj || new /obj/ambient
-				station_repair.ambient_obj.color = ambient_light
-			else
-				station_repair.ambient_light = new /image/ambient
-				station_repair.ambient_light.color = ambient_light
-
-
 			var/list/space = list()
 			for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
 				space += S
-			convert_turfs(space)
-			for (var/turf/S in space)
-				if(rain)
+			convert_turfs(space, params)
+			if(rain)
+				for (var/turf/S in space)
 					if(istype(S,/turf/unsimulated/floor/auto/swamp))
 						S.ReplaceWith(/turf/unsimulated/floor/auto/swamp/rain, force=TRUE)
-					if(rain == "Yes")
-						S.AddOverlays(station_repair.weather_img, "rain")
-					else
-						new station_repair.weather_effect(S)
-				if(params["Ambient Light Obj"])
-					S.vis_contents |= station_repair.ambient_obj
-				else
-					S.AddOverlays(station_repair.ambient_light, "ambient")
-
-			if(params["Prefabs"])
-				place_prefabs(10)
-
-			station_repair.clean_up_station_level(params["vehicle"] & TERRAINIFY_VEHICLE_CARS, params["vehicle"] & TERRAINIFY_VEHICLE_FABS)
-			handle_mining(params, space)
+						if(rain == "Yes")
+							S.AddOverlays(station_repair.weather_img, "rain")
+						else
+							new station_repair.weather_effect(S)
+						if(params["Ambient Light Obj"])
+							S.vis_contents |= station_repair.ambient_obj
+						else
+							S.AddOverlays(station_repair.ambient_light, "ambient")
 
 			log_terrainify(user, "turned space into a swamp.")
 
@@ -671,24 +694,16 @@ ABSTRACT_TYPE(/datum/terrainify)
 	desc = "Turns space into Mars.  A sprawl of stand, stone, and an unyielding wind."
 	additional_options = list("Mining"=list("None","Normal","Rich"))
 	additional_toggles = list("Ambient Light Obj"=FALSE, "Duststorm"=TRUE, "Prefabs"=FALSE)
+	ambient_color = "#222222"
 
 	convert_station_level(params, mob/user)
 		if(..())
-			var/ambient_value
-
 			if(params["Duststorm"])
 				station_repair.station_generator = new/datum/map_generator/mars_generator/duststorm
 				station_repair.weather_img = image(icon = 'icons/turf/areas.dmi', icon_state = "dustverlay", layer = EFFECTS_LAYER_BASE)
 			else
 				station_repair.station_generator = new/datum/map_generator/mars_generator
 			station_repair.overlay_delay = 3.5 SECONDS // Delay to let rocks cull
-
-			if(params["Ambient Light Obj"])
-				station_repair.ambient_obj = station_repair.ambient_obj || new /obj/ambient
-				var/const/ambient_light = "#222222"
-				station_repair.ambient_obj.color = ambient_light
-			else
-				station_repair.ambient_light = new /image/ambient
 
 			station_repair.default_air.carbon_dioxide = 500
 			station_repair.default_air.nitrogen = 0
@@ -698,9 +713,10 @@ ABSTRACT_TYPE(/datum/terrainify)
 			var/list/space = list()
 			for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
 				space += S
-			convert_turfs(space)
+			convert_turfs(space, params)
 			sleep(3 SECONDS) // Let turfs initialize and re-orient before applying overlays
 
+			var/ambient_value
 			for (var/turf/S in space)
 				S.UpdateOverlays(station_repair.weather_img, "weather")
 
@@ -736,8 +752,6 @@ ABSTRACT_TYPE(/datum/terrainify)
 				ambient_value = lerp(20,80,0.5)
 				station_repair.ambient_light.color = rgb(ambient_value+((rand()*3)),ambient_value,ambient_value)
 
-			handle_mining(params, space)
-
 			log_terrainify(user, "turned space into Mars.")
 
 	special_repair(list/turf/TS)
@@ -751,7 +765,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 /datum/terrainify/trenchify
 	name = "Trench Station"
 	desc = "Generates trench caves on the station Z"
-	additional_toggles = list("Hostile Mobs"=TRUE)
+	additional_toggles = list("Hostile Mobs"=TRUE, "Re-Entry"=FALSE)
 	allow_underwater = TRUE
 
 	convert_station_level(params, mob/user)
@@ -820,7 +834,8 @@ ABSTRACT_TYPE(/datum/terrainify)
 	name = "Winter Station"
 	desc = "Turns space into a colder snowy place"
 	additional_options = list("Weather"=list("Snow", "Light Snow", "None"), "Mining"=list("None","Normal","Rich"), "Season"=list("None", "Winter"))
-	additional_toggles = list("Ambient Light Obj"=TRUE, "Prefabs"=FALSE)
+	additional_toggles = list("Ambient Light Obj"=TRUE, "Prefabs"=FALSE, "Re-Entry"=FALSE)
+	ambient_color = "#222222"
 
 	New()
 		syndi_camo_color = list("#50587a", "#bbdbdd", nuke_op_color_matrix[3])
@@ -828,16 +843,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 
 	convert_station_level(params, mob/user)
 		if(..())
-			var/const/ambient_light = "#222"
 			station_repair.station_generator = new/datum/map_generator/snow_generator
-
-			if(params["Ambient Light Obj"])
-				station_repair.ambient_obj = station_repair.ambient_obj || new /obj/ambient
-				station_repair.ambient_obj.color = ambient_light
-			else
-				station_repair.ambient_light = new /image/ambient
-				station_repair.ambient_light.color = ambient_light
-
 			station_repair.default_air.temperature = 235
 
 			var/snow = params["Weather"]
@@ -850,20 +856,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 			var/list/space = list()
 			for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
 				space += S
-			convert_turfs(space)
-			for (var/turf/S as anything in space)
-				if(params["Ambient Light Obj"])
-					S.vis_contents |= station_repair.ambient_obj
-				else
-					S.AddOverlays(station_repair.ambient_light, "ambient")
-				if(snow)
-					new station_repair.weather_effect(S)
-
-			if(params["Prefabs"])
-				place_prefabs(10)
-
-			station_repair.clean_up_station_level(params["vehicle"] & TERRAINIFY_VEHICLE_CARS, params["vehicle"] & TERRAINIFY_VEHICLE_FABS, season=params["Season"])
-			handle_mining(params, space)
+			convert_turfs(space, params)
 
 			log_terrainify(user, "turned space into a snowscape.")
 
@@ -871,7 +864,8 @@ ABSTRACT_TYPE(/datum/terrainify)
 	name = "Forest Station"
 	desc = "Turns space into a lush and wooden place"
 	additional_options = list("Mining"=list("None", "Normal", "Rich"), "Season"=list("None", "Autumn"))
-	additional_toggles = list("Ambient Light Obj"=TRUE, "Prefabs"=FALSE, "Spooky"=FALSE)
+	additional_toggles = list("Ambient Light Obj"=TRUE, "Prefabs"=FALSE, "Spooky"=FALSE, "Re-Entry"=FALSE)
+	ambient_color = "#211"
 
 	New()
 		syndi_camo_color = list(nuke_op_color_matrix[1], "#3d8f29", nuke_op_color_matrix[3])
@@ -879,35 +873,15 @@ ABSTRACT_TYPE(/datum/terrainify)
 
 	convert_station_level(params, mob/user)
 		if(..())
-			var/const/ambient_light = "#211"
-
 			if(params["Spooky"])
 				station_repair.station_generator = new/datum/map_generator/forest_generator/dark
 			else
 				station_repair.station_generator = new/datum/map_generator/forest_generator
 
-			if(params["Ambient Light Obj"])
-				station_repair.ambient_obj = station_repair.ambient_obj || new /obj/ambient
-				station_repair.ambient_obj.color = ambient_light
-			else
-				station_repair.ambient_light = new /image/ambient
-				station_repair.ambient_light.color = ambient_light
-
 			var/list/space = list()
 			for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
 				space += S
-			convert_turfs(space)
-			for (var/turf/S as anything in space)
-				if(params["Ambient Light Obj"])
-					S.vis_contents |= station_repair.ambient_obj
-				else
-					S.AddOverlays(station_repair.ambient_light, "ambient")
-
-			if(params["Prefabs"])
-				place_prefabs(10)
-
-			station_repair.clean_up_station_level(params["vehicle"] & TERRAINIFY_VEHICLE_CARS, params["vehicle"] & TERRAINIFY_VEHICLE_FABS, season=params["Season"])
-			handle_mining(params, space)
+			convert_turfs(space, params)
 
 			if(params["Spooky"])
 				// The following should be removed iff Caustics Parallax #16477 is merged
@@ -939,7 +913,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 		var/list/turf/space = list()
 		for(var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
 			space += S
-		convert_turfs(space)
+		convert_turfs(space, params)
 
 		log_terrainify(user, "turned space into a plasma space.")
 
@@ -1083,7 +1057,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 			convert_params["vehicle"] = (TERRAINIFY_VEHICLE_CARS * cars) + (TERRAINIFY_VEHICLE_FABS * fabricator) + (TERRAINIFY_ALLOW_VEHCILES * allowVehicles)
 			var/datum/terrainify/T = locate(terrain) in terrains
 			if(T)
-				T.convert_station_level(convert_params, ui.user)
+				T.perform_terrainify(convert_params, ui.user)
 				tgui_process.close_uis(src)
 				T.terrainify_lock = null
 				. = TRUE

--- a/code/modules/admin/terrainify.dm
+++ b/code/modules/admin/terrainify.dm
@@ -277,7 +277,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 						shake_camera(player_mob, 4 SECONDS, rand(55,85))
 					player_mob.changeStatus("knockdown", 5 SECONDS)
 
-		REMOVE_PARALLAX_RENDER_SOURCE_FROM_GROUP(Z_LEVEL_STATION, list(/atom/movable/screen/parallax_render_source/foreground/embers/atmosphere_entry, /atom/movable/screen/parallax_render_source/foreground/snow/atmosphere_entry), 10 SECONDS)
+			REMOVE_PARALLAX_RENDER_SOURCE_FROM_GROUP(Z_LEVEL_STATION, list(/atom/movable/screen/parallax_render_source/foreground/embers/atmosphere_entry, /atom/movable/screen/parallax_render_source/foreground/snow/atmosphere_entry), 10 SECONDS)
 		return
 
 	proc/convert_station_level(params, mob/user)

--- a/code/modules/worldgen/mapgen/JungleGenerator.dm
+++ b/code/modules/worldgen/mapgen/JungleGenerator.dm
@@ -117,6 +117,9 @@
 
 				air.temperature = temperature
 
+		if(station_repair.allows_vehicles)
+			src.allows_vehicles = station_repair.allows_vehicles
+
 		return src
 
 /turf/unsimulated/floor/plating/asteroid/mountain

--- a/code/modules/worldgen/prefab/mining/planet.dm
+++ b/code/modules/worldgen/prefab/mining/planet.dm
@@ -165,8 +165,8 @@ ABSTRACT_TYPE(/datum/mapPrefab/planet)
 		prefabPath = "assets/maps/prefabs/planet/prefab_syndicate_taken_factory.dmm"
 		prefabSizeX = 20
 		prefabSizeY = 20
-		maxNum = 2
-		probability = 30
+		maxNum = 1
+		probability = 15
 
 	rogue_syndicate
 		maxNum = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Example:
https://cdn.discordapp.com/attachments/834308203041783868/1264719658741792910/Re-Entry_Proto01.mp4?ex=669ee577&is=669d93f7&hm=ac6562519fb3a302eddeff558ec2d089254a10a3b9e7b5f7bf245404a6d4f2ad&

Allows for a Re-Entry effect to block vision outside the station while shaking the station during re-entry and then making contact with the planet.  Allow for storytelling to involve crash landing on a planet.

Large refactor to eliminate a lot of duplicate code.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
@cogwerks brought this up as an idea
Cleans up some Terrainify code.
