### PR TITLE
Place MechComps to turf and snap them to a neat grid

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -496,7 +496,7 @@
 
 	pixelaction(atom/target, params, mob/user)
 		var/turf/hit_turf = target
-		if (!istype(hit_turf) || !hit_turf || GET_DIST(hit_turf, user) > 1)
+		if (!istype(hit_turf) || !hit_turf || hit_turf.density || !can_reach(user, hit_turf))
 			..()
 			return FALSE
 		src.place_to_turf_by_grid(user, params, hit_turf, grid = 2, centered = 1, offsetx = 0, offsety = 2)

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -498,12 +498,8 @@
 		var/turf/hit_turf = target
 		if (!istype(hit_turf) || !hit_turf || GET_DIST(hit_turf, user) > 1)
 			..()
-			return 0
+			return FALSE
 		src.place_to_turf_by_grid(user, params, hit_turf, grid = 2, centered = 1, offsetx = 0, offsety = 2)
-		//user.next_click = world.time //get rid of click delay so we can place stuff fast
-		//if (params && islist(params))
-		//boutput(user, params)
-
 
 	pick_up_by(var/mob/M)
 		if(level == OVERFLOOR) return ..()

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -499,7 +499,7 @@
 		if (!istype(hit_turf) || !hit_turf || GET_DIST(hit_turf, user) > 1)
 			..()
 			return 0
-		src.place_to_turf_by_grid(user, params, hit_turf)
+		src.place_to_turf_by_grid(user, params, hit_turf, grid = 2, centered = 1, offsetx = 0, offsety = 2)
 		//user.next_click = world.time //get rid of click delay so we can place stuff fast
 		//if (params && islist(params))
 		//boutput(user, params)

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -494,6 +494,15 @@
 			return 1
 		return ..()
 
+	pixelaction(atom/target, mob/user)
+		var/turf/hit_turf = target
+		if (!istype(hit_turf) || !hit_turf || GET_DIST(hit_turf, user) > 1)
+			..()
+			return 0
+		//get rid of click delay so we can place stuff fast
+		user.next_click = world.time
+
+
 	pick_up_by(var/mob/M)
 		if(level == OVERFLOOR) return ..()
 		//If it's anchored, it can't be picked up!

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -494,13 +494,15 @@
 			return 1
 		return ..()
 
-	pixelaction(atom/target, mob/user)
+	pixelaction(atom/target, params, mob/user)
 		var/turf/hit_turf = target
 		if (!istype(hit_turf) || !hit_turf || GET_DIST(hit_turf, user) > 1)
 			..()
 			return 0
-		//get rid of click delay so we can place stuff fast
-		user.next_click = world.time
+		src.place_to_turf_by_grid(user, params, hit_turf)
+		//user.next_click = world.time //get rid of click delay so we can place stuff fast
+		//if (params && islist(params))
+		//boutput(user, params)
 
 
 	pick_up_by(var/mob/M)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1788,9 +1788,6 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 			var/grid32 = (32 / grid)
 			var/gridx = round( round((text2num(params["icon-x"]) - 16) / grid32) * grid32 + grid32 / 2 * centered)
 			var/gridy = round( round((text2num(params["icon-y"]) - 16) / grid32) * grid32 + grid32 / 2 * centered)
-
 			src.pixel_x = gridx + offsetx
 			src.pixel_y = gridy + offsety
-			boutput(user, params["icon-x"])
-			boutput(user, params["icon-y"])
 		. = TRUE

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1786,8 +1786,9 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 		src.set_loc(target)
 		if (islist(params) && params["icon-y"] && params["icon-x"])
 			var/grid32 = (32 / grid)
-			var/gridx = round( round((text2num(params["icon-x"]) - 16) / grid32, 1) * grid32 + grid32 / 2 * centered, 1)
-			var/gridy = round( round((text2num(params["icon-y"]) - 16) / grid32, 1) * grid32 + grid32 / 2 * centered, 1)
-			src.pixel_x = gridx + offsetx
-			src.pixel_y = gridy + offsety
+			// the inner round is flooring, the outer round is rounding, yes that's right
+			var/gridx = round( round((text2num(params["icon-x"])) / grid32) * grid32 + grid32 / 2 * centered, 1)
+			var/gridy = round( round((text2num(params["icon-y"])) / grid32) * grid32 + grid32 / 2 * centered, 1)
+			src.pixel_x = gridx + offsetx - 16 // -16 to center the sprite
+			src.pixel_y = gridy + offsety - 16
 		. = TRUE

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1786,8 +1786,11 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 		src.set_loc(target)
 		if (islist(params) && params["icon-y"] && params["icon-x"])
 			var/grid32 = (32 / grid)
-			var/gridx = round( round((text2num(params["icon-x"]) - 16) / grid32) * grid32 + grid32 / 2 * centered)
-			var/gridy = round( round((text2num(params["icon-y"]) - 16) / grid32) * grid32 + grid32 / 2 * centered)
+			var/gridx = round( round((text2num(params["icon-x"]) - 16) / grid32, 1) * grid32 + grid32 / 2 * centered, 1)
+			var/gridy = round( round((text2num(params["icon-y"]) - 16) / grid32, 1) * grid32 + grid32 / 2 * centered, 1)
 			src.pixel_x = gridx + offsetx
 			src.pixel_y = gridy + offsety
+			boutput(user, "gridX: [gridx] // gridY: [gridy]")
+			boutput(user, "icon-x: [params["icon-x"]] // icon-y: [params["icon-y"]]")
+			boutput(user, "roundx: [round((text2num(params["icon-x"]) - 16) / grid32)] // roundy: [round((text2num(params["icon-y"]) - 16) / grid32)]")
 		. = TRUE

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1771,8 +1771,8 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 	src.inhand_image.pixel_x = 0
 	src.inhand_image.pixel_y = hand_offset
 
+/// Move item to turf, and snap its pixel offsets to a grid of the input size.
 /obj/item/proc/place_to_turf_by_grid(mob/user, params, turf/target, grid = 2, centered = 1, offsetx = 0, offsety = 0)
-	// a nice copypaste from /obj/proc/place_on
 	. = FALSE
 	if (src && !isghostdrone(user))
 		var/dirbuffer

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1770,3 +1770,21 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 		src.inhand_image.color = src.inhand_color
 	src.inhand_image.pixel_x = 0
 	src.inhand_image.pixel_y = hand_offset
+
+/obj/item/proc/place_to_turf_by_grid(mob/user, params, turf/target, grid = 2)
+	// a nice copypaste from /obj/proc/place_on
+	. = FALSE
+	if (src && !isghostdrone(user))
+		var/dirbuffer
+		dirbuffer = src.dir
+		if (user)
+			if (src.cant_drop)
+				return
+			user.drop_item()
+		if(src.dir != dirbuffer)
+			src.set_dir(dirbuffer)
+		src.set_loc(target)
+		if (islist(params) && params["icon-y"] && params["icon-x"])
+			src.pixel_x = text2num(params["icon-x"]) - 16
+			src.pixel_y = text2num(params["icon-y"]) - 16
+		. = TRUE

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1790,7 +1790,4 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 			var/gridy = round( round((text2num(params["icon-y"]) - 16) / grid32, 1) * grid32 + grid32 / 2 * centered, 1)
 			src.pixel_x = gridx + offsetx
 			src.pixel_y = gridy + offsety
-			boutput(user, "gridX: [gridx] // gridY: [gridy]")
-			boutput(user, "icon-x: [params["icon-x"]] // icon-y: [params["icon-y"]]")
-			boutput(user, "roundx: [round((text2num(params["icon-x"]) - 16) / grid32)] // roundy: [round((text2num(params["icon-y"]) - 16) / grid32)]")
 		. = TRUE

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1771,7 +1771,7 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 	src.inhand_image.pixel_x = 0
 	src.inhand_image.pixel_y = hand_offset
 
-/obj/item/proc/place_to_turf_by_grid(mob/user, params, turf/target, grid = 2)
+/obj/item/proc/place_to_turf_by_grid(mob/user, params, turf/target, grid = 2, centered = 1, offsetx = 0, offsety = 0)
 	// a nice copypaste from /obj/proc/place_on
 	. = FALSE
 	if (src && !isghostdrone(user))
@@ -1785,6 +1785,12 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 			src.set_dir(dirbuffer)
 		src.set_loc(target)
 		if (islist(params) && params["icon-y"] && params["icon-x"])
-			src.pixel_x = text2num(params["icon-x"]) - 16
-			src.pixel_y = text2num(params["icon-y"]) - 16
+			var/grid32 = (32 / grid)
+			var/gridx = round( round((text2num(params["icon-x"]) - 16) / grid32) * grid32 + grid32 / 2 * centered)
+			var/gridy = round( round((text2num(params["icon-y"]) - 16) / grid32) * grid32 + grid32 / 2 * centered)
+
+			src.pixel_x = gridx + offsetx
+			src.pixel_y = gridy + offsety
+			boutput(user, params["icon-x"])
+			boutput(user, params["icon-y"])
 		. = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
You can now click on the floor while holding a MechComp to put it on the floor, snapping its pixel offset to a 2x2 grid.
Also adds the generalized /obj/item/proc/place_to_turf_by_grid() and uses it for the above feature.

Parts of the new proc, such as the valid/sanity checks, are copied from /obj/proc/place_on.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If my mech comp monstrosities don't look pretty and neat then what's the point?

![image](https://github.com/user-attachments/assets/d0d9aedf-3ed3-4acd-8795-8090710b5115)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Smilg
(*)You can now hit the floor with MechComps to place them on a neat 2x2 grid.
```
