### PR TITLE
Earnable Agent B and Methane canisters for Toxin Lab

### DIFF
--- a/code/modules/atmospherics/portable/canister.dm
+++ b/code/modules/atmospherics/portable/canister.dm
@@ -124,6 +124,12 @@ ADMIN_INTERACT_PROCS(/obj/machinery/portable_atmospherics/canister, proc/toggle_
 	icon_state = "darkgreen"
 	casecolor = "darkgreen"
 
+/obj/machinery/portable_atmospherics/canister/agentb
+	name = "Canister \[Agent B\]"
+	icon_state = "bluish"
+	casecolor = "bluish"
+	volume = 500
+
 /obj/machinery/portable_atmospherics/canister/update_icon()
 	if (src.destroyed)
 		src.icon_state = "[src.casecolor]-1"
@@ -797,5 +803,12 @@ ADMIN_INTERACT_PROCS(/obj/machinery/portable_atmospherics/canister, proc/toggle_
 	..()
 	if (!src.isempty)
 		src.air_contents.farts = (src.maximum_pressure*filled)*air_contents.volume/(R_IDEAL_GAS_EQUATION*air_contents.temperature)
+	src.UpdateIcon()
+	return 1
+
+/obj/machinery/portable_atmospherics/canister/agentb/New()
+	..()
+	if (!src.isempty)
+		src.air_contents.oxygen_agent_b = (src.maximum_pressure*filled)*air_contents.volume/(R_IDEAL_GAS_EQUATION*air_contents.temperature)
 	src.UpdateIcon()
 	return 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SCIENCE] [BALANCE] [FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds preset pressure crystal bounties with preset rewards.
* The planned rewards are 1 oxygen agent B canister, and 1 methane canister. Also considering 1 fallout canister.
* These bounties can only be done once per round.
* 1 bounty rewards 1 item, so there will be multiple bounties, but a predictable number of them.
* The required pressure value on the crystal will be randomized. It'll be limited to powers attainable by TTV bombs.
* As a small aside, the Agent B canister is 500L instead of the usual 1,000L. (The sprite I reused is a cute little half canister)
![image](https://github.com/user-attachments/assets/d11e7a82-69fb-4984-bddd-d9587ca26a86)


So there's the balance plan, more or less. Now here's some implementation details.

The bounties will be in a new section of the Crystal Bazaar PDA app. Like normal bounties, they're claimed simply by launching the crystal out of Cargo. In case of conflict, these special bounties will take sale priority over the standard credit bounties.
Canister delivery will also pass through Cargo. Ideally they go into card-locked science crates; you only get one canister, so you don't want it easily stolen and used for giga-fires.
It won't use the same valuation system as today's crystal sales. Instead it'll have a simple yes/no range: for example, you have to get a crystal pressure between 266 and 271. Anything outside an unclaimed bounty's range gets sent to the regular sale market.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Primarily, this adds some in-round progression to Toxin Lab. The crystal market is neat, number go up is fun, but it's just credits for Cargo. Here, we're directly linking starter Toxlab gameplay to its endgame: playing with the exotic gases, and maybe learning canister bombs.
Secondarily, it's really tedious and/or difficult to get large quantities of these gases. Especially farts which is just time-consuming button mashing. I don't know the reasons behind the difficulty, so, this is just a draft with some arguments behind it: in case canisters of these gases are a hard "no".

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Smilg
(*)placeholder
```
