### PR TITLE
sea elevator tech storage board 2

### DIFF
--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -170,6 +170,9 @@ TYPEINFO(/obj/item/circuitboard)
 /obj/item/circuitboard/chem_request_receiver
 	name = "circuit board (chemical request receiver)"
 	computertype = /obj/machinery/computer/chem_request_receiver
+/obj/item/circuitboard/sea_elevator
+	name = "circuit board (sea elevator control)"
+	computertype = /obj/machinery/computer/elevator/sea
 
 /obj/computerframe/meteorhit(obj/O as obj)
 	qdel(src)

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -405,14 +405,6 @@ ABSTRACT_TYPE(/obj/machinery/computer/elevator)
 	var/logBioeleAccident = FALSE
 	var/adminOnly = FALSE
 
-	New()
-		..()
-		var/area/top = locate(areaUpper)
-		var/turf/topshaft = top.find_middle()
-		if(topshaft.type == endTurfToLeave)
-			location = 0
-		else
-			location = 1
 
 /obj/machinery/computer/elevator/icebase
 	machine_registry_idx = MACHINES_ELEVATORICEBASE
@@ -433,6 +425,15 @@ ABSTRACT_TYPE(/obj/machinery/computer/elevator)
 	areaUpper = /area/shuttle/sea_elevator/upper
 	endTurfToLeave = /turf/simulated/floor/specialroom/sea_elevator_shaft
 	circuit_type = /obj/item/circuitboard/sea_elevator
+
+	New()
+		..()
+		var/area/top = locate(areaUpper)
+		var/turf/topshaft = top.find_middle()
+		if(topshaft.type == endTurfToLeave)
+			location = 0
+		else
+			location = 1
 
 /obj/machinery/computer/elevator/centcomm
 	machine_registry_idx = MACHINES_ELEVATORCENTCOM

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -430,7 +430,7 @@ ABSTRACT_TYPE(/obj/machinery/computer/elevator)
 		..()
 		var/area/top = locate(areaUpper)
 		var/turf/topshaft = top.find_middle()
-		if(topshaft.type == endTurfToLeave)
+		if(topshaft?.type == endTurfToLeave)
 			location = 0
 		else
 			location = 1

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -405,6 +405,15 @@ ABSTRACT_TYPE(/obj/machinery/computer/elevator)
 	var/logBioeleAccident = FALSE
 	var/adminOnly = FALSE
 
+	New()
+		..()
+		var/area/top = locate(areaUpper)
+		var/turf/topshaft = top.find_middle()
+		if(topshaft.type == endTurfToLeave)
+			location = 0
+		else
+			location = 1
+
 /obj/machinery/computer/elevator/icebase
 	machine_registry_idx = MACHINES_ELEVATORICEBASE
 	areaLower = /area/shuttle/icebase_elevator/lower
@@ -423,6 +432,7 @@ ABSTRACT_TYPE(/obj/machinery/computer/elevator)
 	areaLower = /area/shuttle/sea_elevator/lower
 	areaUpper = /area/shuttle/sea_elevator/upper
 	endTurfToLeave = /turf/simulated/floor/specialroom/sea_elevator_shaft
+	circuit_type = /obj/item/circuitboard/sea_elevator
 
 /obj/machinery/computer/elevator/centcomm
 	machine_registry_idx = MACHINES_ELEVATORCENTCOM

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -430,7 +430,7 @@ ABSTRACT_TYPE(/obj/machinery/computer/elevator)
 		..()
 		var/area/top = locate(areaUpper)
 		var/turf/topshaft = top.find_middle()
-		if(topshaft?.type == endTurfToLeave)
+		if(topshaft && topshaft?.type == endTurfToLeave)
 			location = 0
 		else
 			location = 1

--- a/code/obj/rack.dm
+++ b/code/obj/rack.dm
@@ -251,3 +251,8 @@
 		/obj/item/circuitboard/chem_request,
 		/obj/item/circuitboard/chem_request_receiver,
 	)
+
+/obj/rack/organized/techstorage_med/sea
+	New()
+		src.items_to_spawn += /obj/item/circuitboard/sea_elevator
+		. = ..()

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -21594,7 +21594,7 @@
 	pixel_x = 5;
 	pixel_y = -7
 	},
-/obj/rack/organized/techstorage_med,
+/obj/rack/organized/techstorage_med/sea,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "jge" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -37974,7 +37974,7 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/sunken_asteroid)
 "kWm" = (
-/obj/rack/organized/techstorage_med,
+/obj/rack/organized/techstorage_med/sea,
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "kXn" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

> - Add sea elevator control circuit board & specify on related computer
> - Add new subtype of med/sci tech storage spawner to include sea elevator control board
> - Change nadir/oshan tech storage to use new spawner
> 
> Note: This makes the sea elevator consoles disassemblable.

A redo of #19613 with a lazy fix I whipped up in 5 minutes that will prevent such issues as #19923.

The fix adds code under /obj/machinery/computer/elevator/sea/New() that checks where the elevator is based on the endTurfToLeave so it should Just Work



## Why's this needed? <!-- Describe why you think this should be added to the game. -->

> Unable to repair sea elevator consoles when they get wrecked by drones/bombs

Fixes #20076 and #19610 and retroactively #19923.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold & soleil
(+)NanoTrasen has supplied Nadir and Oshan with a backup sea elevator control board.
```
