### PR TITLE
Armory cooldown on Auth

### DIFF
--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -136,6 +136,8 @@
 		src.icon_state = "drawbr-alert"
 		src.UpdateIcon()
 
+		ON_COOLDOWN(src, "unauth", 5 MINUTES)
+
 		src.authorized = null
 		src.authorized_registered = null
 
@@ -312,7 +314,6 @@
 			boutput(user, SPAN_ALERT(" The armory computer cannot take your commands at the moment! Wait [GET_COOLDOWN(src, "unauth")/10] seconds!"))
 			playsound( src.loc, 'sound/machines/airlock_deny.ogg', 10, 0 )
 			return
-		if(!ON_COOLDOWN(src, "unauth", 5 MINUTES))
-			unauthorize()
-			playsound(src.loc, 'sound/machines/chime.ogg', 10, 1)
-			boutput(user,SPAN_NOTICE(" The armory's equipments have returned to having their default access!"))
+		unauthorize()
+		playsound(src.loc, 'sound/machines/chime.ogg', 10, 1)
+		boutput(user,SPAN_NOTICE(" The armory's equipments have returned to having their default access!"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the armory deauthorization cooldown from deauth to auth


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Forces armory auths to be more risky by ensuring it is open for a minimum of 5 minutes


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Armory deauthorization cooldown now starts upon authorization.
```
