### PR TITLE
Common criteria for ejecting occupants from machines

### DIFF
--- a/code/modules/medical/genetics/geneticsScanner.dm
+++ b/code/modules/medical/genetics/geneticsScanner.dm
@@ -149,7 +149,7 @@ TYPEINFO(/obj/machinery/genetics_scanner)
 
 
 	verb/eject_occupant(var/mob/user)
-		if (!isalive(user) || iswraith(user))
+		if (!can_eject_occupant(user))
 			return
 		if (src.locked)
 			boutput(user, SPAN_ALERT("<b>The scanner door is locked!</b>"))

--- a/code/modules/medical/genetics/geneticsScanner.dm
+++ b/code/modules/medical/genetics/geneticsScanner.dm
@@ -149,7 +149,7 @@ TYPEINFO(/obj/machinery/genetics_scanner)
 
 
 	verb/eject_occupant(var/mob/user)
-		if (!can_eject_occupant(user))
+		if (!src.can_eject_occupant(user))
 			return
 		if (src.locked)
 			boutput(user, SPAN_ALERT("<b>The scanner door is locked!</b>"))

--- a/code/obj/machinery.dm
+++ b/code/obj/machinery.dm
@@ -418,6 +418,10 @@
 		A2.machines += src
 		src.power_change()
 
+/// check if a mob is allowed to eject occupants from various machines
+/obj/machinery/proc/can_eject_occupant(mob/user)
+	return !(isintangible(user) || isghostcritter(user) || isghostdrone(user) || !can_act(user))
+
 /datum/action/bar/icon/rotate_machinery
 	duration = 3 SECONDS
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
@@ -450,3 +454,4 @@
 	onEnd()
 		..()
 		src.machine.set_dir(turn(src.machine.dir, -90))
+

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -618,7 +618,7 @@ TYPEINFO(/obj/machinery/clone_scanner)
 		return
 
 	verb/eject_occupant(var/mob/user)
-		if (!can_eject_occupant(user))
+		if (!src.can_eject_occupant(user))
 			return
 		src.go_out()
 		add_fingerprint(user)

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -618,7 +618,7 @@ TYPEINFO(/obj/machinery/clone_scanner)
 		return
 
 	verb/eject_occupant(var/mob/user)
-		if (!isalive(user) || iswraith(user) || isintangible(user))
+		if (!can_eject_occupant(user))
 			return
 		src.go_out()
 		add_fingerprint(user)

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -482,7 +482,7 @@ TYPEINFO(/obj/machinery/port_a_brig)
 	verb/move_eject()
 		set src in oview(1)
 		set category = "Local"
-		if (!isalive(usr) || isintangible(usr) || usr.hasStatus(list("stunned", "unconscious", "knockdown", "handcuffed")))
+		if (!can_eject_occupant(usr))
 			return
 		src.go_out()
 		add_fingerprint(usr)

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -482,7 +482,7 @@ TYPEINFO(/obj/machinery/port_a_brig)
 	verb/move_eject()
 		set src in oview(1)
 		set category = "Local"
-		if (!can_eject_occupant(usr))
+		if (!src.can_eject_occupant(usr))
 			return
 		src.go_out()
 		add_fingerprint(usr)

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -605,7 +605,7 @@ TYPEINFO(/obj/machinery/sleeper)
 		eject_occupant(usr)
 
 	verb/eject_occupant(var/mob/user)
-		if (!can_eject_occupant(user))
+		if (!src.can_eject_occupant(user))
 			return
 		src.go_out()
 		add_fingerprint(user)

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -605,7 +605,8 @@ TYPEINFO(/obj/machinery/sleeper)
 		eject_occupant(usr)
 
 	verb/eject_occupant(var/mob/user)
-		if (!isalive(user) || iswraith(user) || isintangible(user)) return
+		if (!can_eject_occupant(user))
+			return
 		src.go_out()
 		add_fingerprint(user)
 

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -824,9 +824,3 @@ proc/get_ouija_word_list(atom/movable/source = null, words_min = 5, words_max = 
 	if (istype(I, /obj/item/magtractor))
 		var/obj/item/magtractor/mag = I
 		return get_id_card(mag.holding)
-
-/// check if a mob is allowed to eject occupants from various machines
-/proc/can_eject_occupant(mob/user)
-	if (!isalive(user) || isintangible(user) || isghostcritter(user) || isghostdrone(user) || !can_act(user))
-		return FALSE
-	return TRUE

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -824,3 +824,9 @@ proc/get_ouija_word_list(atom/movable/source = null, words_min = 5, words_max = 
 	if (istype(I, /obj/item/magtractor))
 		var/obj/item/magtractor/mag = I
 		return get_id_card(mag.holding)
+
+/// check if a mob is allowed to eject occupants from various machines
+/proc/can_eject_occupant(mob/user)
+	if (!isalive(user) || isintangible(user) || isghostcritter(user) || isghostdrone(user) || !can_act(user))
+		return FALSE
+	return TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Creates a common check for whether a mob can eject an occupant:
* Alive
* Not intangbile,
* Not ghost critters
* Not ghost drones
* Can act (i.e. not restrained/unconscious)

Applies to the `eject_occupant` verb on the following machines:
* port-a-brig
* clone scanner
* genetics scanner
* sleeper

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #20085
