### PR TITLE
Moved spatial tear to plane layer above lighting

### DIFF
--- a/code/modules/events/spatial_tear.dm
+++ b/code/modules/events/spatial_tear.dm
@@ -34,7 +34,7 @@
 	opacity = 1
 	density = 1
 	var/stabilized = 0
-	layer = NOLIGHT_EFFECTS_LAYER_BASE
+	plane = PLANE_ABOVE_LIGHTING
 
 	New(var/loc,var/duration)
 		..()


### PR DESCRIPTION
[Events][Bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Spatial tears were appearing below certain objects that didnt make any visual sense (apcs, fire alarms, wall lettering...). This shoves the spatial tear to the `PLANE_ABOVE_LIGHTING` plane, which seems to be the home of other analgous sprites such as explosions.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes https://github.com/goonstation/goonstation/issues/20042.

