### PR TITLE
Fix syndicate scuttlebot deleting items

### DIFF
--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -471,6 +471,7 @@ TYPEINFO(/obj/item/clothing/glasses/visor)
 					if (S.is_inspector)
 						newscuttle.make_inspector()
 			boutput(user, "You stuff the goggles back into the detgadget hat. It powers down with a low whirr.")
+			S.drop_item()
 			qdel(S)
 			qdel(src)
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix #20108 
I misunderstood the code when redoing this and thought the drop item was making the player drop the glasses before deleting them forgetting the syndiebot can hold items.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix good
