### PR TITLE
Fix typo in Brick Suicide text

### DIFF
--- a/code/obj/item/misc_junk.dm
+++ b/code/obj/item/misc_junk.dm
@@ -222,7 +222,7 @@ TYPEINFO(/obj/item/disk)
 		if (!src.user_can_suicide(user))
 			return 0
 		APPLY_ATOM_PROPERTY(user, PROP_MOB_CANTMOVE, "brick_suicide")
-		user.visible_message(SPAN_ALERT("<b>[user] throws the [src] into the air!.</b>"))
+		user.visible_message(SPAN_ALERT("<b>[user] throws [src] into the air!</b>"))
 
 		src.set_loc(get_turf(user))
 		src.pixel_x = 0


### PR DESCRIPTION
[Bug][Player Actions]

## About the PR
fixes the tyopo in texxt for the funny new brick suiside
Originally is "[user] throws the the brick into the air!."
now it is "[user] throws the brick into the air!"

## Why's this needed?
No ypos is good, i think.