### PR TITLE
Make NTSC a roundstart job

### DIFF
--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -134,6 +134,9 @@ var/datum/job_controller/job_controls
 			if (job && check_job_eligibility(player, job, STAPLE_JOBS))
 				player.mind.assigned_role = job.name
 				job.assigned++
+				if (job.counts_as)
+					var/datum/job/other = find_job_in_controller_by_string(job.counts_as)
+					other.assigned++
 				return job
 		return
 
@@ -152,6 +155,9 @@ var/datum/job_controller/job_controls
 				job = find_job_in_controller_by_path(/datum/job/civilian/staff_assistant) // very random
 				player.mind.assigned_role = job.name
 				job.assigned++
+				if (job.counts_as)
+					var/datum/job/other = find_job_in_controller_by_string(job.counts_as)
+					other.assigned++
 			logTheThing(LOG_DEBUG, player, "<b>Jobs:</b> Assigned job: [job.name] (random job)")
 			return job
 
@@ -170,6 +176,9 @@ var/datum/job_controller/job_controls
 				if (check_job_eligibility(player, job, STAPLE_JOBS))
 					player.mind.assigned_role = job.name
 					job.assigned++
+					if (job.counts_as)
+						var/datum/job/other = find_job_in_controller_by_string(job.counts_as)
+						other.assigned++
 					logTheThing(LOG_DEBUG, player, "<b>Jobs:</b> Assigned job: [job.name] (favorite job)")
 					return job
 
@@ -196,6 +205,9 @@ var/datum/job_controller/job_controls
 			var/datum/job/job = pick(low_priority_jobs)
 			player.mind.assigned_role = job.name
 			job.assigned++
+			if (job.counts_as)
+				var/datum/job/other = find_job_in_controller_by_string(job.counts_as)
+				other.assigned++
 			logTheThing(LOG_DEBUG, player, "<b>Jobs:</b> Assigned job: [job.name] (fallback job).")
 			return job
 

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -501,6 +501,47 @@ ABSTRACT_TYPE(/datum/job/security)
 	receives_miranda = TRUE
 	job_category = JOB_SECURITY
 
+// Use this one for late respawns to deal with existing antags. they are weaker cause they dont get a laser rifle or frags
+/datum/job/security/nt_security
+	linkcolor = "#3348ff"
+	name = "Nanotrasen Security Consultant"
+	limit = 1 // backup during HELL WEEK. players will probably like it
+	unique = TRUE
+	wages = PAY_TRADESMAN
+	trait_list = list("training_security")
+	requires_whitelist = TRUE
+	counts_as = "Security Officer"
+	allow_traitors = FALSE
+	allow_spy_theft = FALSE
+	can_join_gangs = FALSE
+	cant_spawn_as_rev = TRUE
+	receives_badge = TRUE
+	receives_miranda = TRUE
+	receives_implants = list(/obj/item/implant/health/security/anti_mindhack)
+	slot_back = list(/obj/item/storage/backpack/NT)
+	slot_belt = list(/obj/item/storage/belt/security/ntsc) //special secbelt subtype that spawns with the NTSO gear inside
+	slot_jump = list(/obj/item/clothing/under/misc/turds)
+	slot_head = list(/obj/item/clothing/head/NTberet)
+	slot_foot = list(/obj/item/clothing/shoes/swat)
+	slot_glov = list(/obj/item/clothing/gloves/swat/NT)
+	slot_eyes = list(/obj/item/clothing/glasses/sunglasses/sechud)
+	slot_ears = list(/obj/item/device/radio/headset/command/nt/consultant) //needs their own secret channel
+	slot_card = /obj/item/card/id/nt_specialist
+	slot_poc1 = list(/obj/item/device/pda2/ntso)
+	slot_poc2 = list(/obj/item/currency/spacecash/fivehundred)
+	items_in_backpack = list(/obj/item/storage/firstaid/regular,
+							/obj/item/clothing/head/helmet/space/ntso,
+							/obj/item/clothing/suit/space/ntso,
+							/obj/item/cloth/handkerchief/nt)
+	wiki_link = "https://wiki.ss13.co/Nanotrasen_Security_Consultant"
+
+	faction = list(FACTION_NANOTRASEN)
+
+	New()
+		..()
+		src.access = get_access("Security Officer") + list(access_heads)
+		return
+
 /datum/job/security/security_officer
 	name = "Security Officer"
 	limit = 5
@@ -2425,48 +2466,6 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	New()
 		..()
 		src.access = get_all_accesses() + access_centcom
-
-// Use this one for late respawns to deal with existing antags. they are weaker cause they dont get a laser rifle or frags
-/datum/job/special/nt_security
-	linkcolor = "#3348ff"
-	name = "Nanotrasen Security Consultant"
-	limit = 1 // backup during HELL WEEK. players will probably like it
-	unique = TRUE
-	wages = PAY_TRADESMAN
-	trait_list = list("training_security")
-	requires_whitelist = TRUE
-	requires_supervisor_job = "Head of Security"
-	counts_as = "Security Officer"
-	allow_traitors = FALSE
-	allow_spy_theft = FALSE
-	can_join_gangs = FALSE
-	cant_spawn_as_rev = TRUE
-	receives_badge = TRUE
-	receives_miranda = TRUE
-	receives_implants = list(/obj/item/implant/health/security/anti_mindhack)
-	slot_back = list(/obj/item/storage/backpack/NT)
-	slot_belt = list(/obj/item/storage/belt/security/ntsc) //special secbelt subtype that spawns with the NTSO gear inside
-	slot_jump = list(/obj/item/clothing/under/misc/turds)
-	slot_head = list(/obj/item/clothing/head/NTberet)
-	slot_foot = list(/obj/item/clothing/shoes/swat)
-	slot_glov = list(/obj/item/clothing/gloves/swat/NT)
-	slot_eyes = list(/obj/item/clothing/glasses/sunglasses/sechud)
-	slot_ears = list(/obj/item/device/radio/headset/command/nt/consultant) //needs their own secret channel
-	slot_card = /obj/item/card/id/nt_specialist
-	slot_poc1 = list(/obj/item/device/pda2/ntso)
-	slot_poc2 = list(/obj/item/currency/spacecash/fivehundred)
-	items_in_backpack = list(/obj/item/storage/firstaid/regular,
-							/obj/item/clothing/head/helmet/space/ntso,
-							/obj/item/clothing/suit/space/ntso,
-							/obj/item/cloth/handkerchief/nt)
-	wiki_link = "https://wiki.ss13.co/Nanotrasen_Security_Consultant"
-
-	faction = list(FACTION_NANOTRASEN)
-
-	New()
-		..()
-		src.access = get_access("Security Officer") + list(access_heads)
-		return
 
 /datum/job/special/headminer
 	name = "Head of Mining"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the Nanotrasen Security Consultant a roundstart job
Add counts_as logic to non-latejoin job assigner to account for the security officer slot it takes

_Supervisor job for roundstart to be implemented_

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
QoL so hoses can ready up with NTSC available 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Nanotrasen Security Consultant is now a roundstart job
```
