### PR TITLE
remove soulsteel from artifact transmutor bomb material pool

### DIFF
--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -378,7 +378,6 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 					100;"silver",
 					100;"cobryl",
 					50;"miracle",
-					50;"soulsteel",
 					50;"hauntium",
 					50;"ectoplasm",
 					10;"ectofibre",


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

title. simple one line change, removes soulsteel from possible transmutation bombs

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

because bombs coat all objects in their radius in their material, you can end up in situations where unbreakable items get coated in soulsteel. ghosts can then possess the items and block entire areas off with basically no way to deal with it aside from blowing the objects up. while rare, it really just shouldnt be happening in general