### PR TITLE
get rid of the flamethrowers in donut 2 mainsec

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -30617,9 +30617,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/storage/secure/crate/plasma/armory/anti_biological{
-	req_access = null
-	},
 /turf/simulated/floor/redblack{
 	dir = 8
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

removes the anti biological crate in the security room on donut 2. these were moved into the armory a few weeks ago but i somehow overlooked this one. there is still a crate in the armory, this one just seems to be a duplicate

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

mistake on my part, it shouldve been put into the armory (or just deleted)