### PR TITLE
Fix fluid group splitting

### DIFF
--- a/code/modules/fluids/fluid_groups.dm
+++ b/code/modules/fluids/fluid_groups.dm
@@ -752,7 +752,7 @@
 		if (!removed_loc || src.qdeled || !src.reagents || !src.reagents.total_volume) //trying to stop the weird bug were a bunch of simultaneous splits removes all reagents
 			return 0
 		contained_amt = src.reagents.total_volume
-
+		connected += split_liq //include the actual splitting liquid object we're looking at
 		//remove some of contained_amt from src and add it to FG
 		src.can_update = 0
 		amt_per_tile = length(members) ? contained_amt / length(members) : 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [AAAA]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes fluid group splitting by adding the initial search tile to the connected list.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Did you know that fluid group splitting has been broken for at least the last 4 years? You know when you close a door and the water just keeps coming and you go "huh that's weird" and *no-one bothered to check if this proc actually worked since pre-open source and*
I'm fine, it's fine, it's fixed.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Closing doors now properly stops fluid puddles flowing under them.
```
