### PR TITLE
Prevent afterattacks when clicking on vis_contents contents

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -388,10 +388,10 @@
 			if (istype(target, /atom/movable))
 				if (isturf(target.loc))
 					pixelable = TRUE
-				else if (istype(target.loc, /obj/item/plate))
-					pixelable = TRUE
-				else if (istype(target.loc, /obj/item/reagent_containers/food/snacks/ingredient/pizza_base))
-					pixelable = TRUE
+				else if (istype(target.loc, /atom/movable))
+					var/atom/movable/location = target.loc
+					if (target in location.vis_contents)
+						pixelable = TRUE
 		if (pixelable)
 			if (!W.pixelaction(target, params, src, reach))
 				if (!QDELETED(W))

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -385,8 +385,13 @@
 	if (!QDELETED(W) && (equipped() == W || usingInner))
 		var/pixelable = isturf(target)
 		if (!pixelable)
-			if (istype(target, /atom/movable) && isturf(target.loc))
-				pixelable = TRUE
+			if (istype(target, /atom/movable))
+				if (isturf(target.loc))
+					pixelable = TRUE
+				else if (istype(target.loc, /obj/item/plate))
+					pixelable = TRUE
+				else if (istype(target.loc, /obj/item/reagent_containers/food/snacks/ingredient/pizza_base))
+					pixelable = TRUE
 		if (pixelable)
 			if (!W.pixelaction(target, params, src, reach))
 				if (!QDELETED(W))

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -385,13 +385,8 @@
 	if (!QDELETED(W) && (equipped() == W || usingInner))
 		var/pixelable = isturf(target)
 		if (!pixelable)
-			if (istype(target, /atom/movable))
-				if (isturf(target.loc))
-					pixelable = TRUE
-				else if (istype(target.loc, /atom/movable))
-					var/atom/movable/location = target.loc
-					if (target in location.vis_contents)
-						pixelable = TRUE
+			if (istype(target, /atom/movable) && (isturf(target.loc) || !reach))
+				pixelable = TRUE
 		if (pixelable)
 			if (!W.pixelaction(target, params, src, reach))
 				if (!QDELETED(W))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Count items placed on plates and pizza bases as pixelable, which prevents afterattacks from firing.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix  #20153