### PR TITLE
Fix to prevent generators from permanently coupling generators together

### DIFF
--- a/code/modules/power/chem_combustion.dm
+++ b/code/modules/power/chem_combustion.dm
@@ -18,6 +18,7 @@ TYPEINFO(/obj/machinery/power/combustion_generator)
 	anchored = UNANCHORED
 	flags = FLUID_SUBMERGE | NOSPLASH
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS
+	interacts_with_wiring = FALSE
 
 	var/active = FALSE
 	var/packet_control = TRUE

--- a/code/modules/power/chem_combustion.dm
+++ b/code/modules/power/chem_combustion.dm
@@ -18,7 +18,6 @@ TYPEINFO(/obj/machinery/power/combustion_generator)
 	anchored = UNANCHORED
 	flags = FLUID_SUBMERGE | NOSPLASH
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS
-	interacts_with_wiring = FALSE
 
 	var/active = FALSE
 	var/packet_control = TRUE

--- a/code/modules/power/lgenerator.dm
+++ b/code/modules/power/lgenerator.dm
@@ -12,6 +12,7 @@ TYPEINFO(/obj/machinery/power/lgenerator)
 	density = 1
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_MULTITOOL
 	requires_power = FALSE
+	interacts_with_wiring = FALSE
 	var/chargeAPC = TRUE // TRUE = charge APC, FALSE = charge inserted power cell.
 	var/active = FALSE
 

--- a/code/modules/power/power_parent.dm
+++ b/code/modules/power/power_parent.dm
@@ -10,20 +10,24 @@
 	/// by default, power machines are connected by a cable in a neighbouring turf
 	/// if set to 0, requires a 0-X cable on this turf
 	var/directwired = 1
+	// Dirty hack to fix issues created by subtypes that don't interact with wiring whatsoever. Can be removed when these are refactored to different types.
+	var/interacts_with_wiring = 1
 
 /obj/machinery/power/New(var/new_loc)
 	..()
-	if (current_state > GAME_STATE_PREGAME)
+	if (current_state > GAME_STATE_PREGAME && src.interacts_with_wiring)
 		SPAWN(0.1 SECONDS) // aaaaaaaaaaaaaaaa
 			recheck_powernet()
 
 /obj/machinery/power/set_loc(atom/target)
 	. = ..()
-	recheck_powernet()
+	if (src.interacts_with_wiring)
+		recheck_powernet()
 
 /obj/machinery/power/Move(atom/target)
 	. = ..()
-	recheck_powernet()
+	if (src.interacts_with_wiring)
+		recheck_powernet()
 
 /obj/machinery/power/proc/recheck_powernet()
 	src.netnum = 0

--- a/code/modules/power/power_parent.dm
+++ b/code/modules/power/power_parent.dm
@@ -171,7 +171,7 @@ var/makingpowernetssince = 0
 
 	if(!cables_only)
 		for(var/obj/machinery/power/P in T)
-			if(P.netnum < 0)	// exclude APCs
+			if(P.netnum < 0 || !P.interacts_with_wiring)	// exclude APCs and power devices that don't interact with wiring.
 				continue
 
 			if(P.directwired)	// true if this machine covers the whole turf (so can be joined to a cable on neighbour turf)


### PR DESCRIPTION
[Station Systems][Bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This is a small hack to prevent experimental local generators from accidentally permanently coupling powernets together. The `Move` proc of `machinery/power` rebuilds the powernet every tile they move. When the generator arrives at an intersection of two unconnected cables, it acts as an omnidirectional connection between every wire on that turf that can't be decoupled.

 The `obj/machinery/power` type seems like it was designed to only be used for machinery that push or pull power from wires on the same turf as them. The prototype generator doesn't interact with wires (it magically beams power to the rooms apcs) and shouldn't ever be rebuilding power nets. Also, it probably probably shouldn't be a subtype of `obj/machinery/power` at all...

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Magically coupled powernet's that people can't figure out how to fix are **very bad**.