### PR TITLE
Shift around Oshan security a bit

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -37614,9 +37614,7 @@
 /obj/disposalpipe/trunk/south{
 	pixel_z = 1
 	},
-/obj/machinery/disposal/small{
-	dir = 8
-	},
+/obj/machinery/disposal,
 /turf/simulated/floor,
 /area/station/security/main)
 "ksg" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -1024,12 +1024,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "adi" = (
@@ -1040,15 +1034,16 @@
 	},
 /area/station/chapel/sanctuary)
 "adj" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/stool/chair/red,
+/obj/landmark/start/job/security_officer,
+/turf/simulated/floor/red,
 /area/station/security/main)
 "adl" = (
 /obj/stool/chair/red,
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/landmark/start/job/security_officer,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "adn" = (
@@ -4573,8 +4568,14 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/armory)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/red,
+/area/station/security/main)
 "apD" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/treatment2)
@@ -4823,10 +4824,6 @@
 /obj/item/reagent_containers/syringe,
 /obj/machinery/light/incandescent/cool,
 /obj/item/storage/firstaid/regular,
-/obj/item/chem_grenade/pepper{
-	pixel_x = 11;
-	pixel_y = 3
-	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "aqm" = (
@@ -12742,6 +12739,8 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/table/reinforced/auto,
+/obj/machinery/phone,
 /turf/simulated/floor,
 /area/station/security/main)
 "aRp" = (
@@ -13111,8 +13110,10 @@
 "aSA" = (
 /obj/stool/chair/red,
 /obj/disposalpipe/segment{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
+/obj/landmark/start/job/security_officer,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "aSB" = (
@@ -13207,6 +13208,8 @@
 	name = "Security persistent notice board";
 	persistent_id = "security"
 	},
+/obj/stool/chair/red,
+/obj/landmark/start/job/security_officer,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "aSU" = (
@@ -13236,6 +13239,10 @@
 	name = "interrogation pipe"
 	},
 /obj/disposalpipe/segment,
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/landmark/start/job/security_officer,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "aSX" = (
@@ -20370,21 +20377,14 @@
 /area/station/bridge/hos)
 "bwr" = (
 /obj/table/reinforced/auto,
-/obj/item/chem_grenade/flashbang{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/obj/item/hand_labeler{
-	pixel_x = 8;
-	pixel_y = 10
-	},
 /obj/disposalpipe/junction/right/west,
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/networked/printer{
+	pixel_y = 4;
+	print_id = "Security"
 	},
-/obj/machinery/phone{
-	pixel_x = 9;
-	pixel_y = -3
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
@@ -26181,8 +26181,6 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bQK" = (
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
 /obj/item/storage/box/handcuff_kit{
 	pixel_x = -6
 	},
@@ -26198,11 +26196,10 @@
 /obj/item/device/ticket_writer{
 	pixel_y = 12
 	},
+/obj/table/reinforced/auto,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bQL" = (
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
 /obj/item/clothing/head/helmet/camera/security{
 	pixel_y = 10
 	},
@@ -26210,6 +26207,10 @@
 	desc = "An underfloor interrogation pipe.";
 	dir = 4;
 	name = "interrogation pipe"
+	},
+/obj/table/reinforced/auto,
+/obj/item/device/prisoner_scanner{
+	pixel_x = -11
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
@@ -26219,8 +26220,9 @@
 	dir = 4;
 	name = "interrogation pipe"
 	},
-/obj/machinery/computer/announcement/station/security{
-	dir = 4
+/obj/table/reinforced/auto,
+/obj/item/hand_labeler{
+	pixel_y = 7
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
@@ -26560,28 +26562,26 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bRM" = (
-/obj/table/reinforced/auto,
-/obj/machinery/networked/printer{
-	pixel_y = 4;
-	print_id = "Security"
-	},
-/obj/item/device/prisoner_scanner,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "0-8"
+/obj/table/reinforced/auto,
+/obj/item/chem_grenade/flashbang{
+	pixel_x = -7;
+	pixel_y = 6
 	},
-/obj/machinery/power/data_terminal,
+/obj/item/chem_grenade/pepper{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bRN" = (
-/obj/machinery/computer/security{
-	dir = 4
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/table/reinforced/auto,
+/obj/item/kitchen/food_box/donut_box,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bRS" = (
@@ -26822,6 +26822,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/landmark/start/job/security_officer,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bSR" = (
@@ -27461,17 +27462,13 @@
 	},
 /area/station/ai_monitored/armory)
 "bVa" = (
-/obj/storage/secure/crate/plasma/armory/anti_biological{
-	req_access = null
-	},
-/obj/item/gun/flamethrower/assembled/loaded,
-/obj/item/ammo/bullets/flare,
-/obj/item/ammo/bullets/flare,
-/obj/item/gun/kinetic/flaregun,
 /obj/machinery/recharger/wall{
 	pixel_y = 28
 	},
-/turf/simulated/floor/redblack,
+/obj/machinery/vending/security_ammo,
+/turf/simulated/floor/redblack/corner{
+	dir = 4
+	},
 /area/station/ai_monitored/armory)
 "bVc" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -27759,6 +27756,10 @@
 	dir = 8;
 	pixel_y = -7
 	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = 12;
+	pixel_y = 3
+	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bWf" = (
@@ -27943,10 +27944,16 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bWJ" = (
-/obj/stool/chair/red{
-	dir = 4
+/obj/storage/secure/crate/plasma/armory/anti_biological{
+	req_access = null
 	},
-/turf/simulated/floor/black,
+/obj/item/gun/kinetic/flaregun,
+/obj/item/ammo/bullets/flare,
+/obj/item/ammo/bullets/flare,
+/obj/item/gun/flamethrower/assembled/loaded,
+/turf/simulated/floor/redblack{
+	dir = 10
+	},
 /area/station/ai_monitored/armory)
 "bWK" = (
 /obj/cable{
@@ -28200,13 +28207,11 @@
 /area/station/ai_monitored/armory)
 "bXw" = (
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer3/generic/communications{
-	dir = 8
-	},
+/obj/machinery/computer3/generic/communications,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/black,
+/turf/simulated/floor/redblack,
 /area/station/ai_monitored/armory)
 "bXx" = (
 /obj/cable{
@@ -28214,6 +28219,9 @@
 	},
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/stool/chair/red{
+	dir = 1
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
@@ -28266,7 +28274,6 @@
 /obj/item/kitchen/food_box/donut_box{
 	pixel_y = 7
 	},
-/obj/item/kitchen/food_box/donut_box,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;
@@ -32657,7 +32664,6 @@
 /area/station/ai_monitored/storage/eva)
 "dth" = (
 /obj/stool/bench/red,
-/obj/landmark/start/job/security_assistant,
 /obj/machinery/light/incandescent/netural{
 	dir = 8
 	},
@@ -33098,9 +33104,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/security/main)
 "dTS" = (
-/obj/machinery/computer/card/department/security{
-	dir = 8
-	},
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/red,
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "dWz" = (
@@ -33608,7 +33613,7 @@
 	icon_state = "4-8"
 	},
 /obj/stool/chair/office/red,
-/obj/landmark/start/job/security_officer,
+/obj/landmark/start/job/security_assistant,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "eHa" = (
@@ -35492,10 +35497,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/landmark/start/job/security_officer,
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/landmark/start/job/security_assistant,
 /turf/simulated/floor,
 /area/station/security/main)
 "gXA" = (
@@ -36215,16 +36220,13 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "ili" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk/south{
-	pixel_z = 1
-	},
 /obj/machinery/light_switch/north{
 	pixel_x = -4
 	},
 /obj/blind_switch/area/north{
 	pixel_x = 4
 	},
+/obj/machinery/computer/security,
 /turf/simulated/floor,
 /area/station/security/main)
 "iln" = (
@@ -37427,6 +37429,9 @@
 	pixel_x = -24;
 	turretArea = /area/station/ai_monitored/armory
 	},
+/obj/machinery/computer/card/department/security{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "jZw" = (
@@ -37606,9 +37611,14 @@
 	name = "Genetic Research"
 	})
 "krS" = (
-/obj/machinery/vending/security_ammo,
-/turf/simulated/floor/redblack,
-/area/station/ai_monitored/armory)
+/obj/disposalpipe/trunk/south{
+	pixel_z = 1
+	},
+/obj/machinery/disposal/small{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/security/main)
 "ksg" = (
 /turf/simulated/floor/black,
 /area/research_outpost)
@@ -40425,7 +40435,7 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/obj/landmark/start/job/security_officer,
+/obj/landmark/start/job/security_assistant,
 /turf/simulated/floor,
 /area/station/security/processing)
 "ofS" = (
@@ -40748,6 +40758,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm/west,
+/obj/machinery/recharger{
+	pixel_x = -7
+	},
+/obj/machinery/recharger{
+	pixel_x = 7
+	},
+/obj/table/reinforced/auto,
 /turf/simulated/floor,
 /area/station/security/main)
 "oEw" = (
@@ -41605,7 +41622,6 @@
 /area/station/crew_quarters/courtroom)
 "pLB" = (
 /obj/stool/bench/red,
-/obj/landmark/start/job/security_assistant,
 /turf/simulated/floor,
 /area/station/security/checkpoint/sec_foyer)
 "pMh" = (
@@ -45234,9 +45250,9 @@
 	},
 /area/station/science/teleporter)
 "vVf" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/red,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/machinery/computer/announcement/station/security{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "vVQ" = (
@@ -45934,10 +45950,10 @@
 	dir = 1
 	},
 /obj/disposalpipe/segment,
-/obj/landmark/start/job/security_officer,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/landmark/start/job/security_officer,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "wNG" = (
@@ -91946,7 +91962,7 @@ kbS
 hmK
 bJR
 bTR
-krS
+bTR
 bXw
 bXx
 bVX
@@ -92844,9 +92860,9 @@ adF
 bIX
 bJR
 ili
-adj
-adj
-adj
+aNx
+aNx
+aNx
 adl
 bQK
 bwr
@@ -93148,7 +93164,7 @@ bJR
 bKX
 bMm
 bMm
-aNx
+krS
 aSA
 bQL
 bRM
@@ -93454,7 +93470,7 @@ bJR
 aST
 bQM
 bRN
-aqk
+adj
 bCP
 jWa
 bWc

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -1024,6 +1024,11 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/item/storage/wall/office{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "adi" = (
@@ -34005,11 +34010,6 @@
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/item/storage/wall/office{
-	dir = 4;
-	pixel_x = -32;
-	pixel_y = 0
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Move the HoS announcement computer into the HoS office 
Move the rechargers and phone off the main sec table to make space for disks and pinpointers
Replace spread out "desk" officer spawns with assistants, officers spawn around main table
Push sec area one tile into armory to expand walkable area
Expand sec table for more space
![image](https://github.com/user-attachments/assets/b9ce9bbf-086f-474b-b909-542242cfd31c)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Im paranoid every time I announce something as HoS on oshan that someone will grab my ID
There is no space for pinpointers and disks unless I want to go grab a decon tool and start destroying stuff
the main walkway from the front to back of sec was cramped at the entrance only being a 1 tile corner, now its bigger
