### PR TITLE
Unify Turret Control ID behaviour

### DIFF
--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -356,7 +356,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/turretid, proc/toggle_active, proc/toggle_le
 	var/emagged = 0
 	var/turretArea = null
 
-	req_access = list(access_ai_upload)
+	req_access = null // because not all turrets are upload ones
 	object_flags = CAN_REPROGRAM_ACCESS | NO_GHOSTCRITTER
 
 	New()

--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -356,7 +356,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/turretid, proc/toggle_active, proc/toggle_le
 	var/emagged = 0
 	var/turretArea = null
 
-	req_access = null // because not all turrets are upload ones
+	req_access = list(access_ai_upload)
 	object_flags = CAN_REPROGRAM_ACCESS | NO_GHOSTCRITTER
 
 	New()
@@ -364,6 +364,36 @@ ADMIN_INTERACT_PROCS(/obj/machinery/turretid, proc/toggle_active, proc/toggle_le
 		if (!src.turretArea)
 			var/area/A = get_area(src)
 			src.turretArea = A.type
+
+/obj/machinery/turretid/ai_upload
+	name = "AI Upload Turret Control"
+	turretArea = /area/station/turret_protected/ai_upload
+	req_access = access_ai_upload
+
+/obj/machinery/turretid/ai_chamber
+	name = "AI Chamber Turret Control"
+	turretArea = /area/station/turret_protected/ai
+	req_access = access_ai_upload
+
+/obj/machinery/turretid/ai_perimeter
+	name = "AI Perimeter Turret Control"
+	turretArea = /area/station/turret_protected/AIbaseoutside
+	req_access = access_ai_upload
+
+/obj/machinery/turretid/computer_core
+	name = "Computer Core Turret Control"
+	turretArea = /area/station/turret_protected/Zeta
+	req_access = access_heads
+
+/obj/machinery/turretid/armory
+	name = "Armory Turret Control"
+	turretArea = /area/station/ai_monitored/armory
+	req_access = access_armory
+
+/obj/machinery/turretid/armory_perimeter
+	name = "Armory Perimeter Turret Control"
+	turretArea = /area/station/turret_protected/armory_outside
+	req_access = access_armory
 
 /obj/machinery/turretid/attackby(obj/item/W, mob/user)
 	if(status & BROKEN) return

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -4426,6 +4426,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "ast" = (

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -4417,16 +4417,15 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/turretid{
-	pixel_x = 24
-	},
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/obj/mapping_helper/access/ai_upload,
+/obj/machinery/turretid/ai_chamber{
+	pixel_x = 24
+	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "ast" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -1350,9 +1350,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/market)
 "ams" = (
-/obj/machinery/turretid{
-	pixel_y = 24
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -1360,7 +1357,9 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/mapping_helper/access/ai_upload,
+/obj/machinery/turretid/ai_upload{
+	pixel_y = 24
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "amy" = (
@@ -33631,9 +33630,6 @@
 	name = "AI Core Shield";
 	pixel_y = -21
 	},
-/obj/machinery/turretid{
-	pixel_x = 24
-	},
 /obj/item/device/radio/intercom/AI{
 	dir = 4
 	},
@@ -33643,7 +33639,9 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/mapping_helper/access/ai_upload,
+/obj/machinery/turretid/ai_chamber{
+	pixel_x = 24
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "rgl" = (
@@ -40577,11 +40575,9 @@
 	name = "autoname  - SS13";
 	pixel_x = -10
 	},
-/obj/machinery/turretid{
-	pixel_x = -24;
-	turretArea = /area/station/turret_protected/Zeta
+/obj/machinery/turretid/computer_core{
+	pixel_x = -24
 	},
-/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
@@ -41458,12 +41454,9 @@
 	pixel_x = 4;
 	pixel_y = 8
 	},
-/obj/machinery/turretid{
-	name = "External perimeter turret deactivation control";
-	pixel_x = -24;
-	turretArea = /area/station/turret_protected/armory_outside
+/obj/machinery/turretid/armory_perimeter{
+	pixel_x = -24
 	},
-/obj/mapping_helper/access/armory,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -1351,8 +1351,7 @@
 /area/station/crew_quarters/market)
 "ams" = (
 /obj/machinery/turretid{
-	pixel_y = 24;
-	req_access_txt = "19"
+	pixel_y = 24
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -1361,6 +1360,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "amy" = (
@@ -33632,8 +33632,7 @@
 	pixel_y = -21
 	},
 /obj/machinery/turretid{
-	pixel_x = 24;
-	req_access_txt = "19"
+	pixel_x = 24
 	},
 /obj/item/device/radio/intercom/AI{
 	dir = 4
@@ -33644,6 +33643,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "rgl" = (
@@ -40579,9 +40579,9 @@
 	},
 /obj/machinery/turretid{
 	pixel_x = -24;
-	req_access_txt = "19";
 	turretArea = /area/station/turret_protected/Zeta
 	},
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -20365,6 +20365,7 @@
 /obj/machinery/turretid{
 	pixel_x = -28
 	},
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "brr" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -20362,10 +20362,9 @@
 /turf/simulated/floor/plating/airless,
 /area/station/ai_monitored/storage/eva)
 "brn" = (
-/obj/machinery/turretid{
-	pixel_x = -28
+/obj/machinery/turretid/ai_chamber{
+	pixel_x = -24
 	},
-/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "brr" = (
@@ -38288,13 +38287,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "dpZ" = (
-/obj/machinery/turretid{
-	pixel_x = -24
-	},
 /obj/window/reinforced{
 	dir = 2
 	},
-/obj/mapping_helper/access/heads,
+/obj/machinery/turretid/computer_core{
+	pixel_x = -24
+	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "dqA" = (
@@ -45176,13 +45174,9 @@
 /area/station/medical/robotics)
 "iqh" = (
 /obj/deployable_turret/riot/active,
-/obj/machinery/turretid{
-	name = "External perimeter turret deactivation control";
-	pixel_y = 28;
-	req_access = null;
-	turretArea = /area/station/turret_protected/armory_outside
+/obj/machinery/turretid/armory_perimeter{
+	pixel_y = 28
 	},
-/obj/mapping_helper/access/armory,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "iqk" = (
@@ -53652,11 +53646,9 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/obj/machinery/turretid{
-	pixel_y = 24;
-	turretArea = /area/station/turret_protected/ai_upload
+/obj/machinery/turretid/ai_upload{
+	pixel_y = 24
 	},
-/obj/mapping_helper/access/heads,
 /turf/simulated/floor/neutral/side{
 	dir = 5
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -1018,13 +1018,11 @@
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai)
 "adp" = (
-/obj/machinery/turretid{
-	layer = 9.1;
-	pixel_y = -5
+/obj/machinery/turretid/ai_chamber{
+	pixel_y = 24
 	},
-/obj/mapping_helper/access/ai_upload,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai)
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai_upload)
 "adr" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/solar/small_backup2)
@@ -2916,15 +2914,14 @@
 /turf/simulated/floor/caution/west,
 /area/station/turret_protected/ai_upload_foyer)
 "ajs" = (
-/obj/machinery/turretid{
-	pixel_y = 24
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/mapping_helper/access/ai_upload,
+/obj/machinery/turretid/ai_upload{
+	pixel_y = 24
+	},
 /turf/simulated/floor,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/ai_upload_foyer)
 "ajt" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -2936,7 +2933,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/ai_upload_foyer)
 "aju" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -133335,8 +133332,8 @@ acn
 abT
 acu
 acV
+abf
 adp
-adW
 aeC
 afr
 ago

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -1022,6 +1022,7 @@
 	layer = 9.1;
 	pixel_y = -5
 	},
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai)
 "adr" = (
@@ -2916,12 +2917,12 @@
 /area/station/turret_protected/ai_upload_foyer)
 "ajs" = (
 /obj/machinery/turretid{
-	pixel_y = 24;
-	req_access_txt = "19"
+	pixel_y = 24
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload)
 "ajt" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -20590,7 +20590,6 @@
 	pixel_x = 8;
 	pixel_y = 26
 	},
-/obj/mapping_helper/access/ai_upload,
 /obj/landmark/start/job/AI,
 /obj/machinery/turretid/ai_chamber{
 	pixel_y = 24;

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -19876,7 +19876,6 @@
 	req_access = null;
 	req_access_txt = null
 	},
-/obj/mapping_helper/access/ai_upload,
 /obj/mapping_helper/access/research_director,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -18419,15 +18419,13 @@
 	c_tag = "AI Upload Entrance";
 	dir = 4
 	},
-/obj/machinery/turretid{
-	pixel_y = 24;
-	req_access = null
-	},
 /obj/machinery/light/emergency{
 	dir = 8
 	},
-/obj/mapping_helper/access/ai_upload,
 /obj/landmark/start/job/cyborg,
+/obj/machinery/turretid/ai_upload{
+	pixel_y = 24
+	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload)
 "ddM" = (
@@ -19871,12 +19869,9 @@
 /turf/simulated/floor,
 /area/station/science/artifact)
 "dZh" = (
-/obj/machinery/turretid{
-	pixel_x = -24;
-	req_access = null;
-	req_access_txt = null
+/obj/machinery/turretid/computer_core{
+	pixel_x = -24
 	},
-/obj/mapping_helper/access/research_director,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "dZI" = (
@@ -20595,13 +20590,12 @@
 	pixel_x = 8;
 	pixel_y = 26
 	},
-/obj/machinery/turretid{
-	pixel_x = -8;
-	pixel_y = 24;
-	req_access = null
-	},
 /obj/mapping_helper/access/ai_upload,
 /obj/landmark/start/job/AI,
+/obj/machinery/turretid/ai_chamber{
+	pixel_y = 24;
+	pixel_x = -8
+	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "euP" = (
@@ -21723,10 +21717,7 @@
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
 "fgk" = (
-/obj/machinery/turretid{
-	req_access = null
-	},
-/obj/mapping_helper/access/ai_upload,
+/obj/machinery/turretid/ai_perimeter,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/AIbaseoutside)
 "fhn" = (
@@ -27504,13 +27495,10 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/obj/machinery/turretid{
-	pixel_x = 24;
-	pixel_y = 1;
-	req_access = null
-	},
 /obj/machinery/light/incandescent,
-/obj/mapping_helper/access/armory,
+/obj/machinery/turretid/armory{
+	pixel_x = 24
+	},
 /turf/simulated/floor/redblack{
 	dir = 9
 	},
@@ -31561,14 +31549,9 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "lFR" = (
-/obj/machinery/turretid{
-	name = "External perimeter turret deactivation control";
-	pixel_x = -24;
-	pixel_y = 1;
-	req_access = null;
-	turretArea = /area/station/turret_protected/armory_outside
+/obj/machinery/turretid/armory_perimeter{
+	pixel_x = -24
 	},
-/obj/mapping_helper/access/armory,
 /turf/simulated/floor/redblack{
 	dir = 5
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -34656,6 +34656,7 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
+/obj/mapping_helper/access/heads,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/AIsat)
 "kwA" = (
@@ -36298,6 +36299,7 @@
 	dir = 4;
 	name = "crematorium pipe"
 	},
+/obj/mapping_helper/access/heads,
 /turf/simulated/floor/airless/plating/jen,
 /area/station/turret_protected/AIbaseoutside)
 "kWU" = (
@@ -51330,7 +51332,7 @@
 	dir = 9;
 	icon_state = "line2"
 	},
-/obj/mapping_helper/access/hos,
+/obj/mapping_helper/access/armory,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "pzp" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -182,9 +182,6 @@
 	},
 /area/mining/magnet)
 "aax" = (
-/obj/machinery/turretid{
-	pixel_y = 28
-	},
 /obj/decal/tile_edge/line/red{
 	dir = 1;
 	icon_state = "line1"
@@ -192,7 +189,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/mapping_helper/access/armory,
+/obj/machinery/turretid/armory_perimeter{
+	pixel_y = 28
+	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/armory_outside)
 "aaz" = (
@@ -1035,7 +1034,7 @@
 /turf/simulated/floor/blueblack/corner{
 	dir = 4
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "alU" = (
 /obj/machinery/r_door_control/podbay/security,
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
@@ -2366,7 +2365,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 6
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "aFn" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/fluid_canister,
@@ -2848,7 +2847,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "aMS" = (
 /obj/decal/tile_edge/line/red{
 	dir = 9;
@@ -6836,7 +6835,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "bUO" = (
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
@@ -7107,7 +7106,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "bZC" = (
 /obj/cable{
 	icon_state = "4-10"
@@ -7118,7 +7117,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "bZM" = (
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass,
@@ -7306,7 +7305,7 @@
 	},
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "ccc" = (
 /obj/table/reinforced/auto,
 /obj/mapping_helper/access/hydro,
@@ -7369,7 +7368,7 @@
 	name = "kitchen freezer pipe"
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "ccK" = (
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -8923,7 +8922,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "cyo" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9614,7 +9613,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "cJi" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 8
@@ -10555,7 +10554,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "daL" = (
 /obj/table/reinforced/auto,
 /turf/simulated/floor/plating/jen,
@@ -10812,7 +10811,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "deC" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
@@ -11673,7 +11672,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "dri" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
@@ -12099,7 +12098,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/circuit/white,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "dzZ" = (
 /turf/simulated/wall/auto/reinforced/jen/dark3,
 /area/station/science/testchamber/bombchamber)
@@ -12365,7 +12364,7 @@
 	name = "kitchen freezer pipe"
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "dEv" = (
 /obj/disposalpipe/segment/food{
 	dir = 1;
@@ -12562,7 +12561,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "dIq" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -13686,7 +13685,7 @@
 	},
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "dYB" = (
 /obj/table/auto,
 /obj/random_item_spawner/desk_stuff,
@@ -15308,13 +15307,11 @@
 	},
 /area/station/ranch)
 "ezP" = (
-/obj/machinery/turretid{
-	pixel_y = 24;
-	turretArea = /area/station/turret_protected/ai_upload
-	},
-/obj/mapping_helper/access/ai_upload,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/turretid/ai_upload{
+	pixel_y = 24
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
@@ -16219,7 +16216,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/circuit/white,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "ePG" = (
 /obj/decal/tile_edge/check{
 	color = "#AB8CB0";
@@ -16823,7 +16820,7 @@
 /area/station/crew_quarters/captain)
 "eYn" = (
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "eYw" = (
 /obj/grille/catwalk/jen,
 /obj/disposalpipe/segment,
@@ -17518,7 +17515,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "fjm" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/grille/catwalk/jen,
@@ -17826,7 +17823,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "fnO" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/storage/closet/emergency,
@@ -18047,7 +18044,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "fqg" = (
 /obj/disposalpipe/segment,
 /obj/machinery/camera{
@@ -18098,7 +18095,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 10
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "fqI" = (
 /turf/simulated/wall/auto/jen/yellow,
 /area/station/maintenance/inner/east)
@@ -19433,7 +19430,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "fMB" = (
 /obj/lattice{
 	dir = 5;
@@ -19490,7 +19487,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "fNL" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/communications_dish,
@@ -19725,7 +19722,7 @@
 	},
 /obj/machinery/light_switch/south,
 /turf/simulated/floor/blueblack/corner,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "fQR" = (
 /obj/item/device/radio/beacon,
 /obj/landmark/gps_waypoint,
@@ -20024,7 +20021,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "fWD" = (
 /obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor/specialroom/arcade,
@@ -22382,7 +22379,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 5
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "gHa" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/decal/cleanable/dirt/jen,
@@ -22862,7 +22859,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "gPb" = (
 /obj/lattice{
 	dir = 1;
@@ -23720,7 +23717,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "hcg" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0;
@@ -24903,7 +24900,7 @@
 	icon_state = "6-10"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "htI" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -27191,7 +27188,7 @@
 	icon_state = "5-10"
 	},
 /turf/simulated/floor/circuit/off,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "ihj" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -27702,7 +27699,7 @@
 	},
 /obj/item/device/radio/intercom/AI,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "iqv" = (
 /obj/machinery/firealarm/north,
 /obj/submachine/seed_manipulator{
@@ -29514,7 +29511,7 @@
 	name = "kitchen freezer pipe"
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "iUe" = (
 /obj/cable/orange{
 	icon_state = "4-8"
@@ -29941,7 +29938,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "jad" = (
 /obj/grille/catwalk/jen,
 /obj/disposalpipe/segment{
@@ -29955,7 +29952,7 @@
 	icon_state = "1-6"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "jaq" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/stripe_delivery,
@@ -30041,7 +30038,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "jby" = (
 /obj/machinery/door/airlock/pyro/glass/security{
 	dir = 4;
@@ -30297,7 +30294,7 @@
 	icon_state = "2-5"
 	},
 /turf/simulated/floor/circuit/off,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "jfL" = (
 /obj/stool/chair/dining/wood{
 	dir = 4
@@ -31175,7 +31172,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "jsP" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 8;
@@ -31532,7 +31529,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "jxw" = (
 /obj/table/wood/auto,
 /obj/machinery/power/data_terminal,
@@ -32716,7 +32713,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "jQq" = (
 /obj/decal/stage_edge/alt,
 /obj/cable{
@@ -32956,7 +32953,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "jUx" = (
 /obj/machinery/light/emergency,
 /obj/cable{
@@ -33025,7 +33022,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "jVH" = (
 /obj/stool/chair/comfy/shuttle{
 	dir = 8
@@ -34641,10 +34638,6 @@
 	dir = 4;
 	icon_state = "line1"
 	},
-/obj/machinery/turretid{
-	pixel_x = -6;
-	pixel_y = 28
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -34656,9 +34649,12 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/mapping_helper/access/heads,
+/obj/machinery/turretid/ai_chamber{
+	pixel_y = 24;
+	pixel_x = -8
+	},
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "kwA" = (
 /obj/cable/orange,
 /obj/machinery/computer/power_monitor/smes,
@@ -35319,7 +35315,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "kGb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -36288,10 +36284,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/turretid{
-	pixel_x = 24;
-	pixel_y = 1
-	},
 /obj/machinery/camera{
 	dir = 4
 	},
@@ -36299,7 +36291,9 @@
 	dir = 4;
 	name = "crematorium pipe"
 	},
-/obj/mapping_helper/access/heads,
+/obj/machinery/turretid/ai_perimeter{
+	pixel_x = 24
+	},
 /turf/simulated/floor/airless/plating/jen,
 /area/station/turret_protected/AIbaseoutside)
 "kWU" = (
@@ -36608,7 +36602,7 @@
 	icon_state = "9-10"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "laZ" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -37753,7 +37747,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "lvL" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/morgue{
@@ -38097,7 +38091,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "lAH" = (
 /obj/machinery/disposal/small{
 	dir = 8
@@ -38741,7 +38735,7 @@
 	icon_state = "6-9"
 	},
 /turf/simulated/floor/circuit/off,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "lIB" = (
 /turf/simulated/floor/black,
 /area/station/science/testchamber/bombchamber)
@@ -39457,7 +39451,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "lTl" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
@@ -40976,7 +40970,7 @@
 	icon_state = "9-10"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "mqY" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -41670,7 +41664,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "mCk" = (
 /obj/machinery/plantpot,
 /turf/simulated/floor/plating/jen,
@@ -42303,7 +42297,7 @@
 	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "mMR" = (
 /obj/cable/blue{
 	icon_state = "1-2"
@@ -42421,7 +42415,7 @@
 	},
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "mQz" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/specialroom/chapel{
@@ -42928,7 +42922,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "mXw" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10
@@ -44353,7 +44347,7 @@
 	icon_state = "2-9"
 	},
 /turf/simulated/floor/circuit/off,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "nss" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -44402,7 +44396,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "nsT" = (
 /turf/simulated/floor/carpet/grime,
 /area/station/security/quarters)
@@ -45548,7 +45542,7 @@
 "nMb" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "nMc" = (
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/crew_quarters/heads)
@@ -45880,7 +45874,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "nQB" = (
 /obj/table/auto{
 	icon_state = "4"
@@ -46073,7 +46067,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "nTr" = (
 /obj/table/auto,
 /obj/machinery/computer3/generic/personal/personel_alt,
@@ -47317,7 +47311,7 @@
 	name = "Danger: High Voltage"
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "onZ" = (
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/hangar/main)
@@ -48004,7 +47998,7 @@
 	icon_state = "6-10"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "oyF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -49138,7 +49132,7 @@
 	},
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "oQI" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -51324,15 +51318,13 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/cafeteria)
 "pzm" = (
-/obj/machinery/turretid{
-	pixel_x = -24;
-	pixel_y = 1
-	},
 /obj/decal/tile_edge/line/red{
 	dir = 9;
 	icon_state = "line2"
 	},
-/obj/mapping_helper/access/armory,
+/obj/machinery/turretid/armory{
+	pixel_x = -24
+	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "pzp" = (
@@ -51385,7 +51377,7 @@
 	icon_state = "2-5"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "pAs" = (
 /obj/disposalpipe/trunk/mail{
 	dir = 4
@@ -52777,7 +52769,7 @@
 	icon_state = "1-6"
 	},
 /turf/simulated/floor/circuit/off,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "pSB" = (
 /obj/decal/tile_edge/line/black{
 	dir = 4;
@@ -53245,7 +53237,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "qbG" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -53314,7 +53306,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "qcO" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable{
@@ -53489,7 +53481,7 @@
 /turf/simulated/wall/auto/reinforced/jen/blue{
 	icon_state = "R8"
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "qeI" = (
 /obj/disposalpipe/switch_junction/right/west{
 	mail_tag = "arcade"
@@ -53943,7 +53935,7 @@
 	name = "kitchen freezer pipe"
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "qlw" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -54308,7 +54300,7 @@
 /area/station/medical/medbay/treatment)
 "qqY" = (
 /turf/simulated/floor/circuit/off,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "qrd" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -55447,7 +55439,7 @@
 	icon_state = "1-10"
 	},
 /turf/simulated/floor/circuit/off,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "qJG" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -55864,7 +55856,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "qPJ" = (
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -56784,7 +56776,7 @@
 /area/station/medical/asylum/main)
 "rdy" = (
 /turf/simulated/floor/circuit/white,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "rdS" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -57210,7 +57202,7 @@
 	icon_state = "5-6"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "rlU" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light/emergency,
@@ -58274,7 +58266,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "rEW" = (
 /obj/table/wood/round/auto,
 /obj/item/clothing/suit/cultist{
@@ -59553,7 +59545,7 @@
 	icon_state = "5-10"
 	},
 /turf/simulated/floor/circuit/off,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "rYu" = (
 /obj/table/wood/auto,
 /obj/item/device/radio/intercom/brig{
@@ -59799,7 +59791,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "sbI" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/wall/auto/reinforced/jen/blue,
@@ -61174,14 +61166,14 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "sxq" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "sxx" = (
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "sxT" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/black,
@@ -61447,7 +61439,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "sCb" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner{
 	dir = 10
@@ -62111,7 +62103,7 @@
 	icon_state = "2-9"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "sOy" = (
 /obj/decal/tile_edge/line/red{
 	dir = 10;
@@ -64818,7 +64810,7 @@
 	name = "AI Core"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "tFa" = (
 /obj/decal/tile_edge/line/white{
 	color = "#ffccff";
@@ -65143,7 +65135,7 @@
 	name = "AI Core"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "tJf" = (
 /obj/table/glass/auto,
 /obj/random_item_spawner/desk_stuff/one_or_zero,
@@ -65568,7 +65560,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "tOW" = (
 /obj/machinery/light_switch/south,
 /obj/cable{
@@ -67779,7 +67771,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit/off,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "uAb" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -68450,7 +68442,7 @@
 	icon_state = "2-5"
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "uIY" = (
 /obj/shrub{
 	dir = 8
@@ -69183,7 +69175,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 9
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "uUN" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -74291,7 +74283,7 @@
 "wvB" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "wvC" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -74373,7 +74365,7 @@
 	icon_state = "6-9"
 	},
 /turf/simulated/floor/circuit/off,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "wwE" = (
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/medical/asylum/kitchen)
@@ -76417,7 +76409,7 @@
 	icon_state = "5-6"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "wYJ" = (
 /obj/railing/orange/reinforced,
 /turf/simulated/floor/grasstodirt,
@@ -77038,7 +77030,7 @@
 /obj/cable,
 /obj/machinery/light/small/floor/cool/very,
 /turf/simulated/floor/circuit/off,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "xhm" = (
 /obj/machinery/light{
 	dir = 8
@@ -77421,7 +77413,7 @@
 /area/station/security/checkpoint/arrivals)
 "xms" = (
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "xmE" = (
 /obj/shrub{
 	icon = 'icons/obj/stationobjs.dmi';
@@ -77792,7 +77784,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "xqR" = (
 /turf/simulated/wall/auto/jen,
 /area/station/hallway/primary/east)
@@ -78158,7 +78150,7 @@
 	icon_state = "1-10"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "xwZ" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -78897,7 +78889,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "xIX" = (
 /obj/stool/chair{
 	dir = 4
@@ -79046,7 +79038,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit/white,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "xKT" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -79380,7 +79372,7 @@
 	icon_state = "4-10"
 	},
 /turf/simulated/floor/circuit/white,
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "xPF" = (
 /obj/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -80464,7 +80456,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/turret_protected/AIsat)
+/area/station/turret_protected/ai)
 "yff" = (
 /obj/storage/closet/wardrobe/pride,
 /turf/unsimulated/floor/shuttle{

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -8385,10 +8385,9 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/turretid{
+/obj/machinery/turretid/ai_chamber{
 	pixel_x = 24
 	},
-/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "aFS" = (
@@ -8861,11 +8860,9 @@
 	dir = 9;
 	icon_state = "xtra_bigstripe-corner2"
 	},
-/obj/machinery/turretid{
-	pixel_y = 24;
-	turretArea = /area/station/turret_protected/ai_upload
+/obj/machinery/turretid/ai_upload{
+	pixel_y = 24
 	},
-/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload_foyer)
 "aHS" = (
@@ -30651,14 +30648,10 @@
 /area/station/hallway/primary/north)
 "cJJ" = (
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
-/obj/machinery/turretid{
-	name = "External perimeter turret deactivation control";
-	pixel_x = -24;
-	req_access = null;
-	turretArea = /area/station/turret_protected/armory_outside
-	},
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/obj/mapping_helper/access/armory,
+/obj/machinery/turretid/armory_perimeter{
+	pixel_x = -24
+	},
 /turf/simulated/floor/engine{
 	allows_vehicles = 0
 	},
@@ -45481,11 +45474,10 @@
 /turf/simulated/floor/grey,
 /area/station/mining/magnet)
 "nkD" = (
-/obj/machinery/turretid{
-	pixel_x = 26
-	},
 /obj/machinery/light,
-/obj/mapping_helper/access/heads,
+/obj/machinery/turretid/computer_core{
+	pixel_x = 24
+	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "nlI" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -8386,9 +8386,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/turretid{
-	pixel_x = 24;
-	req_access_txt = "19"
+	pixel_x = 24
 	},
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "aFS" = (
@@ -30658,6 +30658,7 @@
 	turretArea = /area/station/turret_protected/armory_outside
 	},
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/obj/mapping_helper/access/armory,
 /turf/simulated/floor/engine{
 	allows_vehicles = 0
 	},
@@ -45484,6 +45485,7 @@
 	pixel_x = 26
 	},
 /obj/machinery/light,
+/obj/mapping_helper/access/heads,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "nlI" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1304,9 +1304,6 @@
 	},
 /area/listeningpost)
 "aBH" = (
-/obj/machinery/turretid{
-	pixel_y = 24
-	},
 /obj/stool/chair/office/blue{
 	dir = 8
 	},
@@ -1316,7 +1313,9 @@
 	layer = 5
 	},
 /obj/machinery/light/small,
-/obj/mapping_helper/access/ai_upload,
+/obj/machinery/turretid/ai_upload{
+	pixel_y = 24
+	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai_upload)
 "aCv" = (
@@ -10840,10 +10839,9 @@
 	name = "Nuclear Control Room"
 	})
 "eSU" = (
-/obj/machinery/turretid{
+/obj/machinery/turretid/ai_chamber{
 	pixel_x = 24
 	},
-/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/darkblue/checker,
 /area/station/turret_protected/ai)
 "eSW" = (
@@ -42464,10 +42462,9 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/machinery/turretid{
+/obj/machinery/turretid/computer_core{
 	pixel_x = 24
 	},
-/obj/mapping_helper/access/heads,
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1305,8 +1305,7 @@
 /area/listeningpost)
 "aBH" = (
 /obj/machinery/turretid{
-	pixel_y = 24;
-	req_access_txt = "19"
+	pixel_y = 24
 	},
 /obj/stool/chair/office/blue{
 	dir = 8
@@ -1317,6 +1316,7 @@
 	layer = 5
 	},
 /obj/machinery/light/small,
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai_upload)
 "aCv" = (
@@ -10841,9 +10841,9 @@
 	})
 "eSU" = (
 /obj/machinery/turretid{
-	pixel_x = 24;
-	req_access_txt = "19"
+	pixel_x = 24
 	},
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/darkblue/checker,
 /area/station/turret_protected/ai)
 "eSW" = (
@@ -42465,9 +42465,9 @@
 	tag = ""
 	},
 /obj/machinery/turretid{
-	pixel_x = 24;
-	req_access_txt = "19"
+	pixel_x = 24
 	},
+/obj/mapping_helper/access/heads,
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -3220,10 +3220,9 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/ce)
 "akO" = (
-/obj/machinery/turretid{
-	pixel_y = 32
+/obj/machinery/turretid/ai_chamber{
+	pixel_y = 24
 	},
-/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "akP" = (
@@ -6830,11 +6829,9 @@
 	dir = 9;
 	icon_state = "line2"
 	},
-/obj/machinery/turretid{
-	pixel_y = 24;
-	turretArea = /area/station/turret_protected/Zeta
+/obj/machinery/turretid/computer_core{
+	pixel_y = 24
 	},
-/obj/mapping_helper/access/heads,
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "awJ" = (
@@ -13299,11 +13296,9 @@
 	name = "Net Cafe"
 	})
 "aTh" = (
-/obj/machinery/turretid{
-	pixel_x = 24;
-	turretArea = /area/station/turret_protected/ai_upload
+/obj/machinery/turretid/ai_upload{
+	pixel_x = 24
 	},
-/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/info{
 	name = "Net Cafe"
@@ -37426,11 +37421,9 @@
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
 "jZj" = (
-/obj/machinery/turretid{
-	pixel_x = -24;
-	turretArea = /area/station/ai_monitored/armory
+/obj/machinery/turretid/armory{
+	pixel_x = -24
 	},
-/obj/mapping_helper/access/armory,
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "jZw" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -3223,6 +3223,7 @@
 /obj/machinery/turretid{
 	pixel_y = 32
 	},
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "akP" = (
@@ -6833,6 +6834,7 @@
 	pixel_y = 24;
 	turretArea = /area/station/turret_protected/Zeta
 	},
+/obj/mapping_helper/access/heads,
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "awJ" = (
@@ -13301,6 +13303,7 @@
 	pixel_x = 24;
 	turretArea = /area/station/turret_protected/ai_upload
 	},
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/info{
 	name = "Net Cafe"
@@ -37427,6 +37430,7 @@
 	pixel_x = -24;
 	turretArea = /area/station/ai_monitored/armory
 	},
+/obj/mapping_helper/access/armory,
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "jZw" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Creates subtypes for turret controls for the below areas with their areas and access defined and places them on all rotation maps.
-AI Chamber
-AI Upload
-AI Perimeter
-Armory
-Armory Perimeter
-Computer Core

I also replaced the "AI satellite" area on donut 3 with "AI chamber" because donut 2 only uses that for the non-turret protected area and I didnt make a subtype for AI satellite for one map.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fun fact: some armory turret controls could be used by anyone with upload access because they were not varedited to be null

