### PR TITLE
Replaces the lawbringer's HIGH EXPLOSIVE mode with a HIGH POWER assault laser mode

### DIFF
--- a/code/modules/projectiles/laser.dm
+++ b/code/modules/projectiles/laser.dm
@@ -123,10 +123,11 @@ toxic - poisons
 	color_red = 0
 	color_green = 0
 	color_blue = 1
+	always_hits_structures = TRUE
 
 	on_hit(atom/hit, dir, obj/projectile/P)
 		fireflash(get_turf(hit), 0, chemfire = CHEM_FIRE_BLUE)
-		if((istype(hit, /turf/simulated) || istype(hit, /obj/structure/girder)))
+		if(!ismob(hit))
 			hit.ex_act(2)
 		else
 			hit.ex_act(3, src, 1.5) //don't stun humans nearly as much

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -563,6 +563,7 @@ ABSTRACT_TYPE(/datum/projectile)
 	var/damage_type = D_KINETIC  // What is our damage type
 	var/hit_type = null          // For blood system damage - DAMAGE_BLUNT, DAMAGE_CUT and DAMAGE_STAB
 	var/hit_ground_chance = 0    // With what % do we hit mobs laying down
+	var/always_hits_structures = FALSE //always hits doors and girders
 	var/window_pass = 0          // Can we pass windows
 	var/obj/projectile/master = null // The projectile obj that we're associated with
 	var/silentshot = 0           // Standard hit message upon bullet_act.

--- a/code/modules/writing/papers.dm
+++ b/code/modules/writing/papers.dm
@@ -623,9 +623,9 @@ Only trained personnel should operate station systems. Follow all procedures car
 	<td>When you just can't get things to slow down, <i>make 'em</i> slow down with these handy haloperidol tranquilizer darts!</td>
 	</tr>
 	<tr>
-	<td><b>"Bigshot" / "High Explosive" / "HE"</b></td>
+	<td><b>"Bigshot" / "High Power" / "Assault"</b></td>
 	<td>170 PU</td>
-	<td>You'll be the talk of the station when you bust down a wall with one of these explosive rounds! May cause loss of limbs or life.</td>
+	<td>You'll be the talk of the station when you bust down a wall with one of these high power assault lasers! May cause small fires and molten metal puddles.</td>
 	</tr>
 	<tr>
 	<td><b>"Clownshot" / "Clown"</b></td>

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1300,7 +1300,16 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 
 	New(var/mob/M)
 		set_current_projectile(new/datum/projectile/energy_bolt/aoe)
-		projectiles = list("detain" = current_projectile, "execute" = new/datum/projectile/bullet/revolver_38/lb, "smokeshot" = new/datum/projectile/bullet/smoke, "knockout" = new/datum/projectile/bullet/tranq_dart/law_giver, "hotshot" = new/datum/projectile/bullet/flare, "bigshot" = new/datum/projectile/bullet/aex/lawbringer, "clownshot" = new/datum/projectile/bullet/clownshot, "pulse" = new/datum/projectile/energy_bolt/pulse)
+		projectiles = list(
+			"detain" = current_projectile,
+			"execute" = new/datum/projectile/bullet/revolver_38/lb,
+			"smokeshot" = new/datum/projectile/bullet/smoke,
+			"knockout" = new/datum/projectile/bullet/tranq_dart/law_giver,
+			"hotshot" = new/datum/projectile/bullet/flare,
+			"assault" = new/datum/projectile/laser/asslaser,
+			"clownshot" = new/datum/projectile/bullet/clownshot,
+			"pulse" = new/datum/projectile/energy_bolt/pulse
+		)
 		// projectiles = list(current_projectile,new/datum/projectile/bullet/revolver_38/lb,new/datum/projectile/bullet/smoke,new/datum/projectile/bullet/tranq_dart/law_giver,new/datum/projectile/bullet/flare,new/datum/projectile/bullet/aex/lawbringer,new/datum/projectile/bullet/clownshot)
 
 		src.indicator_display = image('icons/obj/items/guns/energy.dmi', "")
@@ -1375,7 +1384,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 			src.change_mode(M, text)
 		else		//if you're not the owner and try to change it, then fuck you
 			switch(text)
-				if ("detain","execute","knockout","hotshot","incendiary","bigshot","highexplosive","he","clownshot","clown", "pulse", "punch")
+				if ("detain","execute","knockout","hotshot","incendiary","assault","highpower","clownshot","clown", "pulse", "punch")
 					random_burn_damage(M, 50)
 					M.changeStatus("knockdown", 4 SECONDS)
 					elecflash(src,power=2)
@@ -1421,15 +1430,15 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 				if (sound)
 					playsound(M, 'sound/vox/hot.ogg', 50)
 				src.toggle_recoil(TRUE)
-			if ("bigshot","highexplosive","he")
-				set_current_projectile(projectiles["bigshot"])
+			if ("assault","highpower", "bigshot")
+				set_current_projectile(projectiles["assault"])
 				current_projectile.cost = 170
 				item_state = "lawg-bigshot"
 				if (sound)
 					playsound(M, 'sound/vox/high.ogg', 50)
-					SPAWN(0.4 SECONDS)
-						playsound(M, 'sound/vox/explosive.ogg', 50)
-				src.toggle_recoil(TRUE)
+					SPAWN(0.6 SECONDS)
+						playsound(M, 'sound/vox/power.ogg', 50)
+				src.toggle_recoil(FALSE)
 			if ("clownshot","clown")
 				set_current_projectile(projectiles["clownshot"])
 				item_state = "lawg-clownshot"
@@ -1553,6 +1562,10 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 
 			if (current_projectile.type == /datum/projectile/bullet/flare)
 				shoot_fire_hotspots(target, start, user)
+			else if (current_projectile.type == /datum/projectile/laser/asslaser)
+				for (var/mob/living/mob in viewers(1, user))
+					mob.flash(1.5 SECONDS)
+				user.changeStatus("disorient", 2 SECONDS)
 		return ..(target, start, user)
 
 /obj/item/gun/energy/lawbringer/emag_act(var/mob/user, var/obj/item/card/emag/E)

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1384,7 +1384,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 			src.change_mode(M, text)
 		else		//if you're not the owner and try to change it, then fuck you
 			switch(text)
-				if ("detain","execute","knockout","hotshot","incendiary","assault","highpower","clownshot","clown", "pulse", "punch")
+				if ("detain","execute","knockout","hotshot","incendiary","bigshot","assault","highpower","clownshot","clown", "pulse", "punch")
 					random_burn_damage(M, 50)
 					M.changeStatus("knockdown", 4 SECONDS)
 					elecflash(src,power=2)

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -122,7 +122,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 /obj/machinery/door/Cross(atom/movable/mover)
 	if(istype(mover, /obj/projectile))
 		var/obj/projectile/P = mover
-		if(P.proj_data.window_pass)
+		if(P.proj_data.window_pass && !P.proj_data.always_hits_structures)
 			return !opacity
 	if(density && mover && mover.flags & DOORPASS && !src.cant_emag)
 		if (ismob(mover))
@@ -398,7 +398,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 		if(1)
 			qdel(src)
 		if(2)
-			if(prob(25))
+			if(prob(66))
 				qdel(src)
 			else
 				take_damage(health_max/2)

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -59,8 +59,8 @@ obj/structure/ex_act(severity)
 			return
 	return
 
-/obj/structure/girder/Cross(atom/movable/mover)
-	if (istype(mover, /obj/projectile) && prob(src.projectile_passthrough_chance))
+/obj/structure/girder/Cross(obj/projectile/mover)
+	if (istype(mover) && !mover.proj_data.always_hits_structures && prob(src.projectile_passthrough_chance))
 		return TRUE
 	return (!density)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Also tweaks some things behind the scenes to make assault lasers slightly more consistent demolition tools and adds a cool flash effect and slight disorient on firing the assault mode.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the high explosive mode isn't very practical for breaching doors/walls since it usually takes out the floor too and any nearby APCs, security assistants etc. Assault lasers do almost exactly the same damage, have similar breaching chances and do not blow holes in the floor.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Replaced the lawbringer's High Explosive mode with a High Power assault laser mode. Keywords are: BIG SHOT, HIGH POWER and ASSAULT.
```
