### PR TITLE
Removes "wifi" from the wifi signal splitter's name

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -1287,7 +1287,7 @@
 		return
 
 /obj/item/mechanics/wifisplit
-	name = "Wifi Signal Splitter Component"
+	name = "Signal Splitter Component"
 	desc = ""
 	icon_state = "comp_split"
 	var/triggerSignal = "1"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Does exactly what it says on the tin and nothing else. It's called the Signal Splitter Component now.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It doesnt actually have anything to do with wifi. Why is it called that?

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cherman0
(+)"Wifi Signal Splitter Component" is now just called "Signal Splitter Component"
```
