### PR TITLE
Make turbine report stator load via mechcomp

### DIFF
--- a/code/obj/nuclearreactor/turbine.dm
+++ b/code/obj/nuclearreactor/turbine.dm
@@ -230,7 +230,7 @@
 
 			src.network1?.update = TRUE
 			src.network2?.update = TRUE
-		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "rpm=[src.RPM]&power=[lastgen]&powerfmt=[engineering_notation(lastgen)]W")
+		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "rpm=[src.RPM]&stator=[src.stator_load]&power=[src.lastgen]&powerfmt=[engineering_notation(src.lastgen)]W")
 
 	suicide(mob/user)
 		user.visible_message(SPAN_ALERT("<b>[user] puts their head into blades of \the [src]!</b>"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Does what it says on the tin. The turbine already reports a packet that has the current RPM, power as a plain number, and power as formatted text. Now it also reports the stator load.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently any automation of the turbine has to externally keep track of the stator load. Which works, but it's a little awkward and can't be made to accomodate for manual adjustments. Now the machine will just tell you what its stator load is set to.
## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cherman0
(+)The nuclear generator turbine now reports its stator load via mechcomp.
```
