### PR TITLE
Unify RP and Classic security access

### DIFF
--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -640,18 +640,10 @@
 	department = 4
 	req_access = list(access_maxsec)
 
-	#ifdef RP_MODE // fuckin RP mode giving secoffs more access *grumble grumble*
-	civilian_access_list = list(access_morgue, access_maint_tunnels, access_chapel_office, access_tech_storage, access_bar, access_janitor, access_crematorium, access_kitchen, access_hydro, access_ranch)
-	engineering_access_list = list(access_engineering, access_engineering_storage, access_engineering_power, access_engineering_engine, access_engineering_mechanic, access_engineering_atmos, access_engineering_control)
-	supply_access_list = list(access_cargo, access_mining, access_mining_outpost)
-	research_access_list = list(access_medical, access_tox, access_tox_storage, access_medlab, access_research, access_robotics, access_chemistry, access_pathology, access_researchfoyer, access_artlab, access_telesci, access_robotdepot)
-	security_access_list = list(access_security, access_brig, access_forensics_lockers, access_maxsec, access_armory, access_securitylockers, access_carrypermit, access_contrabandpermit)
-	command_access_list = list(access_eva)
-	#else
 	civilian_access_list = list(access_morgue, access_maint_tunnels, access_tech_storage, access_bar, access_crematorium, access_kitchen, access_hydro)
 	engineering_access_list = list(access_engineering, access_engineering_control)
 	supply_access_list = list(access_cargo)
 	research_access_list = list(access_medical, access_research, access_chemistry, access_researchfoyer)
 	security_access_list = list(access_security, access_brig, access_forensics_lockers, access_maxsec, access_armory, access_securitylockers, access_carrypermit, access_contrabandpermit)
 	command_access_list = list(access_eva)
-	#endif
+

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -213,7 +213,7 @@
 						access_forensics_lockers, access_armory, access_tox, access_tox_storage, access_chemistry, access_medical, access_morgue,
 						access_change_ids, access_eva, access_heads, access_medical_lockers, access_medlab,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
-						access_crematorium, access_kitchen, access_robotics, access_cargo, access_money
+						access_crematorium, access_kitchen, access_robotics, access_cargo, access_money,
 						access_research, access_dwaine_superuser, access_hydro, access_ranch, access_mail, access_ai_upload,
 						access_engineering, access_teleporter, access_engineering_engine, access_engineering_control,
 						access_mining, access_pathology, access_researchfoyer, access_chapel_office, access_telesci,

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -213,7 +213,7 @@
 						access_forensics_lockers, access_armory, access_tox, access_tox_storage, access_chemistry, access_medical, access_morgue,
 						access_change_ids, access_eva, access_heads, access_medical_lockers, access_medlab,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
-						access_crematorium, access_kitchen, access_robotics, access_cargo, access_money, access_change_ids
+						access_crematorium, access_kitchen, access_robotics, access_cargo, access_money,
 						access_research, access_dwaine_superuser, access_hydro, access_ranch, access_mail, access_ai_upload,
 						access_engineering, access_teleporter, access_engineering_engine, access_engineering_control,
 						access_mining, access_pathology, access_researchfoyer, access_chapel_office, access_telesci,

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -209,21 +209,16 @@
 						access_research, access_hydro, access_ranch, access_mail, access_ai_upload, access_pathology, access_researchfoyer,
 						access_telesci, access_teleporter, access_money)
 		if("Head of Security")
-#ifdef RP_MODE
-			var/list/hos_access = get_all_accesses()
-			hos_access += access_maxsec
-			hos_access += access_armory
-			return hos_access
-#else
-			return list(access_security, access_carrypermit, access_contrabandpermit, access_maxsec, access_brig, access_securitylockers, access_forensics_lockers, access_armory,
-						access_tox, access_tox_storage, access_chemistry, access_medical, access_morgue, access_medlab,
-						access_change_ids, access_eva, access_heads, access_medical_lockers,
+			return list(access_security, access_carrypermit, access_contrabandpermit, access_maxsec, access_brig, access_securitylockers,
+						access_forensics_lockers, access_armory, access_tox, access_tox_storage, access_chemistry, access_medical, access_morgue,
+						access_change_ids, access_eva, access_heads, access_medical_lockers, access_medlab,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
-						access_crematorium, access_kitchen, access_robotics, access_cargo,
+						access_crematorium, access_kitchen, access_robotics, access_cargo, access_money
 						access_research, access_dwaine_superuser, access_hydro, access_ranch, access_mail, access_ai_upload,
 						access_engineering, access_teleporter, access_engineering_engine, access_engineering_power, access_engineering_control,
-						access_mining, access_pathology, access_researchfoyer)
-#endif
+						access_mining, access_pathology, access_researchfoyer, access_chapel_office, access_telesci, access_artlab, access_robotdepot,
+						access_engineering_eva, access_engineering_storage, access_engineering_mechanic, access_engineering_atmos, access_mining_outpost
+						)
 		if("Research Director")
 			return list(access_research, access_research_director, access_dwaine_superuser,
 						access_tech_storage, access_maint_tunnels, access_heads, access_eva, access_tox,
@@ -248,23 +243,10 @@
 
 		///////////////////////////// Security
 		if("Security Officer")
-#ifdef RP_MODE
-			return list(access_security, access_brig, access_forensics_lockers,
-				access_medical, access_medlab, access_morgue, access_securitylockers,
-				access_tox, access_tox_storage, access_chemistry, access_carrypermit, access_contrabandpermit,
-				access_chapel_office, access_kitchen,
-				access_bar, access_janitor, access_robotics, access_cargo, access_hydro, access_mail,
-				access_engineering, access_maint_tunnels,
-				access_tech_storage, access_engineering_storage, access_engineering_eva,
-				access_engineering_engine,
-				access_engineering_control, access_engineering_mechanic, access_mining, access_mining_outpost,
-				access_research, access_engineering_atmos, access_ranch, access_pathology, access_artlab, access_telesci,
-				access_researchfoyer, access_robotdepot)
-#else
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig, access_maint_tunnels,
-			access_medical, access_morgue, access_crematorium, access_research, access_cargo, access_engineering, access_engineering_control,
-			access_chemistry, access_bar, access_kitchen, access_hydro, access_pathology, access_researchfoyer)
-#endif
+			access_medical, access_morgue, access_research, access_cargo, access_engineering, access_engineering_control,
+			access_chemistry, access_bar, access_kitchen, access_hydro, access_pathology, access_researchfoyer
+			)
 		if("Vice Officer")
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_maint_tunnels,access_hydro, access_bar, access_kitchen, access_ranch)
 		if("Security Assistant")

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -244,7 +244,7 @@
 		if("Security Officer")
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig, access_maint_tunnels,
 			access_medical, access_morgue, access_research, access_cargo, access_engineering, access_engineering_control,
-			access_chemistry, access_bar, access_kitchen, access_hydro, access_pathology, access_researchfoyer, access_mining, access_tox
+			access_chemistry, access_bar, access_kitchen, access_hydro, access_pathology, access_researchfoyer, access_mining
 			)
 		if("Vice Officer")
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_maint_tunnels,access_hydro, access_bar, access_kitchen, access_ranch)

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -215,10 +215,9 @@
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
 						access_crematorium, access_kitchen, access_robotics, access_cargo, access_money
 						access_research, access_dwaine_superuser, access_hydro, access_ranch, access_mail, access_ai_upload,
-						access_engineering, access_teleporter, access_engineering_engine, access_engineering_power, access_engineering_control,
-						access_mining, access_pathology, access_researchfoyer, access_chapel_office, access_telesci, access_artlab, access_robotdepot,
-						access_engineering_eva, access_engineering_storage, access_engineering_mechanic, access_engineering_atmos, access_mining_outpost
-						)
+						access_engineering, access_teleporter, access_engineering_engine, access_engineering_control,
+						access_mining, access_pathology, access_researchfoyer, access_chapel_office, access_telesci,
+						access_engineering_eva, access_engineering_storage, access_engineering_mechanic)
 		if("Research Director")
 			return list(access_research, access_research_director, access_dwaine_superuser,
 						access_tech_storage, access_maint_tunnels, access_heads, access_eva, access_tox,

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -213,7 +213,7 @@
 						access_forensics_lockers, access_armory, access_tox, access_tox_storage, access_chemistry, access_medical, access_morgue,
 						access_change_ids, access_eva, access_heads, access_medical_lockers, access_medlab,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
-						access_crematorium, access_kitchen, access_robotics, access_cargo, access_money,
+						access_crematorium, access_kitchen, access_robotics, access_cargo, access_money, access_change_ids
 						access_research, access_dwaine_superuser, access_hydro, access_ranch, access_mail, access_ai_upload,
 						access_engineering, access_teleporter, access_engineering_engine, access_engineering_control,
 						access_mining, access_pathology, access_researchfoyer, access_chapel_office, access_telesci,

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -244,7 +244,7 @@
 		if("Security Officer")
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig, access_maint_tunnels,
 			access_medical, access_morgue, access_research, access_cargo, access_engineering, access_engineering_control,
-			access_chemistry, access_bar, access_kitchen, access_hydro, access_pathology, access_researchfoyer
+			access_chemistry, access_bar, access_kitchen, access_hydro, access_pathology, access_researchfoyer, access_mining, access_tox
 			)
 		if("Vice Officer")
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_maint_tunnels,access_hydro, access_bar, access_kitchen, access_ranch)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes RP and Classic  security officer/HoS accesses the same, removing a large portion of RP's officer access in the process
I made a forum post to discuss this which can be found [here](https://forum.ss13.co/showthread.php?tid=23020)
I was going to wait for more feedback on this but Leah expressed interest in testmerging these changes
(Below spreadsheet may be inaccurate if testmerge is not updated)
![image](https://github.com/user-attachments/assets/4f489813-180d-47ab-a742-35ee55f98740)

**WIP ACCESS LIST**, if you think either job should/shouldn't get an access please mention it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Please read the comment below by TobleroneSwordfish because they did a much better explanation than I did.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)RP and Classic security officer and HoS accesses have been unified. See the PR for a more in depth comparison and report any issues that may arise to the forum thread.
```
