### PR TITLE
Adds Medical Crash Cart to Atlas Medbay

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -16469,8 +16469,8 @@
 /area/station/maintenance/southwest)
 "jUF" = (
 /obj/machinery/firealarm/north,
-/obj/storage/cart/medcart,
 /obj/item/reagent_containers/syringe/haloperidol,
+/obj/storage/cart/medcart/crash,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
<!-- [mapping][qol] -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the medical crash cart to Atlas' Medbay as it did not have one.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Medical Cart originally just had a Haloperidol syringe. Now it is the Crash Cart with the various medical supplies, which is inline with all other maps currently in rotation.
