### PR TITLE
Fixes wizard max name length.

### DIFF
--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -82,7 +82,6 @@
 					newname = randomname
 
 				if (newname)
-					if (length(newname) >= 26) newname = copytext(newname, 1, 26)
 					newname = strip_html(newname)
 					H.real_name = newname
 					H.on_realname_change()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes an unnecessary trim that was truncating wizard names too much.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wizard names were being shortened to a maximum of 25 characters instead of the 28 limited by the tgui input window. As per Leah, the tgui input is verified server-side as well as client-side, so the trim/clamp is unneeded.