### PR TITLE
Have the Port-a-Brig make noises

### DIFF
--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -533,7 +533,7 @@ TYPEINFO(/obj/machinery/port_a_brig)
 		for(var/obj/O in src.brig)
 			O.set_loc(src.brig.loc)
 		src.brig.build_icon()
-		playsound(src.loc, 'sound/machines/sleeper_close.ogg', 50, 1)
+		playsound(brig.loc, 'sound/machines/sleeper_close.ogg', 50, 1)
 		qdel(G)
 
 /obj/machinery/port_a_brig/proc/pry_open()

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -366,6 +366,7 @@ TYPEINFO(/obj/machinery/port_a_brig)
 		var/req = unlock_timer_req - (world.timeofday - unlock_timer_start)
 		if (req <= 0)
 			locked = 0
+			playsound(src, 'sound/machines/airlock_unbolt.ogg', 40, TRUE, -2)
 			go_out()
 			.= 0
 		.= req
@@ -438,6 +439,10 @@ TYPEINFO(/obj/machinery/port_a_brig)
 			if (src.allowed(user))
 				src.locked = !src.locked
 				boutput(user, "You [ src.locked ? "lock" : "unlock"] the [src].")
+				if (src.locked)
+					playsound(src, 'sound/machines/airlock_unbolt.ogg', 40, TRUE, -2)
+				else
+					playsound(src, 'sound/machines/airlock_bolt.ogg', 40, TRUE, -2)
 				if (src.occupant)
 					logTheThing(LOG_STATION, user, "[src.locked ? "locks" : "unlocks"] [src.name] with [constructTarget(src.occupant,"station")] inside at [log_loc(src)].")
 			else
@@ -539,6 +544,7 @@ TYPEINFO(/obj/machinery/port_a_brig)
 /obj/machinery/port_a_brig/proc/pry_open()
 	playsound(src.loc, 'sound/items/Crowbar.ogg', 100, TRUE)
 	src.locked = FALSE
+	playsound(src, 'sound/machines/airlock_unbolt.ogg', 40, TRUE, -2)
 
 /obj/item/paper/Port_A_Brig
 	name = "paper - 'A-97 Port-A-Brig Manual"

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -477,6 +477,7 @@ TYPEINFO(/obj/machinery/port_a_brig)
 		if(src.occupant)
 			src.occupant.set_loc(src.loc)
 			src.occupant.changeStatus("knockdown", 2 SECONDS)
+			playsound(src.loc, 'sound/machines/sleeper_open.ogg', 50, 1)
 		return
 
 	verb/move_eject()
@@ -532,6 +533,7 @@ TYPEINFO(/obj/machinery/port_a_brig)
 		for(var/obj/O in src.brig)
 			O.set_loc(src.brig.loc)
 		src.brig.build_icon()
+		playsound(src.loc, 'sound/machines/sleeper_close.ogg', 50, 1)
 		qdel(G)
 
 /obj/machinery/port_a_brig/proc/pry_open()


### PR DESCRIPTION
[SOUNDS] [FEATURE]
## About the PR
Have the Port-a-Brig make the same sound effects as the med sleeper when an occupant is put inside or removed. Also clunks like an airlock whenever it's locked or unlocked.

## Why's this needed?
It was a bit strange that it was dead silent.

## Changelog
```changelog
(u)Tyrant
(+)Due to budget cuts, Port-a-Brigs are no longer equipped with soundproofing.
```