### PR TITLE
Pizza Snipping 2 (possibly controversial)

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -17,7 +17,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 	var/doants = TRUE 							//! Will ants spawn to eat this food if it's on the floor
 	var/tmp/made_ants = FALSE 					//! Has this food already spawned ants
 	var/ant_amnt = 5 							//! How many ants are added to food / how much reagents removed?
-	var/sliceable = FALSE 						//! Can this food be sliced with a knife
+	var/sliceable = FALSE						//! Can this food be sliced
+	var/slice_tools = TOOL_CUTTING | TOOL_SAWING	//! Which tools can be used to slice this food
 	var/slice_product = null 					//! Type to spawn when we slice this food
 	var/slice_amount = 1						//! How many slices to spawn after slicing
 	var/slice_inert = FALSE						//! If the food is inert while slicing (ie chemical reactions won't occur)
@@ -104,9 +105,9 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 		else
 			M.HealDamage("All", healing, healing)
 
-	//slicing food can be done here using sliceable == TRUE, slice_amount, and slice_product
+	//slicing food can be done here using sliceable == TRUE, slice_amount and slice_product; slice_tools can be overridden if needed (e.g. snipping food)
 	attackby(obj/item/W, mob/user)
-		if (src.sliceable && istool(W, TOOL_CUTTING | TOOL_SAWING))
+		if (src.sliceable && istool(W, slice_tools))
 			if(user.bioHolder.HasEffect("clumsy") && prob(50))
 				user.visible_message(SPAN_ALERT("<b>[user]</b> fumbles and jabs [himself_or_herself(user)] in the eye with [W]."))
 				user.change_eye_blurry(5)

--- a/code/modules/food_and_drink/pizza.dm
+++ b/code/modules/food_and_drink/pizza.dm
@@ -309,6 +309,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/pizza)
 	slice_amount = 6
 	sliceable = TRUE
 	slice_product = /obj/item/reagent_containers/food/snacks/pizzaslice
+	slice_tools = TOOL_SNIPPING | TOOL_CUTTING | TOOL_SAWING
 	initial_volume = 60 // 40 units will be available to stuff the crust
 	custom_food = FALSE
 	initial_reagents = list("bread" = 20)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[CATERING][GAME-OBJECTS][FEATURE][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes pizza snippable again by implementing a `slice_tools` var in the food parent and using it in the parent's attackby proc. This doesn't impact any other foods at the moment, since slice_tools is just TOOL_CUTTING | TOOL_SAWING at the moment.
Pizza's slice_tools are the same, with the addition of the TOOL_SNIPPING flag.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The Pizza rework changed how pizza slices are handled, presumably unintentionally reverting #17747.
To quote my previous pizza PR:

> I believe this could help with the issue of people not having any tools nearby to cut pizza with. Since scissors can already be found in lockers all around the station (usually closer than knives), allowing them to cut pizza could improve the pizza-eating experience.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chasu
(+)Pizzas can (again) be cut with snipping tools. Knifeless rejoice!
```
