### PR TITLE
Remove Katana and Wrestling Belt from surplus crates

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1064,7 +1064,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Black Market Megaphone"
 	desc = "An illegal megaphone with the limiter taken off, and a loudener added. Not for the subtle."
 	item = /obj/item/megaphone/syndicate
-	cost = 5
+	cost = 3
 	vr_allowed = FALSE // no
 	job = list("Captain", "VIP", "Inspector", "Head of Personnel")
 

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -278,6 +278,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	item = /obj/item/swords_sheaths/katana
 	cost = 7
 	desc = "A Japanese sword created in the fire of a dying star. Comes with a sheath for easier storage"
+	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP | UPLINK_SPY_THIEF
 
 /datum/syndicate_buylist/generic/wrestling
@@ -285,6 +286,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	item = /obj/item/storage/belt/wrestling
 	cost = 7
 	desc = "A haunted antique wrestling belt, imbued with the spirits of wrestlers past. Wearing it unlocks a number of wrestling moves, which can be accessed in a separate command tab."
+	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP
 
 /datum/syndicate_buylist/generic/spy_sticker_kit
@@ -1064,7 +1066,6 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	item = /obj/item/megaphone/syndicate
 	cost = 5
 	vr_allowed = FALSE // no
-	not_in_crates = TRUE
 	job = list("Captain", "VIP", "Inspector", "Head of Personnel")
 
 /datum/syndicate_buylist/traitor/ai_disguised_module

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1064,8 +1064,9 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	name = "Black Market Megaphone"
 	desc = "An illegal megaphone with the limiter taken off, and a loudener added. Not for the subtle."
 	item = /obj/item/megaphone/syndicate
-	cost = 3
+	cost = 5
 	vr_allowed = FALSE // no
+	not_in_crates = TRUE
 	job = list("Captain", "VIP", "Inspector", "Head of Personnel")
 
 /datum/syndicate_buylist/traitor/ai_disguised_module


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes both the katana and wrestling belt from surplus crates

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The wiki states "some items cannot appear in them, primarily those geared towards murder" and these 2 items in particular are if anything stronger at rampaging than a csaber, let alone them appearing with other items like stimulants.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Removed Wrestling Belt and Katana from Surplus crates.
```
