### PR TITLE
fixes a secret medal

### DIFF
--- a/code/datums/components/hattable.dm
+++ b/code/datums/components/hattable.dm
@@ -63,6 +63,12 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 		RegisterSignal(src.parent, COMSIG_MOB_DEATH, PROC_REF(die), override = TRUE)
 	RegisterSignal(src.hat, COMSIG_ITEM_PICKUP, PROC_REF(take_hat_off), override = TRUE)
 	UnregisterSignal(src.parent, COMSIG_ATTACKBY)
+
+	if (istype(item, /obj/item/clothing/head/butt) && isAI(target))
+		var/obj/item/clothing/head/butt/butt = item
+		if (butt.donor == attacker)
+			attacker.unlock_medal("Law 1: Don't be an asshat", TRUE)
+
 	return TRUE
 
 /datum/component/hattable/proc/take_hat_off(mob/target, mob/user)

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -587,11 +587,12 @@ or don't if it uses a custom topopen overlay
 			user.visible_message(SPAN_ALERT("<b>[user.name]</b> uploads a moustache to [src.name]!"))
 		else if (src.dismantle_stage == 4 || isdead(src))
 			boutput(user, SPAN_ALERT("Using this on a deactivated AI would be silly."))
-		if(istype(W, /obj/item/clothing/head/butt))
-			var/obj/item/clothing/head/butt/butt = W
-			if(butt.donor == user)
-				user.unlock_medal("Law 1: Don't be an asshat", 1)
-		return
+			return
+	else if (istype(W, /obj/item/clothing/head/butt))
+		var/obj/item/clothing/head/butt/butt = W
+		if (butt.donor == user)
+			user.unlock_medal("Law 1: Don't be an asshat", TRUE)
+			boutput(user, SPAN_ALERT("WORKING!!!!!!!!."))
 
 	else if(istype(W,/obj/item/ai_plating_kit))
 		if(src.coreSkin != "default") // to avoid having your hard-earned skin being lost because someone bought the clown one or something

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -587,7 +587,7 @@ or don't if it uses a custom topopen overlay
 			user.visible_message(SPAN_ALERT("<b>[user.name]</b> uploads a moustache to [src.name]!"))
 		else if (src.dismantle_stage == 4 || isdead(src))
 			boutput(user, SPAN_ALERT("Using this on a deactivated AI would be silly."))
-			return
+		return
 	else if(istype(W,/obj/item/ai_plating_kit))
 		if(src.coreSkin != "default") // to avoid having your hard-earned skin being lost because someone bought the clown one or something
 			user.show_message(SPAN_ALERT("[src] already has a plating kit installed!"))

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -588,12 +588,6 @@ or don't if it uses a custom topopen overlay
 		else if (src.dismantle_stage == 4 || isdead(src))
 			boutput(user, SPAN_ALERT("Using this on a deactivated AI would be silly."))
 			return
-	else if (istype(W, /obj/item/clothing/head/butt))
-		var/obj/item/clothing/head/butt/butt = W
-		if (butt.donor == user)
-			user.unlock_medal("Law 1: Don't be an asshat", TRUE)
-			boutput(user, SPAN_ALERT("WORKING!!!!!!!!."))
-
 	else if(istype(W,/obj/item/ai_plating_kit))
 		if(src.coreSkin != "default") // to avoid having your hard-earned skin being lost because someone bought the clown one or something
 			user.show_message(SPAN_ALERT("[src] already has a plating kit installed!"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][medal][secret]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the secret medal "Law 1: Don't be an asshat" be able to be earned

the medal was last earned 5 months ago
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The current requirements for completing that medal is to attack the ai with an item that:
1: is not /obj/item/clothing/head/ (hattable component overrides the attackby function)
2: is /obj/item/clothing/mask/moustache/ (broken indentation)
3: is /obj/item/clothing/head/butt
4: has you as a donor
This is obviously nonsensical
