### PR TITLE
Fix up manufacturer buttons a bit

### DIFF
--- a/tgui/packages/tgui/interfaces/Manufacturer/components/BlueprintButton.tsx
+++ b/tgui/packages/tgui/interfaces/Manufacturer/components/BlueprintButton.tsx
@@ -16,7 +16,7 @@ import {
 import { round } from 'tgui-core/math';
 
 import { truncate } from '../../../format';
-import { BlueprintButtonStyle, BlueprintMiniButtonStyle } from '../constant';
+import { BlueprintButtonStyle, BlueprintMiniButtonStyle, CSS_StyleDisplay } from '../constant';
 import { ManufacturableData, RequirementData, ResourceData } from '../type';
 import { ButtonWithBadge } from './ButtonWithBadge';
 import { CenteredText } from './CenteredText';
@@ -146,8 +146,12 @@ export const BlueprintButton = (props: BlueprintButtonProps) => {
   } else {
     content_info = blueprintData?.item_descriptions?.[0] ?? '';
   }
+  // For some reason, formatting errors show unless done as a separate var
+  const style = {align: CSS_StyleDisplay}
   return (
-    <Stack inline>
+    <Stack
+      style = {style}
+    >
       <Stack.Item
         ml={BlueprintButtonStyle.MarginX}
         my={BlueprintButtonStyle.MarginY}
@@ -167,7 +171,7 @@ export const BlueprintButton = (props: BlueprintButtonProps) => {
         </ButtonWithBadge>
       </Stack.Item>
       <Stack.Item mr={BlueprintButtonStyle.MarginX}>
-        <Stack vertical my={BlueprintButtonStyle.MarginY}>
+        <Stack inline vertical my={BlueprintButtonStyle.MarginY}>
           <Stack.Item mb={BlueprintMiniButtonStyle.Spacing}>
             <Tooltip content={content_info}>
               <Button

--- a/tgui/packages/tgui/interfaces/Manufacturer/components/BlueprintButton.tsx
+++ b/tgui/packages/tgui/interfaces/Manufacturer/components/BlueprintButton.tsx
@@ -16,7 +16,7 @@ import {
 import { round } from 'tgui-core/math';
 
 import { truncate } from '../../../format';
-import { BlueprintButtonStyle, BlueprintMiniButtonStyle, CSS_StyleDisplay } from '../constant';
+import { BlueprintButtonStyle, BlueprintMiniButtonStyle } from '../constant';
 import { ManufacturableData, RequirementData, ResourceData } from '../type';
 import { ButtonWithBadge } from './ButtonWithBadge';
 import { CenteredText } from './CenteredText';
@@ -147,11 +147,8 @@ export const BlueprintButton = (props: BlueprintButtonProps) => {
     content_info = blueprintData?.item_descriptions?.[0] ?? '';
   }
   // For some reason, formatting errors show unless done as a separate var
-  const style = {align: CSS_StyleDisplay}
   return (
-    <Stack
-      style = {style}
-    >
+    <Stack style={{ display: BlueprintButtonStyle.Display }}>
       <Stack.Item
         ml={BlueprintButtonStyle.MarginX}
         my={BlueprintButtonStyle.MarginY}

--- a/tgui/packages/tgui/interfaces/Manufacturer/components/BlueprintButton.tsx
+++ b/tgui/packages/tgui/interfaces/Manufacturer/components/BlueprintButton.tsx
@@ -146,7 +146,6 @@ export const BlueprintButton = (props: BlueprintButtonProps) => {
   } else {
     content_info = blueprintData?.item_descriptions?.[0] ?? '';
   }
-  // For some reason, formatting errors show unless done as a separate var
   return (
     <Stack style={{ display: BlueprintButtonStyle.Display }}>
       <Stack.Item

--- a/tgui/packages/tgui/interfaces/Manufacturer/constant.ts
+++ b/tgui/packages/tgui/interfaces/Manufacturer/constant.ts
@@ -32,6 +32,7 @@ export enum BlueprintButtonStyle {
   Height = 5,
   MarginX = 0.5,
   MarginY = 0.5,
+  CSS_StyleDisplay = 'inline-flex',
 }
 
 // Controls the smaller 'settings' and 'info' buttons on the side of each larger button.

--- a/tgui/packages/tgui/interfaces/Manufacturer/constant.ts
+++ b/tgui/packages/tgui/interfaces/Manufacturer/constant.ts
@@ -32,7 +32,7 @@ export enum BlueprintButtonStyle {
   Height = 5,
   MarginX = 0.5,
   MarginY = 0.5,
-  CSS_StyleDisplay = 'inline-flex',
+  Display = 'inline-flex',
 }
 
 // Controls the smaller 'settings' and 'info' buttons on the side of each larger button.

--- a/tgui/packages/tgui/interfaces/Manufacturer/index.tsx
+++ b/tgui/packages/tgui/interfaces/Manufacturer/index.tsx
@@ -159,11 +159,10 @@ export const Manufacturer = () => {
                       title={`${category} (${blueprints_by_category[category].length})`}
                     >
                       {(blueprints_by_category[category] ?? []).map(
-                        (blueprint, index) => (
+                        (blueprint) => (
                           <BlueprintButton
                             actionRemoveBlueprint={actionRemoveBlueprint}
                             actionVendProduct={actionVendProduct}
-                            key={index}
                             blueprintData={blueprint}
                             manufacturerSpeed={data.speed}
                             materialData={data.resource_data}
@@ -364,7 +363,6 @@ export const Manufacturer = () => {
                     (queued: ManufacturableData, index: number) =>
                       queued && (
                         <ProductionCard
-                          key={index}
                           index={index}
                           actionQueueRemove={actionQueueRemove}
                           mode={data.mode}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Turn this
![firefox_1aSrLG1URP](https://github.com/user-attachments/assets/87864598-21bb-43d3-b75d-eda66d74f7da)

Into this
![IjssgmB1gc](https://github.com/user-attachments/assets/b0932f26-12ad-485e-891c-4479502d0f2e)

I dont know why the inline-flex property matters but it fixed it so i suppose it should be good

