### PR TITLE
Add a blowgun with knockout darts to the traitor and spy-thief buylists

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2656,7 +2656,7 @@ ABSTRACT_TYPE(/datum/job/daily)
 	slot_head = list(/obj/item/clothing/head/flatcap)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
 	slot_ears = list(/obj/item/device/radio/headset/civilian)
-	items_in_backpack = list(/obj/item/instrument/saxophone,/obj/item/instrument/guitar,/obj/item/instrument/bagpipe,/obj/item/instrument/fiddle)
+	slot_lhan = list(/obj/item/storage/briefcase/instruments)
 	change_name_on_spawn = TRUE
 	wiki_link = "https://wiki.ss13.co/Musician"
 

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -465,6 +465,13 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	desc = "A tool which allows you to scan and plant fingerprints."
 	cost = 1
 
+/datum/syndicate_buylist/traitor/blowgun
+	name = "Blowgun"
+	item = /obj/item/storage/briefcase/instruments/blowgun/tranq
+	desc = "A blowgun with a set of 8 knockout darts. \"Cunningly\" disguised as a flute."
+	cost = 4
+	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
+
 //////////////////////////////////////////////// Objective-specific items //////////////////////////////////////////////
 
 /datum/syndicate_buylist/traitor/idtracker

--- a/code/obj/item/storage/ammo_pouches.dm
+++ b/code/obj/item/storage/ammo_pouches.dm
@@ -47,9 +47,6 @@
 		can_hold = list(/obj/item/gun/kinetic/blowgun, /obj/item/ammo/bullets/tranq_darts)
 		spawn_contents = list(/obj/item/ammo/bullets/tranq_darts/blow_darts = 2, /obj/item/ammo/bullets/tranq_darts/blow_darts/madness = 1, /obj/item/ammo/bullets/tranq_darts/blow_darts/ls_bee = 1)
 
-		tranq
-			spawn_contents = list(/obj/item/gun/kinetic/blowgun/tranq, /obj/item/ammo/bullets/tranq_darts/blow_darts/ketamine = 2)
-
 	det_38
 		name = ".38 rounds pouch"
 		icon_state = "ammopouch-double"

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -365,12 +365,19 @@
 	spawn_contents = list(/obj/item/reagent_containers/glass/bottle/poison = 7)
 
 
-/obj/item/storage/box/blowgun
+/obj/item/storage/briefcase/instruments
 	name = "instrument case"
 	desc = "A hardshell case for musical instruments."
 	icon_state = "briefcase_black"
+	item_state = "sec-case"
+	spawn_contents = list(/obj/item/instrument/saxophone,/obj/item/instrument/guitar,/obj/item/instrument/bagpipe,/obj/item/instrument/fiddle)
+
+/obj/item/storage/briefcase/instruments/blowgun
 	spawn_contents = list(/obj/item/gun/kinetic/blowgun,\
 	/obj/item/storage/pouch/poison_dart = 2)
+
+/obj/item/storage/briefcase/instruments/blowgun/tranq
+	spawn_contents = list(/obj/item/gun/kinetic/blowgun/tranq, /obj/item/ammo/bullets/tranq_darts/blow_darts/ketamine = 2)
 
 /obj/item/storage/box/chameleonbomb
 	name = "chameleon bomb case"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [FEATURE] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The blowgun already exists and was made by @cogwerks a while back, this PR just add a buy option for 4TC to buy an "instrument case" containing a blowgun and two clips of 4 knockout darts. The darts are barbed and contain enough ketamine to reliably knock someone out for about 30 seconds after a short delay.

This PR also changes musicians to spawn with an identical instrument case containing their actual instruments to make the blowgun one less recognizable.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A lack of non-lethal kidnapping options besides the sleepy pen, new traitor items are cool, the thing already exists so why not make it available!


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech and Cogwerks
(*)Added a blowgun complete with 8 knockout darts to the traitor and spy-thief purchase lists. It costs 4TC.
```
