### PR TITLE
[Debug Tool] Add new define to spawn as arbitrary job roundstart

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -48,6 +48,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define SHUT_UP_AND_GIVE_ME_MEDAL_STUFF // causes has_medal to always return true - good for testing medal rewards etc.
 //#define SHOW_ME_STATUSES // incredibly hacky visible status effects
 //#define ME_AND_MY_40_ALT_ACCOUNTS // Override game mode minimum player requirements for testing revs, nukies etc.
+//#define GIVE_ME_COOL_STUFF_IMMEDIATELY // Spawn as a 'imcoder' job. Gives CE belt, captain ID, etc.
 
 //#define STOP_DISTRACTING_ME //All of the below
 

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -48,7 +48,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define SHUT_UP_AND_GIVE_ME_MEDAL_STUFF // causes has_medal to always return true - good for testing medal rewards etc.
 //#define SHOW_ME_STATUSES // incredibly hacky visible status effects
 //#define ME_AND_MY_40_ALT_ACCOUNTS // Override game mode minimum player requirements for testing revs, nukies etc.
-//#define GIVE_ME_COOL_STUFF_IMMEDIATELY // Spawn as a 'imcoder' job. Gives CE belt, captain ID, etc.
+//#define I_WANNA_BE_THE_JOB "IMCODER" // Spawn as a 'imcoder' job. Gives CE belt, captain ID, etc. Change string to different job ID as needed
 
 //#define STOP_DISTRACTING_ME //All of the below
 

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1012,6 +1012,30 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	wages = PAY_UNTRAINED
 	wiki_link = "https://wiki.ss13.co/Jobs#Gimmick_Jobs" // fallback for those without their own page
 
+#ifdef I_WANNA_BE_THE_JOB
+/datum/job/special/imcoder
+	name = "IMCODER"
+	// Used for debug testing. No need to define special landmark, this overrides job picks
+	access_string = "Captain"
+
+	slot_belt = list(/obj/item/storage/belt/utility/prepared/ceshielded)
+	slot_jump = list(/obj/item/clothing/under/rank/assistant)
+	slot_foot = list(/obj/item/clothing/shoes/magnetic)
+	slot_glov = list(/obj/item/clothing/gloves/yellow)
+	slot_ears = list(/obj/item/device/radio/headset)
+	slot_head = list(/obj/item/clothing/head/helmet/space/light/engineer)
+	slot_suit = list(/obj/item/clothing/suit/space/light/engineer)
+	slot_back = list(/obj/item/storage/backpack)
+	slot_mask = list(/obj/item/clothing/mask/gas)
+	items_in_backpack = list(
+		/obj/item/rcd/construction/safe/admin_crimes,
+		/obj/item/device/analyzer/atmospheric/upgraded,
+		/obj/item/sheet/steel/fullstack,
+		/obj/item/storage/box/cablesbox,
+		/obj/item/tank/oxygen,
+	)
+#endif
+
 /datum/job/special/station_builder
 	// Used for Construction game mode, where you build the station
 	name = "Station Builder"

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -69,6 +69,12 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 			player.mind.assigned_role = "Construction Worker"
 		return
 
+	#ifdef I_WANNA_BE_THE_JOB
+	for (var/mob/new_player/player in unassigned)
+		player.mind.assigned_role = I_WANNA_BE_THE_JOB
+	return
+	#endif
+
 	var/list/pick1 = list()
 	var/list/pick2 = list()
 	var/list/pick3 = list()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds 
`//#define I_WANNA_BE_THE_JOB "IMCODER" // Spawn as a 'imcoder' job. Gives CE belt, captain ID, etc. Change string to different job ID as needed`
To let you spawn as the job you might want to be. Does not override all job spawns, so future re-spawns can still be other jobs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Easier spawning as jobs for testing speeds up development. The inclusion of the "IMCODER" role reduces the dev overhead of spawning various different items for testing which are otherwise commonly used. Also provides a safe space kind of job to edit as needed for niche use cases not able to be included under this general role.

