### PR TITLE
Adds Lore to the PDA space GPS program

### DIFF
--- a/code/modules/parallax/parallax_render_sources/parallax_render_source_parent.dm
+++ b/code/modules/parallax/parallax_render_sources/parallax_render_source_parent.dm
@@ -8,6 +8,12 @@
 	appearance_flags = KEEP_TOGETHER | TILE_BOUND
 	screen_loc = "CENTER,CENTER"
 
+	name = null
+	desc = null
+
+	///Is this a celestial feature that shows up on PDA space GPS programs
+	var/visible_to_gps = FALSE
+
 	/// The icon file that the icon for each tile of the parallax layer will draw from.
 	var/parallax_icon = 'icons/misc/parallax.dmi'
 	/// The icon state that the icon for each tile of the parallax layer will use.

--- a/code/modules/parallax/parallax_render_sources/parallax_render_sources.dm
+++ b/code/modules/parallax/parallax_render_sources/parallax_render_sources.dm
@@ -48,6 +48,10 @@
 	static_colour = TRUE
 	parallax_value = 0.015
 	tessellate = FALSE
+	visible_to_gps = TRUE
+	name = "Typhon"
+	desc = "Y-CLASS BROWN DWARF<br>\
+		Somewhere between a star and a planet, also known as a \"Plasma Giant\" due to the ferocious FAAE storms that ravage its surface."
 
 /atom/movable/screen/parallax_render_source/typhon/cogmap
 	initial_x_coordinate = 0
@@ -85,12 +89,23 @@
 	initial_x_coordinate = 50
 	initial_y_coordinate = -80
 	parallax_value = 0.03
+	visible_to_gps = TRUE
+	name = "Quadriga"
+	desc = "ABLATED PLANET CORE<br>\
+		Surface Outposts: PIEDRA DE ORO, NT-Δ<br>\
+		The crust has been shattered off of a silicate planet, leaving a partially exposed inner core and a thin volcanic mantle. The Frontier's access point to the Channel is found above this wrecked world. Crustal ejecta fills the surrounding region."
 
 /atom/movable/screen/parallax_render_source/planet/amantes // the space butt, haven of gangs, clown town, shanty colonies
 	parallax_icon_state = "amantes"
 	initial_x_coordinate = 250
 	initial_y_coordinate = 225
 	parallax_value = 0.04
+	visible_to_gps = TRUE
+	name = "Amantes"
+	desc = "CONTACT BINARY<br>\
+		Surface Outposts: BUTTES JUNCTION, NT-Κ, CLOWN TOWN<br>\
+		A pair of inhabited rubble-pile asteroids merged together in a slow collision, likely coalesced from the rubble of Quadriga.<br>\
+		Travel advisories are in effect due to high crime within the countless warrens and unlisted settlements of this infamous Frontier landmark. "
 
 // donut 2 neighborhood
 
@@ -99,6 +114,12 @@
 	initial_x_coordinate = 0
 	initial_y_coordinate = 50
 	parallax_value = 0.034
+	visible_to_gps = TRUE
+	name = "Fatuus"
+	desc = "STEAM PLANET<br>\
+		L5 Stations: NT-Ι<br>\
+		Surface Outposts: NEW MEMPHIS, NT-Γ, NT-Σ, NT-Χ<br>\
+		A carboniferous world with shallow boiling seas and fog-shrouded bogs. The colony of New Memphis and the lights of the Bonktek Shopping Pyramid can be seen from orbit."
 
 /*
 /atom/movable/screen/parallax_render_source/planet/domusdei // need to resprite this
@@ -115,18 +136,35 @@
 	initial_x_coordinate = 200
 	initial_y_coordinate = 100
 	parallax_value = 0.02
+	visible_to_gps = TRUE
+	name = "Mundus"
+	desc = "MINI-TERRAN PLANET<br>\
+		L1 Stations: NT-Ν<br>\
+		A chilly earthlike dwarf planet. Home to Space Quebec, the oldest surviving ground settlement in the frontier."
 
 /atom/movable/screen/parallax_render_source/planet/iustitia // a moon with a major spaceport, diplomatic and cultural hub
 	parallax_icon_state = "iustitia"
 	initial_x_coordinate = 380
 	initial_y_coordinate = 100
 	parallax_value = 0.032
+	visible_to_gps = TRUE
+	name = "Iustitia"
+	desc = "SILICATE MOON<br>\
+		SECURE AREA<br>\
+		Surface Outposts: PORT ROERICH, IUSTITIA COSMOTHEQUE, NT-Α<br>\
+		The diplomatic, cultural, and financial center of the Frontier is found here at Port Roerich and its adjacent citydomes."
 
 /atom/movable/screen/parallax_render_source/planet/iudicium // a desolate moon with old military sites, bunkers, Ainley hospital
 	parallax_icon_state = "iudicium"
 	initial_x_coordinate = -75
 	initial_y_coordinate = 185
 	parallax_value = 0.042
+	visible_to_gps = TRUE
+	desc = "SILICATE MOON<br>\
+		SECURE AREA<br>\
+		Surface Outposts: NT-Λ, NT-Ξ<br>\
+		A desolate moon dotted with old retired military sites and a few corporate holdings.<br>\
+		NT Security's Instructional Outpost Xi, aka 'Fight School' is one of the few remaining sites in operation here."
 
 /// fortuna area
 
@@ -135,6 +173,13 @@
 	initial_x_coordinate = 0
 	initial_y_coordinate = 100
 	parallax_value = 0.04
+	visible_to_gps = TRUE
+	name = "Rota Fortuna"
+	desc = "VESTOID DWARF<br>\
+		HIGH TRAFFIC AREA<br>\
+		L2 Stations: NT-13, NT-14<br>\
+		L3 Stations: NT-15<br>\
+		The namesake of Waypoint Fortuna, a fiercely contested landmark during the Pod Wars. This major asteroid remains an important stopover and refueling point between the inner and outer rings."
 
 // outer rings
 
@@ -143,12 +188,23 @@
 	initial_x_coordinate = 200
 	initial_y_coordinate = 100
 	parallax_value = 0.035
+	visible_to_gps = TRUE
+	name = "Mors"
+	desc = "CORELESS PLANET<br>\
+		L? Stations: NT-Ρ<br>\
+		A rusty, porous Mars-like, once covered in deep oceans, now a deadly world of toxic brine pools, claretine salt-flats and fractured mudstone terrain. Heavily bombarded and irradiated when the Martian War continued into a Mortian War."
 
 /atom/movable/screen/parallax_render_source/planet/regis // possibly blob infested
 	parallax_icon_state = "regis"
 	initial_x_coordinate = -150
 	initial_y_coordinate = -50
 	parallax_value = 0.025
+	visible_to_gps = TRUE
+	name = "Regis"
+	desc = "SILICATE MOONLET<br>\
+		L2 Stations: NT-Ρ<br>\
+		Mostly quiet now, this highly restricted moon was used as a staging ground for Joint Fleet operations in the early Frontier.<br>\
+		Though the missile silos are long silent, the old howitzer platforms here still occasionally conduct routine suppressive fire-missions towards Mors. Just in case."
 
 ///////
 
@@ -157,6 +213,11 @@
 	initial_x_coordinate = 50
 	initial_y_coordinate = 100
 	parallax_value = 0.03
+	visible_to_gps = TRUE
+	name = "Magus"
+	desc = "SULFUR PLANET<br>\
+		Surface Outposts: NADIR EXTRACTION SITE<br>\
+		A viciously corrosive planet which provides many industrially valuable resources and reagents. The super-acid seas are rich in both dissolved and crystallized exotic compounds. NADIR Station lays on the seafloor below."
 
 /atom/movable/screen/parallax_render_source/planet/regina // a captive comet, hosts a flea market, ice-water mining
 	parallax_icon = 'icons/obj/large/320x320.dmi'
@@ -164,7 +225,12 @@
 	initial_x_coordinate = 120
 	initial_y_coordinate = 120
 	parallax_value = 0.04
-
+	visible_to_gps = TRUE
+	name = "Regina"
+	desc = "CAPTIVE COMET<br>\
+		Surface Outposts: NT-Μ<br>\
+		This comet core is caught in the gravity well of MAGUS.<br>\
+		The old Regina Anchorage here is still a popular flea market and space bazaar today. Agricultural Outpost Mu's hydroponic produce fills many Frontier kitchens. Mining Outpost Iota magnet-harvests material from the comet's tail."
 
 // Asteroid Layers
 /atom/movable/screen/parallax_render_source/asteroids_far

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1362,17 +1362,19 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 	var/x = -1
 	var/y = -1
 	var/z = -1
+	///Fully rendered text data about nearby celestial objects, cached here to line up with the coordinates
+	var/parallax_data = null
 
 	return_text()
 		if(..())
 			return
 
 		var/dat = src.return_text_header()
-		dat += "<h4>Space GPS: Pocket Edition</h4>"
+		dat += "<h3>Space GPS: Pocket Edition</h3>"
 
 		dat += "<a href='byond://?src=\ref[src];getloc=1'>Get Coordinates</a>"
-		if (x >= 0)
 
+		if (x >= 0)
 			var/landmark = "Unknown"
 			switch (src.z)
 				if (1)
@@ -1388,7 +1390,10 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 					landmark = "Asteroid Field"
 					#endif
 
-			dat += "<BR>X = [src.x], Y = [src.y], Landmark: [landmark]"
+			dat += "<BR><b>\[</b>X = [src.x], Y = [src.y], Landmark: [landmark]<b>\]</b>"
+			dat += "<br>------------------------------------------------------------------------------"
+			dat += "<br><h4>Currently visible celestial bodies:</h4>"
+			dat += src.parallax_data
 
 		return dat
 
@@ -1401,6 +1406,11 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 			src.x = T.x
 			src.y = T.y
 			src.z = T.z
+			src.parallax_data = ""
+			var/list/render_sources = usr.client?.parallax_controller?.parallax_render_sources
+			for (var/atom/movable/screen/parallax_render_source/source in render_sources)
+				if (source.visible_to_gps)
+					src.parallax_data += "<br><b>[source.name]</b> - [source.desc]<br>"
 
 		src.master.add_fingerprint(usr)
 		src.master.updateSelfDialog()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[LORE] [FEATURE] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a name and brief description for all background parallax objects to the space GPS PDA program, it updates when you hit "Get Coordinates" and can show information from the station z, debris field, etc.
![image](https://github.com/user-attachments/assets/16f45616-eb62-4892-942c-53174d9191be)
This game looks really cool sometimes :)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More lore in game is cool, especially for things you can see in a normal round.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)The Thinktronic™ Space GPS PDA program has been updated to include information on nearby visible celestial bodies (background parallax objects)
```
