### PR TITLE
Fix nonhuman players being able to communicate using the ship alert button

### DIFF
--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -34,7 +34,6 @@ TYPEINFO(/obj/machinery/shipalert)
 /obj/machinery/shipalert/attack_hand(mob/user)
 	if (user.stat || isghostdrone(user) || !isliving(user) || isintangible(user))
 		return
-
 	src.add_fingerprint(user)
 
 	switch (usageState)
@@ -128,7 +127,12 @@ TYPEINFO(/obj/machinery/shipalert)
 #ifdef MAP_OVERRIDE_MANTA
 		command_alert("This is not a drill. This is not a drill. General Quarters, General Quarters. All hands man your battle stations. Crew without military training shelter in place. Set material condition '[rand(1, 100)]-[pick_string("station_name.txt", "militaryLetters")]' throughout the ship. The route of travel is forward and up to starboard, down and aft to port. Prepare for hostile contact.", "NSS Manta - General Quarters")
 #else //frick manta, no reason for you
-		var/reason = tgui_input_text(user, "Please describe the nature of the threat:", "Alert", max_length = src.max_msg_length)
+		var/reason
+		// no flockdrones, critters, etc
+		if(!ishuman(user))
+			reason = "Unknown"
+		else
+			reason = tgui_input_text(user, "Please describe the nature of the threat:", "Alert", max_length = src.max_msg_length)
 		if (!length(reason))
 			src.working = FALSE
 			return FALSE

--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -34,7 +34,6 @@ TYPEINFO(/obj/machinery/shipalert)
 /obj/machinery/shipalert/attack_hand(mob/user)
 	if (user.stat || isghostdrone(user) || !isliving(user) || isintangible(user))
 		return
-		
 	src.add_fingerprint(user)
 
 	switch (usageState)

--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -34,6 +34,7 @@ TYPEINFO(/obj/machinery/shipalert)
 /obj/machinery/shipalert/attack_hand(mob/user)
 	if (user.stat || isghostdrone(user) || !isliving(user) || isintangible(user))
 		return
+		
 	src.add_fingerprint(user)
 
 	switch (usageState)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Forces the reason to be "unknown" if the instigator of the ship alert is not human.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #20206, since agreeably nonhuman stuff shouldn't get to communicate with this
