### PR TITLE
Add minimum player count for gangs

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -14,6 +14,8 @@
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 
+	var/minimum_players = 15 // Minimum ready players for the mode
+
 	var/slow_process = 0			//number of ticks to skip the extra gang process loops
 	var/shuttle_called = FALSE
 
@@ -29,6 +31,13 @@
 #endif
 /datum/game_mode/gang/pre_setup()
 	var/num_players = src.roundstart_player_count()
+
+#ifndef ME_AND_MY_40_ALT_ACCOUNTS
+	if (num_players < minimum_players)
+		message_admins("<b>ERROR: Minimum player count of [minimum_players] required for Gang game mode, aborting gang round pre-setup.</b>")
+		logTheThing(LOG_GAMEMODE, src, "Failed to start gang mode. [num_players] players were ready but a minimum of [minimum_players] players is required. ")
+		return 0
+#endif
 
 	var/num_teams = clamp(round((num_players) / PLAYERS_PER_GANG_GENERATED), setup_min_teams, setup_max_teams) //1 gang per 9 players, 15 on RP
 	logTheThing(LOG_GAMEMODE, src, "Counted [num_players] available, with [PLAYERS_PER_GANG_GENERATED] per gang that means [num_teams] gangs.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds 15 player minimum for the gang gamemode, same as nuclear


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gangs can currently roll with 6 people, this is not really fun for anyone as gangs is based around, having a couple gangs to go back and forth, often one of the 2 leaders just dies early so nothing happens.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)The gang gamemode now requires a minimum of 15 players.
```
