### PR TITLE
Minimaps Now Depict Walls & Doors

### DIFF
--- a/code/modules/minimap/minimap.dm
+++ b/code/modules/minimap/minimap.dm
@@ -1,253 +1,270 @@
 /datum/minimap
-	///The holder for the render of the minimap, allowing for offsets and other effects to be applied to the render without modifying the render itself.
+	/// The holder for the render of the minimap, allowing for offsets and other effects to be applied to the render without modifying the render itself.
 	var/atom/movable/minimap_holder
-	///The minimap render to be displayed, containing both the map, and icons.
+	/// The minimap render to be displayed, containing both the map, and icons.
 	var/atom/movable/minimap_render
-	///The minimap, without minimap markers. Kept separate for the purpose of scaling the minimap without scaling the markers.
+	/// The minimap, without minimap markers. Kept separate for the purpose of scaling the minimap without scaling the markers.
 	var/atom/movable/map
 
-	///An associative list of all the targets and associated minimap markers the minimap is currently tracking and displaying.
-	var/list/minimap_markers = list()
+	/// An associative list of all minimap markers the minimap is currently tracking and displaying, indexed by their target.
+	var/list/datum/minimap_marker/minimap_markers
 
-	///A bitflag that determines which areas and minimap markers are to be rendered on the minimap. For available flags, see `_std/defines/minimap.dm`.
+	/// A bitflag that determines which areas and minimap markers are to be rendered on the minimap. For available flags, see `_std/defines/minimap.dm`.
 	var/minimap_type
 
-	///The z-level that the minimap is to be rendered from.
+	/// The z-level that the minimap is to be rendered from.
 	var/z_level = null
-	///The maximum x coordinate to be rendered, in world coordinates.
+	/// The maximum x coordinate to be rendered, in world coordinates.
 	var/x_max = null
-	///The minimum x coordinate to be rendered, in world coordinates.
+	/// The minimum x coordinate to be rendered, in world coordinates.
 	var/x_min = null
-	///The maximum y coordinate to be rendered, in world coordinates.
+	/// The maximum y coordinate to be rendered, in world coordinates.
 	var/y_max = null
-	///The minimum y coordinate to be rendered, in world coordinates.
+	/// The minimum y coordinate to be rendered, in world coordinates.
 	var/y_min = null
 
-	///The scale that the minimap should be zoomed to; it does not affect the physical size of the minimap, as the alpha mask will take care of any map area scaled outside of the minimap boundaries.
+	/// The scale that the minimap should be zoomed to; it does not affect the physical size of the minimap, as the alpha mask will take care of any map area scaled outside of the minimap boundaries.
 	var/zoom_coefficient = 1
-	///The current scale of the physical map, as a multiple of the original size (300x300px).
+	/// The current scale of the physical map, as a multiple of the original size (300x300px).
 	var/map_scale = 1
-	///The desired scale of the minimap markers, as a multiple of the original size (32x32px).
+	/// The desired scale of the minimap markers, as a multiple of the original size (32x32px).
 	var/marker_scale = 1
 
-	New(var/minimap_type)
-		. = ..()
-		START_TRACKING
-		src.minimap_holder = new
-		src.minimap_holder.vis_flags = VIS_INHERIT_LAYER
-		src.minimap_holder.appearance_flags = KEEP_TOGETHER | PIXEL_SCALE
-		src.minimap_holder.mouse_opacity = 0
+/datum/minimap/New(minimap_type)
+	. = ..()
 
-		src.minimap_render = new
-		src.map = minimap_renderer.generate_minimap_render(minimap_type)
-		src.minimap_type = minimap_type
+	START_TRACKING
+	src.minimap_markers = list()
 
-		src.minimap_render.vis_flags = VIS_INHERIT_LAYER
-		src.minimap_render.appearance_flags = KEEP_TOGETHER | PIXEL_SCALE
-		src.minimap_render.mouse_opacity = 0
-		src.map.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
-		src.map.mouse_opacity = 0
+	src.minimap_holder = new
+	src.minimap_holder.vis_flags = VIS_INHERIT_LAYER
+	src.minimap_holder.appearance_flags = KEEP_TOGETHER | PIXEL_SCALE
+	src.minimap_holder.mouse_opacity = 0
 
-		src.minimap_render.vis_contents += src.map
-		src.minimap_holder.vis_contents += src.minimap_render
+	src.minimap_render = new
+	src.map = minimap_renderer.generate_minimap_render(minimap_type)
+	src.minimap_type = minimap_type
 
-	disposing()
-		STOP_TRACKING
-		. = ..()
+	src.minimap_render.vis_flags = VIS_INHERIT_LAYER
+	src.minimap_render.appearance_flags = KEEP_TOGETHER | PIXEL_SCALE
+	src.minimap_render.mouse_opacity = 0
+	src.map.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
+	src.map.mouse_opacity = 0
 
-	///Checks whether a turf should be rendered on the map through the minimaps_to_render_on bitflag on /area.
-	proc/valid_turf(var/turf/T)
-		if (!T.loc)
-			return FALSE
-		var/area/A = T.loc
-		if (!(src.minimap_type & A.minimaps_to_render_on))
-			return FALSE
-		return TRUE
+	src.minimap_render.vis_contents += src.map
+	src.minimap_holder.vis_contents += src.minimap_render
 
-	///Create an alpha mask to hide anything outside the bounds of the physical map.
-	proc/create_alpha_mask()
-		var/icon/mask_icon = icon('icons/obj/minimap/minimap.dmi', "blank")
-		mask_icon.Scale(x_max * src.map_scale, y_max * src.map_scale)
-		var/x_offset = ((x_max * src.map_scale) / 2) - 16
-		var/y_offset = ((y_max * src.map_scale) / 2) - 16
-		src.minimap_holder.add_filter("map_cutoff", 1, alpha_mask_filter(x_offset, y_offset, mask_icon))
+/datum/minimap/disposing()
+	STOP_TRACKING
+	. = ..()
 
-	///Creates a minimap marker from a specified target, icon, and icon state. 'marker_name' will override the marker inheriting the target's name.
-	proc/create_minimap_marker(var/atom/target, var/icon, var/icon_state, var/marker_name, var/can_be_deleted_by_player = FALSE, var/list_on_ui = TRUE)
-		if (target in src.minimap_markers)
-			return
+/// Checks whether a turf is rendered on this minimap type.
+/datum/minimap/proc/valid_turf(turf/T)
+	if (!T.loc)
+		return FALSE
 
-		var/datum/minimap_marker/marker = new /datum/minimap_marker(target, marker_name, can_be_deleted_by_player, list_on_ui, src.marker_scale)
-		marker.map = src
-		marker.marker.icon = icon(icon, icon_state)
+	var/area/A = T.loc
+	if (!(src.minimap_type & A.minimaps_to_render_on))
+		return FALSE
 
-		src.minimap_markers[target] = marker
+	return TRUE
 
-		src.minimap_render.vis_contents += marker.marker
-		src.set_marker_position(marker, target.x, target.y, target.z)
+/// Create an alpha mask to hide anything outside the bounds of the physical map.
+/datum/minimap/proc/create_alpha_mask()
+	var/icon/mask_icon = icon('icons/obj/minimap/minimap.dmi', "blank")
+	mask_icon.Scale(src.x_max * src.map_scale, src.y_max * src.map_scale)
+	var/x_offset = ((src.x_max * src.map_scale) / 2) - 16
+	var/y_offset = ((src.y_max * src.map_scale) / 2) - 16
+	src.minimap_holder.add_filter("map_cutoff", 1, alpha_mask_filter(x_offset, y_offset, mask_icon))
 
-	///Sets the x and y position of a specified minimap marker, in world coordinates.
-	proc/set_marker_position(var/datum/minimap_marker/map_marker, var/x, var/y, var/z)
-		if (z != src.z_level)
-			map_marker.marker.alpha = 0
-			map_marker.on_minimap_z_level = FALSE
-		else
-			if (map_marker.visible)
-				map_marker.marker.alpha = map_marker.alpha_value
-			map_marker.on_minimap_z_level = TRUE
-			map_marker.marker.pixel_x = (x * src.zoom_coefficient * src.map_scale) - 16
-			map_marker.marker.pixel_y = (y * src.zoom_coefficient * src.map_scale) - 16
+/// Creates a minimap marker from a specified target, icon, and icon state. `marker_name` will override the marker inheriting the target's name.
+/datum/minimap/proc/create_minimap_marker(atom/target, icon, icon_state, marker_name, can_be_deleted_by_player = FALSE, list_on_ui = TRUE)
+	if (src.minimap_markers[target])
+		return
 
-	proc/remove_minimap_marker(var/atom/target)
-		if (!(target in src.minimap_markers))
-			return
+	var/datum/minimap_marker/marker = new(target, marker_name, can_be_deleted_by_player, list_on_ui, src.marker_scale)
+	marker.map = src
+	marker.marker.icon = icon(icon, icon_state)
 
-		var/datum/minimap_marker/marker = src.minimap_markers[target]
-		src.minimap_render.vis_contents -= marker.marker
-		src.minimap_markers -= target
-		qdel(marker)
+	src.minimap_markers[target] = marker
+
+	src.minimap_render.vis_contents += marker.marker
+	src.set_marker_position(marker, target.x, target.y, target.z)
+
+/// Sets the x and y position of a specified minimap marker, in world coordinates.
+/datum/minimap/proc/set_marker_position(datum/minimap_marker/map_marker, x, y, z)
+	if (z != src.z_level)
+		map_marker.marker.alpha = 0
+		map_marker.on_minimap_z_level = FALSE
+	else
+		if (map_marker.visible)
+			map_marker.marker.alpha = map_marker.alpha_value
+		map_marker.on_minimap_z_level = TRUE
+		map_marker.marker.pixel_x = (x * src.zoom_coefficient * src.map_scale) - 16
+		map_marker.marker.pixel_y = (y * src.zoom_coefficient * src.map_scale) - 16
+
+/// Removes a minimap marker from this minimap.
+/datum/minimap/proc/remove_minimap_marker(atom/target)
+	if (!src.minimap_markers[target])
+		return
+
+	var/datum/minimap_marker/marker = src.minimap_markers[target]
+	src.minimap_render.vis_contents -= marker.marker
+	src.minimap_markers -= target
+	qdel(marker)
+
 
 /datum/minimap/z_level
 	z_level = Z_LEVEL_STATION
 	x_min = 1
 	y_min = 1
 
-	var/icon/initial_minimap_icon
-
-	///The minimum value which the zoom coefficient should be permitted to zoom to.
+	/// The minimum value which the zoom coefficient should be permitted to zoom to.
 	var/min_zoom = 0.95
-	///The maximum value which the zoom coefficient should be permitted to zoom to.
+	/// The maximum value which the zoom coefficient should be permitted to zoom to.
 	var/max_zoom = 10
 
-	///The width in pixels between the edge of the station and the edge of the map.
+	/// The width in pixels between the edge of the station and the edge of the map.
 	var/border_width = 20
 
-	New(var/minimap_type, var/scale, var/marker_scale)
-		x_max = world.maxx
-		y_max = world.maxy
+	/// The x coordinate that of the centre of the focused map.
+	var/centre_focus_x
+	/// The y coordinate that of the centre of the focused map.
+	var/centre_focus_y
+	/// The scale used to fit all visible turfs on the focused map.
+	var/centre_scale
 
-		. = ..()
-		src.initial_minimap_icon = src.map.icon
+/datum/minimap/z_level/New(minimap_type, scale, marker_scale)
+	src.x_max = world.maxx
+	src.y_max = world.maxy
 
-		if (scale)
-			src.scale_map(scale)
-		if (marker_scale)
-			src.marker_scale = marker_scale
+	. = ..()
 
-		src.find_focal_point()
+	if (scale)
+		src.scale_map(scale)
+	if (marker_scale)
+		src.marker_scale = marker_scale
 
-	///Locate the focal point of the map by using the furthest valid turf in each direction.
-	proc/find_focal_point()
-		if (!x_max || !x_min || !y_max || !y_min || !z_level)
-			return
+	src.find_focal_point()
+
+/// Locate the focal point of the map by using the furthest valid turf in each direction.
+/datum/minimap/z_level/proc/find_focal_point()
+	if (!src.x_max || !src.x_min || !src.y_max || !src.y_min || !src.z_level)
+		return
+
+	if (!src.centre_focus_x || !src.centre_focus_y || !src.centre_scale)
 		var/max_x = src.x_min
 		var/min_x = src.x_max
 		var/max_y = src.y_min
 		var/min_y = src.y_max
-		for (var/turf/T in block(locate(src.x_min, src.y_min, src.z_level), locate(src.x_max, src.y_max, src.z_level)))
+
+		for (var/turf/T as anything in block(locate(src.x_min, src.y_min, src.z_level), locate(src.x_max, src.y_max, src.z_level)))
 			if (!src.valid_turf(T))
 				continue
+
 			max_x = max(max_x, T.x)
 			min_x = min(min_x, T.x)
 			max_y = max(max_y, T.y)
 			min_y = min(min_y, T.y)
 
-		var/focus_x = ((max_x + min_x) - 1) / 2
-		var/focus_y = ((max_y + min_y) - 1) / 2
+		src.centre_focus_x = ((max_x + min_x) - 1) / 2
+		src.centre_focus_y = ((max_y + min_y) - 1) / 2
 
-		var/scale_x = world.maxx / ((max_x - min_x) + border_width)
-		var/scale_y = world.maxy / ((max_y - min_y) + border_width)
+		src.centre_scale = min(world.maxx / ((max_x - min_x) + src.border_width), world.maxy / ((max_y - min_y) + src.border_width))
 
-		src.centre_on_point(min(scale_x, scale_y), focus_x, focus_y)
+	src.centre_on_point(src.centre_scale, src.centre_focus_x, src.centre_focus_y)
 
-	///Zooms the minimap by the zoom coefficient while moving the minimap so that the specified point lies at the same position on the displayed minimap as it did prior to the zoom. The alpha mask takes care of any map area scaled outside of the map boundaries.
-	proc/zoom_on_point(var/zoom, var/map_x, var/map_y)
-		if (!zoom || zoom < min_zoom || zoom > max_zoom || !map_x || !map_y)
-			return
+/// Zooms the minimap by the zoom coefficient while moving the minimap so that the specified point lies at the same position on the displayed minimap as it did prior to the zoom. The alpha mask takes care of any map area scaled outside of the map boundaries.
+/datum/minimap/z_level/proc/zoom_on_point(zoom, map_x, map_y)
+	if (!zoom || (zoom < src.min_zoom) || (zoom > src.max_zoom) || !map_x || !map_y)
+		return
 
-		var/zoom_factor = (zoom / src.zoom_coefficient)
-		src.map.Scale(zoom_factor, zoom_factor)
+	var/zoom_factor = (zoom / src.zoom_coefficient)
+	src.map.Scale(zoom_factor, zoom_factor)
 
-		// Align the bottom left corner of the scaled map with the bottom left corner of the map boundaries.
-		var/x_align_offset = ((src.x_max - (src.x_max * zoom * src.map_scale)) / 2) + src.map.pixel_x
-		var/y_align_offset = ((src.y_max - (src.y_max * zoom * src.map_scale)) / 2) + src.map.pixel_y
-		src.map.pixel_x -= x_align_offset
-		src.map.pixel_y -= y_align_offset
-		src.minimap_render.pixel_x += x_align_offset
-		src.minimap_render.pixel_y += y_align_offset
+	// Align the bottom left corner of the scaled map with the bottom left corner of the map boundaries.
+	var/x_align_offset = ((src.x_max - (src.x_max * zoom * src.map_scale)) / 2) + src.map.pixel_x
+	var/y_align_offset = ((src.y_max - (src.y_max * zoom * src.map_scale)) / 2) + src.map.pixel_y
+	src.map.pixel_x -= x_align_offset
+	src.map.pixel_y -= y_align_offset
+	src.minimap_render.pixel_x += x_align_offset
+	src.minimap_render.pixel_y += y_align_offset
 
-		// Account for the number of pixels moved due to scaling.
-		var/x_offset = ((((src.x_max * src.zoom_coefficient) - (src.x_max * zoom)) * src.map_scale) / 2) * clamp(((src.x_max / 2) - map_x) / (src.x_max / 2), -1, 1)
-		var/y_offset = ((((src.y_max * src.zoom_coefficient) - (src.y_max * zoom)) * src.map_scale) / 2) * clamp(((src.y_max / 2) - map_y) / (src.y_max / 2), -1, 1)
-		src.minimap_render.pixel_x -= x_offset
-		src.minimap_render.pixel_y -= y_offset
+	// Account for the number of pixels moved due to scaling.
+	var/x_offset = ((((src.x_max * src.zoom_coefficient) - (src.x_max * zoom)) * src.map_scale) / 2) * clamp(((src.x_max / 2) - map_x) / (src.x_max / 2), -1, 1)
+	var/y_offset = ((((src.y_max * src.zoom_coefficient) - (src.y_max * zoom)) * src.map_scale) / 2) * clamp(((src.y_max / 2) - map_y) / (src.y_max / 2), -1, 1)
+	src.minimap_render.pixel_x -= x_offset
+	src.minimap_render.pixel_y -= y_offset
 
-		src.zoom_coefficient = zoom
+	src.zoom_coefficient = zoom
 
-		for (var/atom/target in src.minimap_markers)
-			var/datum/minimap_marker/minimap_marker = src.minimap_markers[target]
-			src.set_marker_position(minimap_marker, minimap_marker.target.x, minimap_marker.target.y, minimap_marker.target.z)
+	for (var/atom/target as anything in src.minimap_markers)
+		var/datum/minimap_marker/minimap_marker = src.minimap_markers[target]
+		src.set_marker_position(minimap_marker, minimap_marker.target.x, minimap_marker.target.y, minimap_marker.target.z)
 
-	///Zooms the minimap by the zoom coefficient while moving the minimap so that the specified point lies at the centre of the displayed minimap. The alpha mask takes care of any map area scaled outside of the map boundaries.
-	proc/centre_on_point(var/zoom, var/focus_x, var/focus_y)
-		if (!zoom || zoom < min_zoom || zoom > max_zoom || !focus_x || !focus_y)
-			return
+/// Zooms the minimap by the zoom coefficient while moving the minimap so that the specified point lies at the centre of the displayed minimap. The alpha mask takes care of any map area scaled outside of the map boundaries.
+/datum/minimap/z_level/proc/centre_on_point(zoom, focus_x, focus_y)
+	if (!zoom || (zoom < src.min_zoom) || (zoom > src.max_zoom) || !focus_x || !focus_y)
+		return
 
-		var/zoom_factor = (zoom / src.zoom_coefficient)
-		src.map.Scale(zoom_factor, zoom_factor)
+	var/zoom_factor = (zoom / src.zoom_coefficient)
+	src.map.Scale(zoom_factor, zoom_factor)
 
-		// Align the bottom left corner of the scaled map with the bottom left corner of the map boundaries.
-		var/x_align_offset = ((src.x_max - (src.x_max * zoom * src.map_scale)) / 2) + src.map.pixel_x
-		var/y_align_offset = ((src.y_max - (src.y_max * zoom * src.map_scale)) / 2) + src.map.pixel_y
-		src.map.pixel_x -= x_align_offset
-		src.map.pixel_y -= y_align_offset
-		src.minimap_render.pixel_x += x_align_offset
-		src.minimap_render.pixel_y += y_align_offset
+	// Align the bottom left corner of the scaled map with the bottom left corner of the map boundaries.
+	var/x_align_offset = ((src.x_max - (src.x_max * zoom * src.map_scale)) / 2) + src.map.pixel_x
+	var/y_align_offset = ((src.y_max - (src.y_max * zoom * src.map_scale)) / 2) + src.map.pixel_y
+	src.map.pixel_x -= x_align_offset
+	src.map.pixel_y -= y_align_offset
+	src.minimap_render.pixel_x += x_align_offset
+	src.minimap_render.pixel_y += y_align_offset
 
-		// Offset so that the focal point is at the centre of the map boundaries.
-		var/x_offset = ((src.x_max / 2) * src.map_scale) - (focus_x * zoom * src.map_scale) - src.minimap_render.pixel_x
-		var/y_offset = ((src.y_max / 2) * src.map_scale) - (focus_y * zoom * src.map_scale) - src.minimap_render.pixel_y
-		src.minimap_render.pixel_x += x_offset
-		src.minimap_render.pixel_y += y_offset
+	// Offset so that the focal point is at the centre of the map boundaries.
+	var/x_offset = ((src.x_max / 2) * src.map_scale) - (focus_x * zoom * src.map_scale) - src.minimap_render.pixel_x
+	var/y_offset = ((src.y_max / 2) * src.map_scale) - (focus_y * zoom * src.map_scale) - src.minimap_render.pixel_y
+	src.minimap_render.pixel_x += x_offset
+	src.minimap_render.pixel_y += y_offset
 
-		src.zoom_coefficient = zoom
+	src.zoom_coefficient = zoom
 
-		for (var/atom/target in src.minimap_markers)
-			var/datum/minimap_marker/minimap_marker = src.minimap_markers[target]
-			src.set_marker_position(minimap_marker, minimap_marker.target.x, minimap_marker.target.y, minimap_marker.target.z)
+	for (var/atom/target as anything in src.minimap_markers)
+		var/datum/minimap_marker/minimap_marker = src.minimap_markers[target]
+		src.set_marker_position(minimap_marker, minimap_marker.target.x, minimap_marker.target.y, minimap_marker.target.z)
 
-	///Scale the map, while retaining the original (x, y) position of the bottom left corner.
-	proc/scale_map(var/scale)
-		if (!scale)
-			return
+/// Scale the map, while retaining the original (x, y) position of the bottom left corner.
+/datum/minimap/z_level/proc/scale_map(scale)
+	if (!scale)
+		return
 
-		var/scale_factor = (scale / src.map_scale)
-		src.map.Scale(scale_factor, scale_factor)
-		src.map.pixel_x += (src.x_max * zoom_coefficient * (scale - src.map_scale)) / 2
-		src.map.pixel_y += (src.y_max * zoom_coefficient * (scale - src.map_scale)) / 2
+	var/scale_factor = (scale / src.map_scale)
+	src.map.Scale(scale_factor, scale_factor)
+	src.map.pixel_x += (src.x_max * src.zoom_coefficient * (scale - src.map_scale)) / 2
+	src.map.pixel_y += (src.y_max * src.zoom_coefficient * (scale - src.map_scale)) / 2
 
-		src.map_scale = scale
+	src.map_scale = scale
 
-		src.create_alpha_mask()
+	src.create_alpha_mask()
 
-		// Update the position of all the map markers to reflect the new map scale.
-		for (var/atom/target in src.minimap_markers)
-			var/datum/minimap_marker/minimap_marker = src.minimap_markers[target]
-			src.set_marker_position(minimap_marker, minimap_marker.target.x, minimap_marker.target.y, minimap_marker.target.z)
+	// Update the position of all the map markers to reflect the new map scale.
+	for (var/atom/target as anything in src.minimap_markers)
+		var/datum/minimap_marker/minimap_marker = src.minimap_markers[target]
+		src.set_marker_position(minimap_marker, minimap_marker.target.x, minimap_marker.target.y, minimap_marker.target.z)
 
-/datum/minimap/z_level/ai
-	//The Kondaru off-station Owlery and Abandoned Research Outpost are both considered part of the station, but have no AI cameras.
-	valid_turf(var/turf/T)
-		if (!T.loc)
-			return FALSE
-		if ((map_settings.name in list("KONDARU", "DONUT3")) && (istype(T.loc, /area/station/garden/owlery) || istype(T.loc, /area/research_outpost/indigo_rye)))
-			return FALSE
 
-		. = ..()
+// The Kondaru off-station Owlery and Abandoned Research Outpost are both considered part of the station, but have no AI cameras.
+/datum/minimap/z_level/ai/valid_turf(turf/T)
+	if (!T.loc)
+		return FALSE
+	if ((map_settings.name in list("KONDARU", "DONUT3")) && (istype(T.loc, /area/station/garden/owlery) || istype(T.loc, /area/research_outpost/indigo_rye)))
+		return FALSE
+
+	. = ..()
+
 
 #ifndef LIVE_SERVER
 /client/verb/save_station_map()
+	if (!global.minimap_renderer)
+		CRASH("The minimap renderer has not yet been instatiated.")
+
 	var/datum/minimap/map = new(MAP_ALL)
-	minimap_renderer.render_minimaps(Z_LEVEL_STATION)
 	src << ftp(map.map.icon, "[map_settings.display_name].png")
 #endif

--- a/code/modules/minimap/minimap_marker.dm
+++ b/code/modules/minimap/minimap_marker.dm
@@ -1,61 +1,63 @@
 /datum/minimap_marker
-	///The minimap datum that the minimap marker belongs to.
+	/// The minimap datum that the minimap marker belongs to.
 	var/datum/minimap/map
-	///The physical marker, determining appearance and position.
+	/// The physical marker, determining appearance and position.
 	var/atom/movable/marker
-	///The target of the minimap marker.
+	/// The target of the minimap marker.
 	var/atom/target
 
-	///The name of the minimap marker, usually inherited from the target, unless overridden on creation.
+	/// The name of the minimap marker, usually inherited from the target, unless overridden on creation.
 	var/name = "Minimap Marker"
-	///Whether the minimap marker is visible, with precedence over alpha settings.
+	/// Whether the minimap marker is visible, with precedence over alpha settings.
 	var/visible = TRUE
-	///The alpha value that the minimap marker should use when visible.
+	/// The alpha value that the minimap marker should use when visible.
 	var/alpha_value = 255
-	///The desired scale of the minimap marker, as a multiple of the original size (32x32px).
+	/// The desired scale of the minimap marker, as a multiple of the original size (32x32px).
 	var/marker_scale = 1
-	///Whether the target is on the minimap datum's rendered z-level, determining whether it is displayed.
+	/// Whether the target is on the minimap datum's rendered z-level, determining whether it is displayed.
 	var/on_minimap_z_level = FALSE
-	///Whether the minimap marker can be deleted by players using minimap controllers.
+	/// Whether the minimap marker can be deleted by players using minimap controllers.
 	var/can_be_deleted_by_player = FALSE
-	///Whether this minimap marker appears on the controller ui, permitting it's visibility to be toggled, or for it to be deleted.
+	/// Whether this minimap marker appears on the controller ui, permitting it's visibility to be toggled, or for it to be deleted.
 	var/list_on_ui = TRUE
 
-	New(var/atom/target, var/name, var/can_be_deleted_by_player = FALSE, var/list_on_ui = TRUE, var/marker_scale)
-		. = ..()
-		src.marker = new /atom/movable
-		src.target = target
+/datum/minimap_marker/New(atom/target, name, can_be_deleted_by_player = FALSE, list_on_ui = TRUE, marker_scale)
+	. = ..()
 
-		src.marker.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
-		src.marker.mouse_opacity = 0
+	src.marker = new /atom/movable()
+	src.marker.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
+	src.marker.mouse_opacity = 0
 
-		if (target && !name)
-			src.name = target.name
-		else
-			src.name = name
+	src.target = target
 
-		if (target && istype(target, /atom/movable))
-			src.RegisterSignal(target, XSIG_MOVABLE_TURF_CHANGED, PROC_REF(handle_move))
-			// set initial marker position
-			src.handle_move(target, null, get_turf(target))
+	if (src.target && !name)
+		src.name = target.name
+	else
+		src.name = name
 
-		src.can_be_deleted_by_player = can_be_deleted_by_player
-		src.list_on_ui = list_on_ui
-		src.scale_marker(marker_scale)
+	if (src.target && istype(src.target, /atom/movable))
+		src.RegisterSignal(src.target, XSIG_MOVABLE_TURF_CHANGED, PROC_REF(handle_move))
+		// Set initial marker position.
+		src.handle_move(src.target, null, get_turf(src.target))
 
-	disposing()
-		if(!QDELETED(target))
-			src.UnregisterSignal(target, XSIG_MOVABLE_TURF_CHANGED)
-		target = null
-		. = ..()
+	src.can_be_deleted_by_player = can_be_deleted_by_player
+	src.list_on_ui = list_on_ui
+	src.scale_marker(marker_scale)
 
-	proc/handle_move(thing, turf/old_turf, turf/new_turf)
-		if (!map || !thing || !new_turf)
-			return
+/datum/minimap_marker/disposing()
+	if (!QDELETED(src.target))
+		src.UnregisterSignal(src.target, XSIG_MOVABLE_TURF_CHANGED)
 
-		map.set_marker_position(src, new_turf.x, new_turf.y, new_turf.z)
+	src.target = null
+	. = ..()
 
-	proc/scale_marker(var/scale)
-		var/scale_factor = (scale / src.marker_scale)
-		src.marker.Scale(scale_factor, scale_factor)
-		src.marker_scale = scale
+/datum/minimap_marker/proc/handle_move(thing, turf/old_turf, turf/new_turf)
+	if (!src.map || !thing || !new_turf)
+		return
+
+	src.map.set_marker_position(src, new_turf.x, new_turf.y, new_turf.z)
+
+/datum/minimap_marker/proc/scale_marker(scale)
+	var/scale_factor = (scale / src.marker_scale)
+	src.marker.Scale(scale_factor, scale_factor)
+	src.marker_scale = scale

--- a/code/modules/minimap/minimap_object.dm
+++ b/code/modules/minimap/minimap_object.dm
@@ -3,59 +3,65 @@
 	layer = TURF_LAYER
 	anchored = ANCHORED
 
-	///The minimap datum for this minimap object, containing data on the appearance and scale of the minimap, handling resizes, and managing markers.
+	/// The minimap datum for this minimap object, containing data on the appearance and scale of the minimap, handling resizes, and managing markers.
 	var/datum/minimap/map
-	///The minimap type path that `map` should use.
+	/// The minimap type path that `map` should use.
 	var/map_path = /datum/minimap
-	///A bitflag that will be passed to the datum and determines which areas and minimap markers are to be rendered on the minimap. For available flags, see `_std/defines/minimap.dm`.
+	/// A bitflag that will be passed to the datum and determines which areas and minimap markers are to be rendered on the minimap. For available flags, see `_std/defines/minimap.dm`.
 	var/map_type
-	///The desired scale of the physical map, as a multiple of the original size (300x300px).
+	/// The desired scale of the physical map, as a multiple of the original size (300x300px).
 	var/map_scale = 1
 
-	New()
-		. = ..()
-		START_TRACKING
-		src.map = new map_path(src.map_type, src.map_scale)
-		src.vis_contents += src.map.minimap_holder
+/obj/minimap/New()
+	. = ..()
+	START_TRACKING
+	if (global.current_state > GAME_STATE_WORLD_NEW)
+		src.initialise_minimap()
 
-		for (var/atom/marker_target in minimap_marker_targets)
-			SEND_SIGNAL(marker_target, COMSIG_NEW_MINIMAP_MARKER, src.map)
+/obj/minimap/disposing()
+	STOP_TRACKING
+	. = ..()
 
-		// As the minimap render is transparent to clicks, the minimap will require an overlay which clicks may register on.
-		if (!src.icon || !src.icon_state)
-			var/icon/click_overlay_icon = icon('icons/obj/minimap/minimap.dmi', "blank")
-			click_overlay_icon.Scale(src.map.x_max * map_scale, src.map.y_max * map_scale)
-			click_overlay_icon.ChangeOpacity(0)
-			src.icon = click_overlay_icon
-			src.mouse_opacity = 2
+/obj/minimap/proc/initialise_minimap()
+	src.map = new map_path(src.map_type, src.map_scale)
+	src.vis_contents += src.map.minimap_holder
 
-	disposing()
-		STOP_TRACKING
-		. = ..()
+	for (var/atom/marker_target in minimap_marker_targets)
+		SEND_SIGNAL(marker_target, COMSIG_NEW_MINIMAP_MARKER, src.map)
+
+	// As the minimap render is transparent to clicks, the minimap will require an overlay which clicks may register on.
+	if (!src.icon || !src.icon_state)
+		var/icon/click_overlay_icon = icon('icons/obj/minimap/minimap.dmi', "blank")
+		click_overlay_icon.Scale(src.map.x_max * map_scale, src.map.y_max * map_scale)
+		click_overlay_icon.ChangeOpacity(0)
+		src.icon = click_overlay_icon
+		src.mouse_opacity = 2
+
 
 /obj/minimap/ai
 	name = "AI Station Map"
 	map_path = /datum/minimap/z_level/ai
 	map_type = MAP_AI
 
-	Click(location, control, params)
-		if (!isAI(usr))
-			return
-		var/list/param_list = params2list(params)
-		var/datum/minimap/z_level/ai_map = map
-		if ("left" in param_list)
-			// Convert from screen (x, y) to map (x, y) coordinates.
-			var/x = round((text2num(param_list["icon-x"]) - ai_map.minimap_render.pixel_x) / (ai_map.zoom_coefficient * ai_map.map_scale))
-			var/y = round((text2num(param_list["icon-y"]) - ai_map.minimap_render.pixel_y) / (ai_map.zoom_coefficient * ai_map.map_scale))
-			var/turf/clicked = locate(x, y, map.z_level)
-			if (isAIeye(usr))
-				usr.set_loc(clicked)
-			else
-				var/mob/living/silicon/ai/mainframe = usr
-				mainframe.eye_view()
-				mainframe.eyecam.set_loc(clicked)
-		if ("right" in param_list)
-			return TRUE
+/obj/minimap/ai/Click(location, control, params)
+	if (!isAI(usr))
+		return
+	var/list/param_list = params2list(params)
+	var/datum/minimap/z_level/ai_map = src.map
+	if ("left" in param_list)
+		// Convert from screen (x, y) to map (x, y) coordinates.
+		var/x = round((text2num(param_list["icon-x"]) - ai_map.minimap_render.pixel_x) / (ai_map.zoom_coefficient * ai_map.map_scale))
+		var/y = round((text2num(param_list["icon-y"]) - ai_map.minimap_render.pixel_y) / (ai_map.zoom_coefficient * ai_map.map_scale))
+		var/turf/clicked = locate(x, y, map.z_level)
+		if (isAIeye(usr))
+			usr.set_loc(clicked)
+		else
+			var/mob/living/silicon/ai/mainframe = usr
+			mainframe.eye_view()
+			mainframe.eyecam.set_loc(clicked)
+	if ("right" in param_list)
+		return TRUE
+
 
 /obj/minimap/map_computer
 	bound_width = 160
@@ -74,52 +80,53 @@
 	var/light_g = 1
 	var/light_b = 1
 
-	New()
-		. = ..()
-		// Magic numbers to align the minimap with the physical frame of the map.
-		src.map.minimap_holder.pixel_x += 5
-		src.map.minimap_holder.pixel_y += 4
+/obj/minimap/map_computer/initialise_minimap()
+	. = ..()
+	// Magic numbers to align the minimap with the physical frame of the map.
+	src.map.minimap_holder.pixel_x += 5
+	src.map.minimap_holder.pixel_y += 4
 
-		src.create_overlays()
+	src.create_overlays()
 
-	proc/create_overlays()
-		// Computer scanlines overlay.
-		var/atom/movable/overlay/scanlines = new /atom/movable/overlay
-		var/icon/scanlines_icon = icon('icons/obj/minimap/map_computer.dmi', "scanlines")
-		scanlines_icon.ChangeOpacity(0.2)
-		scanlines.icon = scanlines_icon
-		scanlines.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
-		scanlines.mouse_opacity = 0
-		scanlines.color = "#303030" // The scanlines are by default white, allowing them to be recoloured.
+/obj/minimap/map_computer/proc/create_overlays()
+	// Computer scanlines overlay.
+	var/atom/movable/overlay/scanlines = new /atom/movable/overlay
+	var/icon/scanlines_icon = icon('icons/obj/minimap/map_computer.dmi', "scanlines")
+	scanlines_icon.ChangeOpacity(0.2)
+	scanlines.icon = scanlines_icon
+	scanlines.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
+	scanlines.mouse_opacity = 0
+	scanlines.color = "#303030" // The scanlines are by default white, allowing them to be recoloured.
 
-		// Glass screen overlay.
-		var/atom/movable/overlay/glass = new /atom/movable/overlay
-		var/icon/glass_icon = icon('icons/obj/minimap/map_computer.dmi', "glass")
-		glass_icon.ChangeOpacity(0.2)
-		glass.icon = glass_icon
-		glass.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
-		glass.mouse_opacity = 0
+	// Glass screen overlay.
+	var/atom/movable/overlay/glass = new /atom/movable/overlay
+	var/icon/glass_icon = icon('icons/obj/minimap/map_computer.dmi', "glass")
+	glass_icon.ChangeOpacity(0.2)
+	glass.icon = glass_icon
+	glass.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
+	glass.mouse_opacity = 0
 
-		// Computer screen glow overlay.
-		var/atom/movable/overlay/screen_light = new /atom/movable/overlay
-		screen_light.icon = icon('icons/obj/minimap/map_computer.dmi', "screen_light")
-		screen_light.vis_flags = VIS_INHERIT_ID
-		screen_light.mouse_opacity = 0
-		screen_light.plane = PLANE_LIGHTING
-		screen_light.blend_mode = BLEND_ADD
-		screen_light.layer = LIGHTING_LAYER_BASE
-		screen_light.color = list(0.33,0.33,0.33, 0.33,0.33,0.33, 0.33,0.33,0.33)
+	// Computer screen glow overlay.
+	var/atom/movable/overlay/screen_light = new /atom/movable/overlay
+	screen_light.icon = icon('icons/obj/minimap/map_computer.dmi', "screen_light")
+	screen_light.vis_flags = VIS_INHERIT_ID
+	screen_light.mouse_opacity = 0
+	screen_light.plane = PLANE_LIGHTING
+	screen_light.blend_mode = BLEND_ADD
+	screen_light.layer = LIGHTING_LAYER_BASE
+	screen_light.color = list(0.33,0.33,0.33, 0.33,0.33,0.33, 0.33,0.33,0.33)
 
-		vis_contents += scanlines
-		vis_contents += glass
-		vis_contents += screen_light
+	src.vis_contents += scanlines
+	src.vis_contents += glass
+	src.vis_contents += screen_light
 
-		var/datum/light/light = new/datum/light/point
-		light.set_brightness(1.3)
-		light.set_color(light_r, light_g, light_b)
-		light.set_height(2)
-		light.attach(src, 2.5 + (src.pixel_x / 32), 2.5 + (src.pixel_y / 32))
-		light.enable()
+	var/datum/light/light = new/datum/light/point
+	light.set_brightness(1.3)
+	light.set_color(src.light_r, src.light_g, src.light_b)
+	light.set_height(2)
+	light.attach(src, 2.5 + (src.pixel_x / 32), 2.5 + (src.pixel_y / 32))
+	light.enable()
+
 
 /obj/minimap/map_computer/nukeop
 	name = "Atrium Station Map"
@@ -130,211 +137,200 @@
 	light_g = 0.3
 	light_b = 0.3
 
-	New()
-		. = ..()
-		START_TRACKING
+/obj/minimap/map_computer/nukeop/New()
+	. = ..()
+	START_TRACKING
 
-	disposing()
-		STOP_TRACKING
-		. = ..()
+/obj/minimap/map_computer/nukeop/disposing()
+	STOP_TRACKING
+	. = ..()
+
 
 /obj/minimap/map_computer/pod_wars
 	name = "Debris Field Map"
 	desc = "A cutting-edge cathode ray tube monitor, actively rendering many dozens of kilobytes of reconnaissance data on the surrounding debris field."
 	map_scale = 0.3
 
-	nanotrasen
-		map_type = MAP_POD_WARS_NANOTRASEN
-		light_r = 0.3
-		light_g = 0.3
-		light_b = 1
 
-		New()
-			. = ..()
-			START_TRACKING
+/obj/minimap/map_computer/pod_wars/nanotrasen
+	map_type = MAP_POD_WARS_NANOTRASEN
+	light_r = 0.3
+	light_g = 0.3
+	light_b = 1
 
-		disposing()
-			STOP_TRACKING
-			. = ..()
+/obj/minimap/map_computer/pod_wars/nanotrasen/New()
+	. = ..()
+	START_TRACKING
 
-	syndicate
-		map_type = MAP_POD_WARS_SYNDICATE
-		light_r = 1
-		light_g = 0.3
-		light_b = 0.3
+/obj/minimap/map_computer/pod_wars/nanotrasen/disposing()
+	STOP_TRACKING
+	. = ..()
 
-		New()
-			. = ..()
-			START_TRACKING
 
-		disposing()
-			STOP_TRACKING
-			. = ..()
+/obj/minimap/map_computer/pod_wars/syndicate
+	map_type = MAP_POD_WARS_SYNDICATE
+	light_r = 1
+	light_g = 0.3
+	light_b = 0.3
 
-	both_teams
-		map_type = MAP_POD_WARS_NANOTRASEN | MAP_POD_WARS_SYNDICATE
+/obj/minimap/map_computer/pod_wars/syndicate/New()
+	. = ..()
+	START_TRACKING
 
-		New()
-			. = ..()
-			START_TRACKING
+/obj/minimap/map_computer/pod_wars/syndicate/disposing()
+	STOP_TRACKING
+	. = ..()
 
-		disposing()
-			STOP_TRACKING
-			. = ..()
+
+/obj/minimap/map_computer/pod_wars/both_teams
+	map_type = MAP_POD_WARS_NANOTRASEN | MAP_POD_WARS_SYNDICATE
+
+/obj/minimap/map_computer/pod_wars/both_teams/New()
+	. = ..()
+	START_TRACKING
+
+/obj/minimap/map_computer/pod_wars/both_teams/disposing()
+	STOP_TRACKING
+	. = ..()
+
 
 /obj/minimap_controller
 	name = "Map Controller"
 	layer = TURF_LAYER
 	anchored = ANCHORED
 
-	///The controlled minimap object.
+	/// The controlled minimap object.
 	var/obj/minimap/controlled_minimap
-	///The minimap to be displayed, mostly identical to the controlled minimap with the exception that the scale will always be 1. Used to circumvent a bug.
+	/// The minimap to be displayed, mostly identical to the controlled minimap with the exception that the scale will always be 1. Used to circumvent a bug.
 	var/datum/minimap/displayed_minimap
 
-	///Whether the next click will sample coordinates at the clicked point, or toggle dragging.
+	/// Whether the next click will sample coordinates at the clicked point, or toggle dragging.
 	var/selecting_coordinates = FALSE
-	///A semi-transparent minimap marker used to communicate where the marker will be placed on the minimap.
+	/// A semi-transparent minimap marker used to communicate where the marker will be placed on the minimap.
 	var/datum/minimap_marker/marker_silhouette
-	///The icon that the marker silouette should use.
+	/// The icon that the marker silouette should use.
 	var/selected_icon = "pin"
-	///The sampled x coordinate.
+	/// The sampled x coordinate.
 	var/selected_x = 1
-	///The sampled y coordinate.
+	/// The sampled y coordinate.
 	var/selected_y = 1
 
-	///Whether or not the minimap is currently being dragged/panned by the user.
+	/// Whether or not the minimap is currently being dragged/panned by the user.
 	var/dragging = FALSE
-	///The "starting" x position of the drag/pan, allowing for distance moved in the x axis to be calculated and applied to the minimap.
+	/// The "starting" x position of the drag/pan, allowing for distance moved in the x axis to be calculated and applied to the minimap.
 	var/start_click_pos_x = null
-	///The "starting" y position of the drag/pan, allowing for distance moved in the y axis to be calculated and applied to the minimap.
+	/// The "starting" y position of the drag/pan, allowing for distance moved in the y axis to be calculated and applied to the minimap.
 	var/start_click_pos_y = null
 
-	New(var/obj/minimap/minimap)
-		if (!minimap)
-			return
+/obj/minimap_controller/New(obj/minimap/minimap)
+	if (!minimap)
+		return
 
-		. = ..()
-		src.controlled_minimap = minimap
+	. = ..()
 
-		src.displayed_minimap = new minimap.map_path(minimap.map_type, 1, (1 / minimap.map_scale))
-		for (var/atom/marker_target in minimap_marker_targets)
-			SEND_SIGNAL(marker_target, COMSIG_NEW_MINIMAP_MARKER, displayed_minimap)
+	src.controlled_minimap = minimap
+	START_TRACKING
 
-		src.vis_contents += src.displayed_minimap.minimap_render
+	if (global.current_state > GAME_STATE_WORLD_NEW)
+		src.initialise_minimap_controller()
 
-		// As the minimap render is transparent to clicks, the minimap will require an overlay which clicks may register on.
-		if (!src.icon || !src.icon_state)
-			var/icon/click_overlay_icon = icon('icons/obj/minimap/minimap.dmi', "blank")
-			click_overlay_icon.Scale(src.displayed_minimap.x_max, src.displayed_minimap.y_max)
-			click_overlay_icon.ChangeOpacity(0)
-			src.icon = click_overlay_icon
-			src.mouse_opacity = 2
+/obj/minimap_controller/disposing()
+	STOP_TRACKING
+	. = ..()
 
-	MouseWheel(dx, dy, loc, ctrl, params)
-		. = TRUE
-		var/list/param_list = params2list(params)
+/obj/minimap_controller/MouseWheel(dx, dy, loc, ctrl, params)
+	. = TRUE
+	var/list/param_list = params2list(params)
+	var/datum/minimap/z_level/minimap = src.displayed_minimap
+	var/datum/minimap/z_level/controlled_minimap = src.controlled_minimap.map
+
+	// Convert from screen (x, y) to map (x, y) coordinates.
+	var/x = round((text2num(param_list["icon-x"]) - minimap.minimap_render.pixel_x) / (minimap.zoom_coefficient * minimap.map_scale))
+	var/y = round((text2num(param_list["icon-y"]) - minimap.minimap_render.pixel_y) / (minimap.zoom_coefficient * minimap.map_scale))
+
+	if (dy > 1)
+		minimap.zoom_on_point(minimap.zoom_coefficient * 1.1, x, y)
+		controlled_minimap.zoom_on_point(minimap.zoom_coefficient, x, y)
+	else if (dy < 1)
+		minimap.zoom_on_point(minimap.zoom_coefficient * 0.9, x, y)
+		controlled_minimap.zoom_on_point(minimap.zoom_coefficient, x, y)
+
+	src.pan_map(0, 0)
+
+/obj/minimap_controller/Click(location, control, params)
+	var/list/param_list = params2list(params)
+	var/x = text2num(param_list["icon-x"])
+	var/y = text2num(param_list["icon-y"])
+
+	if (src.selecting_coordinates)
+		src.dragging = FALSE
+		var/datum/minimap/minimap = src.displayed_minimap
+
+		// Convert from screen (x, y) to map (x, y) coordinates, and save to selected x, y vars.
+		src.selected_x = round((x - minimap.minimap_render.pixel_x) / (minimap.zoom_coefficient * minimap.map_scale))
+		src.selected_y = round((y - minimap.minimap_render.pixel_y) / (minimap.zoom_coefficient * minimap.map_scale))
+
+		src.selecting_coordinates = FALSE
+	else
+		src.start_click_pos_x = x
+		src.start_click_pos_y = y
+		src.dragging = !src.dragging
+
+/obj/minimap_controller/MouseMove(location, control, params)
+	if (!src.dragging && !src.selecting_coordinates)
+		return
+
+	var/list/param_list = params2list(params)
+	var/x = text2num(param_list["icon-x"])
+	var/y = text2num(param_list["icon-y"])
+
+	if (src.dragging)
+		src.pan_map(x - src.start_click_pos_x, y - src.start_click_pos_y)
+		src.start_click_pos_x = x
+		src.start_click_pos_y = y
+
+	if (src.selecting_coordinates)
 		var/datum/minimap/z_level/minimap = src.displayed_minimap
-		var/datum/minimap/z_level/controlled_minimap = src.controlled_minimap.map
 
 		// Convert from screen (x, y) to map (x, y) coordinates.
-		var/x = round((text2num(param_list["icon-x"]) - minimap.minimap_render.pixel_x) / (minimap.zoom_coefficient * minimap.map_scale))
-		var/y = round((text2num(param_list["icon-y"]) - minimap.minimap_render.pixel_y) / (minimap.zoom_coefficient * minimap.map_scale))
+		x = round((x - minimap.minimap_render.pixel_x) / (minimap.zoom_coefficient * minimap.map_scale))
+		y = round((y - minimap.minimap_render.pixel_y) / (minimap.zoom_coefficient * minimap.map_scale))
+		var/turf/map_location = locate(x, y, src.displayed_minimap.z_level)
 
-		if (dy > 1)
-			minimap.zoom_on_point(minimap.zoom_coefficient * 1.1, x, y)
-			controlled_minimap.zoom_on_point(minimap.zoom_coefficient, x, y)
-		else if (dy < 1)
-			minimap.zoom_on_point(minimap.zoom_coefficient * 0.9, x, y)
-			controlled_minimap.zoom_on_point(minimap.zoom_coefficient, x, y)
+		if (!src.marker_silhouette)
+			src.displayed_minimap.create_minimap_marker(map_location, 'icons/obj/minimap/minimap_markers.dmi', src.selected_icon)
+			src.marker_silhouette = src.displayed_minimap.minimap_markers[map_location]
+			src.marker_silhouette.alpha_value = 175
+			src.marker_silhouette.marker.alpha = 175
 
-		src.pan_map(0, 0)
+		src.marker_silhouette.target = map_location
+		src.displayed_minimap.set_marker_position(src.marker_silhouette, src.marker_silhouette.target.x, src.marker_silhouette.target.y, src.displayed_minimap.z_level)
 
-	Click(location, control, params)
-		var/list/param_list = params2list(params)
-		var/x = text2num(param_list["icon-x"])
-		var/y = text2num(param_list["icon-y"])
+/obj/minimap_controller/proc/pan_map(x, y)
+	src.displayed_minimap.minimap_render.pixel_x += x
+	src.displayed_minimap.minimap_render.pixel_y += y
 
-		if (src.selecting_coordinates)
-			src.dragging = FALSE
-			var/datum/minimap/minimap = src.displayed_minimap
+	src.controlled_minimap.map.minimap_render.pixel_x = (src.displayed_minimap.minimap_render.pixel_x - 8) * src.controlled_minimap.map_scale
+	src.controlled_minimap.map.minimap_render.pixel_y = (src.displayed_minimap.minimap_render.pixel_y - 8) * src.controlled_minimap.map_scale
 
-			// Convert from screen (x, y) to map (x, y) coordinates, and save to selected x, y vars.
-			src.selected_x = round((x - minimap.minimap_render.pixel_x) / (minimap.zoom_coefficient * minimap.map_scale))
-			src.selected_y = round((y - minimap.minimap_render.pixel_y) / (minimap.zoom_coefficient * minimap.map_scale))
+/obj/minimap_controller/proc/reset_scale()
+	if (!istype(src.controlled_minimap.map, /datum/minimap/z_level))
+		return
 
-			src.selecting_coordinates = FALSE
-		else
-			src.start_click_pos_x = x
-			src.start_click_pos_y = y
-			src.dragging = !src.dragging
+	var/datum/minimap/z_level/controlled_minimap = src.controlled_minimap.map
+	controlled_minimap.find_focal_point()
 
-	MouseMove(location, control, params)
-		if (!src.dragging && !src.selecting_coordinates)
-			return
+	var/datum/minimap/z_level/displayed_minimap = src.displayed_minimap
+	displayed_minimap.find_focal_point()
 
-		var/list/param_list = params2list(params)
-		var/x = text2num(param_list["icon-x"])
-		var/y = text2num(param_list["icon-y"])
+/obj/minimap_controller/proc/toggle_visibility_all(visible)
+	for (var/atom/target in src.controlled_minimap.map.minimap_markers)
+		if (target.z != src.controlled_minimap.map.z_level)
+			continue
 
-		if (src.dragging)
-			src.pan_map(x - src.start_click_pos_x, y - src.start_click_pos_y)
-			src.start_click_pos_x = x
-			src.start_click_pos_y = y
-
-		if (src.selecting_coordinates)
-			var/datum/minimap/z_level/minimap = src.displayed_minimap
-
-			// Convert from screen (x, y) to map (x, y) coordinates.
-			x = round((x - minimap.minimap_render.pixel_x) / (minimap.zoom_coefficient * minimap.map_scale))
-			y = round((y - minimap.minimap_render.pixel_y) / (minimap.zoom_coefficient * minimap.map_scale))
-			var/turf/map_location = locate(x, y, src.displayed_minimap.z_level)
-
-			if (!src.marker_silhouette)
-				src.displayed_minimap.create_minimap_marker(map_location, 'icons/obj/minimap/minimap_markers.dmi', src.selected_icon)
-				src.marker_silhouette = src.displayed_minimap.minimap_markers[map_location]
-				src.marker_silhouette.alpha_value = 175
-				src.marker_silhouette.marker.alpha = 175
-
-			src.marker_silhouette.target = map_location
-			src.displayed_minimap.set_marker_position(src.marker_silhouette, src.marker_silhouette.target.x, src.marker_silhouette.target.y, src.displayed_minimap.z_level)
-
-	proc/pan_map(var/x, var/y)
-		src.displayed_minimap.minimap_render.pixel_x += x
-		src.displayed_minimap.minimap_render.pixel_y += y
-
-		src.controlled_minimap.map.minimap_render.pixel_x = (src.displayed_minimap.minimap_render.pixel_x - 8) * src.controlled_minimap.map_scale
-		src.controlled_minimap.map.minimap_render.pixel_y = (src.displayed_minimap.minimap_render.pixel_y - 8) * src.controlled_minimap.map_scale
-
-	proc/reset_scale()
-		if (istype(src.controlled_minimap.map, /datum/minimap/z_level))
-			var/datum/minimap/z_level/controlled_minimap = src.controlled_minimap.map
-			controlled_minimap.find_focal_point()
-
-			var/datum/minimap/z_level/displayed_minimap = src.displayed_minimap
-			displayed_minimap.find_focal_point()
-
-	proc/toggle_visibility_all(var/visible)
-		for (var/atom/target in src.controlled_minimap.map.minimap_markers)
-			if (target.z != src.controlled_minimap.map.z_level)
-				continue
-
-			var/datum/minimap_marker/marker_cm = src.controlled_minimap.map.minimap_markers[target]
-			var/datum/minimap_marker/marker_dm = src.displayed_minimap.minimap_markers[target]
-			if (visible == FALSE)
-				marker_cm.marker.alpha = 0
-				marker_cm.visible = FALSE
-				marker_dm.marker.alpha = 0
-				marker_dm.visible = FALSE
-			else
-				marker_cm.marker.alpha = marker_cm.alpha_value
-				marker_cm.visible = TRUE
-				marker_dm.marker.alpha = marker_dm.alpha_value
-				marker_dm.visible = TRUE
-
-	proc/toggle_visibility(var/datum/minimap_marker/marker_cm)
-		var/datum/minimap_marker/marker_dm = src.displayed_minimap.minimap_markers[marker_cm.target]
-		if (marker_dm.marker.alpha == marker_dm.alpha_value)
+		var/datum/minimap_marker/marker_cm = src.controlled_minimap.map.minimap_markers[target]
+		var/datum/minimap_marker/marker_dm = src.displayed_minimap.minimap_markers[target]
+		if (!visible)
 			marker_cm.marker.alpha = 0
 			marker_cm.visible = FALSE
 			marker_dm.marker.alpha = 0
@@ -345,13 +341,42 @@
 			marker_dm.marker.alpha = marker_dm.alpha_value
 			marker_dm.visible = TRUE
 
-	proc/new_marker(var/location, var/icon_state, var/name)
-		src.displayed_minimap.create_minimap_marker(location, 'icons/obj/minimap/minimap_markers.dmi', icon_state, name, TRUE)
-		src.controlled_minimap.map.create_minimap_marker(location, 'icons/obj/minimap/minimap_markers.dmi', icon_state, name, TRUE)
+/obj/minimap_controller/proc/toggle_visibility(datum/minimap_marker/marker_cm)
+	var/datum/minimap_marker/marker_dm = src.displayed_minimap.minimap_markers[marker_cm.target]
+	if (marker_dm.marker.alpha == marker_dm.alpha_value)
+		marker_cm.marker.alpha = 0
+		marker_cm.visible = FALSE
+		marker_dm.marker.alpha = 0
+		marker_dm.visible = FALSE
+	else
+		marker_cm.marker.alpha = marker_cm.alpha_value
+		marker_cm.visible = TRUE
+		marker_dm.marker.alpha = marker_dm.alpha_value
+		marker_dm.visible = TRUE
 
-	proc/delete_marker(var/datum/minimap_marker/marker)
-		src.displayed_minimap.remove_minimap_marker(marker.target)
-		src.controlled_minimap.map.remove_minimap_marker(marker.target)
+/obj/minimap_controller/proc/new_marker(location, icon_state, name)
+	src.displayed_minimap.create_minimap_marker(location, 'icons/obj/minimap/minimap_markers.dmi', icon_state, name, TRUE)
+	src.controlled_minimap.map.create_minimap_marker(location, 'icons/obj/minimap/minimap_markers.dmi', icon_state, name, TRUE)
+
+/obj/minimap_controller/proc/delete_marker(datum/minimap_marker/marker)
+	src.displayed_minimap.remove_minimap_marker(marker.target)
+	src.controlled_minimap.map.remove_minimap_marker(marker.target)
+
+/obj/minimap_controller/proc/initialise_minimap_controller()
+	src.displayed_minimap = new src.controlled_minimap.map_path(src.controlled_minimap.map_type, 1, (1 / src.controlled_minimap.map_scale))
+	for (var/atom/marker_target in minimap_marker_targets)
+		SEND_SIGNAL(marker_target, COMSIG_NEW_MINIMAP_MARKER, displayed_minimap)
+
+	src.vis_contents += src.displayed_minimap.minimap_render
+
+	// As the minimap render is transparent to clicks, the minimap will require an overlay which clicks may register on.
+	if (!src.icon || !src.icon_state)
+		var/icon/click_overlay_icon = icon('icons/obj/minimap/minimap.dmi', "blank")
+		click_overlay_icon.Scale(src.displayed_minimap.x_max, src.displayed_minimap.y_max)
+		click_overlay_icon.ChangeOpacity(0)
+		src.icon = click_overlay_icon
+		src.mouse_opacity = 2
+
 
 /obj/item/nukeop_minimap_controller
 	name = "atrium station map controller"
@@ -367,31 +392,32 @@
 	var/obj/minimap_controller/minimap_controller
 	var/atom/movable/minimap_ui_handler/minimap_controller/minimap_ui
 
-	New()
-		. = ..()
-		START_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
+/obj/item/nukeop_minimap_controller/New()
+	. = ..()
+	START_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
+	src.connect_to_minimap()
+
+/obj/item/nukeop_minimap_controller/disposing()
+	STOP_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
+	. = ..()
+
+/obj/item/nukeop_minimap_controller/attack_self(mob/user)
+	. = ..()
+	if (!src.minimap_controller || !src.minimap_ui)
 		src.connect_to_minimap()
-
-	disposing()
-		STOP_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
-		. = ..()
-
-	attack_self(mob/user)
-		. = ..()
 		if (!src.minimap_controller || !src.minimap_ui)
-			src.connect_to_minimap()
-			if (!src.minimap_controller || !src.minimap_ui)
-				return
-		src.minimap_ui.ui_interact(user)
+			return
+	src.minimap_ui.ui_interact(user)
 
-	proc/connect_to_minimap()
-		var/obj/minimap/map_computer/nukeop/minimap
-		for_by_tcl(map, /obj/minimap/map_computer/nukeop)
-			minimap = map
+/obj/item/nukeop_minimap_controller/proc/connect_to_minimap()
+	var/obj/minimap/map_computer/nukeop/minimap
+	for_by_tcl(map, /obj/minimap/map_computer/nukeop)
+		minimap = map
 
-		if (minimap)
-			src.minimap_controller = new(minimap)
-			src.minimap_ui = new(src, "nukeop_map", src.minimap_controller, "Atrium Station Map Controller", "syndicate")
+	if (minimap)
+		src.minimap_controller = new(minimap)
+		src.minimap_ui = new(src, "nukeop_map", src.minimap_controller, "Atrium Station Map Controller", "syndicate")
+
 
 ABSTRACT_TYPE(/obj/machinery/computer/pod_wars_minimap_controller)
 /obj/machinery/computer/pod_wars_minimap_controller
@@ -405,59 +431,61 @@ ABSTRACT_TYPE(/obj/machinery/computer/pod_wars_minimap_controller)
 	var/atom/movable/minimap_ui_handler/minimap_controller/minimap_ui
 	var/team_num = null
 
-	New()
-		. = ..()
+/obj/machinery/computer/pod_wars_minimap_controller/New()
+	. = ..()
+	src.connect_to_minimap()
+
+	var/image/screen_light = image('icons/obj/large/64x64.dmi', "minimap_controller_lights")
+	screen_light.plane = PLANE_LIGHTING
+	screen_light.blend_mode = BLEND_ADD
+	screen_light.layer = LIGHTING_LAYER_BASE
+	screen_light.color = list(0.33,0.33,0.33, 0.33,0.33,0.33, 0.33,0.33,0.33)
+	src.AddOverlays(screen_light, "screen_light")
+
+/obj/machinery/computer/pod_wars_minimap_controller/attack_hand(mob/user)
+	if (status & (BROKEN|NOPOWER))
+		return
+
+	src.add_fingerprint(user)
+	if (!src.minimap_controller || !src.minimap_ui)
 		src.connect_to_minimap()
-
-		var/image/screen_light = image('icons/obj/large/64x64.dmi', "minimap_controller_lights")
-		screen_light.plane = PLANE_LIGHTING
-		screen_light.blend_mode = BLEND_ADD
-		screen_light.layer = LIGHTING_LAYER_BASE
-		screen_light.color = list(0.33,0.33,0.33, 0.33,0.33,0.33, 0.33,0.33,0.33)
-		src.AddOverlays(screen_light, "screen_light")
-
-	attack_hand(mob/user)
-		if(status & (BROKEN|NOPOWER))
-			return
-
-		add_fingerprint(user)
 		if (!src.minimap_controller || !src.minimap_ui)
-			src.connect_to_minimap()
-			if (!src.minimap_controller || !src.minimap_ui)
-				return
-		src.minimap_ui.ui_interact(user)
+			return
+	src.minimap_ui.ui_interact(user)
 
-	proc/connect_to_minimap()
-		var/obj/minimap/map_computer/pod_wars/minimap
-		switch(team_num)
-			if (TEAM_NANOTRASEN)
-				for_by_tcl(map, /obj/minimap/map_computer/pod_wars/nanotrasen)
-					minimap = map
+/obj/machinery/computer/pod_wars_minimap_controller/proc/connect_to_minimap()
+	var/obj/minimap/map_computer/pod_wars/minimap
+	switch(team_num)
+		if (TEAM_NANOTRASEN)
+			for_by_tcl(map, /obj/minimap/map_computer/pod_wars/nanotrasen)
+				minimap = map
 
-				if (minimap)
-					src.minimap_controller = new(minimap)
-					src.minimap_ui = new(src, "nt_debris_minimap", src.minimap_controller, "Debris Field Map Controller", "ntos")
+			if (minimap)
+				src.minimap_controller = new(minimap)
+				src.minimap_ui = new(src, "nt_debris_minimap", src.minimap_controller, "Debris Field Map Controller", "ntos")
 
-			if (TEAM_SYNDICATE)
-				for_by_tcl(map, /obj/minimap/map_computer/pod_wars/syndicate)
-					minimap = map
+		if (TEAM_SYNDICATE)
+			for_by_tcl(map, /obj/minimap/map_computer/pod_wars/syndicate)
+				minimap = map
 
-				if (minimap)
-					src.minimap_controller = new(minimap)
-					src.minimap_ui = new(src, "synd_debris_minimap", src.minimap_controller, "Debris Field Map Controller", "syndicate")
+			if (minimap)
+				src.minimap_controller = new(minimap)
+				src.minimap_ui = new(src, "synd_debris_minimap", src.minimap_controller, "Debris Field Map Controller", "syndicate")
 
-			if (TEAM_NEUTRAL)
-				for_by_tcl(map, /obj/minimap/map_computer/pod_wars/both_teams)
-					minimap = map
+		if (TEAM_NEUTRAL)
+			for_by_tcl(map, /obj/minimap/map_computer/pod_wars/both_teams)
+				minimap = map
 
-				if (minimap)
-					src.minimap_controller = new(minimap)
-					src.minimap_ui = new(src, "neutral_debris_minimap", src.minimap_controller, "Debris Field Map Controller", "retro-dark")
-	nanotrasen
-		team_num = TEAM_NANOTRASEN
+			if (minimap)
+				src.minimap_controller = new(minimap)
+				src.minimap_ui = new(src, "neutral_debris_minimap", src.minimap_controller, "Debris Field Map Controller", "retro-dark")
 
-	syndicate
-		team_num = TEAM_SYNDICATE
 
-	neutral
-		team_num = TEAM_NEUTRAL
+/obj/machinery/computer/pod_wars_minimap_controller/nanotrasen
+	team_num = TEAM_NANOTRASEN
+
+/obj/machinery/computer/pod_wars_minimap_controller/syndicate
+	team_num = TEAM_SYNDICATE
+
+/obj/machinery/computer/pod_wars_minimap_controller/neutral
+	team_num = TEAM_NEUTRAL

--- a/code/modules/minimap/minimap_renderer.dm
+++ b/code/modules/minimap/minimap_renderer.dm
@@ -1,157 +1,159 @@
 /datum/minimap_renderer
-	var/list/minimap_type_renders = list()
-	var/list/dynamic_area_overlays = list()
+	var/list/icon/minimap_type_renders
+	var/list/list/atom/movable/dynamic_area_overlays
 
-	New()
-		. = ..()
-		src.render_minimaps(Z_LEVEL_STATION)
+/datum/minimap_renderer/New()
+	. = ..()
 
-	proc/render_minimaps(var/z_level)
-		if (!z_level)
-			return
+	src.minimap_type_renders = list()
+	src.dynamic_area_overlays = list()
+	src.render_minimaps(Z_LEVEL_STATION)
 
-		var/x_max = world.maxx
-		var/x_min = 1
-		var/y_max = world.maxy
-		var/y_min = 1
+/// Set up all `/obj/minimap` and `/obj/minimap_controller` types.
+/datum/minimap_renderer/proc/initialise_minimaps()
+	for_by_tcl(minimap, /obj/minimap)
+		minimap.initialise_minimap()
 
-		// Iterates through all turfs on the map, creating a list for each minimap type required, this minimap type list itself containing lists of turfs to be drawn to an icon.
-		var/list/area_directory = list()
-		var/list/dynamic_area_directory = list()
-		for (var/turf/T in block(locate(x_min, y_min, z_level), locate(x_max, y_max, z_level)))
-			if (!src.valid_turf(T))
-				continue
-			var/area/A = T.loc
+	for_by_tcl(controller, /obj/minimap_controller)
+		controller.initialise_minimap_controller()
 
-			var/flags = list()
-			if (A.minimaps_to_render_on == MAP_ALL)
-				flags += MAP_ALL
-			else
-				flags = src.separate_bitflag(A.minimaps_to_render_on)
+/// Renders a minimap portion for each map flag, and renders dynamic area overlays, storing them in `minimap_type_renders` and `dynamic_area_overlays` respectively.
+/datum/minimap_renderer/proc/render_minimaps(z_level)
+	if (!z_level)
+		return
 
-			// Sort areas with dynamic map colours into their own list, so that they may be drawn separately on an atom/movable which will be overlayed onto minimaps.
-			if (A.dynamic_map_colour_group)
-				// For each minimap type flag in the `minimaps_to_render_on` bitflag on the area, create a list for that minimap type in the directory, then populate that list with other lists containing turfs, organised by area type.
-				for (var/flag in flags)
-					if (!("[flag]" in dynamic_area_directory))
-						dynamic_area_directory["[flag]"] = list()
+	// Iterates through all turfs on the map, creating a list for each minimap type required, this minimap type list itself containing lists of turfs to be drawn to an icon.
+	var/list/turf/area_directory = list()
+	var/list/list/turf/dynamic_area_directory = list()
+	for (var/turf/T as anything in block(locate(1, 1, z_level), locate(world.maxx, world.maxy, z_level)))
+		if (!src.valid_turf(T))
+			continue
+		var/area/A = T.loc
 
-					var/list/area_group_list = dynamic_area_directory["[flag]"]
-					if (!("[A.dynamic_map_colour_group]" in area_group_list))
-						area_group_list["[A.dynamic_map_colour_group]"] = list()
+		var/list/flags = list()
+		if (A.minimaps_to_render_on == MAP_ALL)
+			flags += MAP_ALL
+		else
+			flags = src.separate_bitflag(A.minimaps_to_render_on)
 
-					var/list/turf_list = area_group_list["[A.dynamic_map_colour_group]"]
-					turf_list.Add(T)
-
-				continue
-
-			// For each minimap type flag in the `minimaps_to_render_on` bitflag on the area, create a list for that minimap type in the directory, then populate that list with turfs belonging to that minimap type.
+		// Sort areas with dynamic map colours into their own list, so that they may be drawn separately on an atom/movable which will be overlayed onto minimaps.
+		if (A.dynamic_map_colour_group)
+			// For each minimap type flag in the `minimaps_to_render_on` bitflag on the area, create a list for that minimap type in the directory, then populate that list with other lists containing turfs, organised by area type.
 			for (var/flag in flags)
-				if (!("[flag]" in area_directory))
-					area_directory["[flag]"] = list()
+				dynamic_area_directory["[flag]"] ||= list()
+				dynamic_area_directory["[flag]"]["[A.dynamic_map_colour_group]"] ||= list()
+				dynamic_area_directory["[flag]"]["[A.dynamic_map_colour_group]"] += T
 
-				var/list/turf_list = area_directory["[flag]"]
-				turf_list.Add(T)
+			continue
 
-		// Iterate over every minimap type in the area directory, and each turf within that minimap type's list, drawing it to an icon for that specific minimap type.
-		for (var/minimap_type in area_directory)
-			var/icon/minimap_type_render = icon('icons/obj/minimap/minimap.dmi', "blank")
-			minimap_type_render.Scale(world.maxx, world.maxy)
-			minimap_type_render.SwapColor(rgb(0, 0, 0), rgb(0, 0, 0, 0))
-
-			var/list/minimap_type_areas = area_directory["[minimap_type]"]
-			for (var/turf/turf in minimap_type_areas)
-				minimap_type_render.DrawBox(turf_color(turf), turf.x, turf.y)
-
-			src.minimap_type_renders["[minimap_type]"] = minimap_type_render
-
-		// Iterate over every minimap type in the dynamic area directory, and create a list corresponding to that minimap type in the area minimap directory, then populate that list with renders of area groups to be overlayed onto minimaps.
-		for (var/minimap_type in dynamic_area_directory)
-			if (!("[minimap_type]" in dynamic_area_overlays))
-				dynamic_area_overlays["[minimap_type]"] = list()
-			var/list/minimap_type_render_list = dynamic_area_overlays["[minimap_type]"]
-
-			var/list/area_groups = dynamic_area_directory[minimap_type]
-			for (var/area_group in area_groups)
-				var/icon/area_render = icon('icons/obj/minimap/minimap.dmi', "blank")
-				area_render.Scale(x_max, y_max)
-				area_render.SwapColor(rgb(0, 0, 0), rgb(0, 0, 0, 0))
-
-				var/list/area_list = area_groups[area_group]
-				for (var/turf/turf in area_list)
-					area_render.DrawBox(turf_color(turf), turf.x, turf.y)
-
-				var/atom/movable/area_render_object = new
-				area_render_object.icon = area_render
-				area_render_object.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
-				area_render_object.mouse_opacity = 0
-
-				minimap_type_render_list["[area_group]"] = area_render_object
-
-	///Separates a given bitflag into a list of the separate bits composing it. Eg. 1011 -> (0001, 0010, 1000), or in base 10: 11 -> (1, 2, 8)
-	proc/separate_bitflag(var/bitflag)
-		var/list/flag_list = list()
-		var/bit_length = ceil(log(2, (bitflag + 1)))
-
-		for (var/i = 0 to bit_length)
-			if ((2**i) & bitflag)
-				flag_list.Add(2**i)
-
-		return flag_list
-
-	///Checks whether a turf should be rendered on the minimap through the minimaps_to_render_on bitflag on /area.
-	proc/valid_turf(var/turf/T)
-		if (!T.loc)
-			return FALSE
-		var/area/A = T.loc
-		if (!A.minimaps_to_render_on)
-			return FALSE
-		return TRUE
-
-	///Determine the colour of a turf on the minimap through the station_map_colour variable on /turf.
-	proc/turf_color(turf/T)
-		if (!T.loc)
-			return
-		var/area/A = T.loc
-		return A.station_map_colour
-
-	///Generates an atom/movable for a specified minimap type.
-	proc/generate_minimap_render(var/minimap_type)
-		var/atom/movable/minimap_render_object = new()
-		var/icon/minimap_render = icon('icons/obj/minimap/minimap.dmi', "blank")
-		minimap_render.Scale(world.maxx, world.maxy)
-
-		var/flags = list()
-		flags += MAP_ALL
-		flags += src.separate_bitflag(minimap_type)
-
+		// For each minimap type flag in the `minimaps_to_render_on` bitflag on the area, create a list for that minimap type in the directory, then populate that list with turfs belonging to that minimap type.
 		for (var/flag in flags)
-			var/list/area_list = src.dynamic_area_overlays["[flag]"]
-			for (var/area in area_list)
-				var/atom/movable/area_render = area_list[area]
-				minimap_render_object.vis_contents += area_render
+			area_directory["[flag]"] ||= list()
+			area_directory["[flag]"] += T
 
-			if (!("[flag]" in src.minimap_type_renders))
-				continue
+	// Iterate over every minimap type in the area directory, and each turf within that minimap type's list, drawing it to an icon for that specific minimap type.
+	for (var/minimap_type in area_directory)
+		var/icon/minimap_type_render = icon('icons/obj/minimap/minimap.dmi', "blank")
+		minimap_type_render.Scale(world.maxx, world.maxy)
+		minimap_type_render.SwapColor(rgb(0, 0, 0), rgb(0, 0, 0, 0))
 
-			var/icon/minimap_type_render = src.minimap_type_renders["[flag]"]
-			minimap_render.Blend(minimap_type_render, ICON_OVERLAY)
+		for (var/turf/turf as anything in area_directory["[minimap_type]"])
+			minimap_type_render.DrawBox(turf_color(turf), turf.x, turf.y)
 
-		minimap_render_object.icon = minimap_render
-		minimap_render_object.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
-		minimap_render_object.mouse_opacity = 0
+		src.minimap_type_renders["[minimap_type]"] = minimap_type_render
 
-		return minimap_render_object
+	// Iterate over every minimap type in the dynamic area directory, and create a list corresponding to that minimap type in the area minimap directory, then populate that list with renders of area groups to be overlayed onto minimaps.
+	for (var/minimap_type in dynamic_area_directory)
+		src.dynamic_area_overlays["[minimap_type]"] ||= list()
 
-	///Recolours a specified area group to a specified colour.
-	proc/recolor_area(var/area_group, var/colour)
-		for (var/map_type in src.dynamic_area_overlays)
-			var/list/area_group_list = src.dynamic_area_overlays[map_type]
+		for (var/area_group in dynamic_area_directory[minimap_type])
+			var/icon/area_render = icon('icons/obj/minimap/minimap.dmi', "blank")
+			area_render.Scale(world.maxx, world.maxy)
+			area_render.SwapColor(rgb(0, 0, 0), rgb(0, 0, 0, 0))
 
-			if ("[area_group]" in area_group_list)
-				var/atom/movable/area_render = area_group_list["[area_group]"]
-				var/icon/area_render_icon = icon(area_render.icon)
+			for (var/turf/turf as anything in dynamic_area_directory[minimap_type][area_group])
+				area_render.DrawBox(turf_color(turf), turf.x, turf.y)
 
-				area_render_icon.SetIntensity(0)
-				area_render_icon.SwapColor(rgb(0, 0, 0, 255), colour)
-				area_render.icon = icon(area_render_icon)
+			var/atom/movable/area_render_object = new
+			area_render_object.icon = area_render
+			area_render_object.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
+			area_render_object.mouse_opacity = 0
+
+			src.dynamic_area_overlays["[minimap_type]"]["[area_group]"] = area_render_object
+
+/// Separates a given bitflag into a list of the separate bits composing it. Eg. 1011 -> (0001, 0010, 1000), or in base 10: 11 -> (1, 2, 8).
+/datum/minimap_renderer/proc/separate_bitflag(bitflag)
+	. = list()
+	var/bit_length = ceil(log(2, (bitflag + 1)))
+
+	for (var/i = 0 to bit_length)
+		var/flag = 2**i
+		if (flag & bitflag)
+			. += flag
+
+/// Checks whether a turf should be rendered on the minimap through the `minimaps_to_render_on` bitflag on `/area`.
+/datum/minimap_renderer/proc/valid_turf(turf/T)
+	if (!T.loc)
+		return FALSE
+
+	var/area/A = T.loc
+	if (!A.minimaps_to_render_on)
+		return FALSE
+
+	return TRUE
+
+/// Determine the colour of a turf on the minimap.
+/datum/minimap_renderer/proc/turf_color(turf/T)
+	if (!T.loc)
+		return
+
+	var/area/A = T.loc
+	var/colour = A.station_map_colour
+
+	if (istype(T, /turf/simulated/wall) || istype(T, /turf/unsimulated/wall) || (locate(/obj/mapping_helper/wingrille_spawn) in T) || (locate(/obj/window) in T))
+		var/list/rgb_list = hex_to_rgb_list(colour)
+		colour = rgb(rgb_list[1] * 0.7, rgb_list[2] * 0.7, rgb_list[3] * 0.7)
+	else if (locate(/obj/machinery/door) in T)
+		var/list/rgb_list = hex_to_rgb_list(colour)
+		colour = rgb(rgb_list[1] * 0.85, rgb_list[2] * 0.85, rgb_list[3] * 0.85)
+
+	return colour
+
+/// Generates an `/atom/movable` for a specified minimap type.
+/datum/minimap_renderer/proc/generate_minimap_render(minimap_type)
+	var/atom/movable/minimap_render_object = new()
+	var/icon/minimap_render = icon('icons/obj/minimap/minimap.dmi', "blank")
+	minimap_render.Scale(world.maxx, world.maxy)
+
+	var/list/flags = list()
+	flags += MAP_ALL
+	flags += src.separate_bitflag(minimap_type)
+
+	for (var/flag in flags)
+		for (var/area in src.dynamic_area_overlays["[flag]"])
+			minimap_render_object.vis_contents += src.dynamic_area_overlays["[flag]"][area]
+
+		if (!src.minimap_type_renders["[flag]"])
+			continue
+
+		var/icon/minimap_type_render = src.minimap_type_renders["[flag]"]
+		minimap_render.Blend(minimap_type_render, ICON_OVERLAY)
+
+	minimap_render_object.icon = minimap_render
+	minimap_render_object.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
+	minimap_render_object.mouse_opacity = 0
+
+	return minimap_render_object
+
+/// Recolours a specified dynamic area group to a given colour.
+/datum/minimap_renderer/proc/recolor_area(area_group, colour)
+	for (var/map_type in src.dynamic_area_overlays)
+		if (!src.dynamic_area_overlays[map_type]["[area_group]"])
+			continue
+
+		var/atom/movable/area_render = src.dynamic_area_overlays[map_type]["[area_group]"]
+		var/icon/area_render_icon = icon(area_render.icon)
+
+		area_render_icon.SetIntensity(0)
+		area_render_icon.SwapColor(rgb(0, 0, 0, 255), colour)
+		area_render.icon = icon(area_render_icon)

--- a/code/modules/minimap/minimap_ui.dm
+++ b/code/modules/minimap/minimap_ui.dm
@@ -1,224 +1,222 @@
 /atom/movable/minimap_ui_handler
-	///The shared maximum minimap id number, used for creating unique minimap IDs.
-	var/static/max_minimap_id = 0
-	///The current unique ID of the minimap, used for rendering it in a ByondUI component.
+	/// The current unique ID of the minimap, used for rendering it in a ByondUI component.
 	var/minimap_id
-	///All clients who currently have the minimap ui open.
-	var/list/client/viewers = list()
-	///The screen handler which the minimap object is placed into.
+	/// All clients who currently have the minimap ui open.
+	var/list/client/viewers
+	/// The screen handler which the minimap object is placed into.
 	var/atom/movable/screen/handler
-	///The "minimap" object which will be displayed onto the client's screen. Not explicitly defined, as it may also be of type `obj/minimap_controller`.
+	/// The "minimap" object which will be displayed onto the client's screen. Not explicitly defined, as it may also be of type `obj/minimap_controller`.
 	var/obj/minimap
 
-	///The title that the tgui window should display.
+	/// The title that the tgui window should display.
 	var/tgui_title
-	///The theme that the tgui window should use. For a list of all themes, see `tgui/packages/tgui/styles/themes`.
+	/// The theme that the tgui window should use. For a list of all themes, see `tgui/packages/tgui/styles/themes`.
 	var/tgui_theme
 
-	New(parent, control_id = null, obj/minimap, tgui_title, tgui_theme)
-		. = ..()
-		START_TRACKING
-		src.loc = parent
-		src.tgui_title = tgui_title
-		src.tgui_theme = tgui_theme
+/atom/movable/minimap_ui_handler/New(parent, control_id = "minimap_ui_\ref[src]", obj/minimap, tgui_title, tgui_theme)
+	. = ..()
 
-		if (isnull(control_id))
-			control_id = "minimap_ui_[max_minimap_id++]"
-		src.minimap_id = "[control_id]"
+	START_TRACKING
+	src.viewers = list()
 
-		src.handler = new
-		src.handler.plane = PLANE_BLACKNESS
-		src.handler.mouse_opacity = 0
-		src.handler.screen_loc = "[src.minimap_id]:1,1"
+	src.loc = parent
+	src.minimap_id = control_id
+	src.tgui_title = tgui_title
+	src.tgui_theme = tgui_theme
 
-		src.minimap = minimap
-		src.minimap.screen_loc = "[src.minimap_id]:1,1"
-		src.handler.vis_contents += src.minimap
+	src.handler = new
+	src.handler.plane = PLANE_BLACKNESS
+	src.handler.mouse_opacity = 0
+	src.handler.screen_loc = "[src.minimap_id]:1,1"
 
-	disposing()
-		STOP_TRACKING
-		for (var/client/viewer in src.viewers)
-			if (viewer)
-				viewer.screen -= src.handler
-				viewer.screen -= src.minimap
-		. = ..()
+	src.minimap = minimap
+	src.minimap.screen_loc = "[src.minimap_id]:1,1"
+	src.handler.vis_contents += src.minimap
 
-	ui_interact(mob/user, datum/tgui/ui)
-		ui = tgui_process.try_update_ui(user, src, ui)
-		if(!ui)
-			ui = new(user, src, "Minimap")
-			ui.open()
+/atom/movable/minimap_ui_handler/disposing()
+	STOP_TRACKING
+	for (var/client/viewer as anything in src.viewers)
+		if (!viewer)
+			continue
 
-	ui_static_data(mob/user)
-		. = list(
-			"title" = src.tgui_title,
-			"theme" = src.tgui_theme,
-			"minimap_id"= src.minimap_id
-		)
+		viewer.screen -= src.handler
+		viewer.screen -= src.minimap
 
-	ui_data(mob/user)
-		src.add_client(user?.client)
+	. = ..()
 
-	ui_close(mob/user)
-		src.remove_client(user?.client)
-		. = ..()
+/atom/movable/minimap_ui_handler/ui_interact(mob/user, datum/tgui/ui)
+	ui = tgui_process.try_update_ui(user, src, ui)
+	if (!ui)
+		ui = new(user, src, "Minimap")
+		ui.open()
 
-	///Adds a subscribed client.
-	proc/add_client(client/viewer)
-		if (viewer && !(viewer in src.viewers))
-			src.viewers += viewer
-			viewer.screen += src.handler
-			viewer.screen += src.minimap
+/atom/movable/minimap_ui_handler/ui_static_data(mob/user)
+	. = list(
+		"title" = src.tgui_title,
+		"theme" = src.tgui_theme,
+		"minimap_id" = src.minimap_id,
+	)
 
-	///Removes a subscribed client.
-	proc/remove_client(client/viewer)
-		if (viewer && (viewer in src.viewers))
-			src.viewers -= viewer
-			viewer.screen -= src.handler
-			viewer.screen -= src.minimap
+/atom/movable/minimap_ui_handler/ui_data(mob/user)
+	src.add_client(user?.client)
+
+/atom/movable/minimap_ui_handler/ui_close(mob/user)
+	src.remove_client(user?.client)
+	. = ..()
+
+/// Adds a subscribed client.
+/atom/movable/minimap_ui_handler/proc/add_client(client/viewer)
+	if (!viewer || (viewer in src.viewers))
+		return
+
+	src.viewers += viewer
+	viewer.screen += src.handler
+	viewer.screen += src.minimap
+
+/// Removes a subscribed client.
+/atom/movable/minimap_ui_handler/proc/remove_client(client/viewer)
+	if (!viewer || !(viewer in src.viewers))
+		return
+
+	src.viewers -= viewer
+	viewer.screen -= src.handler
+	viewer.screen -= src.minimap
 
 
 /atom/movable/minimap_ui_handler/minimap_controller
 	///The minimap controller object, containing data on selected coordinates and the controlled minimap.
 	var/obj/minimap_controller/minimap_controller
-	///The minimap datum, containing data on the appearance and scale of the minimap, handling resizes, and managing markers.
-	var/datum/minimap/minimap_datum
 	///An associative list of data for each minimap marker, so that the UI may read it.
 	var/list/minimap_markers_list
 	///Whether the next call of `"toggle_visibility_all"` will turn all markers opaque or transparent. Does not reflect whether the markers are opaque or transparent.
 	var/markers_visible = TRUE
 
-	New(parent, control_id = null, obj/minimap_controller/minimap_controller, tgui_title, tgui_theme)
-		..(parent, control_id, minimap_controller, tgui_title, tgui_theme)
-		src.minimap_controller = minimap_controller
-		src.minimap_datum = minimap_controller.controlled_minimap.map
+/atom/movable/minimap_ui_handler/minimap_controller/New(parent, control_id = "minimap_ui_\ref[src]", obj/minimap_controller/minimap_controller, tgui_title, tgui_theme)
+	. = ..()
+	src.minimap_controller = minimap_controller
 
-	ui_interact(mob/user, datum/tgui/ui)
-		ui = tgui_process.try_update_ui(user, src, ui)
-		if(!ui)
-			ui = new(user, src, "MinimapController")
-			ui.open()
+/atom/movable/minimap_ui_handler/minimap_controller/ui_interact(mob/user, datum/tgui/ui)
+	ui = tgui_process.try_update_ui(user, src, ui)
+	if (!ui)
+		ui = new(user, src, "MinimapController")
+		ui.open()
 
-	ui_static_data(mob/user)
-		. = ..()
-		var/list/placable_marker_states = list()
-		var/list/placable_marker_images = list()
-		for(var/icon_state in icon_states('icons/obj/minimap/minimap_markers.dmi'))
-			placable_marker_states.Add(icon_state)
-			var/icon/marker_icon = icon('icons/obj/minimap/minimap_markers.dmi', icon_state)
-			placable_marker_images[icon_state] = icon2base64(marker_icon)
+/atom/movable/minimap_ui_handler/minimap_controller/ui_static_data(mob/user)
+	. = ..()
+	var/list/placable_marker_states = list()
+	var/list/placable_marker_images = list()
+	for (var/icon_state in icon_states('icons/obj/minimap/minimap_markers.dmi'))
+		placable_marker_states.Add(icon_state)
+		var/icon/marker_icon = icon('icons/obj/minimap/minimap_markers.dmi', icon_state)
+		placable_marker_images[icon_state] = icon2base64(marker_icon)
 
+	. += list(
+		"placable_marker_states" = placable_marker_states,
+		"placable_marker_images" = placable_marker_images,
+		"pos_x" = 1,
+		"pos_y" = 1,
+		"icon" = "pin",
+		"image" = placable_marker_images["pin"]
+	)
+
+/atom/movable/minimap_ui_handler/minimap_controller/ui_data(mob/user)
+	..()
+	minimap_markers_list = list()
+	for (var/atom/target as anything in src.minimap_controller.controlled_minimap.map.minimap_markers)
+		var/datum/minimap_marker/marker = src.minimap_controller.controlled_minimap.map.minimap_markers[target]
+		if (!marker.on_minimap_z_level || !marker.list_on_ui)
+			continue
+
+		minimap_markers_list.Add(list(list(
+			"name" = marker.name,
+			"pos" = "[target.x], [target.y]",
+			"visible" = marker.visible,
+			"can_be_deleted" = marker.can_be_deleted_by_player,
+			"marker" = marker,
+			"index" = length(minimap_markers_list) + 1
+		)))
+
+	. = list(
+		"markers_visible" = markers_visible,
+		"selecting_coordinates" = src.minimap_controller.selecting_coordinates,
+		"minimap_markers" = minimap_markers_list
+	)
+
+	if (src.minimap_controller.selected_x && src.minimap_controller.selected_y)
 		. += list(
-			"placable_marker_states" = placable_marker_states,
-			"placable_marker_images" = placable_marker_images,
-			"pos_x" = 1,
-			"pos_y" = 1,
-			"icon" = "pin",
-			"image" = placable_marker_images["pin"]
+			"pos_x" = src.minimap_controller.selected_x,
+			"pos_y" = src.minimap_controller.selected_y
 		)
+		src.minimap_controller.selected_x = null
+		src.minimap_controller.selected_y = null
 
-	ui_data(mob/user)
-		..()
-		minimap_markers_list = list()
-		for (var/atom/target in src.minimap_datum.minimap_markers)
-			var/datum/minimap_marker/marker = src.minimap_datum.minimap_markers[target]
-			if (!marker.on_minimap_z_level || !marker.list_on_ui)
-				continue
+/atom/movable/minimap_ui_handler/minimap_controller/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	var/mob/user = ui.user
 
-			minimap_markers_list.Add(list(list(
-				"name" = marker.name,
-				"pos" = "[target.x], [target.y]",
-				"visible" = marker.visible,
-				"can_be_deleted" = marker.can_be_deleted_by_player,
-				"marker" = marker,
-				"index" = length(minimap_markers_list) + 1
-			)))
+	if (is_incapacitated(user))
+		return
 
-		. = list(
-			"markers_visible" = markers_visible,
-			"selecting_coordinates" = src.minimap_controller.selecting_coordinates,
-			"minimap_markers" = minimap_markers_list
-		)
+	switch (action)
+		if ("reset_scale")
+			src.minimap_controller.reset_scale()
 
-		if (src.minimap_controller.selected_x && src.minimap_controller.selected_y)
-			. += list(
-				"pos_x" = src.minimap_controller.selected_x,
-				"pos_y" = src.minimap_controller.selected_y
-			)
-			src.minimap_controller.selected_x = null
-			src.minimap_controller.selected_y = null
+		if ("toggle_visibility_all")
+			src.markers_visible = !src.markers_visible
+			src.minimap_controller.toggle_visibility_all(src.markers_visible)
 
-	ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-		var/mob/user = ui.user
+		if ("toggle_visibility")
+			if (!(src.minimap_markers_list[params["index"]]))
+				return
+			var/list/list_entry = src.minimap_markers_list[params["index"]]
 
-		if(is_incapacitated(user))
-			return
+			if (!(list_entry["marker"]))
+				return
+			var/datum/minimap_marker/marker = list_entry["marker"]
 
-		switch (action)
-			if ("reset_scale")
-				src.minimap_controller.reset_scale()
+			if (!marker)
+				return
+			src.minimap_controller.toggle_visibility(marker)
 
-			if ("toggle_visibility_all")
-				if (markers_visible == TRUE)
-					markers_visible = FALSE
-				else
-					markers_visible = TRUE
+		if ("location_from_minimap")
+			if (src.minimap_controller.marker_silhouette)
+				src.minimap_controller.marker_silhouette.visible = TRUE
+				src.minimap_controller.marker_silhouette.marker.alpha = src.minimap_controller.marker_silhouette.alpha_value
+			src.minimap_controller.selecting_coordinates = TRUE
 
-				src.minimap_controller.toggle_visibility_all(markers_visible)
+		if ("update_icon")
+			src.minimap_controller.marker_silhouette?.marker.icon = icon('icons/obj/minimap/minimap_markers.dmi', params["icon"])
+			src.minimap_controller.selected_icon = params["icon"]
 
-			if ("toggle_visibility")
-				if (!(src.minimap_markers_list[params["index"]]))
-					return
-				var/list/list_entry = src.minimap_markers_list[params["index"]]
+		if ("new_marker")
+			var/name = params["name"]
+			var/icon_state = params["icon"]
+			var/x = params["pos_x"]
+			var/y = params["pos_y"]
 
-				if (!(list_entry["marker"]))
-					return
-				var/datum/minimap_marker/marker = list_entry["marker"]
+			var/turf/location = locate(x, y, src.minimap_controller.controlled_minimap.map.z_level)
+			if (!location)
+				return
 
-				if (!marker)
-					return
-				src.minimap_controller.toggle_visibility(marker)
+			src.minimap_controller.new_marker(location, icon_state, name)
 
-			if ("location_from_minimap")
-				if (src.minimap_controller.marker_silhouette)
-					src.minimap_controller.marker_silhouette.visible = TRUE
-					src.minimap_controller.marker_silhouette.marker.alpha = src.minimap_controller.marker_silhouette.alpha_value
-				src.minimap_controller.selecting_coordinates = TRUE
+			src.minimap_controller.marker_silhouette?.visible = FALSE
+			src.minimap_controller.marker_silhouette?.marker.alpha = 0
 
-			if ("update_icon")
-				src.minimap_controller.marker_silhouette?.marker.icon = icon('icons/obj/minimap/minimap_markers.dmi', params["icon"])
-				src.minimap_controller.selected_icon = params["icon"]
+		if ("cancel_new_marker")
+			src.minimap_controller.marker_silhouette?.visible = FALSE
+			src.minimap_controller.marker_silhouette?.marker.alpha = 0
 
-			if ("new_marker")
-				var/name = params["name"]
-				var/icon_state = params["icon"]
-				var/x = params["pos_x"]
-				var/y = params["pos_y"]
+		if ("delete_marker")
+			if (!(src.minimap_markers_list[params["index"]]))
+				return
+			var/list/list_entry = src.minimap_markers_list[params["index"]]
 
-				var/turf/location = locate(x, y, src.minimap_datum.z_level)
-				if (!location)
-					return
+			if (!(list_entry["marker"]))
+				return
+			var/datum/minimap_marker/marker = list_entry["marker"]
 
-				src.minimap_controller.new_marker(location, icon_state, name)
+			if (!marker)
+				return
+			src.minimap_controller.delete_marker(marker)
 
-				src.minimap_controller.marker_silhouette?.visible = FALSE
-				src.minimap_controller.marker_silhouette?.marker.alpha = 0
-
-			if ("cancel_new_marker")
-				src.minimap_controller.marker_silhouette?.visible = FALSE
-				src.minimap_controller.marker_silhouette?.marker.alpha = 0
-
-			if ("delete_marker")
-				if (!(src.minimap_markers_list[params["index"]]))
-					return
-				var/list/list_entry = src.minimap_markers_list[params["index"]]
-
-				if (!(list_entry["marker"]))
-					return
-				var/datum/minimap_marker/marker = list_entry["marker"]
-
-				if (!marker)
-					return
-				src.minimap_controller.delete_marker(marker)
-
-		return TRUE
+	return TRUE

--- a/code/world/initialization/0_preMapLoad.dm
+++ b/code/world/initialization/0_preMapLoad.dm
@@ -128,9 +128,6 @@
 		Z_LOG_DEBUG("Preload", " camera_coverage_controller")
 		camera_coverage_controller = new /datum/controller/camera_coverage()
 
-		Z_LOG_DEBUG("Preload", "Generating minimaps...")
-		minimap_renderer = new
-
 		Z_LOG_DEBUG("Preload", "hydro_controls set_up")
 		hydro_controls.set_up()
 		Z_LOG_DEBUG("Preload", "manuf_controls set_up")

--- a/code/world/initialization/1_New.dm
+++ b/code/world/initialization/1_New.dm
@@ -29,6 +29,9 @@
 	Z_LOG_DEBUG("World/New", "Setting up powernets...")
 	makepowernets()
 
+	Z_LOG_DEBUG("World/New", "Generating minimaps...")
+	minimap_renderer = new /datum/minimap_renderer()
+	minimap_renderer.initialise_minimaps()
 
 	Z_LOG_DEBUG("World/New", "Setting up changelogs...")
 	changelog = new /datum/changelog()


### PR DESCRIPTION
[Feature] [Internal] [Code Quality]



## About The PR:
Walls and doors are now visible on station minimaps. To accommodate for this, minimap renderer initialisation has been delayed until after world generation, which also means minimap initialisation has been postponed.

![image](https://github.com/user-attachments/assets/7b5e7522-6f65-4d76-a97c-e607afe2a681)

Additionally the code has been cleaned up, including the use of absolute paths, correct typepathing on lists, and the use of `||=`. The absolute pathing changes make this PR look much larger than it is.


## Why Is This Needed?
Additional clarity for minimaps, especially for large single-area departments, and code cleanliness.


## Changelog:
```changelog
(u)Mr. Moriarty
(+)Minimaps now depict walls and doors.
```
