### PR TITLE
Lightswitch map fixes for donut3 and cog2

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -15394,7 +15394,6 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/machinery/light_switch/east,
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
@@ -20547,11 +20546,7 @@
 /obj/disposalpipe/segment/transport,
 /obj/item/device/radio/intercom/brig,
 /obj/machinery/phone,
-/obj/blind_switch/area{
-	dir = 4;
-	pixel_x = -22;
-	pixel_y = 4
-	},
+/obj/blind_switch/area/west,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
 "bkI" = (
@@ -23669,9 +23664,7 @@
 /area/station/routing/security)
 "buh" = (
 /obj/disposalpipe/segment/mail/vertical,
-/obj/machinery/light_switch/east{
-	dir = 8
-	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/caution/south,
 /area/station/routing/security)
 "bui" = (
@@ -24335,11 +24328,14 @@
 	icon_state = "plant";
 	level = 1.9
 	},
-/obj/machinery/light_switch/east,
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
+	},
+/obj/machinery/light_switch/north{
+	pixel_x = -10;
+	pixel_y = 28
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/main)
@@ -24474,10 +24470,6 @@
 	icon_state = "bedsheet-red"
 	},
 /obj/landmark/start/job/head_of_security,
-/obj/machinery/light_switch/east{
-	dir = 8;
-	pixel_x = 22
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 8;
@@ -24488,6 +24480,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
 "bwn" = (
@@ -34685,9 +34678,7 @@
 	bcolor = "red";
 	icon_state = "bedsheet-red"
 	},
-/obj/machinery/light_switch/west{
-	dir = 4
-	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred2"
@@ -57280,6 +57271,17 @@
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/west)
+"fjM" = (
+/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
+	dir = 1
+	},
+/obj/machinery/light_switch/east{
+	pixel_y = 6
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/hallway/primary/northwest)
 "fjS" = (
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/tools,
@@ -110117,7 +110119,7 @@ aPP
 aOD
 aOD
 aTI
-aOD
+fjM
 aWt
 aXT
 aZz

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -383,15 +383,13 @@
 	},
 /area/station/medical/head)
 "abW" = (
-/obj/blind_switch/area{
-	pixel_x = 23;
-	pixel_y = 9
-	},
-/obj/machinery/light_switch{
-	pixel_x = 23;
-	pixel_y = -5
-	},
 /obj/disposalpipe/segment/morgue,
+/obj/blind_switch/area/east{
+	pixel_y = 10
+	},
+/obj/machinery/light_switch/east{
+	pixel_y = -1
+	},
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "fblue3"
@@ -15272,7 +15270,6 @@
 	name = "Detective's Office persistent notice board";
 	persistent_id = "detectives office"
 	},
-/obj/machinery/light_switch/east,
 /turf/simulated/floor/wood/seven,
 /area/station/security/detectives_office)
 "ezc" = (
@@ -21375,17 +21372,13 @@
 	},
 /area/station/crew_quarters/cafeteria)
 "gqO" = (
-/obj/machinery/light_switch/east{
-	dir = 4;
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/blind_switch/east{
-	dir = 4;
-	pixel_x = -28;
+/obj/storage/secure/closet/civilian/ranch,
+/obj/blind_switch/area/west{
 	pixel_y = 4
 	},
-/obj/storage/secure/closet/civilian/ranch,
+/obj/machinery/light_switch/west{
+	pixel_y = -7
+	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "gqX" = (
@@ -28750,15 +28743,13 @@
 /obj/stool/chair/comfy{
 	dir = 8
 	},
-/obj/blind_switch/area{
-	pixel_x = 22;
-	pixel_y = 7
-	},
-/obj/machinery/light_switch{
-	pixel_x = 22;
-	pixel_y = -5
-	},
 /obj/landmark/start/job/detective,
+/obj/machinery/light_switch/east{
+	pixel_y = -4
+	},
+/obj/blind_switch/area/east{
+	pixel_y = 6
+	},
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "red2"
@@ -36868,7 +36859,6 @@
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
 /obj/blind_switch/area/east,
-/obj/machinery/light_switch/auto,
 /turf/simulated/floor/specialroom/bar,
 /area/station/wreckage{
 	name = "Restricted Area"
@@ -58102,10 +58092,7 @@
 	pixel_y = 1
 	},
 /obj/random_item_spawner/desk_stuff,
-/obj/blind_switch/area{
-	pixel_x = -20;
-	pixel_y = 10
-	},
+/obj/blind_switch/area/west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "rAR" = (
@@ -66314,13 +66301,13 @@
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
 	},
-/obj/machinery/light_switch/west{
-	dir = 4;
-	pixel_y = -5
-	},
 /obj/blind_switch/area/west{
-	dir = 4;
-	pixel_y = 5
+	pixel_y = 5;
+	pixel_x = -27
+	},
+/obj/machinery/light_switch/west{
+	pixel_y = -6;
+	pixel_x = -27
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)


### PR DESCRIPTION
[Mapping]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes changes to certain lights/blinds switches on the Donut3 and Cog2, mostly changing the dir to fit the wall better, but in a few cases I delete an extra switch/move switches from busy tiles.
I'll make a different PR for some of the other maps so it's hopefully easier to review.

Changes made to Cog2
- Fixed dir of blinds+lightswitch in HOS room
- Fixed dir of lightswitch in Sec locker room
- Moved a single lightswitch in interro because it was covered up by the light
- Moved a single lightswitch in the NW hallway by the bar because it was covered up by the light and camera

Changes made to Donut3
- Fixed dir of blinds+lightswitch in Mdir room
- Fixed dir of blinds+lightswitch in Morgue
- Fixed dir of blindswitch in HOP's room
- Fixed dir of blinds+lightswitch in Ranch
- Fixed dir of blinds+lightswitch in Det's office + deleted an extra lightswitch 
- Deleted extra lightswitch in the secret bar behind Robotics because it was directly on top of the blindswitch

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
New sprites look super wonky in spots where the dir is incorrect + some other lightswitch mapping stuff I wanted to fix
