### PR TITLE
Add new drink, Iron Brew

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -2077,6 +2077,24 @@ datum
 					M.bodytemperature += 5 * mult
 				..()
 
+		fooddrink/alcoholic/ironbrew
+			name = "Iron Brew" //They changed the name back after altering to recipe to make it 'literally true', incidentally rendering it alcoholic
+			id = "ironbrew"
+			fluid_r = 255
+			fluid_g = 75
+			fluid_b = 1
+			transparency = 190
+			description = "A fizzy and bright orange beverage that's made from girders."
+			reagent_state = LIQUID
+			taste = list("like battery acid", "rust")
+
+			// decays into ethanol and iron
+			on_mob_life(var/mob/M, var/mult = 1)
+				if(!M) M = holder.my_atom
+				M.reagents.add_reagent("iron", src.calculate_depletion_rate(M, mult))
+				..()
+				return
+
 		fooddrink/alcoholic/spacemas_spirit
 			name = "Spacemas Spirit"
 			id = "spacemas_spirit"

--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -218,7 +218,7 @@ ABSTRACT_TYPE(/obj/item/plant/herb)
 	name = "steelwheat"
 	desc = "Never eat iron filings."
 	icon_state = "metalwheat"
-	brew_result = list("beer"=20, "iron"=20)
+	brew_result = list("ironbrew"=20)
 
 	make_reagents()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Added an alcoholic beverage called Iron Brew, a mick take on Irn Bru.
Iron brew decays into ethanol and iron.
Steel wheat now distills into iron brew instead of iron and beer.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

There's not already a drink based on irn bru.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Egregorious
(*)Added Iron Brew, a drink which can be distilled from steel wheat.
```

[catering][feature]