### PR TITLE
Allow usage of a local file in "code/WorkInProgress/__development.local.dm"

### DIFF
--- a/.github/CODE_GUIDELINES.md
+++ b/.github/CODE_GUIDELINES.md
@@ -466,14 +466,18 @@ So in general, use `round(A,1)` for your rounding needs.
 ## VSCode Debugger
 You can check out a guide on using the debugger in the guide located in the [Developer Guide](https://hackmd.io/@goonstation/dev#How-to-use-the-VS-Code-Debugger).
 
-## Local `__build.dm` changes
-
-If you're tired of having to constantly add & remove `#define IM_REALLY_IN_A_FUCKING_HURRY_HERE` and similar from `__build.dm`, there's a solution!
-
+## Local `__build.dm`, and other local code changes
+ 
+If you're tired of having to constantly add & remove `#define IM_REALLY_IN_A_FUCKING_HURRY_HERE` and similar from `__build.dm`, along with stashing and re-stashing your own development tools, there's a solution!
+ 
 Create a file named `__build.local.dm` right next to it. Named exactly that.
 This file will not get picked up by Git, and will let you keep whatever defines you want in there.
-
-However, be sure that you remember you put your config in there! Please don't come to #imcoder asking why your local setup always compiles Nadir 😸
+ 
+There is additional support for a file called `__development.local.dm`, which is included in `goonstation.dme` after the build defines so that you can add new testing tools for yourself there. *Be sure to create this file in the right directory!*
+ 
+Specifically, it needs to be created under `code/WorkInProgress/__development.local.dm`. Additionally, there is a build flag, `DISABLE_DEVFILE`, which will stop this from loading. Use this before asking for help if your local development environment is breaking! And on the flip side, if your code changes are *not* showing up from this file, make sure this flag is **disabled**.
+ 
+Most importantly of all, be sure that you remember you put your configs and/or code into those locations! Please don't come to #imcoder asking why your local setup always compiles Nadir 😸, or why your map is full of capybaras.
 
 
 ## Debugging Overlays

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ Desktop.ini
 
 # Local define usage
 /_std/__build.local.dm
+/code/WorkInProgress/__development.local.dm
 
 # OpenDream compiled bytecode
 goonstation.json

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -42,6 +42,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define I_DONT_WANNA_WAIT_FOR_THIS_PREGAME_SHIT_JUST_GO // Automatically ready up and start the game ASAP. No input required.
 
 //////--- CONVENIENCE OPTIONS FOR TESTING ETC ---//
+//#define DISABLE_DEVFILE // Don't load things defined in '__local.development.dm'. Use if you have some breaking changes in there or whatnot
 //#define DEBUG_EVERYONE_GETS_CAPTAIN_ID // all IDs are captain rank, kept separate from below options to avoid disrupting access-related tests
 //#define NO_COOLDOWNS // disables all /datum/targetable cooldowns
 //#define BONUS_POINTS // gives a bunch of starting points to various abilities/uplinks/weapon vendors

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -33,8 +33,8 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\__secret_public.dme"
 
 // Local development file handling
-#if fexists("code/WorkInProgress/__local.development.dm") && !defined (DISABLE_DEVFILE)
-#include "code\WorkInProgress\__local.development.dm"
+#if fexists("code/WorkInProgress/__development.local.dm") && !defined (DISABLE_DEVFILE)
+#include "code\WorkInProgress\__development.local.dm"
 #endif
 
 // BEGIN_INCLUDE

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -33,7 +33,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\__secret_public.dme"
 
 // Local development file handling
-#if fexists("code/WorkInProgress/__development.local.dm") && !defined (DISABLE_DEVFILE)
+#if fexists("code/WorkInProgress/__development.local.dm") && !defined(DISABLE_DEVFILE)
 #include "code\WorkInProgress\__development.local.dm"
 #endif
 

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -32,6 +32,11 @@ var/datum/preMapLoad/preMapLoad = new
 #endif
 #include "code\__secret_public.dme"
 
+// Local development file handling
+#if fexists("code/WorkInProgress/__local.development.dm") && !defined (DISABLE_DEVFILE)
+#include "code\WorkInProgress\__local.development.dm"
+#endif
+
 // BEGIN_INCLUDE
 #include "code\area.dm"
 #include "code\atom.dm"

--- a/strings/changelog.txt
+++ b/strings/changelog.txt
@@ -1,4 +1,9 @@
 
+(t)fri aug 09 24
+(u)JORJ949
+(p)20226
+(e)⚖🧛|C-Balance, A-Gamemodes
+(*)The gang gamemode now requires a minimum of 15 players.
 (t)wed aug 07 24
 (u)LeahTheTech
 (p)20219


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds support for an untracked file, __development.local.dm, for code changes to take place in.

Due to the order in which __build.local.dm is included in goonstation.dme, you cannot make local code changes inside that file. Thus, another file included after all the define flags and _std files is necessary to support such a thing without being caught under the watchful eyes of git version control.

There is also support for a new define `DISABLE_DEVFILE`, which will prevent including this file. Good for testing if your local tools are breaking things.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Making changes to the codebase is made much simpler by creating personal tools and widgets to speed along development. However, such tools are often unfit for the main code repository and thus become a burden to maintain/tug around with version control. Having a standard location, much like __build.local.dm, where code changes can be made and kept should be a good QoL for development going foward.

Feel free to make your own judgements on this, this may also create issues where people have errors resulting from their own tooling and then forget it's there. I doubt it'd happen, but who knows!
