### PR TITLE
Makes omnitools mechscannable

### DIFF
--- a/code/obj/item/tool/omnitool.dm
+++ b/code/obj/item/tool/omnitool.dm
@@ -1,8 +1,8 @@
 TYPEINFO(/obj/item/tool/omnitool)
-	mats = list("metal_dense" = 80,
-				"conductive_high" = 50,
-				"energy_property_high" = 50,
-				"crystal" = 30,)
+	mats = list("dense_super" = 20,
+				"conductive_high" = 20,
+				"insulated_property" = 15,
+				"miracle" = 10,)
 
 /obj/item/tool/omnitool
 	name = "omnitool"
@@ -228,10 +228,10 @@ TYPEINFO(/obj/item/tool/omnitool)
 			return null
 
 TYPEINFO (/obj/item/tool/omnitool/syndicate)
-	mats = list("metal_dense" = 80,
-				"conductive_high" = 50,
-				"energy_property_high" = 50,
-				"crystal" = 30,)
+	mats = list("dense_property_ultra" = 20,
+				"conductive_high" = 20,
+				"insulated_property" = 15,
+				"miracle" = 20,)
 
 /obj/item/tool/omnitool/syndicate
 	icon_state = "syndicate-omnitool-prying"

--- a/code/obj/item/tool/omnitool.dm
+++ b/code/obj/item/tool/omnitool.dm
@@ -1,3 +1,9 @@
+TYPEINFO(/obj/item/tool/omnitool)
+	mats = list("metal_dense" = 80,
+				"conductive_high" = 50,
+				"energy_property_high" = 50,
+				"crystal" = 30,)
+
 /obj/item/tool/omnitool
 	name = "omnitool"
 	desc = "Multiple tools in one, like an old-fashioned Swiss army knife. Truly, we are living in the future."
@@ -221,6 +227,11 @@
 		else
 			return null
 
+TYPEINFO (/obj/item/tool/omnitool/syndicate)
+	mats = list("metal_dense" = 80,
+				"conductive_high" = 50,
+				"energy_property_high" = 50,
+				"crystal" = 30,)
 
 /obj/item/tool/omnitool/syndicate
 	icon_state = "syndicate-omnitool-prying"
@@ -262,6 +273,9 @@
 		..()
 
 
+
+TYPEINFO(/obj/item/tool/omnitool/silicon)
+	mats = null // no stealing cyborgs arms
 
 /obj/item/tool/omnitool/silicon
 	prefix = "silicon-omnitool"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes normal and syndicate omnitools mechscannable (NOT silicon ones). Current material requirements are a rough guess and I'm fine to adjust these. Similarly, happy to make this a syndicate scanner only thing.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Someone brought it up on the discord so I figured I'd make the pr. Could be useful for salvagers or traitors to make more omnitools in the case that they lose them or get them confiscated.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Munien
(+)Omnitools are now mechscannable.
```
