### PR TITLE
Add mixer recipe for gravy & soy sauce

### DIFF
--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -1883,6 +1883,17 @@ ABSTRACT_TYPE(/datum/cookingrecipe/mixer)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/ingredient/meatpaste
 
+/datum/cookingrecipe/mixer/soysauce
+	item1 =  /obj/item/reagent_containers/food/snacks/plant/soy
+	cookbonus = 4
+	output = /obj/item/reagent_containers/food/snacks/condiment/soysauce
+
+/datum/cookingrecipe/mixer/gravy
+	item1 =  /obj/item/reagent_containers/food/snacks/ingredient/meatpaste
+	item2 = /obj/item/reagent_containers/food/snacks/ingredient/flour
+	cookbonus = 4
+	output = /obj/item/reagent_containers/food/snacks/condiment/gravyboat
+
 /datum/cookingrecipe/mixer/fishpaste
 	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet
 	cookbonus = 4

--- a/code/obj/machinery/food_and_drink/mixer.dm
+++ b/code/obj/machinery/food_and_drink/mixer.dm
@@ -48,6 +48,8 @@ TYPEINFO(/obj/machinery/mixer)
 			src.recipes += new /datum/cookingrecipe/mixer/meatpaste(src)
 			src.recipes += new /datum/cookingrecipe/mixer/wonton_wrapper(src)
 			src.recipes += new /datum/cookingrecipe/mixer/butters(src)
+			src.recipes += new /datum/cookingrecipe/mixer/soysauce(src)
+			src.recipes += new /datum/cookingrecipe/mixer/gravy(src)
 
 		src.blender_off = image(src.icon, "blender_off")
 		src.blender_powered = image(src.icon, "blender_powered")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Catering] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds `/datum/cookingrecipe/mixer/soysauce` and `/datum/cookingrecipe/mixer/gravy`.
Soy sauce is made out of soy bean, gravy is made out of meat paste and flour.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Soy sauce and gravy can't currently be crafted, but some recipes require them, so if you run out, it's game over.
Also was suggested in the forums:
https://forum.ss13.co/showthread.php?tid=23030

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(+)Soy sauce and gravy can now be created via mixer.
```
