### PR TITLE
Allows insertion of headsets into devil horns headband.

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2039,7 +2039,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 	access_string = "Chaplain"
 	limit = 0
 	change_name_on_spawn = TRUE
-	slot_head = list(/obj/item/clothing/head/devil)
+	slot_head = list(/obj/item/clothing/head/headband/devil)
 	slot_mask = list(/obj/item/clothing/mask/moustache/safe)
 	slot_ears = list(/obj/item/device/radio/headset)
 	slot_jump = list(/obj/item/clothing/under/misc/lawyer/red/demonic)

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -1010,7 +1010,7 @@ ADMIN_INTERACT_PROCS(/obj/critter/domestic_bee, proc/dance, proc/puke_honey)
 			if (time2text(world.realtime, "MM DD") == "10 31")
 				name = "Beezlebubs"
 				desc = "Oh no, a terrifying demon!!  Oh, wait, no, nevermind, it's just the fat and sassy space-bee.  Wow, really had me fooled for a moment...guess that's a Halloween trick...."
-				src.hat = new /obj/item/clothing/head/devil (src)
+				src.hat = new /obj/item/clothing/head/headband/devil (src)
 				src.hat_that_bee(src.hat)
 				src.UpdateIcon()
 

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -313,12 +313,6 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 			return
 		. = ..()
 
-/obj/item/clothing/head/devil
-	name = "devil horns"
-	desc = "Plastic devil horns attached to a headband as part of a Halloween costume."
-	icon_state = "devil"
-	item_state = "devil"
-
 // Donk clothes
 
 /obj/item/clothing/head/helmet/space/donk

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -1519,6 +1519,14 @@ ABSTRACT_TYPE(/obj/item/clothing/head/headband/nyan)
 		icon_state = "cat-tiger"
 		item_state = "cat-tiger"
 
+/obj/item/clothing/head/headband/devil
+	name = "devil horns"
+	desc = "Plastic devil horns attached to a headband as part of a Halloween costume."
+	icon = 'icons/obj/clothing/item_hats.dmi'
+	wear_image_icon = 'icons/mob/clothing/head.dmi'
+	icon_state = "devil"
+	item_state = "devil"
+
 /obj/item/clothing/head/headband/antlers
 	name = "antlers"
 	desc = "Be a deer and wear these, won't you?"

--- a/code/obj/random_spawners.dm
+++ b/code/obj/random_spawners.dm
@@ -1542,7 +1542,7 @@
 						/obj/item/clothing/head/odlawhat,
 						/obj/item/clothing/head/fake_waldohat,
 						/obj/item/clothing/head/flatcap,
-						/obj/item/clothing/head/devil,
+						/obj/item/clothing/head/headband/devil,
 						/obj/item/clothing/head/biker_cap,
 						/obj/item/clothing/head/mj_hat,
 						/obj/item/clothing/head/genki,

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -38580,7 +38580,7 @@
 /obj/item/clothing/under/shirt_pants,
 /obj/item/clothing/under/suit/black,
 /obj/item/clothing/head/mime_beret,
-/obj/item/clothing/head/devil,
+/obj/item/clothing/head/headband/devil,
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
 "lQo" = (

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -48447,7 +48447,7 @@
 /turf/unsimulated/floor/white/checker,
 /area/centcom/offices/gerhazo)
 "dye" = (
-/obj/item/clothing/head/devil{
+/obj/item/clothing/head/headband/devil{
 	pixel_y = 10
 	},
 /obj/item/dice/d100/satan,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes the Devil Horns a headband subtype, allows for putting radio headsets inside the same as you can with other headbands (ie. cat ears)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The description already calls them a headband `"Plastic devil horns attached to a headband as part of a Halloween costume."` so this just made sense in my mind. Being able to shove the headset in other headbands is a neat feature and I don't see why it should be any different for this one.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Munien
(+)Headsets can now be inserted into Devil Horns the same as other headbands.
```
