### PR TITLE
Adds a new clown traitor item: The twirl gun

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1084,6 +1084,14 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	job = list("Captain", "Head of Personnel", "Research Director", "Medical Director", "Chief Engineer")
 	can_buy = UPLINK_TRAITOR
 
+/datum/syndicate_buylist/traitor/twirlgun
+	name = "Twirl gun"
+	item = /obj/item/gun/energy/twirlgun
+	cost = 5
+	desc = "<b>Spin me right round...</b>"
+	job = list("Clown")
+	can_buy = UPLINK_TRAITOR
+
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////
 
 ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -453,7 +453,23 @@ toxic - poisons
 	shot_number = 1
 	damage_type = D_ENERGY
 	fullauto_valid = 1
+	disruption = 2
 
+/datum/projectile/energy_bolt/twirlbeam
+	name = "energy bolt"
+	icon = 'icons/obj/projectiles.dmi'
+	icon_state = "green_spark"
+	stun = 0
+	power = 0
+	damage = 5
+	cost = 25
+	max_range = 10
+	sname = "burst"
+	shot_sound = 'sound/weapons/Taser.ogg'
+	shot_sound_extrarange = 3
+	shot_number = 1
+	damage_type = D_ENERGY
+	fullauto_valid = 1
 	disruption = 2
 
 /datum/projectile/energy_bolt/dazzler

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1053,7 +1053,6 @@ TYPEINFO(/obj/item/gun_parts)
 		projectiles = list(current_projectile)
 		..()
 
-
 ///////////////////////////////////////Glitch Gun
 /obj/item/gun/energy/glitch_gun
 	name = "glitch gun"
@@ -1957,6 +1956,43 @@ TYPEINFO(/obj/item/gun/energy/vexillifer4)
 				user.do_disorient(stamina_damage = 20, disorient = 3 SECONDS)
 				ON_COOLDOWN(src, "raygun_cooldown", 2 SECONDS)
 		return ..(target, start, user)
+
+// twirl ray
+/obj/item/gun/energy/twirlgun
+	name = "very experimental ray gun"
+	desc = "A weapon that looks vaguely like a cheap twirly toy and is definitely unsafe. It is currently 0% powerful."
+	icon = 'icons/obj/items/guns/gimmick.dmi'
+	icon_state = "raygun"
+	item_state = "raygun"
+	force = 5
+	can_dual_wield = 0
+	muzzle_flash = "muzzle_flash_laser"
+
+	New()
+		set_current_projectile(new/datum/projectile/energy_bolt/twirlbeam)
+		projectiles = list(current_projectile)
+		..()
+
+	on_spin_emote(mob/living/carbon/human/user)
+		src.current_projectile.power += 20
+		. = ..(user)
+		if ((user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(5)) || (user.bioHolder && !user.bioHolder.HasEffect("clumsy")))
+			user.visible_message(SPAN_ALERT("<b>[user] accidentally shoots [him_or_her(user)]self with [src], trying to charge it up!</b>"))
+			src.ShootPointBlank(user, user)
+			JOB_XP(user, "Clown", 3)
+		else
+			user.visible_message("<B>[user]</B> [pick("spins", "twirls")] [src] around in [his_or_her(user)] hand, charging it up.")
+		desc = "A weapon that looks vaguely like a cheap twirly toy and is definitely unsafe. It is currently [src.current_projectile.power / 200]% powerful."
+
+	shoot(turf/target, turf/start, mob/user, POX, POY, is_dual_wield, atom/called_target = null)
+		if (canshoot(user))
+			if (((user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(src.current_projectile.power/2)) || (prob(src.current_projectile.power) && user.bioHolder && !user.bioHolder.HasEffect("clumsy"))))
+				user.visible_message(SPAN_ALERT("<b>[user] tries to twirl the gun to fire it, but accidentally shoots [him_or_her(user)]self with [src]!</b>"))
+				src.ShootPointBlank(user, user)
+				JOB_XP(user, "Clown", 7)
+				return
+		return ..(target, start, user)
+
 
 /obj/item/gun/energy/dazzler
 	name = "dazzler"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The twirl gun:
The more you twirl it, the higher the damage, but the higher the chance to shoot yourself when you fire it. For every two damage added, adds 1 percent to shooting yourself when you fire it, caps off at 200 damage. Each twirl adds 20 damage.
Only the clown can twirl it without shooting themselves (there's still a small chance you will even as a clown), but everyone can try to shoot it. Non clowns have twice the chance of shooting themselves.
The gun costs 5 TC.

Unsure about whether some other jobs might take it as well, and about the TC cost.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Funny.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chatauscours
(*)Adds a new clown traitor item: the twirl gun. The more you twirl, the higher the damage and the chance to land a bullet in yourself.
```
