### PR TITLE
Remove "HoS" from owned lawbringer names

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1346,7 +1346,10 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 			if (H.bioHolder)
 				boutput(M, SPAN_ALERT("[src] has accepted the DNA string. You are now the owner!"))
 				owner_prints = H.bioHolder.Uid
-				src.name = "HoS [H.real_name]'s Lawbringer"
+				if (M.job == "Head of Security")
+					src.name = "HoS [H.real_name]'s Lawbringer"
+				else
+					src.name = "[H.real_name]'s Lawbringer"
 				tooltip_rebuild = 1
 
 	//stolen the heartalk of microphone. the microphone can hear you from one tile away. unless you wanna

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1346,10 +1346,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 			if (H.bioHolder)
 				boutput(M, SPAN_ALERT("[src] has accepted the DNA string. You are now the owner!"))
 				owner_prints = H.bioHolder.Uid
-				if (M.job == "Head of Security")
-					src.name = "HoS [H.real_name]'s Lawbringer"
-				else
-					src.name = "[H.real_name]'s Lawbringer"
+				src.name = "[H.real_name]'s Lawbringer"
 				tooltip_rebuild = 1
 
 	//stolen the heartalk of microphone. the microphone can hear you from one tile away. unless you wanna


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the "HoS" part from owned lawbringer names (currently "HoS [NAME]'s Lawbringer")

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not all lawbringer owners are HoSes


