### PR TITLE
light switch fixes for kondaru and donut2

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -4067,20 +4067,14 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "awG" = (
-/obj/blind_switch/area{
-	dir = 4;
-	pixel_x = -22;
-	pixel_y = 4
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	name = "W light switch";
-	on = 0;
-	pixel_x = -22;
-	pixel_y = -4
-	},
 /obj/machinery/optable{
 	name = "Autopsy Table"
+	},
+/obj/blind_switch/area/west{
+	pixel_y = 6
+	},
+/obj/machinery/light_switch/west{
+	pixel_y = -4
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
@@ -6534,10 +6528,8 @@
 	pixel_y = 8
 	},
 /obj/disposalpipe/segment,
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = -8
+/obj/machinery/light_switch/east{
+	pixel_y = -6
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
@@ -17683,10 +17675,7 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24
-	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
 "cGc" = (
@@ -18447,10 +18436,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24
-	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "des" = (
@@ -18757,11 +18743,8 @@
 "doU" = (
 /obj/cable,
 /obj/machinery/power/apc/autoname_south,
-/obj/machinery/light_switch{
-	name = "W light switch";
-	pixel_x = -24
-	},
 /obj/machinery/vending/security,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "dpc" = (
@@ -18892,15 +18875,11 @@
 	},
 /area/station/medical/medbay/psychiatrist)
 "dtU" = (
-/obj/machinery/light_switch{
-	name = "W light switch";
-	on = 0;
-	pixel_x = -24
-	},
 /obj/decal/tile_edge/line/black{
 	dir = 1;
 	icon_state = "line1"
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
 "dug" = (
@@ -20389,11 +20368,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24
-	},
 /obj/item/paper/donut2smesinstructions,
+/obj/machinery/light_switch/east,
 /turf/simulated/floor,
 /area/station/engine/substation/east)
 "epp" = (
@@ -20489,10 +20465,7 @@
 	c_tag = "General Storage Entrance";
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	name = "W light switch";
-	pixel_x = -24
-	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor,
 /area/station/storage/tools)
 "eto" = (
@@ -20850,10 +20823,7 @@
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24
-	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -21796,19 +21766,13 @@
 /obj/machinery/computer/card/department/medical{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	name = "W light switch";
-	on = 0;
-	pixel_x = -20;
-	pixel_y = -1
-	},
-/obj/blind_switch/area{
-	pixel_x = -20;
-	pixel_y = 10
-	},
 /obj/machinery/door_control/bolter/new_walls/north{
 	id = "quarters_mdir"
 	},
+/obj/machinery/light_switch/west{
+	pixel_y = -8
+	},
+/obj/blind_switch/area/west,
 /turf/simulated/floor/wood,
 /area/station/medical/head)
 "fjy" = (
@@ -23764,10 +23728,7 @@
 /turf/simulated/floor/plating,
 /area/station/atmos/highcap_storage)
 "gEA" = (
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24
-	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
@@ -26257,10 +26218,7 @@
 /area/space)
 "inW" = (
 /obj/machinery/computer/tetris,
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24
-	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "iod" = (
@@ -28440,14 +28398,10 @@
 /area/station/hallway/primary/west)
 "jHJ" = (
 /obj/machinery/chem_dispenser/soda,
-/obj/machinery/light_switch{
-	name = "W light switch";
-	on = 0;
-	pixel_x = -24
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
@@ -43265,10 +43219,7 @@
 /turf/simulated/floor/plating,
 /area/station/janitor/office)
 "sMH" = (
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24
-	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/blueblack{
 	dir = 5
 	},
@@ -45521,10 +45472,6 @@
 /turf/simulated/floor/black,
 /area/station/security/processing)
 "ujv" = (
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24
-	},
 /obj/machinery/computer/power_monitor{
 	dir = 8
 	},
@@ -45533,6 +45480,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "ujJ" = (
@@ -45830,10 +45778,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "uve" = (
-/obj/machinery/light_switch{
-	name = "W light switch";
-	pixel_x = -24
-	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "uvh" = (
@@ -47488,10 +47433,7 @@
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24
-	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/west)
 "vzb" = (
@@ -48760,13 +48702,10 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "woD" = (
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24
-	},
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/grime,
 /area/station/engine/substation/north)
 "woL" = (
@@ -49639,11 +49578,8 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24
-	},
 /obj/storage/secure/closet/engineering/engineer,
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -4144,10 +4144,7 @@
 "aoQ" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/west,
-/obj/machinery/light_switch/east{
-	pixel_x = 10;
-	pixel_y = 27
-	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
 "aoT" = (
@@ -28876,10 +28873,7 @@
 "cmb" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet,
-/obj/machinery/light_switch{
-	name = "W light switch";
-	pixel_x = -24
-	},
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/carpet/grime,
 /area/listeningpost)
 "cmc" = (
@@ -54555,13 +54549,11 @@
 "tRW" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet,
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = -8
-	},
 /obj/item/device/radio/intercom/security{
 	dir = 8
+	},
+/obj/machinery/light_switch/east{
+	pixel_y = -16
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
@@ -56616,7 +56608,7 @@
 	pixel_x = 12
 	},
 /obj/machinery/manufacturer/general{
-	free_resources = list(/obj/item/material_piece/steel = 1, /obj/item/material_piece/copper = 1, /obj/item/material_piece/glass = 1)
+	free_resources = list(/obj/item/material_piece/steel=1,/obj/item/material_piece/copper=1,/obj/item/material_piece/glass=1)
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/indigo_rye)


### PR DESCRIPTION
[Mapping]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes changes to certain lights/blinds switches on Donut 2 and Kondaru
Changes made to Kondaru
- Fixed dir of lightswitch in Crematorium
- Fixed dir of lightswitch in Listening Post Bedroom
- Fixed dir of lightswitch in Listening Post Techroom

Changes made to Donut2
- Fixed dir of lightswitch and blindswitch in Medical Director's Office
- Fixed dir of lightswitch in West Electrical Substation
- Fixed dir of lightswitch in East Electrical Substation
- Fixed dir of lightswitch in North Electrical Substation
- Fixed dir of lightswitch in Tool Storage
- Fixed dir of lightswitch in Engineering (x4)
- Fixed dir of lightswitch in Pool (x2)
- Fixed dir of lightswitch in Arcade
- Fixed dir of lightswitch in QM
- Fixed dir of lightswitch in Arrivals
- Fixed dir of lightswitch in Chapel (x2)
- Fixed dir of lightswitch and Blindswitch in Crematorium
- Fixed dir of lightswitch in Detective's Office
- Fixed dir of lightswitch in Bridge
- Fixed dir of lightswitch next to Research Security Checkpoint




## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Going through all the maps to make sure lightswitches fit on the walls nicely with the new sprites, god has cursed me for my hubris
