### PR TITLE
Remove robotalk implants from robotics manufacturers

### DIFF
--- a/assets/maps/prefabs/underwater/nadir_safe/prefab_water_sketchy.dmm
+++ b/assets/maps/prefabs/underwater/nadir_safe/prefab_water_sketchy.dmm
@@ -398,7 +398,6 @@
 /turf/simulated/floor/scorched2,
 /area/prefab/sea_sketch)
 "bK" = (
-/obj/item/implant/robotalk,
 /turf/simulated/floor/plating/scorched,
 /area/prefab/sea_sketch)
 "bL" = (

--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -162,7 +162,6 @@
 		/datum/manufacture/robup_visualizer,
 		/datum/manufacture/robup_efficiency,
 		/datum/manufacture/robup_repair,
-		/datum/manufacture/implant_robotalk,
 		/datum/manufacture/sbradio,
 		/datum/manufacture/implant_health,
 		/datum/manufacture/implant_antirot,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the recipe to produce machine translator implants from robotics manufacturers. Doesn't remove the item or associated helper types as they are still used for some gimmick things.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's really weird that the dedicated "machine talk" channel is almost always compromised and therefore can't be reliably used to discuss law changes or coordinate silicon-based crime. A lot of players have taken to using the silicon PDA group, but that's clunky and can still be snooped on by standard PDA means.
I dunno, people have been complaining about this thing for a long time and while I definitely am exactly the player who prints one at the start of every round because *I like to know things*, I can definitely see how it discourages silicons from coordinating with each other to execute their laws.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Removed the machine translator implant recipe from the robotics fabricator. Silicons may now communicate freely without fear of being overheard.
```
