### PR TITLE
Fixes null.air runtime

### DIFF
--- a/code/modules/atmospherics/pipe_network.dm
+++ b/code/modules/atmospherics/pipe_network.dm
@@ -101,7 +101,7 @@ var/global/list/datum/pipe_network/pipe_networks = list()
 
 	for(var/obj/machinery/atmospherics/normal_member as anything in src.normal_members)
 		var/result = normal_member.return_network_air(src)
-		if(result)
+		if(length(result))
 			gases += result
 
 	for(var/datum/pipeline/line_member as anything in src.line_members)

--- a/code/modules/atmospherics/portable/canister.dm
+++ b/code/modules/atmospherics/portable/canister.dm
@@ -194,6 +194,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/portable_atmospherics/canister, proc/toggle_
 		var/atom/location = src.loc
 		location.assume_air(air_contents)
 		air_contents = null
+		disconnect()
 
 		if (src.det)
 			processing_items.Remove(src.det)

--- a/code/modules/atmospherics/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/portable/portable_atmospherics.dm
@@ -50,6 +50,7 @@
 		if (air_contents)
 			qdel(air_contents)
 			air_contents = null
+		disconnect()
 
 		..()
 

--- a/code/modules/atmospherics/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/portable/portable_atmospherics.dm
@@ -47,10 +47,10 @@
 			air_contents?.react() //ZeWaka: Fix for null.react()
 
 	disposing()
+		disconnect()
 		if (air_contents)
 			qdel(air_contents)
 			air_contents = null
-		disconnect()
 
 		..()
 


### PR DESCRIPTION
[ATMOSPHERICS][BUG]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes null.air runtime by properly disconnecting before destruction, also length checks rather than nullchecks.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug bad