### PR TITLE
Fixes 'authenticaion' spelling

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -694,7 +694,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 					return
 				if(tgui_alert(usr, "Are you sure you want to remove [I.name] from the [src]?", "Confirmation", list("Yes", "No")) == "Yes")
 					if (!src.allowed(usr))
-						src.grump_message(usr, "ERROR: Could not re-validate authenticaion credentials. Aborting.", sound = TRUE)
+						src.grump_message(usr, "ERROR: Could not re-validate authentication credentials. Aborting.", sound = TRUE)
 						return
 					if (!src.can_use_ranged(src) && !src.check_physical_proximity(usr))
 						return

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -119,11 +119,11 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 		. = list()
 		if (src.armed)
 			. += "It is currently counting down to detonation. Ohhhh shit."
-			. += "The timer reads [get_countdown_timer()].[src.disk && istype(src.disk) ? " The authenticaion disk has been inserted." : ""]"
+			. += "The timer reads [get_countdown_timer()].[src.disk && istype(src.disk) ? " The authentication disk has been inserted." : ""]"
 		else
 			. += "It is not armed. That's a relief."
 			if (src.disk && istype(src.disk))
-				. += "The authenticaion disk has been inserted."
+				. += "The authentication disk has been inserted."
 
 		if (!src.anchored)
 			. += "The floor bolts are unsecure. The bomb can be moved around."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][UI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #20307, and fixes a misspelling of authentication in the manufacturer that nobody noticed as well.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Spelling good.
