### PR TITLE
Remove Antibiological cargo crates

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1136,17 +1136,6 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate/packing
 	containername = "Utility Belt Crate"
 
-/datum/supply_packs/antibio
-	name = "Anti-Biological Hazard Supplies"
-	desc = " A couple of tools for combatting rogue biological lifeforms."
-	category = "Security Department"
-	contains = list(/obj/item/gun/flamethrower/assembled/loaded,
-					/obj/item/storage/box/flaregun)
-	cost = PAY_IMPORTANT*2
-	containertype = /obj/storage/secure/crate
-	containername = "Anti-Biological Hazard Supplies (Cardlocked \[Security Equipment])"
-	access = access_securitylockers
-
 /datum/supply_packs/counterrevimplant
 	name = "Counter-Revolutionary Kit"
 	desc = "Implanters and counter-revolutionary implants to suppress rebellion against Nanotrasen."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the "Anti-Biological Hazard Supplies" from cargo's orderable crates


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is only ever ordered for blob and it absolutely demolishes them, its also an armory crate and flamethrowers can be made anyway, it should take more effort than ordering 4 of these to defeat an entire gamemode with ease

If this ends up with blobs being overpowered then i'm honestly fine with that as a change of pace from what they are right now, which is "this round will end in 15m when we flamer the blobs with our 15 flamers"


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Removed Anti-Biological Hazard Supply crate from cargo's orderable crates
```
