### PR TITLE
Changes pipe pressure limits

### DIFF
--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -83,7 +83,7 @@
 	/// How well we share temperature.
 	var/thermal_conductivity = WALL_HEAT_TRANSFER_COEFFICIENT
 	/// Pressure needed before the pipe gets a chance to burst, see proc/effective_fatigue_pressure for the value that takes into account material stats too
-	var/fatigue_pressure = 150*ONE_ATMOSPHERE
+	var/fatigue_pressure = 500*ONE_ATMOSPHERE
 	/// Can this pipe rupture?
 	var/can_rupture = FALSE // Currently only used for red pipes (insulated).
 	/// How broken is our pipe.
@@ -96,7 +96,7 @@
 	alpha = 128
 
 /obj/machinery/atmospherics/pipe/simple/proc/effective_fatigue_pressure()
-	return src.fatigue_pressure * ((src.material?.getProperty("density") ** 2) || 1)
+	return src.fatigue_pressure * (src.material?.getProperty("density") || 1)
 
 /// Returns list of coordinates to start and stop welding animation.
 /obj/machinery/atmospherics/pipe/simple/proc/get_welding_positions()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Increases the amount of pressure that the pipes can withstand and decreases the amount that plating the pipes increases it by. More specifically, the pipe burst threshold increases from 15 MPa to 50 MPa and the plating effect decreases from `density^2` to `density`. Overall, this has the effect that unplated pipes are more durable than before but plated pipes are not as durable as before.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

`density^2` is crazy scaling and results in absurdly resistant pipes. On the flipside, a standard no-frills chamberburn will break unplated pipes if you put more than like, half a plasma tank in the hot loop. This should normalize things a bit and make it so that plating the pipes is not always necessary for any burn.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cherman0
(+)The base maximum pressure of pipes has increased to 50 MPa but the effects of plating have been reduced.
```
