### PR TITLE
Add area to donut2 singularity core

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -9339,7 +9339,7 @@
 /area/station/medical/medbay/psychiatrist)
 "aWx" = (
 /turf/simulated/floor/circuit,
-/area/space)
+/area/station/engine/singcore)
 "aWz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -11461,7 +11461,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "bhY" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/construction)
@@ -17709,6 +17709,12 @@
 /obj/item/device/radio/intercom/bridge,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
+"cHn" = (
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engine/singcore)
 "cIh" = (
 /obj/machinery/hydro_growlamp,
 /obj/cable{
@@ -18215,7 +18221,7 @@
 	},
 /obj/mapping_helper/access/engineering_engine,
 /turf/simulated/floor,
-/area/station/engine/inner)
+/area/station/engine/singcore)
 "cWz" = (
 /obj/cable/blue{
 	icon_state = "4-8"
@@ -18500,7 +18506,7 @@
 "dfS" = (
 /obj/machinery/the_singularitygen,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "dgc" = (
 /obj/machinery/door_control{
 	id = "pubscienceteleporter";
@@ -19577,6 +19583,13 @@
 	dir = 1
 	},
 /area/station/science/lobby)
+"dRX" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/engine/singcore)
 "dSI" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable/blue,
@@ -19904,7 +19917,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "eav" = (
 /obj/storage/crate{
 	name = "Discount Dan's Liquidation Clothes Crate"
@@ -20103,6 +20116,13 @@
 	dir = 10
 	},
 /area/station/crew_quarters/stockex)
+"ehi" = (
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/engine/singcore)
 "ehN" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -21566,6 +21586,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"fcT" = (
+/obj/machinery/light/incandescent,
+/turf/space,
+/area/station/engine/singcore)
 "fds" = (
 /obj/machinery/secscanner{
 	dir = 4;
@@ -23905,7 +23929,7 @@
 	icon_state = "2-4"
 	},
 /turf/space,
-/area/space)
+/area/station/engine/singcore)
 "gKz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -24830,6 +24854,13 @@
 /obj/storage/secure/crate/weapon/confiscated_items,
 /turf/simulated/floor/grime,
 /area/station/security/equipment)
+"hsV" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/engine/singcore)
 "htm" = (
 /obj/machinery/firealarm/west,
 /obj/cable{
@@ -25181,6 +25212,13 @@
 	},
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
+"hDS" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/engine/singcore)
 "hDV" = (
 /obj/grille/catwalk,
 /obj/cable/yellow{
@@ -25382,6 +25420,9 @@
 /obj/machinery/firealarm/west,
 /turf/unsimulated/floor,
 /area/station/hangar/arrivals)
+"hLB" = (
+/turf/space,
+/area/station/engine/singcore)
 "hLH" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -25608,7 +25649,7 @@
 	icon_state = "1-2"
 	},
 /turf/space,
-/area/space)
+/area/station/engine/singcore)
 "hRU" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4;
@@ -26223,7 +26264,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "inW" = (
 /obj/machinery/computer/tetris,
 /obj/machinery/light_switch/east,
@@ -27560,7 +27601,7 @@
 	name = "autoname - SS13"
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "jis" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -27822,7 +27863,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "jsg" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	req_access = null
@@ -28424,7 +28465,7 @@
 	},
 /obj/cable/orange,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "jIt" = (
 /obj/machinery/light/small/sticky/frostedred,
 /obj/machinery/portable_atmospherics/pump,
@@ -28499,6 +28540,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"jKU" = (
+/turf/simulated/floor/plating/airless,
+/area/station/engine/singcore)
 "jKV" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -28859,7 +28903,7 @@
 	},
 /obj/mapping_helper/access/engineering_engine,
 /turf/simulated/floor,
-/area/station/engine/inner)
+/area/station/engine/singcore)
 "kaC" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -28889,6 +28933,13 @@
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/south)
+"kbI" = (
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/engine/singcore)
 "kbT" = (
 /turf/simulated/floor/green/side{
 	dir = 1
@@ -29049,7 +29100,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "kio" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -29115,7 +29166,7 @@
 	icon_state = "1-8"
 	},
 /turf/space,
-/area/space)
+/area/station/engine/singcore)
 "kkp" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -29949,7 +30000,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/space)
+/area/station/engine/singcore)
 "kMZ" = (
 /obj/decal/poster/wallsign/danger_highvolt,
 /turf/simulated/wall/auto/supernorn,
@@ -30568,7 +30619,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "leK" = (
 /obj/machinery/optable{
 	id = "robotics"
@@ -31679,7 +31730,7 @@
 	},
 /obj/machinery/light/incandescent,
 /turf/space,
-/area/space)
+/area/station/engine/singcore)
 "lKg" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -32024,7 +32075,7 @@
 "lVO" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "lVX" = (
 /obj/machinery/disposal/mail{
 	mail_tag = "toxins";
@@ -33949,7 +34000,7 @@
 	icon_state = "4-8"
 	},
 /turf/space,
-/area/space)
+/area/station/engine/singcore)
 "nfc" = (
 /obj/decal/poster/wallsign/poster_y4nt{
 	pixel_x = 30
@@ -34474,7 +34525,7 @@
 	icon_state = "1-4"
 	},
 /turf/space,
-/area/space)
+/area/station/engine/singcore)
 "nxa" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -34879,7 +34930,7 @@
 	},
 /obj/cable/orange,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "nKw" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/crew_quarters/locker)
@@ -35178,7 +35229,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "nUH" = (
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
@@ -35700,7 +35751,7 @@
 	icon_state = "4-8"
 	},
 /turf/space,
-/area/space)
+/area/station/engine/singcore)
 "okU" = (
 /obj/stool/bar,
 /turf/simulated/floor/carpet{
@@ -35887,7 +35938,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "ore" = (
 /obj/decal/cleanable/oil/streak,
 /obj/cable{
@@ -37912,7 +37963,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "pvz" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37980,7 +38031,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "pwG" = (
 /obj/table/auto,
 /obj/bedsheetbin,
@@ -38230,7 +38281,7 @@
 	},
 /obj/cable/orange,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "pDg" = (
 /obj/disposalpipe/segment,
 /obj/machinery/camera{
@@ -39135,7 +39186,7 @@
 	},
 /obj/cable/orange,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "qiC" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide,
 /obj/machinery/light/incandescent,
@@ -39241,7 +39292,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "qkY" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
@@ -39390,6 +39441,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
+"qpc" = (
+/obj/lattice,
+/turf/space,
+/area/station/engine/singcore)
 "qpC" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -40166,6 +40221,12 @@
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
 	})
+"qPe" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/engine/singcore)
 "qPC" = (
 /obj/item/cable_coil/cut{
 	icon_state = "coil1"
@@ -40297,7 +40358,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "qSL" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -40776,7 +40837,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "rlf" = (
 /obj/stool/chair/comfy{
 	dir = 4
@@ -41491,7 +41552,7 @@
 	icon_state = "4-8"
 	},
 /turf/space,
-/area/space)
+/area/station/engine/singcore)
 "rLP" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 8;
@@ -41814,7 +41875,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "rVC" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating{
@@ -42945,7 +43006,7 @@
 	},
 /obj/machinery/field_generator,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "sEx" = (
 /obj/machinery/computer3/terminal/zeta{
 	dir = 8;
@@ -43015,7 +43076,7 @@
 	icon_state = "1-2"
 	},
 /turf/space,
-/area/space)
+/area/station/engine/singcore)
 "sGt" = (
 /obj/machinery/light/emergency{
 	dir = 1
@@ -43374,7 +43435,7 @@
 	icon_state = "1-2"
 	},
 /turf/space,
-/area/space)
+/area/station/engine/singcore)
 "sPL" = (
 /obj/rack,
 /obj/item/tank/jetpack/micro,
@@ -44705,7 +44766,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "tGm" = (
 /obj/storage/crate{
 	name = "Silent Crate"
@@ -46654,7 +46715,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "vaR" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -47527,6 +47588,12 @@
 	dir = 4
 	},
 /area/station/medical/medbay/cloner)
+"vBh" = (
+/obj/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engine/singcore)
 "vBR" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -48108,7 +48175,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "vTU" = (
 /obj/decal/poster/wallsign/stencil/right/o{
 	pixel_x = 8;
@@ -48549,7 +48616,7 @@
 	},
 /obj/machinery/field_generator,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "wkL" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -48870,7 +48937,7 @@
 	icon_state = "2-8"
 	},
 /turf/space,
-/area/space)
+/area/station/engine/singcore)
 "wtq" = (
 /obj/cable/yellow{
 	icon_state = "1-8"
@@ -51557,7 +51624,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engine/singcore)
 "ykF" = (
 /obj/machinery/camera{
 	c_tag = "Bridge";
@@ -79252,9 +79319,9 @@ hRr
 sFQ
 tGg
 qkP
-aai
-acK
-aai
+dRX
+jKU
+dRX
 kie
 tGg
 sFQ
@@ -79549,18 +79616,18 @@ aaa
 aaa
 aaa
 neM
-aaa
-aaa
-aaA
-acK
-apU
-aaa
-adQ
-aaa
-aaA
-acK
-aas
-aas
+hLB
+hLB
+ehi
+jKU
+hDS
+hLB
+hsV
+hLB
+ehi
+jKU
+qpc
+qpc
 okI
 bcG
 bck
@@ -79851,17 +79918,17 @@ aaa
 aaa
 aaa
 neM
-aaa
+hLB
 rVr
-vSb
+vBh
 yjV
-vSb
-vSb
-vSb
-vSb
-vSb
+vBh
+vBh
+vBh
+vBh
+vBh
 jHV
-vSb
+vBh
 vam
 qSI
 cWt
@@ -80153,19 +80220,19 @@ aaa
 aaa
 aaa
 rLD
-aaa
-bca
+hLB
+cHn
 lVO
-bca
-apU
-aaa
-aaa
-aaa
-aaA
-bca
+cHn
+hDS
+hLB
+hLB
+hLB
+ehi
+cHn
 lVO
-bca
-bbS
+cHn
+fcT
 bco
 uft
 ppU
@@ -80455,9 +80522,9 @@ aaa
 aaa
 aaa
 pvt
-vSb
+vBh
 qhO
-acK
+jKU
 wkn
 aWx
 aWx
@@ -80465,9 +80532,9 @@ aWx
 aWx
 aWx
 wkn
-acK
+jKU
 oqQ
-acK
+jKU
 bco
 sWj
 ppU
@@ -80757,19 +80824,19 @@ aaa
 aaa
 uzN
 pwl
-aaa
-aaA
-aai
+hLB
+ehi
+dRX
 aWx
-acK
-apU
-aaa
-aaA
-acK
+jKU
+hDS
+hLB
+ehi
+jKU
 aWx
-aai
-apU
-aaa
+dRX
+hDS
+hLB
 bco
 uft
 ppU
@@ -81058,20 +81125,20 @@ eZW
 eZW
 lJH
 wAc
-apU
-aaa
-adQ
-aaa
+hDS
+hLB
+hsV
+hLB
 aWx
-aai
-aas
-aag
-aas
-aai
+dRX
+qpc
+kbI
+qpc
+dRX
 aWx
-aaa
-adQ
-aaa
+hLB
+hsV
+hLB
 bco
 uft
 ppU
@@ -81361,18 +81428,18 @@ nTr
 uAS
 anM
 jif
-ajz
-aas
-ajz
+qPe
+qpc
+qPe
 aWx
-aaa
-aaA
+hLB
+ehi
 dfS
-apU
-aaa
+hDS
+hLB
 aWx
-ajz
-aas
+qPe
+qpc
 lJU
 bco
 csd
@@ -81662,20 +81729,20 @@ eZW
 eZW
 xsS
 dkD
-apU
-aaa
-adQ
-aaa
+hDS
+hLB
+hsV
+hLB
 aWx
-aag
-aas
-aai
-aas
-aag
+kbI
+qpc
+dRX
+qpc
+kbI
 aWx
-aaa
-adQ
-aaa
+hLB
+hsV
+hLB
 bco
 uft
 eDd
@@ -81965,19 +82032,19 @@ aaa
 aaa
 jQH
 inL
-aaa
-aaA
-aag
+hLB
+ehi
+kbI
 aWx
-acK
-apU
-aaa
-aaA
-acK
+jKU
+hDS
+hLB
+ehi
+jKU
 aWx
-aag
-apU
-aaa
+kbI
+hDS
+hLB
 bco
 uft
 qoZ
@@ -82267,9 +82334,9 @@ aaa
 aaa
 aaa
 ear
-vSb
+vBh
 nKt
-acK
+jKU
 sEg
 aWx
 aWx
@@ -82277,9 +82344,9 @@ aWx
 aWx
 aWx
 sEg
-acK
+jKU
 leC
-acK
+jKU
 bco
 sWj
 qoZ
@@ -82569,19 +82636,19 @@ aaa
 aaa
 aaa
 rLD
-aaa
-bca
+hLB
+cHn
 lVO
-bca
-apU
-aaa
-aaa
-aaa
-aaA
-bca
+cHn
+hDS
+hLB
+hLB
+hLB
+ehi
+cHn
 lVO
-bca
-bbS
+cHn
+fcT
 bco
 uft
 qoZ
@@ -82871,17 +82938,17 @@ aaa
 aaa
 aaa
 neM
-aaa
+hLB
 nTO
-vSb
+vBh
 pCY
-vSb
-vSb
-vSb
-vSb
-vSb
+vBh
+vBh
+vBh
+vBh
+vBh
 bhX
-vSb
+vBh
 qSI
 vam
 jZS
@@ -83173,18 +83240,18 @@ aaa
 aaa
 aaa
 neM
-aaa
-aaa
-aaA
-acK
-apU
-aaa
-adQ
-aaa
-aaA
-acK
-aas
-aas
+hLB
+hLB
+ehi
+jKU
+hDS
+hLB
+hsV
+hLB
+ehi
+jKU
+qpc
+qpc
 okI
 bcG
 bck
@@ -83480,9 +83547,9 @@ hRr
 sPF
 rjN
 vTQ
-aag
-acK
-aag
+kbI
+jKU
+kbI
 jsb
 rjN
 kMS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an area to the donut2 singularity core


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It should have an area + lack of area potentially causing emitters to stop working (may just be coincidence but whenever I try a bigulo on donut2 it ALWAYS looses)
