### PR TITLE
Make lightswitches deconstructible

### DIFF
--- a/code/obj/machinery/lightswitch.dm
+++ b/code/obj/machinery/lightswitch.dm
@@ -19,6 +19,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/light_switch, proc/trigger)
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light1"
 	anchored = ANCHORED
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_MULTITOOL | DECON_WIRECUTTERS
 	plane = PLANE_NOSHADOW_ABOVE
 	text = ""
 	var/on = 1
@@ -97,7 +98,12 @@ ADMIN_INTERACT_PROCS(/obj/machinery/light_switch, proc/trigger)
 
 /obj/machinery/light_switch/was_deconstructed_to_frame(mob/user)
 	. = ..()
-	area.machines -= src
+	// Might be the last light switch in the area, ensure lights stay on
+	if (!src.on)
+		src.on = TRUE
+		src.area.lightswitch = TRUE
+		src.area.power_change()
+	src.area.machines -= src
 	REMOVE_SWITCHED_OBJ(SWOB_LIGHTS)
 
 /obj/machinery/light_switch/update_icon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lightswitches can be deconstructed with a screwdriver, wirecutters, and multitool using the decon device. Deconstructing a switch will turn the lights on if they weren't on already.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Medass wont leave me alone

![Screenshot 2024-08-16 190454](https://github.com/user-attachments/assets/e67cd0da-3f23-484e-8f52-8c02d757b22a)

(In seriousness, this is just a nice kind of change to have for making space on station)
