### PR TITLE
Fixes the dir of the sign-switches

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -29658,7 +29658,8 @@
 	icon_state = "1-2"
 	},
 /obj/sign_switch/east{
-	id = "nadiradio"
+	id = "nadiradio";
+	dir = 4
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
@@ -31135,7 +31136,8 @@
 	dir = 8
 	},
 /obj/sign_switch/east{
-	id = "kitchenopen"
+	id = "kitchenopen";
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)


### PR DESCRIPTION
[Mapping]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the dir of the sign-switches in Nadir's radio room and kitchen

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Looked wonky especially next to ligthswitches that were oriented correctly. 
 #20349 

