### PR TITLE
Cleans up redundant hair-related code.

### DIFF
--- a/code/WorkInProgress/SpyGuyStuff.dm
+++ b/code/WorkInProgress/SpyGuyStuff.dm
@@ -391,7 +391,7 @@ proc/Create_Tommyname()
 
 		if(ishuman(hit))
 			var/mob/living/carbon/human/H = hit
-			if(!istype(H.head, /obj/item/clothing/head/wig))
+			if(!H.is_bald())
 				var/obj/item/clothing/head/wig/W = H.create_wig()
 				H.drop_from_slot(H.head)
 				H.force_equip(W, SLOT_HEAD)

--- a/code/WorkInProgress/SpyGuyStuff.dm
+++ b/code/WorkInProgress/SpyGuyStuff.dm
@@ -393,7 +393,6 @@ proc/Create_Tommyname()
 			var/mob/living/carbon/human/H = hit
 			if(!istype(H.head, /obj/item/clothing/head/wig))
 				var/obj/item/clothing/head/wig/W = H.create_wig()
-				H.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
 				H.drop_from_slot(H.head)
 				H.force_equip(W, SLOT_HEAD)
 				H.update_colorful_parts()

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -134,7 +134,7 @@ TYPEINFO_NEW(/datum/component/barber/shave)
 		boutput(user, SPAN_NOTICE("You're going to need to remove that mask/helmet/glasses first."))
 		non_murderous_failure = BARBERY_FAILURE
 
-	if(istype(AH.customization_first,/datum/customization_style/none) && istype(AH.customization_second,/datum/customization_style/none) && istype(AH.customization_third,/datum/customization_style/none))
+	if(H.is_bald())
 		boutput(user, SPAN_ALERT("There is nothing to cut!"))
 		non_murderous_failure = BARBERY_FAILURE
 
@@ -167,7 +167,6 @@ TYPEINFO_NEW(/datum/component/barber/shave)
 
 	var/non_murderous_failure = 0
 	var/mob/living/carbon/human/H = M
-	var/datum/appearanceHolder/AH = M.bioHolder.mobAppearance
 	if(ishuman(M) && ((H.head && H.head.c_flags & COVERSEYES) || (H.wear_mask && H.wear_mask.c_flags & COVERSEYES) || (H.glasses && H.glasses.c_flags & COVERSEYES)))
 		// you can't stab someone in the eyes wearing a mask!
 		boutput(user, SPAN_NOTICE("You're going to need to remove that mask/helmet/glasses first."))
@@ -197,7 +196,7 @@ TYPEINFO_NEW(/datum/component/barber/shave)
 			M.organHolder.head.UpdateIcon()
 		return ATTACK_PRE_DONT_ATTACK // gottem
 
-	if(istype(AH.customization_first,/datum/customization_style/none) && istype(AH.customization_second,/datum/customization_style/none) && istype(AH.customization_third,/datum/customization_style/none))
+	if(H.is_bald())
 		boutput(user, SPAN_ALERT("There is nothing to cut!"))
 		non_murderous_failure = BARBERY_FAILURE
 
@@ -583,9 +582,7 @@ TYPEINFO_NEW(/datum/component/barber/shave)
 			if (!barber || !barbee) // If either don't exist anymore, it's safe to say we have been disposed of.
 				return
 
-			if(istype(barbee.bioHolder.mobAppearance.customization_first,/datum/customization_style/none) && \
-			istype(barbee.bioHolder.mobAppearance.customization_second,/datum/customization_style/none) && \
-			istype(barbee.bioHolder.mobAppearance.customization_third,/datum/customization_style/none))
+			if(barbee.is_bald())
 				src.ui_close(src.barber) // There is nothing more to cut.
 
 			if (!barber || !barbee)

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -128,7 +128,6 @@ TYPEINFO_NEW(/datum/component/barber/shave)
 
 	var/non_murderous_failure = 0
 	var/mob/living/carbon/human/H = M
-	var/datum/appearanceHolder/AH = M.bioHolder.mobAppearance
 	if(ishuman(M) && ((H.head && H.head.c_flags & COVERSEYES) || (H.wear_mask && H.wear_mask.c_flags & COVERSEYES) || (H.glasses && H.glasses.c_flags & COVERSEYES)))
 		// you can't stab someone in the eyes wearing a mask!
 		boutput(user, SPAN_NOTICE("You're going to need to remove that mask/helmet/glasses first."))

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -707,9 +707,7 @@ ABSTRACT_TYPE(/datum/action/bar/barber)
 					SPAN_ALERT("You [cut] all of [M]'s hair off!"))
 				var/obj/item/wig = M.create_wig()
 				wig.set_loc(M.loc)
-				M.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
-				M.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
-				M.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
+
 				M.TakeDamage("head", rand(5,10), 0)
 				take_bleeding_damage(M, user, 1, DAMAGE_CUT, 1)
 				M.emote("scream")
@@ -737,9 +735,6 @@ ABSTRACT_TYPE(/datum/action/bar/barber)
 						SPAN_NOTICE("You [cut] all of [M]'s hair off and make it into a wig."))
 					var/obj/item/wig = M.create_wig()
 					wig.set_loc(M.loc)
-					M.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
-					M.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
-					M.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
 				else
 					logTheThing(LOG_COMBAT, user, "cuts [constructTarget(M,"combat")]'s hair at [log_loc(user)].")
 					M.tri_message(user, "[user] [cuts] [M]'s hair.",\

--- a/code/datums/preferences/preferences.dm
+++ b/code/datums/preferences/preferences.dm
@@ -1150,7 +1150,7 @@ var/list/removed_jobs = list(
 			qdel(ourWig)
 
 		if (src.traitPreferences.traits_selected.Find("bald") && mutantRace)
-			H.equip_if_possible(H.create_wig(), SLOT_HEAD)
+			H.equip_if_possible(H.create_wig(keep_hair = TRUE), SLOT_HEAD)
 
 		for (var/slot_id in src.custom_parts)
 			var/datum/part_customization/customization = get_part_customization(src.custom_parts[slot_id])

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2802,6 +2802,9 @@
 			ret += A
 	return ret
 
+/mob/living/carbon/human/proc/is_bald()
+	return istype(src.bioHolder.mobAppearance.customization_first,/datum/customization_style/none) && istype(src.bioHolder.mobAppearance.customization_second,/datum/customization_style/none) && istype(src.bioHolder.mobAppearance.customization_third,/datum/customization_style/none)
+
 /mob/living/carbon/human/proc/create_wig(var/keep_hair = FALSE)
 	if (!src.bioHolder || !src.bioHolder.mobAppearance)
 		return null

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2804,7 +2804,9 @@
 
 /mob/living/carbon/human/proc/is_bald()
 	var/datum/appearanceHolder/AH = src.bioHolder.mobAppearance
-	return istype(AH.customization_first,/datum/customization_style/none) && istype(AH.customization_second,/datum/customization_style/none) && istype(AH.customization_third,/datum/customization_style/none)
+	return istype(AH.customization_first,/datum/customization_style/none) \
+	&& istype(AH.customization_second,/datum/customization_style/none) \
+	&& istype(AH.customization_third,/datum/customization_style/none)
 
 /mob/living/carbon/human/proc/create_wig(var/keep_hair = FALSE)
 	if (!src.bioHolder || !src.bioHolder.mobAppearance)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2803,7 +2803,8 @@
 	return ret
 
 /mob/living/carbon/human/proc/is_bald()
-	return istype(src.bioHolder.mobAppearance.customization_first,/datum/customization_style/none) && istype(src.bioHolder.mobAppearance.customization_second,/datum/customization_style/none) && istype(src.bioHolder.mobAppearance.customization_third,/datum/customization_style/none)
+	var/datum/appearanceHolder/AH = src.bioHolder.mobAppearance
+	return istype(AH.customization_first,/datum/customization_style/none) && istype(AH.customization_second,/datum/customization_style/none) && istype(AH.customization_third,/datum/customization_style/none)
 
 /mob/living/carbon/human/proc/create_wig(var/keep_hair = FALSE)
 	if (!src.bioHolder || !src.bioHolder.mobAppearance)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2784,7 +2784,7 @@
 			if (prob(75) && organHolder.tail.loc == src)
 				ret += organHolder.tail
 		if (prob(50) && !isskeleton(src)) // Skeletons don't have hair, so don't create and drop a wig for them on death
-			var/obj/item/clothing/head/wig/W = create_wig()
+			var/obj/item/clothing/head/wig/W = create_wig(keep_hair = TRUE)
 			if (W)
 				processed += W
 				ret += W
@@ -2802,7 +2802,7 @@
 			ret += A
 	return ret
 
-/mob/living/carbon/human/proc/create_wig()
+/mob/living/carbon/human/proc/create_wig(var/keep_hair = FALSE)
 	if (!src.bioHolder || !src.bioHolder.mobAppearance)
 		return null
 	var/obj/item/clothing/head/wig/W = new(src)
@@ -2818,6 +2818,11 @@
 
 	W.setup_wig(hair_list)
 
+	if (!keep_hair)
+		src.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
+		src.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
+		src.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
+		src.update_colorful_parts()
 	return W
 
 

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -636,10 +636,6 @@ var/list/antag_respawn_critter_types =  list(/mob/living/critter/small_animal/fl
 
 	if (newbody.traitHolder && newbody.traitHolder.hasTrait("bald"))
 		newbody.stow_in_available(newbody.create_wig())
-		newbody.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
-		newbody.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
-		newbody.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
-		newbody.update_colorful_parts()
 
 	// No contact between the living and the dead.
 	var/obj/to_del = newbody.ears

--- a/code/modules/chemistry/Chemistry-Reactions.dm
+++ b/code/modules/chemistry/Chemistry-Reactions.dm
@@ -202,10 +202,6 @@
 	H.reagents.del_reagent("unstable_omega_hairgrownium")
 	var/obj/item/I = H.create_wig()
 	I.set_loc(H.loc)
-	H.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
-	H.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
-	H.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
-	H.update_colorful_parts()
 
 /proc/flashpowder_reaction(turf/center, amount)
 	elecflash(center)

--- a/code/modules/chemistry/Chemistry-Reactions.dm
+++ b/code/modules/chemistry/Chemistry-Reactions.dm
@@ -197,11 +197,15 @@
 	boutput(H, SPAN_NOTICE("Your entire head feels extremely itchy!"))
 
 /proc/omega_hairgrownium_drop_hair(var/mob/living/carbon/human/H)
-	H.visible_message("<strong style='font-size: 170%;'>[H.name] hair fall out!!</strong>", "<strong style='font-size: 170%;'>you hair fall out!!</strong>")
+	H.visible_message("<strong style='font-size: 170%;'>[H.name] [H.is_bald()?"hairn't":"hair"] hair fall out!!</strong>", "<strong style='font-size: 170%;'>you [H.is_bald()?"hairn't":"hair"] fall out!!</strong>")
+	var/obj/item/I = new /obj/item
+	if(H.is_bald())
+		I = new /obj/item/clothing/head/bald_cap
+	else
+		I = H.create_wig()
+	I.set_loc(H.loc)
 	H.reagents.del_reagent("stable_omega_hairgrownium")
 	H.reagents.del_reagent("unstable_omega_hairgrownium")
-	var/obj/item/I = H.create_wig()
-	I.set_loc(H.loc)
 
 /proc/flashpowder_reaction(turf/center, amount)
 	elecflash(center)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -606,10 +606,6 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 		trinket = null //You better stay null, you hear me!
 	else if (src.traitHolder && src.traitHolder.hasTrait("bald"))
 		trinket = src.create_wig()
-		src.bioHolder.mobAppearance.customization_first = new /datum/customization_style/none
-		src.bioHolder.mobAppearance.customization_second = new /datum/customization_style/none
-		src.bioHolder.mobAppearance.customization_third = new /datum/customization_style/none
-		src.update_colorful_parts()
 	else if (src.traitHolder && src.traitHolder.hasTrait("loyalist"))
 		trinket = new/obj/item/clothing/head/NTberet(src)
 	else if (src.traitHolder && src.traitHolder.hasTrait("petasusaphilic"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INTERNAL] [CODE QUALITY] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR consolidates and cleans up code related to hair and barbery to remove certain redundant lines.

First, the `create_wig()` proc has been given an argument that determines whether or not the target's hair should be removed afterward. This logic is now baked into the proc instead of being written separately every time it is needed.

Second, this PR adds an `is_bald()` proc to human mobs, which returns true if the target's hair styles are all set to none. Parts of the code that check this manually have been changed to use this proc instead.

Additionally, this PR fixes a bug that was caused by one instance of `create_wig()` being called on someone without checking that they had any actual hair, creating a weird bald-wig that had no worn sprite. If this does happen it will create a bald cap instead. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I was planning to add something barber-related to the game, and having these changes would make my implementation far cleaner, on top of making barber code more readable. All but two of the mentions of 'create_wig()' removed the target's hair afterward, so it made sense to me to bake it into the proc as an argument. Also, bug fix good.

