### PR TITLE
Fix Breaker Airlock mapping helpers

### DIFF
--- a/code/modules/mapping/helpers/airlock_helpers.dm
+++ b/code/modules/mapping/helpers/airlock_helpers.dm
@@ -70,7 +70,7 @@ so I feel they're better and more versatile, even if they're harder to set up.. 
 			if (D.welded)
 				src.weld = TRUE
 			// now we know it is bolted/welded; create the door
-			var/obj/fakeobject/airlock_broken/F = new /obj/fakeobject/airlock_broken
+			var/obj/fakeobject/airlock_broken/F = new /obj/fakeobject/airlock_broken(D.loc)
 			// make sure it's using the right icon state
 			if (src.bolt)
 				D.locked = TRUE
@@ -85,7 +85,6 @@ so I feel they're better and more versatile, even if they're harder to set up.. 
 			F.name = D.name
 			F.desc = D.desc
 			F.density = D.density
-			F.set_loc(D.loc)
 			qdel(D)
 
 /obj/mapping_helper/airlock/aiDisabler

--- a/code/modules/mapping/helpers/airlock_helpers.dm
+++ b/code/modules/mapping/helpers/airlock_helpers.dm
@@ -6,7 +6,7 @@ ABSTRACT_TYPE(/obj/mapping_helper/airlock)
 	var/weld = FALSE
 
 	setup()
-		for (var/obj/machinery/door/airlock/D in src.loc)
+		for (var/obj/machinery/door/airlock/D in get_turf(src))
 			if (src.bolt)
 				D.locked = TRUE
 			if (src.weld)
@@ -48,7 +48,7 @@ so I feel they're better and more versatile, even if they're harder to set up.. 
 	setup()
 		if (!src.cycle_id)
 			CRASH("[src] has no cycle ID set. Coords: [src.x], [src.y], [src.z]")
-		for (var/obj/machinery/door/airlock/D in src.loc)
+		for (var/obj/machinery/door/airlock/D in get_turf(src))
 			D.cycle_id = src.cycle_id
 			D.cycle_enter_id = src.enter_id
 			D.attempt_cycle_link()
@@ -60,7 +60,7 @@ so I feel they're better and more versatile, even if they're harder to set up.. 
 
 	setup()
 		// use the bolt and weld vars to determine how the fake door should look.
-		for (var/atom/A in src.loc)
+		for (var/atom/A in get_turf(src))
 			if (istype(A, /obj/mapping_helper/airlock/bolter))
 				src.bolt = TRUE
 				qdel(A)
@@ -70,7 +70,7 @@ so I feel they're better and more versatile, even if they're harder to set up.. 
 				qdel(A)
 				continue
 		var/counter = 0
-		for (var/obj/machinery/door/airlock/D in src.loc)
+		for (var/obj/machinery/door/airlock/D in get_turf(src))
 			counter++
 			var/obj/fakeobject/airlock_broken/F = new /obj/fakeobject/airlock_broken(D.loc)
 			if (!src.bolt && D.locked) // it's possible for a bolter to activate first
@@ -93,5 +93,5 @@ so I feel they're better and more versatile, even if they're harder to set up.. 
 
 	setup()
 		. = ..()
-		for (var/obj/machinery/door/airlock/secure_airlock in src.loc)
+		for (var/obj/machinery/door/airlock/secure_airlock in get_turf(src))
 			secure_airlock.aiControlDisabled = TRUE

--- a/code/modules/mapping/helpers/airlock_helpers.dm
+++ b/code/modules/mapping/helpers/airlock_helpers.dm
@@ -80,7 +80,7 @@ so I feel they're better and more versatile, even if they're harder to set up.. 
 				F.UpdateOverlays(image(D.icon, D.welded_icon_state), "weld")
 			// set icon on the fake image
 			F.icon = D.icon
-			F.icon_state = F.icon_state
+			F.icon_state = D.icon_state
 			// final touches
 			F.name = D.name
 			F.desc = D.desc

--- a/code/modules/mapping/helpers/airlock_helpers.dm
+++ b/code/modules/mapping/helpers/airlock_helpers.dm
@@ -60,32 +60,32 @@ so I feel they're better and more versatile, even if they're harder to set up.. 
 
 	setup()
 		// use the bolt and weld vars to determine how the fake door should look.
-		if (/obj/mapping_helper/airlock/bolter in range(0,src))
-			src.bolt = TRUE
-		if (/obj/mapping_helper/airlock/welder in range(0,src))
-			src.weld = TRUE
-		for (var/obj/machinery/door/airlock/D in range(0,src))
-			if (D.locked)
+		for (var/atom/A in src.loc)
+			if (istype(A, /obj/mapping_helper/airlock/bolter))
 				src.bolt = TRUE
-			if (D.welded)
+				qdel(A)
+				continue
+			if (istype(A, /obj/mapping_helper/airlock/welder))
 				src.weld = TRUE
-			// now we know it is bolted/welded; create the door
+				qdel(A)
+				continue
+		var/counter = 0
+		for (var/obj/machinery/door/airlock/D in src.loc)
+			counter++
 			var/obj/fakeobject/airlock_broken/F = new /obj/fakeobject/airlock_broken(D.loc)
-			// make sure it's using the right icon state
-			if (src.bolt)
-				D.locked = TRUE
-				D.UpdateIcon()
-			// apply the welded effect if there is one
-			if (src.weld)
+			if (!src.bolt && D.locked) // it's possible for a bolter to activate first
+				src.bolt = TRUE
+			if (src.weld || D.welded)
 				F.UpdateOverlays(image(D.icon, D.welded_icon_state), "weld")
 			// set icon on the fake image
 			F.icon = D.icon
-			F.icon_state = D.icon_state
-			// final touches
+			F.icon_state = (src.bolt ? "[D.icon_base]_locked" : D.icon_state)
 			F.name = D.name
 			F.desc = D.desc
 			F.density = D.density
 			qdel(D)
+		if (counter > 1)
+			CRASH("[counter] airlocks on tile [src.x], [src.y], [src.x]")
 
 /obj/mapping_helper/airlock/aiDisabler
 	name = "airlock aiDisabler"

--- a/code/modules/mapping/helpers/airlock_helpers.dm
+++ b/code/modules/mapping/helpers/airlock_helpers.dm
@@ -85,6 +85,7 @@ so I feel they're better and more versatile, even if they're harder to set up.. 
 			F.name = D.name
 			F.desc = D.desc
 			F.density = D.density
+			F.set_loc(D.loc)
 			qdel(D)
 
 /obj/mapping_helper/airlock/aiDisabler


### PR DESCRIPTION
[BUG]
## About the PR
They did not correctly work before, due to `range(0,src)` apparently deciding to fuck with me for some reason. They should now work as intended. Some minor performance enhancements too.

Also replaced use of `src.loc` within the file with `get_turf(src)`.

## Why's this needed?
They should work