### PR TITLE
Borgproofs the robotics control console.

### DIFF
--- a/code/obj/machinery/computer/robotics.dm
+++ b/code/obj/machinery/computer/robotics.dm
@@ -1,5 +1,5 @@
 /obj/machinery/computer/robotics
-	name = "robotics control"
+	name = "robotics control console"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "robotics"
 	req_access = list(access_ai_upload)
@@ -23,9 +23,14 @@
 		STOP_TRACKING
 
 
-/obj/machinery/computer/robotics/attackby(obj/item/I, user)
+/obj/machinery/computer/robotics/attackby(obj/item/I, mob/user)
 	if (perma && isscrewingtool(I))
 		boutput(user, SPAN_ALERT("The screws are all weird safety-bit types! You can't turn them!"))
+		return
+	else if (issilicon(user) && isscrewingtool(I))
+		boutput(user, SPAN_ALERT("[src]'s anti-intrusion countermeasures activate and flash you!"))
+		user.apply_flash(30,5,5,5)
+		playsound(src, 'sound/weapons/flash.ogg', 50, TRUE)
 		return
 	..()
 	return

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -257,7 +257,7 @@
 		return 0
 	return 0
 
-/mob/proc/apply_flash(var/animation_duration, var/knockdown, var/stnu, var/misstep, var/eyes_blurry, var/eyes_damage, var/eye_tempblind, var/burn, var/uncloak_prob, var/stamina_damage,var/disorient_time)
+/mob/proc/apply_flash(var/animation_duration, var/knockdown, var/stun, var/misstep, var/eyes_blurry, var/eyes_damage, var/eye_tempblind, var/burn, var/uncloak_prob, var/stamina_damage,var/disorient_time)
 	return
 
 // We've had like 10+ code snippets for a variation of the same thing, now it's just one mob proc (Convair880).


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SILICONS] [GAME OBJECTS] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR prevents borgs from disassembling the robotics control (IE killswitch) console by making it flash them when they try to unscrew the panel. Why the flash? It was the only mechanism I could think of that would make sense working against all borgs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Working under the assumption that people are supposed to activate the killswitch in case of rogue silicons, it is laughably easy for a borg to remove it before the crew has any reason to suspect a thing. With this change, silicons can't disable the console without a human accomplice, making it less trivial. Most of the time, the robotics control console is either just as fortified as the law rack, or literally in the same room, so this shouldn't make thwarting evil robots _too_ easy. My hope is that this change makes people at least consider killswitching more often when fighting the silicons.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)The robotics control console has been fitted with countermeasures to prevent the silicons from tampering with it.
```
