### PR TITLE
[TGUI REACT] Reimplement functionality for TGUI console history

### DIFF
--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -1,4 +1,5 @@
 
+#define MAX_INPUT_HISTORY_LENGTH 100 //! Maximum amount of things some nerd can put in here until we've had enough
 
 /obj/machinery/computer3
 	name = "computer"
@@ -35,6 +36,11 @@
 	/// does it have a glow in the dark screen? see computer_screens.dmi
 	var/glow_in_dark_screen = TRUE
 	var/image/screen_image
+
+	// Vars for command history
+	var/list/list/tgui_input_history //! (Keyed by CKEY) A list of strings representing the terminal's command execution history. New history is appended as commands are executed
+	var/list/tgui_input_index //! (Keyed by CKEY)  An index pointing to the position in tgui_input_history to update tgui_last_accessed with
+	var/list/tgui_last_accessed //! (Keyed by CKEY)  The most recently accessed command from the console
 
 	power_usage = 250
 
@@ -276,6 +282,9 @@
 	light.attach(src)
 
 	src.base_icon_state = src.icon_state
+	src.tgui_input_history = list()
+	src.tgui_input_index = list()
+	src.tgui_last_accessed = list()
 
 	if(glow_in_dark_screen)
 		src.screen_image = image('icons/obj/computer_screens.dmi', src.icon_state, -1)
@@ -345,14 +354,16 @@
 		ui.open()
 
 /obj/machinery/computer3/ui_static_data(mob/user)
-	. = list()
+	. = list(
+		"ckey" = user.ckey,
+	)
 	if(src.setup_has_internal_disk) // the magic internal floppy drive is in here
 		. += list("peripherals" = list(list(
 		"icon" = "save",
 		"card" = "internal",
 		"color" = src.diskette,
 		"contents" = src.diskette,
-		"label" = "Disk"
+		"label" = "Disk",
 		)))
 	for (var/i in 1 to length(src.peripherals)) // originally i had all this stuff in static data, but the buttons didnt update.
 		var/obj/item/peripheral/periph = src.peripherals[i]
@@ -365,6 +376,7 @@
 				.["peripherals"] += list(pdata)
 
 /obj/machinery/computer3/ui_data(mob/user)
+	src.tgui_last_accessed[user.ckey] ||= ""
 	. = list(
 		"displayHTML" = src.temp, // display data
 		"TermActive" = src.active_program, // is the terminal running or restarting
@@ -373,7 +385,44 @@
 		"user" = user,
 		"fontColor" = src.setup_font_color, // display monochrome values
 		"bgColor" = src.setup_bg_color,
+		"inputValue" = src.tgui_last_accessed[user.ckey],
 	)
+
+/// Get the history entry at a certain index. Returns null if the index is out of bounds or the ckey is null. Will return an empty string for length+1
+/obj/machinery/computer3/proc/get_history(ckey, index)
+	if (isnull(ckey))
+		return
+	// Allow length+1 to simulate hitting the 'end' of the history and ending up on an empty line
+	if (index == length(src.tgui_input_history[ckey]) + 1)
+		return ""
+	// Ensure index with key exists
+	src.tgui_input_history[ckey] ||= list()
+	// Ensure we can return a value
+	if (index < 1 || length(src.tgui_input_history[ckey]) < index)
+		return
+	return src.tgui_input_history[ckey][index]
+
+/obj/machinery/computer3/proc/add_history(ckey, new_history)
+	// Ensure index with key exists
+	src.tgui_input_history[ckey] ||= list()
+	src.tgui_input_history[ckey].Add(new_history)
+	// Ensure not over limit after adding new entry
+	if (length(src.tgui_input_history) > MAX_INPUT_HISTORY_LENGTH)
+		src.tgui_input_history[ckey].Remove(src.tgui_input_history[ckey][1])
+	// After typing something else in the console, history is always most recent entry
+	src.tgui_input_index[ckey] = length(src.tgui_input_history[ckey])
+
+/// Traverse the current history by some amount. Returns true if different history was accessed, false otherwise (usually if new index OOB)
+/obj/machinery/computer3/proc/traverse_history(ckey, amount)
+	// Most recent entry in history if first time accessing
+	src.tgui_input_index[ckey] ||= length(src.tgui_input_history[ckey])
+	// Ensure previous history exists
+	var/result = src.get_history(ckey, src.tgui_input_index[ckey] + amount)
+	if (isnull(result))
+		return FALSE
+	src.tgui_input_index[ckey] = src.tgui_input_index[ckey] + amount
+	src.tgui_last_accessed[ckey] = result
+	return TRUE
 
 /obj/machinery/computer3/ui_act(action, params)
 	. = ..()
@@ -383,12 +432,18 @@
 		if("restart")
 			src.restart()
 			src.updateUsrDialog()
+		if("history")
+			if (params["direction"] == "prev")
+				return src.traverse_history(params["ckey"], -1)
+			if (params["direction"] == "next")
+				return src.traverse_history(params["ckey"],  1)
 		if("text")
 			if(src.active_program && params["value"]) // haha it fucking works WOOOOOO
 				if(params["value"] == "term_clear")
 					src.temp = "Cleared\n"
 					return
 				src.active_program.input_text(params["value"])
+				src.add_history(params["ckey"], params["value"])
 				playsound(src.loc, "keyboard", 50, 1, -15)
 				src.updateUsrDialog()
 		if("buttonPressed")
@@ -666,6 +721,8 @@
 		src.processing_programs.len = 0
 		src.processing_programs = null
 
+	tgui_input_history = null
+
 	active_program = null
 	host_program = null
 
@@ -762,6 +819,8 @@
 		src.processing_programs = new
 		src.temp = ""
 		src.temp_add = "Restarting system...<br>"
+		src.tgui_input_history = list()
+		src.tgui_input_index = 0
 		src.updateUsrDialog()
 		playsound(src.loc, 'sound/machines/keypress.ogg', 50, 1, -15)
 		SPAWN(2 SECONDS)
@@ -1048,3 +1107,5 @@
 		src.set_loc(src.case)
 		src.deployed = 0
 		return
+
+#undef MAX_INPUT_HISTORY_LENGTH

--- a/tgui/packages/tgui/interfaces/Terminal/TerminalInput.tsx
+++ b/tgui/packages/tgui/interfaces/Terminal/TerminalInput.tsx
@@ -1,0 +1,26 @@
+/**
+ * @file
+ * @copyright 2024
+ * @author Romayne (https://github.com/MyNameIsRomayne)
+ * @license ISC
+ */
+
+import { KEY } from 'common/keys';
+import { Input } from 'tgui-core/components';
+
+export const TerminalInput = (props) => {
+  const { onKeyUp, onKeyDown, onKey, ...rest } = props;
+
+  const checkArrows = (e) => {
+    const e_value = e.key;
+    if (e_value === KEY.Up) {
+      onKeyUp?.(e, e_value);
+    } else if (e_value === KEY.Down) {
+      onKeyDown?.(e, e_value);
+    } else {
+      onKey?.(e, e_value);
+    }
+  };
+
+  return <Input onKeyDown={checkArrows} {...rest} />;
+};

--- a/tgui/packages/tgui/interfaces/Terminal/types.ts
+++ b/tgui/packages/tgui/interfaces/Terminal/types.ts
@@ -23,4 +23,7 @@ export type TerminalData = {
   fontColor: string;
   bgColor: string;
   peripherals: Array<PeripheralData>;
+  inputValue: string;
+  loadTimestamp: number;
+  ckey: string;
 };


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

writing commands adds them to the history, and sets the current command to the front-most entry.
restarting the console clears the history.
up and down arrow keys choose previous/next entries in the console.
choosing beyond the last command executed (trying command executed after than that) changes it back to empty

note that this has a difference in behavior compared to current because in this implementation, commands are stored as strings server-side. this means that closing/re-opening the terminal will show the last saved command in the history (if exists)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

broke in the port/upgrade, should really be fixed.
