### PR TITLE
Give borgs synthetic brains

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -233,9 +233,8 @@
 
 		SPAWN(1.5 SECONDS)
 			if (!src.part_head.brain && src.key && !(src.dependent || src.shell || src.part_head.ai_interface))
-				var/obj/item/organ/brain/B = new /obj/item/organ/brain(src)
+				var/obj/item/organ/brain/B = new /obj/item/organ/brain/ai(src)
 				B.owner = src.mind
-				B.icon_state = "borg_brain"
 				if (!B.owner) //Oh no, they have no mind!
 					logTheThing(LOG_DEBUG, null, "<b>Mind</b> Cyborg spawn forced to create new mind for key \[[src.key ? src.key : "INVALID KEY"]]")
 					stack_trace("[identify_object(src)] was created without a mind, somehow. Mind force-created for key \[[src.key ? src.key : "INVALID KEY"]]. That's bad.")

--- a/code/obj/item/organs/brain.dm
+++ b/code/obj/item/organs/brain.dm
@@ -140,7 +140,7 @@
 
 /obj/item/organ/brain/ai
 	name = "neural net processor"
-	desc = "A heavily augmented human brain, upgraded to deal with the large amount of information an AI unit must process."
+	desc = "A digital mind modeled after human neurology and enhanced to deal with the large amount of information an AI unit must process."
 	icon_state = "ai_brain"
 	item_state = "ai_brain"
 	created_decal = /obj/decal/cleanable/oil


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes roundstart borgs spawn with the metallic AI brain subtype instead of a human brain.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Has essentially no mechanical effect, but should help to reduce the notion of borgs being a human consciousness/soul in a metal body. This often causes uncomfortable discussion which is not really fit for the tone of the server. Also edits the description of the AI brain to make it no longer state that it is an actual human brain, instead states that it is a machine modeled after the human brain. It was already made of pharosium metal and bled oil, so this does not conflict with the existing theming.

And as a matter of code quality the borg brain was not an actual subtype of brains. It was actually a plain human brain that just has its icon state edited when a cyborg spawns with one.