### PR TITLE
Replaces instance of "lynched" with "gibbed" in the critter compendium.

### DIFF
--- a/strings/books/critter_compendium.txt
+++ b/strings/books/critter_compendium.txt
@@ -55,7 +55,7 @@
 				<span class="critter_name">Space seal pup (<span class="science_name">Arctocephalus gazella peur spatium</span>)</span><BR>
 				<span class="location"><B>Location:</B> Pool</span>
 				</p>
-				<p class="description">The actual most adorable things in existence.  The only specimens that one will be able to find are in Space Station 13's pool.  They never seem to age due to a quirk in their genetic code that seems to be incompatible with any other species.  Anyone who attacks them is clearly an immoral monster and are to be lynched with utmost haste.</p>
+				<p class="description">The actual most adorable things in existence.  The only specimens that one will be able to find are in Space Station 13's pool.  They never seem to age due to a quirk in their genetic code that seems to be incompatible with any other species.  Anyone who attacks them is clearly an immoral monster and are to be gibbed with utmost haste.</p>
 
 				<p>
 					<span class="critter_name">Meat cube (<span class="science_name">Carnis cubus</span>)</span><br>


### PR DESCRIPTION

## About the PR 
Replaces instance of "lynched" with "gibbed" in the critter compendium.

## Why's this needed?

Bad terminology with racist connotations due to history. Probably accidental on the part of the author, but better to use gibbed instead; gitblame on this line only goes back to 3 years ago so no idea if this is a holdover from the before times.

## Changelog 

```changelog
(u)Iamgoofball
(+)Replaces instance of "lynched" with "gibbed" in the critter compendium.
```
