### PR TITLE
Bugfix, replacing incorrect reagent in Bathsalts Recipe

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -4200,7 +4200,7 @@
 		name = "Bath Salts"
 		id= "bathsalts"
 		result = "bathsalts"
-		required_reagents = list("msg" = 1, "yuck" = 1, "denatured_enzyme" = 1, "saltpetre" = 1, "cleaner" = 1, "mercury" = 1, "el_diablo" = 1)
+		required_reagents = list("msg" = 1, "yuck" = 1, "denatured_enzyme" = 1, "saltpetre" = 1, "cleaner" = 1, "mercury" = 1, "ghostchilijuice" = 1)
 		min_temperature = T0C + 100
 		result_amount = 6
 		mix_phrase = "Tiny cubic crystals precipitate out of the mixture. Huh."

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -4200,7 +4200,7 @@
 		name = "Bath Salts"
 		id= "bathsalts"
 		result = "bathsalts"
-		required_reagents = list("msg" = 1, "yuck" = 1, "denatured_enzyme" = 1, "saltpetre" = 1, "cleaner" = 1, "mercury" = 1, "ghostchilijuice" = 1)
+		required_reagents = list("msg" = 1, "yuck" = 1, "denatured_enzyme" = 1, "saltpetre" = 1, "cleaner" = 1, "mercury" = 1, "el_diablo" = 1)
 		min_temperature = T0C + 100
 		result_amount = 6
 		mix_phrase = "Tiny cubic crystals precipitate out of the mixture. Huh."


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When I made the initial PR, I misread the reagents and added Ghost Chili Juice instead of El Diablo Chili.
This is an important distinction, because EDC can be found in the DDnoodles  "Brimstone BBQ Flavor", and GCJ, 
(while mentioned in the code) cannot be found in any discount dans noodles. 
This caused the main function of the recipe to be broken: 
(a bunch of chems found in noodles that can be heated up in a bath) 

See initial PR here: https://github.com/goonstation/goonstation/pull/18087

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The change to El Diablo Chili ultimately doesn't change much in the way of synthesising bath salts. The only added complexity is that you now have to get chilis AND go to the chef, or space diner to make some El Diablo Chili food.
The main issue was that Ghost Chili Juice doesn't actually appear in Discount Dans Noodles, but El Diablo Chili does.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->


```changelog
(u)ithebinman
(+) Fixed incorrect reagent in Bath Salts recipe - You now require El Diablo Chili instead of Ghost Chili Juice.
```
