### PR TITLE
Lower classic shuttle autocall to 1h

### DIFF
--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -9,7 +9,11 @@ ABSTRACT_TYPE(/datum/game_mode)
 
 	var/shuttle_available = 1 // 0: Won't dock. | 1: Normal. | 2: Won't dock if called too early.
 	var/shuttle_available_threshold = 12000 // 20 min. Only works when shuttle_available == SHUTTLE_AVAILABLE_DELAY.
+	#ifdef RP_MODE
 	var/shuttle_auto_call_time = 90 MINUTES // 120 minutes.  Shuttle auto-called at this time and then again at this time + 1/2 this time, then every 1/2 this time after that. Set to 0 to disable.
+	#else
+	var/shuttle_auto_call_time = 60 MINUTES // Less for classic, rounds going beyond this time are rare and almost always should have had the shuttle called already
+	#endif
 	var/shuttle_last_auto_call = 0
 	var/shuttle_initial_auto_call_done = 0 // set to 1 after first call so we know to start checking shuttle_auto_call_time/2
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduces the time on non-RP servers for the shuttle to be automatically called from 90m -> 60m


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Classic rounds rarely reach 60m without a shuttle call and rounds in which they do almost always are due to nobody being able or willing to call in a round that should have had the shuttle called a while ago. The autoshuttle can still be recalled.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Classic shuttle is now autocalled at 60 minutes rather than 90
```
