### PR TITLE
Fix psych office mail on kondaru

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -32787,7 +32787,9 @@
 "efc" = (
 /obj/machinery/firealarm/west,
 /obj/disposalpipe/trunk/mail/east,
-/obj/machinery/disposal/mail/autoname,
+/obj/machinery/disposal/mail/autoname{
+	mail_tag = "psychiatry"
+	},
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
@@ -49975,8 +49977,8 @@
 /area/station/crew_quarters/quarters_south)
 "qAY" = (
 /obj/disposalpipe/switch_junction/right/north{
-	mail_tag = "pathology";
-	name = "pathology mail junction"
+	mail_tag = "psychiatry";
+	name = "psychiatry mail junction"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 8


### PR DESCRIPTION
[bug][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Psych office on kondaru still had the pathology mail_tag on the junction and a mail chute that lacked a tag

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Someone tried to send me mail and it didn't work so I opened strong.dmm