### PR TITLE
Fixes #20337 by enabling the mechcomp link visuals on the cyborg meson upgrade.

### DIFF
--- a/code/mob/living/life/sight.dm
+++ b/code/mob/living/life/sight.dm
@@ -47,27 +47,13 @@
 		else
 			if (robot_owner)
 				//var/sight_therm = 0 //todo fix this
-				var/sight_meson = 0
 				var/sight_constr = 0
 				for (var/obj/item/roboupgrade/R in robot_owner.upgrades)
 					if (R && istype(R, /obj/item/roboupgrade/visualizer) && R.activated && (T && !isrestrictedz(T.z)))
 						sight_constr = 1
-					if (R && istype(R, /obj/item/roboupgrade/opticmeson) && R.activated && (T && !isrestrictedz(T.z)))
-						sight_meson = 1
 					//if (R && istype(R, /obj/item/roboupgrade/opticthermal) && R.activated)
 					//	sight_therm = 1
 
-				if (sight_meson)
-					robot_owner.sight &= ~SEE_BLACKNESS
-					robot_owner.sight |= SEE_TURFS
-					robot_owner.render_special.set_centerlight_icon("meson", rgb(0.5 * 255, 0.5 * 255, 0.5 * 255), wide = (owner.client?.widescreen))
-					robot_owner.vision.set_scan(1)
-					robot_owner.client.set_color(normalize_color_to_matrix("#c2ffc2"))
-				else
-					robot_owner.sight |= SEE_BLACKNESS
-					robot_owner.sight &= ~SEE_TURFS
-					robot_owner.client.set_color()
-					robot_owner.vision.set_scan(0)
 				//if (sight_therm)
 				//	src.sight |= SEE_MOBS //todo make borg thermals have a purpose again
 				//else

--- a/code/modules/robotics/robot/upgrade/meson_scanner.dm
+++ b/code/modules/robotics/robot/upgrade/meson_scanner.dm
@@ -8,11 +8,9 @@
 /obj/item/roboupgrade/opticmeson/upgrade_activate(var/mob/living/silicon/robot/user)
 	if (..())
 		return
-	APPLY_ATOM_PROPERTY(user, PROP_MOB_MESONVISION, src)
-	get_image_group(CLIENT_IMAGE_GROUP_MECHCOMP).add_mob(user)
+	user.meson(src)
 
 /obj/item/roboupgrade/opticmeson/upgrade_deactivate(var/mob/living/silicon/robot/user)
 	if (..())
 		return
-	REMOVE_ATOM_PROPERTY(user, PROP_MOB_MESONVISION, src)
-	get_image_group(CLIENT_IMAGE_GROUP_MECHCOMP).remove_mob(user)
+	user.unmeson(src)

--- a/code/modules/robotics/robot/upgrade/meson_scanner.dm
+++ b/code/modules/robotics/robot/upgrade/meson_scanner.dm
@@ -4,3 +4,15 @@
 	icon_state = "up-opticmes"
 	drainrate = 5
 	borg_overlay = "up-meson"
+
+/obj/item/roboupgrade/opticmeson/upgrade_activate(var/mob/living/silicon/robot/user)
+	if (..())
+		return
+	APPLY_ATOM_PROPERTY(user, PROP_MOB_MESONVISION, src)
+	get_image_group(CLIENT_IMAGE_GROUP_MECHCOMP).add_mob(user)
+
+/obj/item/roboupgrade/opticmeson/upgrade_deactivate(var/mob/living/silicon/robot/user)
+	if (..())
+		return
+	REMOVE_ATOM_PROPERTY(user, PROP_MOB_MESONVISION, src)
+	get_image_group(CLIENT_IMAGE_GROUP_MECHCOMP).remove_mob(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #20337 by enabling the mechcomp link visuals on the cyborg meson upgrade.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Figured it was useful to transfer the meson goggle change for humans over to the cyborg upgrade as well.
