### PR TITLE
Fix (AI Core Skin) Salvaged being unavailable to eligible players

### DIFF
--- a/code/modules/medals/rewardsAI.dm
+++ b/code/modules/medals/rewardsAI.dm
@@ -58,7 +58,7 @@ datum/achievementReward/aicase/ai_industrial
 datum/achievementReward/aicase/ai_salvage
 	title = "(AI Core Skin) Salvaged"
 	desc = "Superficially smashes up your AI core a bit - for that really RUGGED aesthetic."
-	required_medal = "40k" //placeholder until salvagers get a greentext medal - ideally also have the core frame in the magpie use this skin
+	required_medal = "40K" //placeholder until salvagers get a greentext medal - ideally also have the core frame in the magpie use this skin
 	aiskin = "salvage"
 
 /datum/achievementReward/aicase/ai_shock


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Allows players who have the `40K` medal to select the salvaged skin


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Salvaged skin was looking for incorrect medal name (case sensitive)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sovexe
(+) Players with the "40K" medal can now redeem the (AI Core Skin) Salvaged reward as expected.
```
