### PR TITLE
Fixes #19908 - Button Panel "set button list" behavior fix

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -2915,9 +2915,12 @@ ADMIN_INTERACT_PROCS(/obj/item/mechanics/trigger/button, proc/press)
 		var/list/work_list = list()
 		var/button_count = 0
 		for (var/index in splittext(inputted_text, ";"))
-			var/list/split = splittext(index, "=")
-			if (length(split) != 2) continue
-			work_list[split[1]] = split[2]
+			var/first_equal_pos = findtext(index, "=")
+			if (!first_equal_pos) continue
+			var/button_name = copytext(index, 1, first_equal_pos)
+			var/signal = copytext(index, first_equal_pos + 1)
+			if (!button_name || !signal) continue
+			work_list[button_name] = signal
 			button_count++
 			if (button_count >= 10) break
 		if (!length(work_list)) return FALSE


### PR DESCRIPTION
[bug]
Fixes #19908 

## About the PR
Allows button panel "set button list" function to parse text with multiple equals sign correctly



## Why's this needed?
I needed this to work with signal splitters where I can just make button names with signals with data in them that have an "=" like "button=data=moredata" so that I can split at "data" and get a wifi signal of "moredata"



## Changelog
```changelog
(u)OmegaShoots
(+)Using the "set button list" on Button Panels can now work properly with inputs containing multiple equal signs.
```
