### PR TITLE
Fixes being able to install mounted Defibrillators into cryo pods

### DIFF
--- a/code/modules/atmospherics/machinery/unary/cryo_cell.dm
+++ b/code/modules/atmospherics/machinery/unary/cryo_cell.dm
@@ -276,6 +276,10 @@
 			if (I.cant_drop)
 				boutput(user, SPAN_ALERT("You can't put that in [src] while it's attached to you!"))
 				return
+			var/obj/item/robodefibrillator/defibrillator = I
+			if(defibrillator.mounted)
+				boutput(user, SPAN_ALERT("You can't install a mounted Defibrillator!"))
+				return
 			src.defib = I
 			boutput(user, SPAN_NOTICE("Defibrillator installed into [src]."))
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 80, 0)

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -337,6 +337,7 @@ TYPEINFO(/obj/item/robodefibrillator)
 	var/charge_time = 100
 	var/emagged = 0
 	var/makeshift = 0
+	var/mounted = FALSE
 	var/obj/item/cell/cell = null
 
 	emag_act(var/mob/user)
@@ -595,6 +596,7 @@ TYPEINFO(/obj/item/robodefibrillator)
 /obj/item/robodefibrillator/mounted
 	var/obj/machinery/defib_mount/parent = null	//temp set while not attached
 	w_class = W_CLASS_BULKY
+	mounted = TRUE
 
 	disposing()
 		parent?.defib = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS] [MEDICAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Stick a `mounted` variable on `/obj/item/robodefibrillator` and check it in `/obj/machinery/atmospherics/unary/cryo_cell/attackby` to stop you from being able to install corded Defibrillators into them

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #20432