### PR TITLE
Revert Security Officer Priority

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -506,9 +506,6 @@ ABSTRACT_TYPE(/datum/job/security)
 	limit = 5
 	lower_limit = 3
 	variable_limit = TRUE
-	high_priority_job = TRUE
-	high_priority_limit = 2 //always try to make sure there's at least a couple of secoffs
-	order_priority = 2 //fill secoffs after captain and AI
 	wages = PAY_TRADESMAN
 	trait_list = list("training_security")
 	access_string = "Security Officer"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reverts Security Officers being a priority job

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I feel this change has had the complete opposite effect than what was intended with #18329, now secoff is "set it unwanted or get it every round" which results in most people having it in unwanted. People want job variety and having a job ALWAYS be yours if not unwanted just results in everyone setting it unwanted and there being no sec, if there IS sec its people that fully knew and expected to be playing sec this round, rather than having a chance at it. The only people this does effect is new players who get forced to play sec and don't understand why.

I agree sec should be more common but it shouldn't be forced like this. A better solution would be weighting the odds of rolling a job depending on how many there already are (E.G. 5 people are going to either be engineer or doc, try to balance them a bit rather than just making 5 engineers)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Security Officer is no longer a priority role.
```
