### PR TITLE
Fixes #20356 glove slap message.

### DIFF
--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -89,8 +89,8 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 		// I demand satisfaction!
 		if (ismob(target))
 			target.visible_message(
-				"<span><b>[challenger]</b> slaps [target] in the face with the the [src]!</span>",
-				SPAN_ALERT("<b>[challenger] slaps you in the face with the [src]! [capitalize(he_or_she(challenger))] has offended your honour!")
+				"<span><b>[challenger]</b> slaps [target] in the face with [src]!</span>",
+				SPAN_ALERT("<b>[challenger] slaps you in the face with [src]! [capitalize(he_or_she(challenger))] has offended your honour!")
 			)
 			logTheThing(LOG_COMBAT, challenger, "glove-slapped [constructTarget(target,"combat")]")
 		else

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -95,7 +95,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 			logTheThing(LOG_COMBAT, challenger, "glove-slapped [constructTarget(target,"combat")]")
 		else
 			target.visible_message(
-				SPAN_ALERT("<b>[challenger]</b> slaps [target] in the face with the [src]!")
+				SPAN_ALERT("<b>[challenger]</b> slaps [target] in the face with [src]!")
 			)
 		playsound(target, 'sound/impact_sounds/Generic_Snap_1.ogg', 100, TRUE)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Simple fix for #20356 to remove extra usage of the word 'the' when slapping someone with gloves.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cleans up the chatbox a touch by removing unnecessarily repeated words with this interaction.
