### PR TITLE
fixes restricted manudrive duping

### DIFF
--- a/code/modules/networks/computer3/smallprogs.dm
+++ b/code/modules/networks/computer3/smallprogs.dm
@@ -610,7 +610,7 @@ file_save - Save file to local disk."}
 
 				var/datum/computer/file/loadedFile = parse_file_directory(toLoadName,src.holding_folder)
 
-				if (istype(loadedFile))
+				if (istype(loadedFile) && !loadedFile.dont_copy)
 					src.print_text("File loaded.")
 					src.temp_file = loadedFile
 					return
@@ -621,6 +621,9 @@ file_save - Save file to local disk."}
 			if("file_save")
 				if (!src.temp_file)
 					src.print_text("Error: No file to save!")
+					return
+				if (src.temp_file.dont_copy)
+					src.print_text("Error: File is copy-protected.")
 					return
 
 				var/toSaveName = "temp"

--- a/code/modules/networks/computer3/terminal.dm
+++ b/code/modules/networks/computer3/terminal.dm
@@ -268,7 +268,7 @@ file_save - Save file to local disk."}
 						continue
 
 					loadedFile = get_file_name(toLoadName, drive.root)
-					if (istype(loadedFile))
+					if (istype(loadedFile) && !loadedFile.dont_copy)
 						src.print_text("File loaded.")
 						src.temp_file = loadedFile
 						return
@@ -289,6 +289,10 @@ file_save - Save file to local disk."}
 			if("file_save")
 				if (!src.temp_file)
 					src.print_text("Alert: No file to save.")
+					return
+				
+				if (src.temp_file.dont_copy)
+					src.print_text("Error: File is copy-protected.")
 					return
 
 				var/toSaveName = "temp"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

FROG (and theoretically a regular terminal if you put termos on the floppy) ignores dont_copy letting you dupe manudrives and potentially other stuff too like detomatix

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

i don't have a screenshot but the exploit resulted in a round where robotics made 5ish AI cores and thats not supposed to happen

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)gus
(+)fixed manudrive duping
```
