### PR TITLE
Increases ether depletion and lowers KO time to 30 cycles

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -129,7 +129,7 @@ datum
 			transparency = 30
 			addiction_prob = 10
 			addiction_min = 15
-			depletion_rate = 0.2
+			depletion_rate = 0.3
 			overdose = 40   //Ether is known for having a big difference in effective to toxic dosage
 			var/counter = 1 //Data is conserved...so some jerkbag could inject a monkey with this, wait for data to build up, then extract some instant KO juice.  Dumb.
 			minimum_reaction_temperature = T0C + 80 //This stuff is extremely flammable
@@ -191,18 +191,18 @@ datum
 					M.changeStatus("recent_trauma", -2 SECONDS * mult)
 				if(holder.has_reagent(src.id,10)) // large doses progress somewhat faster than small ones
 					counter += mult
-					depletion_rate = 0.4 // depletes faster in large doses as well
+					depletion_rate = 0.6 // depletes faster in large doses as well
 				else
-					depletion_rate = 0.2
+					depletion_rate = 0.3
 
 				switch(counter += 1 * mult)
-					if(1 to 12)
+					if(1 to 7)
 						if(probmult(7)) M.emote("yawn")
-					if(12 to 40)
+					if(7 to 30)
 						M.setStatus("drowsy", 40 SECONDS)
 						if(probmult(9)) M.emote(pick("smile","giggle","yawn"))
-					if(40 to INFINITY)
-						depletion_rate = 0.4
+					if(30 to INFINITY)
+						depletion_rate = 0.6
 						M.setStatusMin("unconscious", 6 SECONDS * mult)
 						M.setStatus("drowsy", 40 SECONDS)
 				..()


### PR DESCRIPTION
[LABEL][chemistry][balance]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR increases the depletion of ether by 50%(from 0.2 and 0.4 to 0.3 and 0.6), and reduces the KO timings by 25%(previously varying from 40 to 20, now going from 30 to 15 based on amount). It also reduces the time for drowsiness to kick in.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The original changes to ether, while also hoping to make it a more interesting precursor chem, did also have the intention of separating it from other KO chems on a similar KO time and depletion, but i've found it did little to actually functionally differentiate it. Capulettium is easier to make and handle, has a lower dose to KO and time to KO, for example.
This PR changes ether from a redundant worse alternative to capu, to a potentially slightly quicker one if in larger doses, but not by a large amount(30 seconds versus 36 seconds), which should introduce some amount of upsides versus downsides to each.


## Changelog 
```changelog
(u)Colossus
(+)Ether now depletes at a 0.3 to 0.6 rate(50% faster), but takes slightly less time to KO and start drowsiness (from 40/20 cycles to 30/15 cycles depending on volume).
```
