### PR TITLE
Tiny-sized items' names are concealed when put in storage containers

### DIFF
--- a/code/modules/storage/storage.dm
+++ b/code/modules/storage/storage.dm
@@ -413,7 +413,7 @@
 	if (visible)
 		animate_storage_rustle(src.linked_item)
 		if (!src.sneaky && !istype(I, /obj/item/gun/energy/crossbow))
-			user.visible_message(SPAN_NOTICE("[user] has added [I] to [src.linked_item]!"),
+			user.visible_message(SPAN_NOTICE("[user] has added [I.w_class == W_CLASS_TINY ? "something" : I] to [src.linked_item]!"),
 				SPAN_NOTICE("You have added [I] to [src.linked_item]."))
 		playsound(src.linked_item.loc, "rustle", 50, TRUE, -5)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Instead of seeing **"Antagonist has added 9mm magazine to the backpack!"**, nearby players will now see **"Antagonist has added something to the backpack!"**.

### _By the way I have not tested this change, because I dont know the debug commands to simulate it, sowwy </3_

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Feels like your character should make an attempt to hide that stolen ID while putting it away.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Smilg
(*)Tiny-sized items are now partially concealed from onlookers when placed into bags or other storage.
```
