### PR TITLE
Fixes fixed floodlight description

### DIFF
--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -739,6 +739,9 @@ TYPEINFO(/obj/item/device/light/floodlight)
 	infinite_power = TRUE
 	power_usage = 0 WATTS
 
+	get_desc()
+		return "A floodlight that can illuminate a large area."
+
 #define FLARE_UNLIT 1
 #define FLARE_LIT 2
 #define FLARE_BURNT 3

--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -520,7 +520,7 @@ TYPEINFO(/obj/item/device/light/floodlight)
 				"metal" = 4)
 /obj/item/device/light/floodlight
 	name = "floodlight"
-	desc = "A floodlight that can illuminate a large area. It can be wrenched to activate it."
+	desc = "A floodlight that can illuminate a large area."
 	icon = 'icons/obj/lighting.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	icon_state = "floodlight_item"
@@ -667,6 +667,8 @@ TYPEINFO(/obj/item/device/light/floodlight)
 
 	get_desc()
 		. = ..() + "\n"
+		if (src.movable)
+			 +=  " It can be wrenched to activate it."
 		if (isnull(cell))
 			. += " It has no APC-sized cell installed."
 		else
@@ -738,9 +740,6 @@ TYPEINFO(/obj/item/device/light/floodlight)
 	rotatable = FALSE
 	infinite_power = TRUE
 	power_usage = 0 WATTS
-
-	get_desc()
-		return "A floodlight that can illuminate a large area."
 
 #define FLARE_UNLIT 1
 #define FLARE_LIT 2

--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -668,7 +668,7 @@ TYPEINFO(/obj/item/device/light/floodlight)
 	get_desc()
 		. = ..() + "\n"
 		if (src.movable)
-			 +=  " It can be wrenched to activate it."
+			. +=  " It can be wrenched to activate it."
 		if (isnull(cell))
 			. += " It has no APC-sized cell installed."
 		else

--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -671,7 +671,7 @@ TYPEINFO(/obj/item/device/light/floodlight)
 			. += " It has no APC-sized cell installed."
 		else
 			. += " [cell] is charged to [cell.charge]/[cell.maxcharge]."
-		if (src.anchored || !src.movable)
+		if (src.anchored)
 			. += " It is wrenched to the ground."
 			if (src.light.enabled)
 				. += " It is currently on."

--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -619,11 +619,11 @@ TYPEINFO(/obj/item/device/light/floodlight)
 				return
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 			if (!src.anchored)
-				src.visible_message(SPAN_NOTICE("[user] starts unwrenching \the [src]."))
+				src.visible_message(SPAN_NOTICE("[user] starts wrenching \the [src]."))
 				SETUP_GENERIC_ACTIONBAR(user, src, 1 SECONDS, PROC_REF(anchor), list(user), src.icon, src.icon_state,\
 					SPAN_NOTICE("[user] finishes wrenching \the [src]."), null)
 			else if(movable)
-				src.visible_message(SPAN_NOTICE("[user] starts wrenching \the [src]."))
+				src.visible_message(SPAN_NOTICE("[user] starts unwrenching \the [src]."))
 				SETUP_GENERIC_ACTIONBAR(user, src, 1 SECONDS, PROC_REF(unanchor), list(user), src.icon, src.icon_state,\
 					SPAN_NOTICE("[user] finishes unwrenching \the [src]."), null)
 		else if (ispryingtool(W))
@@ -671,7 +671,7 @@ TYPEINFO(/obj/item/device/light/floodlight)
 			. += " It has no APC-sized cell installed."
 		else
 			. += " [cell] is charged to [cell.charge]/[cell.maxcharge]."
-		if (src.anchored)
+		if (src.anchored || !src.movable)
 			. += " It is wrenched to the ground."
 			if (src.light.enabled)
 				. += " It is currently on."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Game-Objects] [C-Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Nadir uses a special sub-type of floodlights that are permanently fixed with infinite power. 

The get_desc() logic for the parent object does not play well with the special subtype; the floodlights are erroneously described as interactable via wrench.

This PR adds another step to the description logic to account for the special subtype. It also fixes a couple of typos (wrenching <> unwrenching).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #20102