### PR TITLE
Fixes buttcoin stacking with spacecash

### DIFF
--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -193,12 +193,14 @@
 		else if(istype(I, /obj/item/currency/spacecash/))
 			if (src.accessed_record)
 				boutput(user, SPAN_NOTICE("You insert the cash into the ATM."))
-
-				if(istype(I, /obj/item/currency/spacecash/buttcoin))
-					boutput(user, SPAN_SUCCESS("Your transaction will complete anywhere within 10 to 10e27 minutes from now."))
-				else
-					src.accessed_record["current_money"] += I.amount
-
+				src.accessed_record["current_money"] += I.amount
+				I.amount = 0
+				qdel(I)
+			else boutput(user, SPAN_ALERT("You need to log in before depositing cash!"))
+		else if(istype(I, /obj/item/currency/buttcoin/))
+			if (src.accessed_record)
+				boutput(user, SPAN_NOTICE("You insert the cash into the ATM."))
+				boutput(user, SPAN_SUCCESS("Your transaction will complete anywhere within 10 to 10e27 minutes from now."))
 				I.amount = 0
 				qdel(I)
 			else boutput(user, SPAN_ALERT("You need to log in before depositing cash!"))

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1353,7 +1353,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	/obj/item/scissors/surgical_scissors = 1)
 
 	items_in_backpack = list(\
-	/obj/item/currency/spacecash/buttcoin,
+	/obj/item/currency/buttcoin,
 	/obj/item/currency/spacecash/fivehundred)
 
 /datum/job/special/souschef

--- a/code/mob/living/critter/drone/x.dm
+++ b/code/mob/living/critter/drone/x.dm
@@ -18,7 +18,7 @@
 
 	setup_loot_table()
 		..()
-		loot_table[/obj/item/currency/spacecash/buttcoin] = 500
+		loot_table[/obj/item/currency/buttcoin] = 500
 
 	setup_healths()
 		add_hh_robot(500, 1)

--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -609,7 +609,7 @@ TYPEINFO(/obj/critter/gunbot/drone/helldrone)
 		health = 800
 		maxhealth = 800
 		score = 500
-		droploot = /obj/item/currency/spacecash/buttcoin // replace with railgun if that's ever safe enough to hand out? idk
+		droploot = /obj/item/currency/buttcoin // replace with railgun if that's ever safe enough to hand out? idk
 		attack_cooldown = 50
 		smashes_shit = 1
 

--- a/code/obj/item/space_cash.dm
+++ b/code/obj/item/space_cash.dm
@@ -130,54 +130,6 @@
 			else // 1mil bby
 				src.icon_state = "cashrbow"
 
-	buttcoin
-		name = "buttcoin"
-		desc = "The crypto-currency of the future (If you don't pay for your own electricity and got in early and don't lose the file and don't want transactions to be faster than half an hour and . . .)"
-		icon_state = "cashblue"
-		stack_type = /obj/item/currency/spacecash/buttcoin
-
-		New()
-			..()
-			processing_items |= src
-
-		_update_stack_appearance()
-			return
-
-		UpdateName()
-			src.name = "[src.amount] [name_prefix(null, 1)][pick("bit","butt","shitty-bill ","bart", "bat", "bet", "bot")]coin[s_es(src.amount)][name_suffix(null, 1)]"
-
-		process()
-			src.amount = rand(1, 1000) / rand(10, 1000)
-			if (prob(25))
-				src.amount *= (rand(1,100)/100)
-
-			if (prob(5))
-				src.amount *= 10000
-
-			src.UpdateName()
-
-		attack_hand(mob/user)
-			if ((user.l_hand == src || user.r_hand == src) && user.equipped() != src)
-				var/amt = round(input("How much cash do you want to take from the stack?") as null|num)
-				if (isnum_safe(amt))
-					if (amt > src.amount || amt < 1)
-						boutput(user, SPAN_ALERT("You wish!"))
-						return
-
-					boutput(user, "Your transaction will complete anywhere within 10 to 10e27 minutes from now.")
-			else
-				..()
-
-		attackby(var/obj/item/I, mob/user)
-			if (istype(I, /obj/item/currency/spacecash/buttcoin) && src.amount < src.max_stack)
-				boutput(user, "Your transaction will complete anywhere within 10 to 10e27 minutes from now.")
-			else
-				..(I, user)
-
-		disposing()
-			processing_items.Remove(src)
-			..()
-
 	five
 		default_min_amount = 5
 		default_max_amount = 5
@@ -244,6 +196,55 @@
 			icon_state = "moneybag"
 			item_state = "moneybag"
 			inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
+
+/obj/item/currency/buttcoin
+	name = "buttcoin"
+	real_name = "credit"
+	desc = "The crypto-currency of the future (If you don't pay for your own electricity and got in early and don't lose the file and don't want transactions to be faster than half an hour and . . .)"
+	icon_state = "cashblue"
+	stack_type = /obj/item/currency/buttcoin
+	display_name = "cash"
+
+	New()
+		..()
+		processing_items |= src
+
+	_update_stack_appearance()
+		return
+
+	UpdateName()
+		src.name = "[src.amount] [name_prefix(null, 1)][pick("bit","butt","shitty-bill ","bart", "bat", "bet", "bot")]coin[s_es(src.amount)][name_suffix(null, 1)]"
+
+	process()
+		src.amount = rand(1, 1000) / rand(10, 1000)
+		if (prob(25))
+			src.amount *= (rand(1,100)/100)
+		if (prob(5))
+			src.amount *= 10000
+
+		src.UpdateName()
+
+	attack_hand(mob/user)
+		if ((user.l_hand == src || user.r_hand == src) && user.equipped() != src)
+			var/amt = round(input("How much cash do you want to take from the stack?") as null|num)
+			if (isnum_safe(amt))
+				if (amt > src.amount || amt < 1)
+					boutput(user, SPAN_ALERT("You wish!"))
+					return
+
+				boutput(user, "Your transaction will complete anywhere within 10 to 10e27 minutes from now.")
+		else
+			..()
+
+	attackby(var/obj/item/I, mob/user)
+		if (istype(I, /obj/item/currency/buttcoin) && src.amount < src.max_stack)
+			boutput(user, "Your transaction will complete anywhere within 10 to 10e27 minutes from now.")
+		else
+			..(I, user)
+
+	disposing()
+		processing_items.Remove(src)
+		..()
 
 /obj/item/currency/spacebux // Not space cash. Actual spacebux. Wow.
 	name = "\improper Spacebux token"

--- a/code/obj/item/space_cash.dm
+++ b/code/obj/item/space_cash.dm
@@ -134,6 +134,7 @@
 		name = "buttcoin"
 		desc = "The crypto-currency of the future (If you don't pay for your own electricity and got in early and don't lose the file and don't want transactions to be faster than half an hour and . . .)"
 		icon_state = "cashblue"
+		stack_type = /obj/item/currency/spacecash/buttcoin
 
 		New()
 			..()

--- a/code/obj/item/storage/secure_safe.dm
+++ b/code/obj/item/storage/secure_safe.dm
@@ -625,7 +625,7 @@ TYPEINFO(/obj/item/storage/secure/ssafe)
 /obj/item/storage/secure/ssafe/larrys
 	configure_mode = FALSE
 	random_code = TRUE
-	spawn_contents = list(/obj/item/paper/IOU, /obj/item/device/key/generic/larrys, /obj/item/currency/spacecash/buttcoin, /obj/item/currency/spacecash/buttcoin)
+	spawn_contents = list(/obj/item/paper/IOU, /obj/item/device/key/generic/larrys, /obj/item/currency/buttcoin, /obj/item/currency/buttcoin)
 
 #undef KEYPAD_ERR
 #undef KEYPAD_SET

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -668,7 +668,7 @@
 			for (var/i in 1 to 10)
 				sleep(0.4 SECONDS)
 				if(src && prob(60))
-					var/obj/mined = new /obj/item/currency/spacecash/buttcoin
+					var/obj/mined = new /obj/item/currency/buttcoin
 					mined.set_loc(src.loc)
 					target = get_step(src, rand(1,8))
 					for (var/mob/living/mob in view(7,src))

--- a/code/obj/random_spawners.dm
+++ b/code/obj/random_spawners.dm
@@ -920,7 +920,7 @@
 		/obj/item/raw_material/uqill,
 		/obj/item/raw_material/cerenkite,
 		/obj/item/raw_material/erebite,
-		/obj/item/currency/spacecash/buttcoin,
+		/obj/item/currency/buttcoin,
 		/obj/item/currency/spacecash/tourist,
 		/obj/item/a_gift/easter)
 

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -1379,7 +1379,7 @@ TYPEINFO(/obj/stool/chair/dining/wood)
 	/obj/item/reagent_containers/food/snacks/candy/lollipop/random_medical,
 	/obj/item/currency/spacecash/small,
 	/obj/item/currency/spacecash/tourist,
-	/obj/item/currency/spacecash/buttcoin)
+	/obj/item/currency/buttcoin)
 
 	New()
 		..()

--- a/code/obj/submachine/slots.dm
+++ b/code/obj/submachine/slots.dm
@@ -305,7 +305,7 @@ TYPEINFO(/obj/submachine/slot_machine)
 		if(istype(I, /obj/item/currency/spacecash/))
 			boutput(user, SPAN_NOTICE("You insert the cash into [src]."))
 
-			if(istype(I, /obj/item/currency/spacecash/buttcoin))
+			if(istype(I, /obj/item/currency/buttcoin))
 				boutput(user, "Your transaction will complete anywhere within 10 to 10e27 minutes from now.")
 			else
 				src.play_money += I.amount

--- a/code/obj/submachine/slots.dm
+++ b/code/obj/submachine/slots.dm
@@ -304,12 +304,12 @@ TYPEINFO(/obj/submachine/slot_machine)
 	attackby(var/obj/item/I, user)
 		if(istype(I, /obj/item/currency/spacecash/))
 			boutput(user, SPAN_NOTICE("You insert the cash into [src]."))
-
-			if(istype(I, /obj/item/currency/buttcoin))
-				boutput(user, "Your transaction will complete anywhere within 10 to 10e27 minutes from now.")
-			else
-				src.play_money += I.amount
-
+			src.play_money += I.amount
+			I.amount = 0
+			qdel(I)
+		else if(istype(I, /obj/item/currency/buttcoin/))
+			boutput(user, SPAN_NOTICE("You insert the cash into [src]."))
+			boutput(user, "Your transaction will complete anywhere within 10 to 10e27 minutes from now.")
 			I.amount = 0
 			qdel(I)
 

--- a/code/z_adventurezones/luna.dm
+++ b/code/z_adventurezones/luna.dm
@@ -727,7 +727,7 @@ Contents:
 						END_NEAT
 					return
 
-				if (!(src.neat_things & NT_PONZI) && (locate(/obj/item/currency/spacecash/buttcoin) in AM.contents))
+				if (!(src.neat_things & NT_PONZI) && (locate(/obj/item/currency/buttcoin) in AM.contents))
 					FOUND_NEAT(NT_PONZI)
 						speak_with_maptext("Um, I'm sorry [AM], we do not accept blockchain-based cryptocurrency as payment.  You aren't one of those guys who yell about gold on the apollo flag or something, right?")
 						H.unlock_medal("To the Moon!",1)

--- a/maps/unused/crash_gimmick.dmm
+++ b/maps/unused/crash_gimmick.dmm
@@ -39205,7 +39205,7 @@
 "fHr" = (
 /obj/machinery/light_switch/north,
 /obj/table/wood/auto,
-/obj/item/currency/spacecash/buttcoin,
+/obj/item/currency/buttcoin,
 /obj/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},

--- a/maps/unused/horizon.dmm
+++ b/maps/unused/horizon.dmm
@@ -48113,7 +48113,7 @@
 "fIw" = (
 /obj/machinery/light_switch/north,
 /obj/table/wood/auto,
-/obj/item/currency/spacecash/buttcoin,
+/obj/item/currency/buttcoin,
 /obj/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -55240,7 +55240,7 @@
 	dir = 8;
 	tag = "icon-toilet (WEST)"
 	},
-/obj/item/currency/spacecash/buttcoin,
+/obj/item/currency/buttcoin,
 /turf/unsimulated/floor/plating,
 /area/afterlife/bar)
 "elx" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Buttcoin can currently stack with spacecash as it's a subtype of /currency/spacecash/.

You can therefore effectively convert it to spacecash (or vice versa) by combining two stacks.

This PR makes it a subtype of /currency/ so you can't do that anymore.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #19705