### PR TITLE
TEG valve rename

### DIFF
--- a/assets/maps/engine_rooms/cogmap/TEG_100.dmm
+++ b/assets/maps/engine_rooms/cogmap/TEG_100.dmm
@@ -98,15 +98,15 @@
 /area/station/engine/core)
 "eN" = (
 /obj/machinery/power/apc/autoname_north,
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "hot loop inlet valve"
-	},
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot inlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -163,7 +163,7 @@
 	},
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "cold loop auxillary west"
+	name = "cold auxillary valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -178,15 +178,15 @@
 /area/station/engine/core)
 "iC" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "cold loop outlet valve"
+	name = "cold outlet valve";
+	dir = 8
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "iO" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop auxillary west"
+	name = "hot auxillary valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -262,7 +262,7 @@
 /area/station/engine/core)
 "pc" = (
 /obj/machinery/atmospherics/binary/valve{
-	name = "outlet purge valve"
+	name = "hot purge valve"
 	},
 /turf/simulated/floor/grey,
 /area/station/engine/inner)
@@ -388,7 +388,7 @@
 "wQ" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "cold loop inlet valve"
+	name = "cold inlet valve"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
@@ -562,12 +562,12 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "cold loop inlet valve"
-	},
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "cold inlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -621,7 +621,7 @@
 /area/station/engine/core)
 "OQ" = (
 /obj/machinery/atmospherics/binary/valve{
-	name = "outlet purge valve"
+	name = "cold purge valve"
 	},
 /obj/cable/orange{
 	icon_state = "1-2"
@@ -631,7 +631,7 @@
 "PX" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop inlet valve"
+	name = "hot inlet valve"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
@@ -681,7 +681,7 @@
 "WR" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop outlet valve"
+	name = "hot outlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -13247,7 +13247,7 @@
 "aYV" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop purge valve"
+	name = "hot purge valve"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southwest)
@@ -13725,8 +13725,8 @@
 /area/station/quartermaster/office)
 "bxK" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "cold loop valve"
+	name = "cold outlet valve";
+	dir = 8
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -14305,7 +14305,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "diS" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "cold inlet valve"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/coldloop)
 "djg" = (
@@ -14564,7 +14566,9 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "dQd" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "mixing valve"
+	},
 /obj/submachine/cargopad/engineering,
 /turf/simulated/floor/caution/west,
 /area/station/engine/core)
@@ -15008,12 +15012,14 @@
 /area/station/hallway/primary/east)
 "fcV" = (
 /obj/machinery/power/apc/autoname_east,
-/obj/machinery/atmospherics/binary/valve,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "hot inlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/hotloop)
@@ -15125,7 +15131,7 @@
 "fyE" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "combustion chamber inlet valve"
+	name = "combustion chamber fuel valve"
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/engine/core)
@@ -15208,7 +15214,8 @@
 /area/station/security/main)
 "fHe" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	name = "hot auxiliary valve";
+	dir = 8
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -16487,7 +16494,7 @@
 "jUG" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "cold loop purge valve"
+	name = "cold purge valve"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southeast)
@@ -18777,9 +18784,11 @@
 "qyp" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable,
-/obj/machinery/atmospherics/binary/valve,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "cold inlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/coldloop)
@@ -19204,7 +19213,9 @@
 /turf/simulated/floor/blueblack,
 /area/station/turret_protected/ai)
 "rFr" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "hot inlet valve"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/hotloop)
 "rGs" = (
@@ -20324,7 +20335,7 @@
 "uSJ" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop valve"
+	name = "hot outlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -20592,7 +20603,7 @@
 /area/station/medical/medbay/surgery)
 "vCI" = (
 /obj/machinery/atmospherics/binary/valve{
-	name = "hot loop bypass valve"
+	name = "combustion chamber bypass valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -17144,7 +17144,6 @@
 	pixel_y = 21
 	},
 /obj/machinery/atmospherics/binary/valve{
-	desc = "hot reserve tank valve";
 	dir = 4;
 	name = "hot reserve tank valve"
 	},
@@ -37327,14 +37326,15 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "cHR" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8;
 	tag = "icon-xtra_bigstripe-edge (WEST)"
 	},
 /obj/machinery/firealarm/south,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot inlet valve"
+	},
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -38014,15 +38014,15 @@
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "djB" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "cold loop pressure release valve"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/cable/blue{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "cold purge valve"
 	},
 /turf/simulated/floor/grey,
 /area/station/engine/inner)
@@ -40173,7 +40173,7 @@
 "eDy" = (
 /obj/machinery/atmospherics/binary/valve{
 	desc = "freezer bypass valve";
-	name = "freezer bypass valve"
+	name = "cold radiator bypass valve"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -40539,9 +40539,8 @@
 	pixel_y = 21
 	},
 /obj/machinery/atmospherics/binary/valve{
-	desc = "cold reserve tank valve";
 	dir = 4;
-	name = "reserve tank valve"
+	name = "cold reserve tank valve"
 	},
 /turf/simulated/floor/grey,
 /area/station/engine/inner)
@@ -43234,8 +43233,7 @@
 /area/station/medical/head)
 "gWZ" = (
 /obj/machinery/atmospherics/binary/valve{
-	desc = "hot radiator outlet valve";
-	name = "hot radiator outlet valve"
+	name = "combustion chamber outlet valve"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
@@ -44284,25 +44282,25 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "hLG" = (
-/obj/machinery/atmospherics/binary/valve{
-	desc = "furnace bypass valve";
-	dir = 4;
-	name = "furnace bypass valve"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 9;
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "combustion chamber bypass valve";
+	dir = 8
+	},
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
 "hLX" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "cold inlet valve"
 	},
 /turf/simulated/floor/black/side{
 	dir = 4
@@ -49483,10 +49481,6 @@
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/construction2)
 "mdv" = (
-/obj/machinery/atmospherics/binary/valve{
-	desc = "hot radiator inlet valve";
-	name = "hot radiator inlet valve"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -49496,6 +49490,9 @@
 	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
+	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "combustion chamber inlet valve"
 	},
 /turf/simulated/floor/black/side{
 	dir = 8
@@ -51744,13 +51741,13 @@
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
 "nOu" = (
-/obj/machinery/atmospherics/binary/valve{
-	name = "gas mix supply valve"
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
 /obj/machinery/light_switch/west,
+/obj/machinery/atmospherics/binary/valve{
+	name = "cold inlet valve"
+	},
 /turf/simulated/floor/black/side{
 	dir = 1
 	},
@@ -56530,12 +56527,13 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "ryf" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8;
 	tag = "icon-xtra_bigstripe-edge (WEST)"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot inlet valve"
 	},
 /turf/simulated/floor/black/side{
 	dir = 8
@@ -57028,17 +57026,6 @@
 /obj/machinery/manufacturer/engineering,
 /turf/simulated/floor/yellow/side,
 /area/station/storage/primary)
-"rPW" = (
-/obj/machinery/atmospherics/binary/valve,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	name = "factory pipe"
-	},
-/turf/simulated/floor/red,
-/area/station/engine/hotloop)
 "rQa" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -59926,7 +59913,7 @@
 "tZk" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop pressure release valve"
+	name = "hot purge valve"
 	},
 /turf/simulated/floor/grey,
 /area/station/engine/inner)
@@ -61665,7 +61652,10 @@
 	},
 /area/station/engine/inner)
 "vjx" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1;
+	name = "combustion chamber fuel valve"
+	},
 /turf/simulated/floor/red,
 /area/station/engine/hotloop)
 "vli" = (
@@ -64614,10 +64604,13 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/binary/valve,
 /obj/disposalpipe/segment{
 	dir = 4;
 	name = "factory pipe"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1;
+	name = "combustion chamber fuel valve"
 	},
 /turf/simulated/floor/red,
 /area/station/engine/hotloop)
@@ -109648,7 +109641,7 @@ bwW
 qva
 uJG
 rSs
-rPW
+xIC
 gni
 ykS
 lyy

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -40172,7 +40172,6 @@
 /area/station/hangar/science)
 "eDy" = (
 /obj/machinery/atmospherics/binary/valve{
-	desc = "freezer bypass valve";
 	name = "cold radiator bypass valve"
 	},
 /obj/cable{

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -146,7 +146,10 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "aaN" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "cold outlet valve";
+	dir = 1
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/coldloop)
 "aaO" = (
@@ -56300,7 +56303,9 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/main)
 "ehC" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "hot inlet valve"
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
 "ehM" = (
@@ -56399,12 +56404,12 @@
 	},
 /area/station/catwalk/north)
 "enN" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "hot loop inlet valve"
-	},
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "combustion chamber bypass valve";
+	dir = 8
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
@@ -57533,13 +57538,16 @@
 /turf/simulated/floor,
 /area/station/storage/emergency)
 "fDX" = (
-/obj/machinery/atmospherics/binary/valve,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
 	name = "autoname - SS13";
 	pixel_x = -10;
 	tag = ""
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 2;
+	name = "cold reserve tank valve"
 	},
 /turf/simulated/floor/blue,
 /area/station/engine/coldloop)
@@ -57753,6 +57761,13 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet/blue/fancy/narrow/T_east,
 /area/station/medical/medbay/psychiatrist)
+"fRs" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "freezer bypass valve"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "fSZ" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -58409,7 +58424,8 @@
 /area/station/hallway/primary/northwest)
 "gEv" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold inlet valve"
 	},
 /turf/simulated/floor/caution/north{
 	dir = 8
@@ -60457,7 +60473,8 @@
 /area/station/mining/staff_room)
 "iEv" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold inlet valve"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/coldloop)
@@ -61226,7 +61243,7 @@
 	},
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop auxillary west"
+	name = "hot auxillary valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -63521,15 +63538,15 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "luz" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "cold loop auxillary west"
-	},
 /obj/cable/orange{
 	icon_state = "2-4"
 	},
 /obj/cable/orange{
 	icon_state = "2-5"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "cold auxillary valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -63954,15 +63971,15 @@
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai)
 "lOr" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "cold loop auxillary west"
-	},
 /obj/cable/orange{
 	icon_state = "1-4"
 	},
 /obj/cable/orange{
 	icon_state = "1-6"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "cold auxillary valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -64242,7 +64259,8 @@
 	})
 "mdZ" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold purge valve"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
@@ -67039,13 +67057,14 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/binary/valve{
-	dir = 1
-	},
 /obj/decal/poster/wallsign/stencil/right/two{
 	pixel_x = 17;
 	pixel_y = 12;
 	layer = 2
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1;
+	name = "combustion chamber fuel valve"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/hotloop)
@@ -67875,7 +67894,6 @@
 /turf/simulated/floor,
 /area/research_outpost)
 "pRE" = (
-/obj/machinery/atmospherics/binary/valve,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -67883,6 +67901,10 @@
 	pixel_y = 12;
 	pixel_x = 15;
 	layer = 2
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1;
+	name = "combustion chamber fuel valve"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/hotloop)
@@ -68044,6 +68066,13 @@
 	dir = 4
 	},
 /area/station/security/main)
+"pZD" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot purge valve"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "qak" = (
 /obj/table/wood/auto,
 /obj/machinery/firealarm/east,
@@ -68912,9 +68941,11 @@
 /turf/simulated/floor/plating/scorched,
 /area/station/maintenance/south)
 "qVF" = (
-/obj/machinery/atmospherics/binary/valve,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "mixing valve"
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/gas)
@@ -69739,7 +69770,7 @@
 "rFr" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop inlet valve"
+	name = "hot inlet valve"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/hotloop)
@@ -70548,7 +70579,7 @@
 "sxL" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "hot loop inlet valve"
+	name = "hot inlet valve"
 	},
 /turf/simulated/floor/caution/north{
 	dir = 8
@@ -71371,7 +71402,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "tni" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1;
+	name = "hot reserve tank valve"
+	},
 /turf/simulated/floor/red,
 /area/station/engine/hotloop)
 "tnE" = (
@@ -71729,14 +71763,10 @@
 /area/station/crew_quarters/pool)
 "tDZ" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4;
-	name = "hot loop auxillary west"
+	name = "combustion chamber inlet valve"
 	},
-/obj/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/hotloop)
 "tFj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -72225,6 +72255,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/customs)
+"ubD" = (
+/obj/machinery/atmospherics/binary/valve{
+	name = "combustion chamber outlet valve"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/hotloop)
 "ubH" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/yellow/side{
@@ -75056,6 +75092,13 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/maintenance/central)
+"xyh" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1;
+	name = "cold inlet valve"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/coldloop)
 "xyo" = (
 /obj/machinery/vending/cards,
 /turf/simulated/floor/carpet/arcade,
@@ -113462,7 +113505,7 @@ wat
 hVd
 bts
 bij
-mdZ
+pZD
 byV
 liE
 jmi
@@ -113471,7 +113514,7 @@ bGc
 gXp
 bGc
 bGc
-tDZ
+jmi
 liE
 bQp
 mdZ
@@ -115286,7 +115329,7 @@ sVT
 sju
 baQ
 bQv
-mdZ
+fRs
 bTE
 bVi
 bWK
@@ -115589,7 +115632,7 @@ bCy
 bPb
 bQu
 bRY
-aaN
+xyh
 bVj
 bWL
 bYf
@@ -115873,7 +115916,7 @@ biR
 bjJ
 blp
 bmH
-ehC
+ubD
 bpU
 brM
 btA
@@ -117081,7 +117124,7 @@ biS
 bjJ
 bmG
 bmH
-ehC
+tDZ
 bpX
 msj
 btE

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -31204,7 +31204,9 @@
 	name = "News Office Bathroom"
 	})
 "dcI" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "combustion chamber inlet valve"
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "ddx" = (
@@ -31380,7 +31382,8 @@
 /area/station/science/lab)
 "dkC" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "hot inlet valve"
 	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
@@ -32051,7 +32054,10 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	name = "hot reserve tank valve";
+	dir = 1;
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "dHl" = (
@@ -32631,6 +32637,13 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
+"dZq" = (
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot auxillary valve"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "dZr" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/south)
@@ -33580,9 +33593,12 @@
 /turf/simulated/floor,
 /area/station/mining/magnet)
 "eFf" = (
-/obj/machinery/atmospherics/binary/valve,
 /obj/cable{
 	icon_state = "2-9"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 2;
+	name = "cold reserve tank valve"
 	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
@@ -34823,9 +34839,12 @@
 /turf/simulated/floor/airless,
 /area/space)
 "fyt" = (
-/obj/machinery/atmospherics/binary/valve,
 /obj/cable{
 	icon_state = "4-10"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1;
+	name = "cold auxillary valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -35403,10 +35422,11 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "fWT" = (
+/obj/machinery/light,
 /obj/machinery/atmospherics/binary/valve{
+	name = "combustion chamber bypass valve";
 	dir = 4
 	},
-/obj/machinery/light,
 /turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
 "fXD" = (
@@ -38719,7 +38739,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "ivr" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 2;
+	name = "cold inlet valve"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -39298,11 +39321,14 @@
 /turf/simulated/floor/plating,
 /area/station/turret_protected/armory_outside)
 "iKX" = (
-/obj/machinery/atmospherics/binary/valve,
 /obj/decal/poster/wallsign/stencil/right/two{
 	layer = 2;
 	pixel_x = 17;
 	pixel_y = 12
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1;
+	name = "combustion chamber fuel valve"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/hotloop)
@@ -40133,13 +40159,14 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "jpe" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 1
-	},
 /obj/decal/poster/wallsign/stencil/right/one{
 	layer = 2;
 	pixel_x = 15;
 	pixel_y = 12
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 1;
+	name = "combustion chamber fuel valve"
 	},
 /turf/simulated/floor/caution/corner/se,
 /area/station/engine/hotloop)
@@ -41386,7 +41413,7 @@
 "knL" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
-	name = "Auxiliary Purge"
+	name = "auxiliary purge valve"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -42454,7 +42481,8 @@
 /area/station/routing/security)
 "kYW" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold inlet valve"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/engine/coldloop)
@@ -44549,7 +44577,8 @@
 /area/station/ai_monitored/armory)
 "mCG" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold inlet valve"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/coldloop)
@@ -47703,7 +47732,8 @@
 /area/station/routing/depot)
 "oVk" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	dir = 4;
+	name = "cold purge valve"
 	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
@@ -48338,11 +48368,12 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/research_outpost/indigo_rye)
 "ptW" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "6-10"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot inlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -49943,13 +49974,14 @@
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/crew_quarters/arcade/dungeon)
 "qzL" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot inlet valve"
 	},
 /turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
@@ -50276,9 +50308,11 @@
 /turf/simulated/floor/blue,
 /area/station/science/lab)
 "qNo" = (
-/obj/machinery/atmospherics/binary/valve,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	name = "combustion chamber outlet valve"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
@@ -50798,13 +50832,14 @@
 /turf/simulated/floor/airless/plating,
 /area/station/quartermaster/cargobay)
 "rhr" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "cold inlet valve"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -51942,10 +51977,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "rXe" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/machinery/light/emergency,
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot purge valve"
+	},
 /turf/simulated/floor/engine/caution/south,
 /area/station/engine/core)
 "rXn" = (
@@ -53906,7 +53942,8 @@
 /area/station/science/chemistry)
 "tuS" = (
 /obj/machinery/atmospherics/binary/valve{
-	dir = 4
+	name = "cold outlet valve";
+	dir = 8
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -55139,11 +55176,12 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
 "urm" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "cold reserve tank valve"
 	},
 /turf/simulated/floor/engine/caution/north,
 /area/station/engine/core)
@@ -105863,7 +105901,7 @@ auN
 wgj
 nLh
 ptW
-tuS
+dZq
 aBY
 iJY
 auL


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[STATION SYSTEMS] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes names for manual valves in the engine rooms of kondaru, cog1, cog2, and atlas to be the same across all of them and label what the valves actually do (e.g. inlet and outlet valves named explicitly).

Also removed loop from all the titles because its implied and some names could get a bit too long with it in there, so for parity they've all been removed.

oh god how did this take me almost a year to get around actually doing properly
third time's the charm this time i wont forget about this whole thing

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Accessibility through having valves describe what they are for allowing new players to learn how to set up an engine and have said skill be more easily transferable to other TEG layouts.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Knipje
(+)Centcom engineers have standardized TEG valve names.
```