### PR TITLE
Enables Sims Mode/Motives on Classic

### DIFF
--- a/code/datums/sims.dm
+++ b/code/datums/sims.dm
@@ -448,11 +448,7 @@
 	var/list/datum/simsHolder/simsHolders = list()
 	var/list/datum/simsMotive/simsMotives = list()
 
-#ifdef RP_MODE
 	var/provide_plumbobs = 0
-#else
-	var/provide_plumbobs = 1
-#endif
 
 	New()
 		..()

--- a/code/global.dm
+++ b/code/global.dm
@@ -399,11 +399,7 @@ var/global
 
 	literal_disarm = 0
 
-#ifdef RP_MODE
 	global_sims_mode = 1 // SET THIS TO 0 TO DISABLE SIMS MODE
-#else
-	global_sims_mode = 0 // SET THIS TO 0 TO DISABLE SIMS MODE
-#endif
 
 	narrator_mode = 0
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -191,11 +191,7 @@
 
 
 	if (global_sims_mode) // IF YOU ARE HERE TO DISABLE SIMS MODE, DO NOT TOUCH THIS. LOOK IN GLOBAL.DM
-#ifdef RP_MODE
 		sims = new /datum/simsHolder/rp(src)
-#else
-		sims = new /datum/simsHolder/human(src)
-#endif
 
 	health_mon = image('icons/effects/healthgoggles.dmi',src,"100",EFFECTS_LAYER_UNDER_4)
 	health_mon.appearance_flags = PIXEL_SCALE | RESET_ALPHA | RESET_COLOR | RESET_TRANSFORM | KEEP_APART

--- a/code/modules/admin/toggles.dm
+++ b/code/modules/admin/toggles.dm
@@ -1004,14 +1004,17 @@ client/proc/toggle_ghost_respawns()
 		if (ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if (global_sims_mode && !H.sims)
-#ifdef RP_MODE
-				H.sims = new /datum/simsHolder/rp(H)
-#else
-				H.sims = new /datum/simsHolder/human(H)
-#endif
+				switch(tgui_alert(usr, "What sims mode do you want to enable?", "Sims Mode", list("RP/Standard", "ALL THE SIMS")))
+					if("RP/Standard")
+						H.sims = new /datum/simsHolder/rp(H)
+						logTheThing(LOG_ADMIN, usr, "enabled Sims mode with RP/Standard motives.")
+					if("ALL THE SIMS")
+						H.sims = new /datum/simsHolder/human(H)
+						logTheThing(LOG_ADMIN, usr, "enabled Sims mode with ALL the motives.")
 			else if (!global_sims_mode && H.sims)
 				qdel(H.sims)
 				H.sims = null
+				logTheThing(LOG_ADMIN, usr, "disabled sims mode/motives.")
 
 /datum/admins/proc/toggle_pull_slowing()
 	SET_ADMIN_CAT(ADMIN_CAT_SERVER_TOGGLES)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Enables RP sims on classic. Also makes the admin "toggle sims mode" button a choice between RP/Standard sims and ALL the sims.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A few things lead into me wanting motives. 

1. Classic needs reasons to drink things. Bartender needs a reason to exist. Food also needs a reason to be eaten, and the (really strong) buffs you get from well made food just doesn't seem to be enough for players. 
2. Even if there isn't RP strictly required on classic, it gives a lot of interaction between the crew and the chef/bartender. Better player experience. 
3. It will give vending machines, and therefore money, more value. If there's not a chef, you NEED to find the vending machines to get food/drinks. 
4. Take a shower you stinker. I like hygiene because it forces players out of their department, even if just briefly. A geneticist in the middle of medbay is hard to kill silently for antags. A geneticist escaping their stench to take a shower is a much better target.
edit: apparently some nerd disabled hygiene on all servers. cowards. stinky cowards.


## Changelog 
```changelog
(u)Sord
(*)Enabled Sims mode/motives on classic
```
