### PR TITLE
Fixes chameleon project/bomb being unable to scan held items

### DIFF
--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -129,7 +129,9 @@ TYPEINFO(/obj/item/device/chameleon)
 			if (user && ismob(user))
 				user.show_text("You are too far away to do that.", "red")
 			return
-		if (target.plane == PLANE_HUD || isgrab(target)) //just don't scan hud stuff or grabs
+		if (isgrab(target)) //don't scan grabs
+			return
+		if (target.plane == PLANE_HUD && !isitem(target)) //don't grab hud stuff _unless_ it's an item. Grabs are the only exception I know
 			return
 		//Okay, enough scanning shit without actual icons yo.
 		if ((target.icon && target.icon_state || length(target.overlays) || length(target.underlays)) && isobj(target))
@@ -250,7 +252,9 @@ TYPEINFO(/obj/item/device/chameleon)
 			if (user && ismob(user))
 				user.show_text("You are too far away to do that.", "red")
 			return
-		if (target.plane == PLANE_HUD  || isgrab(target)) //just don't scan hud stuff and grabs
+		if (isgrab(target)) //don't scan grabs
+			return
+		if (target.plane == PLANE_HUD && !isitem(target)) //don't grab hud stuff _unless_ it's an item. Grabs are the only exception I know
 			return
 		if ((target.icon && target.icon_state || length(target.overlays) || length(target.underlays)) && (isitem(target) || istype(target, /obj/shrub) || istype(target, /obj/critter) || istype(target, /obj/machinery/bot))) // cogwerks - added more fun
 			playsound(src, 'sound/weapons/flash.ogg', 100, TRUE, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Chameleon scan items are forbidden from scanning anything on the PLANE_HUD. 

This correctly prevents scanning ability buttons and hud icons. However items held or in the inventory also sit on the PLANE_HUD, thus meaning that items can only be scanned when laid on the ground.

This PR tweaks the logic: only items on the PLANE_HUD can be scanned, with the exception of grab icons. This PR relies on the following bases to make sense:
- The only item on the PLANE_HUD that shouldnt be scanned is /obj/item/grab/.
- Every other item that could end up on the PLANE_HUD is ok to scan (subject to other checks).
- All scannable things that we can pick up will be /obj/items/.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #11708
