### PR TITLE
Fixes derringer drop location

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1641,7 +1641,7 @@
 							var/obj/item/gun/kinetic/derringer/D = (locate(/obj/item/gun/kinetic/derringer) in C)
 							var/drophand = (src.hand == RIGHT_HAND ? SLOT_R_HAND : SLOT_L_HAND)
 							drop_item()
-							D.set_loc(src)
+							D.set_loc(src.loc)
 							equip_if_possible(D, drophand)
 							src.visible_message(SPAN_ALERT("<B>[src] pulls a derringer out of \the [C]!</B>"))
 							playsound(src.loc, "rustle", 60, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a player emotes *wink, any derringer in items held on their person:
1) First has their location set to the player
then
2) Are force equipped to the currently selected hand (if possible).

However, if the force equip fails - say, due to an item arm - the derringer gets stuck _inside_ the person instead (talk about rolling a nat 1 on drawing a concealed weapon).

This PR sets the location in step 1) to the players location, not the player. We could instead add more checks for item arms etc. but simply dropping it on the floor feels like it'll catch more edgecases.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #12655

