### PR TITLE
Fixes chameleon projector breaking on exited()

### DIFF
--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -176,8 +176,8 @@ TYPEINFO(/obj/item/device/chameleon)
 			playsound(src, 'sound/effects/pop.ogg', 100, TRUE, 1)
 			cham.master = src
 			cham.set_loc(get_turf(src))
-			usr.set_loc(cham)
 			src.active = 1
+			usr.set_loc(cham)
 
 			boutput(usr, SPAN_NOTICE("You activate the [src]."))
 			anim.set_loc(get_turf(src))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] {GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The chameleon projector disrupts on drop: any time we are forced to drop the chameleon projector it should also deactivate.  We never want to end up in a situation where it's activated and we don't have it, as then we're stuck.

Currently, when we activate the projector it first moves us into the projector dimension _then_ registers as activated. Moving into the projector dimension can trigger exited(): on some objects this makes us drop our items via force laydown (such as the sleeper). Interrupting the activation sequence to drop the projector before it registers as activated means it can't subsequently deactivate when it disrupts on drop - we end up in a situation where it then gets activated and we don't have it.

This PR just makes sure it registers as activated before we can trigger exited() on anything.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #14969

