### PR TITLE
Fixes player vending machines registering MechComp signals

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -133,7 +133,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 	///The product currently being vended
 	var/datum/data/vending_product/currently_vending = null // zuh
 
-	var/mechcomp_compatible = TRUE
+	var/mechcomp_compatible = TRUE //Can this vending machine take mechcomp inputs?
 
 	power_usage = 50
 
@@ -2093,7 +2093,7 @@ TYPEINFO(/obj/item/machineboard/vending/monkeys)
 	player_list = list()
 	var/lastPlayerPrice = 0
 	icon_panel = "standard-panel"
-	var/mechcomp_compatible = FALSE
+	mechcomp_compatible = FALSE //Player vending machines can't take mechcomp inputs
 
 	New()
 		. = ..()

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -133,6 +133,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 	///The product currently being vended
 	var/datum/data/vending_product/currently_vending = null // zuh
 
+	var/mechcomp_compatible = TRUE
+
 	power_usage = 50
 
 	New()
@@ -146,7 +148,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 
 		AddComponent(/datum/component/mechanics_holder)
 		AddComponent(/datum/component/bullet_holes, 8, 5)
-		if (!istype(src,/obj/machinery/vending/player))
+		if (mechcomp_compatible)
 			SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Vend Random", PROC_REF(vendinput))
 			SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Vend by Name", PROC_REF(vendname))
 		light = new /datum/light/point
@@ -2091,6 +2093,7 @@ TYPEINFO(/obj/item/machineboard/vending/monkeys)
 	player_list = list()
 	var/lastPlayerPrice = 0
 	icon_panel = "standard-panel"
+	var/mechcomp_compatible = FALSE
 
 	New()
 		. = ..()

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -133,7 +133,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 	///The product currently being vended
 	var/datum/data/vending_product/currently_vending = null // zuh
 
-	var/mechcomp_compatible = TRUE //Can this vending machine take mechcomp inputs?
+	var/uses_mechcomp = TRUE //Can this vending machine take mechcomp inputs?
 
 	power_usage = 50
 
@@ -148,7 +148,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 
 		AddComponent(/datum/component/mechanics_holder)
 		AddComponent(/datum/component/bullet_holes, 8, 5)
-		if (mechcomp_compatible)
+		if (uses_mechcomp)
 			SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Vend Random", PROC_REF(vendinput))
 			SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Vend by Name", PROC_REF(vendname))
 		light = new /datum/light/point
@@ -2093,7 +2093,7 @@ TYPEINFO(/obj/item/machineboard/vending/monkeys)
 	player_list = list()
 	var/lastPlayerPrice = 0
 	icon_panel = "standard-panel"
-	mechcomp_compatible = FALSE //Player vending machines can't take mechcomp inputs
+	uses_mechcomp = FALSE //Player vending machines can't take mechcomp inputs
 
 	New()
 		. = ..()

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -146,8 +146,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 
 		AddComponent(/datum/component/mechanics_holder)
 		AddComponent(/datum/component/bullet_holes, 8, 5)
-		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Vend Random", PROC_REF(vendinput))
-		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Vend by Name", PROC_REF(vendname))
+		if (!istype(src,/obj/machinery/vending/player))
+			SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Vend Random", PROC_REF(vendinput))
+			SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Vend by Name", PROC_REF(vendname))
 		light = new /datum/light/point
 		light.attach(src)
 		light.set_brightness(0.6)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Player vending machines, like all vending machines, are registered for the "Vend Random" and "Vend by Name" signals. These signals use procs that interact with the vending machines product_list. 

However, player vending machines store their inventory in player_list not product_list: player vending machines can receive mechcomp signals but nothing will actually happen if they're triggered (as their product_list is always empty). 

This PR makes it so player vending machines aren't registered for the two MechComp signals.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #20362
