### PR TITLE
Fixes Bombini is Missing medal capitalisation

### DIFF
--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -1128,7 +1128,7 @@ ABSTRACT_TYPE(/obj/npc/trader/robot/robuddy)
 		if (istype(W, /obj/item/coin/bombini))
 			for(var/mob/M in AIviewers(src))
 				boutput(M, "<B>[src.name]</B> buzzes excitedly! \"BZZ?? BZZ!!\"")
-				M.unlock_medal("Bombini is missing!", 1)
+				M.unlock_medal("Bombini is Missing!", 1)
 				M.add_karma(15) // This line originally tried to give the karma to Bombini. Definitely a bug but I like to imagine that she just managed to pickpocket your karma or something.
 			user.u_equip(W)
 			qdel(W)

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -1412,7 +1412,7 @@
 /datum/achievementReward/beefriend
 	title = "(Reagent) Bee"
 	desc = "You're gonna burp one up, probably."
-	required_medal = "Bombini is missing!"
+	required_medal = "Bombini is Missing!"
 
 	rewardActivate(var/mob/activator)
 		if (!activator.reagents) return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
With the move from BYOND to Goonhub medals are now case sensitive. 

The "Bombini is Missing" reward string has capitilisation inconsistent with that on GoonHub. Accordingly, the medal is currently unearnable.

This PR gives the medal name capitalisation consistent with the Goonhub website.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #20132
