### PR TITLE
Meters now report the moles of gases.

### DIFF
--- a/code/obj/machinery/meter.dm
+++ b/code/obj/machinery/meter.dm
@@ -65,8 +65,11 @@
 		signal.data["pressure"] = round(env_pressure)
 
 		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, signal)
-
-	SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "pressure=[env_pressure]&temperature=[environment.temperature]")
+	var/list/signal = list("pressure=[env_pressure]&temperature=[environment.temperature]")
+	#define COMPILE_GAS_MOLES(GAS, ...) if(environment.GAS) {signal += "&[#GAS]=[environment.GAS]"}
+	APPLY_TO_GASES(COMPILE_GAS_MOLES)
+	#undef COMPILE_GAS_MOLES
+	SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, signal.Join())
 
 
 /obj/machinery/meter/get_desc(dist, mob/user)


### PR DESCRIPTION
[ATMOSPHERICS][FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The meter can now report gas moles.
![image](https://github.com/user-attachments/assets/310d8638-8cb2-43f7-8d3e-c871fd2a0db4)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lets more atmos shenanigans happen.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)cringe
(+)Meters now report the moles of gases that currently exist in their pipeline through MechComp.
```