### PR TITLE
Correctly override PDA assignment for respawn gang members

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2860,9 +2860,14 @@ ABSTRACT_TYPE(/datum/job/special/pod_wars)
 
 	special_setup(var/mob/living/carbon/human/M)
 		..()
-		var/obj/item/card/id/C = M.get_slot(SLOT_WEAR_ID)
-		C.assignment = "Staff Assistant"
-		C.name = "[C.registered]'s ID Card ([C.assignment])"
+		SPAWN(0)
+			var/obj/item/card/id/C = M.get_slot(SLOT_WEAR_ID)
+			C.assignment = "Staff Assistant"
+			C.name = "[C.registered]'s ID Card ([C.assignment])"
+
+			var/obj/item/device/pda2/pda = locate() in M
+			pda.assignment = "Staff Assistant"
+			pda.ownerAssignment = "Staff Assistant"
 
 /datum/job/special/pathologist
 	name = "Pathologist"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][respawn]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The job name "Gang Respawn" is use as assignment/ownerAssignment on the PDA during job setup. This sets the assignment fields akin to the existing ID assignment override. 

During local testing, the spawn was required to allow for both the ID and PDA to be found during `special_setup`.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #20482
