### PR TITLE
Remove sims motives from virtual characters

### DIFF
--- a/code/mob/living/carbon/human/virtual.dm
+++ b/code/mob/living/carbon/human/virtual.dm
@@ -15,6 +15,7 @@
 		src.bioHolder.mobAppearance.fartsound = "virtual"
 		sound_snap = 'sound/voice/virtual_snap.ogg'
 		sound_fingersnap = 'sound/voice/virtual_snap.ogg'
+		src.sims = null
 		SPAWN(0)
 			src.set_mutantrace(/datum/mutantrace/virtual)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][rp]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Nullify the sims motive holder when creating virtual human characters

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #20462