### PR TITLE
Check if our antag's job is "MODE" before putting it in printout

### DIFF
--- a/code/datums/intercept_text.dm
+++ b/code/datums/intercept_text.dm
@@ -96,7 +96,7 @@
 	var/prob_right_dude = rand(prob_correct_person_lower, prob_correct_person_higher)
 	var/prob_right_job = rand(prob_correct_job_lower, prob_correct_job_higher)
 	if(prob(prob_right_job))
-		if (correct_mob)
+		if (correct_mob && correct_mob:assigned_role != "MODE")
 			traitor_job = correct_mob:assigned_role
 	else
 		var/list/job_tmp = get_all_jobs()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Checks if our correct_mob's assigned_role is "MODE" before putting it in the printout, as MODE jobs could appear in the case we chose to roll the correct mob and job for our rev printout


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #20473

