### PR TITLE
Fixes Floor Planner clicks triggering the Mass Drivers

### DIFF
--- a/code/obj/machinery/launcherloader.dm
+++ b/code/obj/machinery/launcherloader.dm
@@ -89,7 +89,7 @@
 
 	Crossed(atom/movable/A)
 		..()
-		if (istype(A, /mob/dead) || isintangible(A) || iswraith(A) || isflockmob(A)) return
+		if (istype(A, /mob/dead) || A.anchored || isintangible(A) || iswraith(A) || isflockmob(A)) return
 		return_if_overlay_or_effect(A)
 		activate()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The floor planner works by placing invisible construction objects. These objects are anchored, but can trigger Crossed().

When an atom crosses onto the mass-driver loader the code doesn't think to check for anchored objects before firing, perhaps because there's no good reason why an anchored object would be roaming around triggering Crossed() on things.

This PR adds a check for anchored before triggering the mass driver loader. Note that the process loop already checks for anchored object before firing, and we can't move anchored objects (like mag boot spacemen) anyway.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #14627
