### PR TITLE
Delete unused reagent cure for cluwne dyspraxia

### DIFF
--- a/code/modules/medical/disabilities/clumsy.dm
+++ b/code/modules/medical/disabilities/clumsy.dm
@@ -5,8 +5,7 @@
 	affected_species = list("Human")
 	cluwne
 		cure_flags = CURE_CUSTOM
-		cure_desc = "Decursing"
-		reagentcure = list("water_holy")
+		cure_desc = "Decursing" // Bible
 
 /datum/ailment/disability/clumsy/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)
 	if (..())


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Code currently suggests holy water is a cure for dyspraxia; it's not, as disabilities can't be cured via reagents.

This PR deletes a line of code that suggests otherwise. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #14837
