### PR TITLE
Lets items/mobs be placed on trays directly

### DIFF
--- a/code/obj/machinery/traymachines.dm
+++ b/code/obj/machinery/traymachines.dm
@@ -276,6 +276,14 @@ ABSTRACT_TYPE(/obj/machine_tray)
 /obj/machine_tray/attack_ai(mob/user as mob)
 	attack_hand(user)
 
+/obj/machine_tray/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/grab))
+		var/obj/item/grab/G = I
+		G.affecting.set_loc(src.loc)
+		qdel(I)
+	else
+		src.place_on(I, user)
+
 /obj/machine_tray/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
 	if (!(isobj(O) || ismob(O)) || O.anchored || BOUNDS_DIST(user, src) > 0 || BOUNDS_DIST(user, O) > 0 || user.contents.Find(O))
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes `machine_tray` objects so that using items and grabs on the tray with `attackby()` places them on it instead of attempting to smack the tray.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

For years, I kept having issues trying to place things into the morgue and crematorium trays. I think this new behavior should make it more intuitive.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)Items and grabbed mobs can now be placed in tray machines (like the morgue) directly.
```
