### PR TITLE
Fixes a typo in microbomb code

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -701,7 +701,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 	/// You probably want to call this parent after exploding or whatever
 	proc/do_effect(power)
 		SHOULD_CALL_PARENT(TRUE)
-		if (. >= 6)
+		if (power >= 6)
 			src.owner.visible_message(SPAN_ALERT("<b>[src.owner][big_message]!</b>"))
 		else
 			src.owner.visible_message("[src.owner][small_message].")
@@ -737,7 +737,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 
 		SPAWN(1)
 			T.hotspot_expose(800,125)
-			explosion_new(src, T, 7 * power, 1) //The . is the tally of explosionPower in this poor slob.
+			explosion_new(src, T, 7 * power, 1) //power is the tally of explosionPower in this poor slob.
 			if (ishuman(src.owner))
 				var/mob/living/carbon/human/H = src.owner
 				H.dump_contents_chance = 80 //hee hee


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
At some point microbomb code got refactored to use 'power' instead of '.' in do_effect().

A line got missed in the refactor; stepping through shows '.' remains null whilst do_effect() is called.

This PR fixes that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Typo.