### PR TITLE
Fixes typo in syndicate drone AI

### DIFF
--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -178,7 +178,7 @@ TYPEINFO(/obj/critter/gunbot/drone/helldrone)
 					var/obj/machinery/vehicle/C = atom
 					if (C.health < 0)
 						continue
-					if (!(C.faction & FACTION_SYNDICATE))
+					if (!(C.faction && FACTION_SYNDICATE))
 						src.attack = 1
 					if (C.name == src.attacker)
 						src.attack = 1

--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -178,7 +178,7 @@ TYPEINFO(/obj/critter/gunbot/drone/helldrone)
 					var/obj/machinery/vehicle/C = atom
 					if (C.health < 0)
 						continue
-					if (!(C.faction && FACTION_SYNDICATE))
+					if (!(C.faction == FACTION_SYNDICATE))
 						src.attack = 1
 					if (C.name == src.attacker)
 						src.attack = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
~Horseman AI has a '&' that should be a '&&' in its logic so the code runtimes when it attempts to target a vehicle.~

Syndicate drone AI has a '&' that should be a '==' in its logic so the code runtimes when it attempts to target a vehicle; at some point the FACTIONS were presumably bitflags.

This PR fixes that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Typo
