### PR TITLE
Fixes implants not transferring to hotdog meatcubes

### DIFF
--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -843,8 +843,8 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close)
 				for (var/obj/item/I in M)
 					if (istype(I, /obj/item/implant))
 						I.set_loc(meatcube)
-
-					I.set_loc(src)
+					else
+						I.set_loc(src)
 
 			src.locked = FALSE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a victim is tossed in a syndicate hotdog cart, any implants within the victim are supposed to transfer to the meatcube the victim becomes.

Due to error in the logic, the implants are transferred then immediately transferred back,

This PR fixes the logic such that the meatcubes are spawned with their implants intact.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #14680
