### PR TITLE
Block arcfiend from using abilities when inside of things

### DIFF
--- a/code/modules/antagonists/arcfiend/abilities/flash.dm
+++ b/code/modules/antagonists/arcfiend/abilities/flash.dm
@@ -5,8 +5,6 @@
 	icon_state = "flash"
 	cooldown = 10 SECONDS
 	pointCost = 25
-	container_safety_bypass = TRUE
-
 
 	cast(atom/target)
 		. = ..()

--- a/code/modules/antagonists/arcfiend/abilities/jamming_field.dm
+++ b/code/modules/antagonists/arcfiend/abilities/jamming_field.dm
@@ -5,7 +5,6 @@
 	icon_state = "jamming_field"
 	cooldown = 2 MINUTES
 	pointCost = 150
-	container_safety_bypass = TRUE
 	var/duration = 30 SECONDS
 
 	cast(atom/target)

--- a/code/modules/antagonists/arcfiend/abilities/polarize.dm
+++ b/code/modules/antagonists/arcfiend/abilities/polarize.dm
@@ -5,7 +5,6 @@
 	icon_state = "polarize"
 	cooldown = 12 SECONDS
 	pointCost = 50
-	container_safety_bypass = TRUE
 	var/range = 4
 	var/duration = 20 SECONDS
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Prevents what few arcfiend abilities that could be used from inside of things from doing so


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Force arcfiend to expose self rather than attacking from within a wire
* Prevent arcfiend from spamming abilities inside of the portabrig


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sovexe
(*)Arcfiends can no longer use Flash, Polarize, or Jamming Field from inside of lockers, wires, etc.
```
