### PR TITLE
Give Departmental announcement computers special titles

### DIFF
--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -226,26 +226,33 @@
 	security
 		req_access = list(access_maxsec)
 		name = "Security Announcement Computer"
+		area_name = "Security"
 
 	research
 		req_access = list(access_research_director)
 		name = "Research Announcement Computer"
+		area_name = "Research"
 
 	medical
 		req_access = list(access_medical_director)
 		name = "Medical Announcement Computer"
+		area_name = "Medical"
 
 	engineering
 		req_access = list(access_engineering_chief)
 		name = "Engineering Announcement Computer"
-
-	cargo
-		req_access = list(access_cargo)
-		name = "QM Announcement Computer"
+		area_name = "Engineering"
 
 	ai
 		req_access = list(access_ai_upload)
 		name = "AI Announcement Computer"
+
+	cargo
+		req_access = list(access_cargo)
+		name = "QM Announcement Computer"
+		area_name = "Cargo"
+		sound_to_play = 'sound/misc/bingbong.ogg'
+		sound_volume = 70
 
 	catering
 		req_access = list(access_bar, access_kitchen)
@@ -266,9 +273,11 @@
 	name = "Syndicate Announcement computer"
 	theme = "syndicate"
 	icon_state = "announcementsyndie"
+	area_name = "Syndicate"
 	req_access = list(access_syndicate_shuttle)
 
 	commander
+		area_name = null
 		req_access = list(access_syndicate_commander)
 
 	console


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives department announcement computers special names 

Also gives the cargo announcement the catering sound because they arent command as much as they think they are

Also the syndicate announcement computer is now from the "Syndicate" rather than the "Listening Post" (Cairngorm still comes from cairngorm)

Also adds a circuitboard to the bridge announcement computer which I missed in the PR which added them to the rest

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Simplify reading it as command office names are long and can make just where the announcement is coming from take up a large portion of chat.

The syndicate probably shouldn't be announcing they have a listening post spying on the station


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Departmental announcements now have a set sender and the syndicate stopped announcing they are spying on you. 
```
