### PR TITLE
Fix Medical Assistant getting their belt overriden

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -732,9 +732,9 @@ ABSTRACT_TYPE(/datum/job/research)
 	slot_belt = list(/obj/item/storage/belt/medical/prepared)
 	slot_foot = list(/obj/item/clothing/shoes/red)
 	slot_ears = list(/obj/item/device/radio/headset/medical)
+	slot_poc1 = list(/obj/item/device/pda2/medical)
 	slot_poc2 = list(/obj/item/paper/book/from_file/pocketguide/medical)
 	slot_jump = list(/obj/item/clothing/under/scrub = 30,/obj/item/clothing/under/scrub/teal = 14,/obj/item/clothing/under/scrub/blue = 14,/obj/item/clothing/under/scrub/purple = 14,/obj/item/clothing/under/scrub/orange = 14,/obj/item/clothing/under/scrub/pink = 14)
-	slot_belt = list(/obj/item/device/pda2/medical)
 	wiki_link = "https://wiki.ss13.co/Medical_Assistant"
 
 // Engineering Jobs


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the PDA on MedAss to `slot_poc1 = list(/obj/item/device/pda2/medical)`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug bad, belt good