### PR TITLE
Fix #20550 - Graffiti specials

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1306,6 +1306,8 @@ proc/broadcast_to_all_gangs(var/message)
 		src.gang.make_tag(target_turf)
 		spraycan.empty = TRUE
 		spraycan.icon_state = "spraycan_crushed_gang"
+		spraycan.setItemSpecial(/datum/item_special/simple)
+		spraycan.tooltip_rebuild = 1
 		gang.add_points(round(100), M, showText = TRUE)
 		if(sprayOver)
 			logTheThing(LOG_GAMEMODE, owner, "[owner] has successfully tagged the [target_area], spraying over another tag.")
@@ -1450,6 +1452,8 @@ proc/broadcast_to_all_gangs(var/message)
 			boutput(M, SPAN_ALERT("The graffiti can's empty!"))
 			playsound(M.loc, "sound/items/can_crush-[rand(1,3)].ogg", 50, 1)
 			spraycan.icon_state = "spraycan_crushed"
+			spraycan.setItemSpecial(/datum/item_special/simple)
+			spraycan.tooltip_rebuild = 1
 
 
 /obj/ganglocker


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

graffiti specials still sprayed graffiti when you ran out - #20550 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

probably better gone, so people don't scavenge empty paint cans to annoy sec/gangs with