### PR TITLE
Prevents appendicitis from being asymptomatic

### DIFF
--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -23,6 +23,7 @@
 	var/detectability = 0				// detectors must >= this to pick up the disease
 	var/resistance_prob = 0				// how likely this disease is to grant immunity once cured
 	var/max_stacks = 1					// how many times at once you can have this ailment
+	var/can_be_asymptomatic = TRUE
 
 	///If we need a specific ailment_data type
 	var/datum/ailment_data/strain_type = /datum/ailment_data
@@ -90,7 +91,7 @@
 
 	setup_strain()
 		var/datum/ailment_data/disease/strain = ..()
-		if (prob(5))
+		if (prob(5) && src.can_be_asymptomatic)
 			strain.state = "Asymptomatic"
 			// carrier - will spread it but won't suffer from it
 		strain.virulence = src.virulence

--- a/code/modules/medical/diseases/organ_diseases/appendicitis.dm
+++ b/code/modules/medical/diseases/organ_diseases/appendicitis.dm
@@ -10,6 +10,10 @@
 	stage_prob = 1
 	var/robo_restart = 0
 
+/datum/ailment/disease/appendicitis/setup_strain() //no more asymptomatic appendicitis
+	var/datum/ailment_data/disease/strain = ..()
+	return strain
+
 /datum/ailment/disease/appendicitis/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)
 	if (..())
 		return

--- a/code/modules/medical/diseases/organ_diseases/appendicitis.dm
+++ b/code/modules/medical/diseases/organ_diseases/appendicitis.dm
@@ -8,11 +8,8 @@
 	recureprob = 10
 	affected_species = list("Human")
 	stage_prob = 1
+	can_be_asymptomatic = FALSE
 	var/robo_restart = 0
-
-/datum/ailment/disease/appendicitis/setup_strain() //no more asymptomatic appendicitis
-	var/datum/ailment_data/disease/strain = ..()
-	return strain
 
 /datum/ailment/disease/appendicitis/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)
 	if (..())


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Appendicitis checks for a(n) (robo)appendix in stage_act, curing itself if it does not find one.

If the disease is asymptomatic however, we never run disease/appendicitis/stage_act() as we early return out of disease/stage_act(). Thus, removing the appendix will not cure the appendicitis.

This PR adds an override that ensures we never roll asymptomatic appendicitis.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #20511
No balance tag as asymptomatic appendicitis doesn't actually do anything than show up on scans. 