### PR TITLE
Makes bald and hairy traits mutually exclusive

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -25,6 +25,7 @@
 		"cloner_stuff",
 		"hemophilia",
 		"nohair",
+		"nowig",
 	)
 
 	var/list/traitData = list()
@@ -637,7 +638,7 @@
 	id = "bald"
 	icon_state = "bald"
 	points = 0
-	category = list("trinkets", "nopug")
+	category = list("trinkets", "nopug","nowig")
 
 
 // Skill - White Border
@@ -1332,7 +1333,7 @@ TYPEINFO(/datum/trait/partyanimal)
 	desc = "You will grow hair even if you usually would not (due to being a lizard or something)."
 	id = "mutant_hair"
 	points = 0
-	category = list("body", "nohair")
+	category = list("body", "nohair","nowig")
 	icon_state = "hair"
 
 	onAdd(mob/owner)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the bald+hairy wig bug, where the resulting hair combo has a broken saturation by introducing the "nowig" hidden category
[INTERNAL][BUG]

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It makes no sense to take bald and hairy at the same time, and it leads to issues

