### PR TITLE
Vampire blood tracking

### DIFF
--- a/code/datums/components/tracker_hud.dm
+++ b/code/datums/components/tracker_hud.dm
@@ -100,3 +100,6 @@
 
 /datum/component/tracker_hud/gang
 	color = "#5a6edd"
+
+/datum/component/tracker_hud/vampire
+	color = "#ff0000ff"

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -2337,6 +2337,15 @@
 				SPAN_NOTICE("You barely slow [src == helper ? "your" : "[src]'s"] bleeding!"),\
 				SPAN_NOTICE("[helper == src ? "You stop" : "<b>[helper]</b> stops"] your bleeding with little success!"))
 
+///helper proc to return a new bioholder to be used for blood reagent data
+/mob/living/proc/get_blood_bioholder()
+	var/datum/bioHolder/bloodHolder = new/datum/bioHolder(null)
+	bloodHolder.CopyOther(src.bioHolder)
+	bloodHolder.ownerName = src.real_name
+	bloodHolder.ownerType = src.type
+	bloodHolder.owner = src
+	return bloodHolder
+
 /mob/living/proc/meson(atom/source)
 	if (!source)
 		CRASH("meson proc called without a source!!")

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -2339,11 +2339,11 @@
 
 ///helper proc to return a new bioholder to be used for blood reagent data
 /mob/living/proc/get_blood_bioholder()
-	var/datum/bioHolder/bloodHolder = new/datum/bioHolder(null)
+	var/datum/bioHolder/unlinked/bloodHolder = new/datum/bioHolder/unlinked(null)
 	bloodHolder.CopyOther(src.bioHolder)
 	bloodHolder.ownerName = src.real_name
 	bloodHolder.ownerType = src.type
-	bloodHolder.owner = src
+	bloodHolder.weak_owner = get_weakref(src)
 	return bloodHolder
 
 /mob/living/proc/meson(atom/source)

--- a/code/modules/antagonists/vampire/abilities/_vampire_ability_holder.dm
+++ b/code/modules/antagonists/vampire/abilities/_vampire_ability_holder.dm
@@ -141,7 +141,10 @@
 
 	proc/change_vampire_blood(var/change = 0, var/total_blood = 0, var/set_null = FALSE, var/mob/victim = null)
 		if (victim)
-			src.last_victim = victim
+			if (src.last_victim != victim)
+				src.last_victim = victim
+				var/datum/targetable/vampire/blood_tracking/tracker = src.getAbility(/datum/targetable/vampire/blood_tracking)
+				tracker.update_target(victim)
 		if (total_blood)
 			if (src.vamp_blood < 0)
 				src.vamp_blood = 0

--- a/code/modules/antagonists/vampire/abilities/_vampire_ability_holder.dm
+++ b/code/modules/antagonists/vampire/abilities/_vampire_ability_holder.dm
@@ -69,8 +69,9 @@
 	notEnoughPointsMessage = SPAN_ALERT("You need more blood to use this ability.")
 	var/vamp_blood = 0
 	points = 0 // Replaces the old vamp_blood_remaining var.
-	var/vamp_blood_tracking = 1
 	var/mob/vamp_isbiting = null
+	///For blood tracking
+	var/mob/last_victim = null
 #ifdef BONUS_POINTS
 	vamp_blood = 99999
 	points = 99999
@@ -138,26 +139,22 @@
 			//var/obj/storage/closet/coffin/C = newloc
 			the_coffin = null
 
-	proc/change_vampire_blood(var/change = 0, var/total_blood = 0, var/set_null = 0)
+	proc/change_vampire_blood(var/change = 0, var/total_blood = 0, var/mob/victim = null)
+		if (victim)
+			src.last_victim = victim
 		if (total_blood)
 			if (src.vamp_blood < 0)
 				src.vamp_blood = 0
 				if (haine_blood_debug) logTheThing(LOG_DEBUG, owner, "<b>HAINE BLOOD DEBUG:</b> [owner]'s vamp_blood dropped below 0 and was reset to 0")
 
-			if (set_null)
-				src.vamp_blood = 0
-			else
-				src.vamp_blood = max(src.vamp_blood + change, 0)
+			src.vamp_blood = max(src.vamp_blood + change, 0)
 
 		else
 			if (src.points < 0)
 				src.points = 0
 				if (haine_blood_debug) logTheThing(LOG_DEBUG, owner, "<b>HAINE BLOOD DEBUG:</b> [owner]'s vamp_blood_remaining dropped below 0 and was reset to 0")
 
-			if (set_null)
-				src.points = 0
-			else
-				src.points = max(src.points + change, 0)
+			src.points = max(src.points + change, 0)
 
 			if (change > 0 && ishuman(src.owner))
 				var/mob/living/carbon/human/H = src.owner
@@ -170,24 +167,6 @@
 			return src.vamp_blood
 		else
 			return src.points
-
-	proc/blood_tracking_output(var/deduct = 0)
-		if (!src.owner || !ismob(src.owner))
-			return
-
-		if (!istype(src, /datum/abilityHolder/vampire))
-			return
-
-		if (!src.vamp_blood_tracking)
-			return
-
-		if (deduct > 1)
-			boutput(src.owner, SPAN_NOTICE("You used [deduct] units of blood, and have [src.points - deduct] remaining."))
-
-		else
-			boutput(src.owner, SPAN_NOTICE("You have accumulated [src.vamp_blood] units of blood and [src.points] left to use."))
-
-		return
 
 	proc/check_for_unlocks()
 		if (!src.owner || !ismob(src.owner))

--- a/code/modules/antagonists/vampire/abilities/_vampire_ability_holder.dm
+++ b/code/modules/antagonists/vampire/abilities/_vampire_ability_holder.dm
@@ -14,13 +14,13 @@
 	else
 		return 0
 
-/mob/proc/change_vampire_blood(var/change = 0, var/total_blood = 0, var/set_null = 0)
+/mob/proc/change_vampire_blood(var/change = 0, var/total_blood = 0, var/set_null = 0, var/mob/victim = null)
 	if (!isvampire(src) && !isvampiricthrall(src))
 		return
 
 	var/datum/abilityHolder/vampire/AH = src.get_ability_holder(/datum/abilityHolder/vampire)
 	if (AH && istype(AH))
-		AH.change_vampire_blood(change, total_blood, set_null)
+		AH.change_vampire_blood(change, total_blood, set_null, victim)
 	else
 		var/datum/abilityHolder/vampiric_thrall/AHZ = src.get_ability_holder(/datum/abilityHolder/vampiric_thrall)
 		if(AHZ && istype(AHZ) && !total_blood)
@@ -139,7 +139,7 @@
 			//var/obj/storage/closet/coffin/C = newloc
 			the_coffin = null
 
-	proc/change_vampire_blood(var/change = 0, var/total_blood = 0, var/mob/victim = null)
+	proc/change_vampire_blood(var/change = 0, var/total_blood = 0, var/set_null = FALSE, var/mob/victim = null)
 		if (victim)
 			src.last_victim = victim
 		if (total_blood)
@@ -147,14 +147,20 @@
 				src.vamp_blood = 0
 				if (haine_blood_debug) logTheThing(LOG_DEBUG, owner, "<b>HAINE BLOOD DEBUG:</b> [owner]'s vamp_blood dropped below 0 and was reset to 0")
 
-			src.vamp_blood = max(src.vamp_blood + change, 0)
+			if (set_null)
+				src.vamp_blood = 0
+			else
+				src.vamp_blood = max(src.vamp_blood + change, 0)
 
 		else
 			if (src.points < 0)
 				src.points = 0
 				if (haine_blood_debug) logTheThing(LOG_DEBUG, owner, "<b>HAINE BLOOD DEBUG:</b> [owner]'s vamp_blood_remaining dropped below 0 and was reset to 0")
 
-			src.points = max(src.points + change, 0)
+			if (set_null)
+				src.points = 0
+			else
+				src.points = max(src.points + change, 0)
 
 			if (change > 0 && ishuman(src.owner))
 				var/mob/living/carbon/human/H = src.owner

--- a/code/modules/antagonists/vampire/abilities/blood_tracking.dm
+++ b/code/modules/antagonists/vampire/abilities/blood_tracking.dm
@@ -1,6 +1,6 @@
 /datum/targetable/vampire/blood_tracking
 	name = "Toggle blood tracking"
-	desc = "Toggles blood gain/loss messages."
+	desc = "Toggles tracking the blood of the last victim you drank from."
 	icon_state = "bloodtrack"
 	targeted = 0
 	target_nodamage_check = 0
@@ -14,26 +14,24 @@
 	ignore_holder_lock = 1
 	do_logs = FALSE
 	interrupt_action_bars = FALSE
+	var/active = FALSE
 
 	cast(mob/target)
-		if (!holder)
-			return 1
-
-		var/mob/living/M = holder.owner
-		var/datum/abilityHolder/vampire/H = holder
-
-		if (!M)
-			return 1
-
-		if (ismobcritter(M) && !istype(H))
-			boutput(M, SPAN_ALERT("Critter mobs currently don't have to worry about blood. Lucky you."))
+		if (!src.holder?.owner)
 			return 1
 
 		. = ..()
-		if (H.vamp_blood_tracking == 1)
-			H.vamp_blood_tracking = 0
-		else
-			H.vamp_blood_tracking = 1
 
-		boutput(M, SPAN_NOTICE("Blood tracking turned [H.vamp_blood_tracking == 1 ? "on" : "off"]."))
-		return 0
+		var/datum/abilityHolder/vampire/vamp_holder = src.holder
+		if (!src.active)
+			if (!vamp_holder.last_victim)
+				boutput(src.holder.owner, SPAN_ALERT("You have yet to drink the blood of an innocent."))
+				return
+			src.holder.owner.AddComponent(/datum/component/tracker_hud/vampire, vamp_holder.last_victim)
+			boutput(src.holder.owner, SPAN_ALERT("You start tracking the blood of your latest victim."))
+			src.active = TRUE
+		else
+			src.holder.owner.RemoveComponentsOfType(/datum/component/tracker_hud/vampire)
+			boutput(src.holder.owner, SPAN_ALERT("You suppress your bloodlust. For now."))
+			src.active = FALSE
+

--- a/code/modules/antagonists/vampire/abilities/blood_tracking.dm
+++ b/code/modules/antagonists/vampire/abilities/blood_tracking.dm
@@ -39,3 +39,8 @@
 			boutput(src.holder.owner, SPAN_ALERT("You suppress your bloodlust. For now."))
 			src.active = FALSE
 
+	proc/update_target(mob/target)
+		if (!active)
+			return
+		var/datum/component/tracker_hud/vampire/tracker = src.holder.owner.GetComponent(/datum/component/tracker_hud/vampire)
+		tracker.target = target

--- a/code/modules/antagonists/vampire/abilities/blood_tracking.dm
+++ b/code/modules/antagonists/vampire/abilities/blood_tracking.dm
@@ -21,8 +21,12 @@
 			return 1
 
 		. = ..()
-
 		var/datum/abilityHolder/vampire/vamp_holder = src.holder
+		if (vamp_holder.last_victim && QDELETED(vamp_holder.last_victim))
+			boutput(src.holder.owner, SPAN_ALERT("Your victim has left this plane."))
+			vamp_holder.last_victim = null
+			src.active = FALSE
+			return
 		if (!src.active)
 			if (!vamp_holder.last_victim)
 				boutput(src.holder.owner, SPAN_ALERT("You have yet to drink the blood of an innocent."))

--- a/code/modules/antagonists/vampire/abilities/call_bats.dm
+++ b/code/modules/antagonists/vampire/abilities/call_bats.dm
@@ -59,9 +59,6 @@
 			boutput(M, SPAN_ALERT("The bats did not respond to your call!"))
 			return 1 // No cooldown here, though.
 
-		if (src.pointCost && istype(H))
-			H.blood_tracking_output(src.pointCost)
-
 		playsound(M.loc, 'sound/effects/gust.ogg', 60, 1)
 
 		logTheThing(LOG_COMBAT, M, "uses call bats at [log_loc(M)].")
@@ -88,7 +85,6 @@
 			return 1
 
 		var/mob/living/M = holder.owner
-		var/datum/abilityHolder/vampire/H = holder
 
 		if (!M)
 			return 1
@@ -96,7 +92,6 @@
 		if (M.wear_mask && istype(M.wear_mask, /obj/item/clothing/mask/muzzle))
 			boutput(M, SPAN_ALERT("How do you expect this to work? You're muzzled!"))
 			M.visible_message(SPAN_ALERT("<b>[M]</b> makes a loud noise."))
-			if (istype(H)) H.blood_tracking_output(src.pointCost)
 			return 0 // Cooldown because spam is bad.
 
 		. = ..()
@@ -112,6 +107,5 @@
 			boutput(M, SPAN_ALERT("The bats did not respond to your call!"))
 			return 1 // No cooldown here, though.
 
-		if (istype(H)) H.blood_tracking_output(src.pointCost)
 		logTheThing(LOG_COMBAT, M, "uses call bats at [log_loc(M)].")
 		return 0

--- a/code/modules/antagonists/vampire/abilities/enthrall.dm
+++ b/code/modules/antagonists/vampire/abilities/enthrall.dm
@@ -141,8 +141,6 @@
 			//we also restore their real actual blood pressure a bit, to allow vampires to save their thralls who are drained
 			target.blood_volume = min(target.blood_volume + 200, initial(target.blood_volume))
 
-			H.blood_tracking_output(cost)
-
 			H.deductPoints(cost)
 
 			boutput(M, SPAN_NOTICE("You donate 200 blood points to [target]."))

--- a/code/modules/antagonists/vampire/abilities/hypnotize.dm
+++ b/code/modules/antagonists/vampire/abilities/hypnotize.dm
@@ -15,7 +15,6 @@
 			return 1
 
 		var/mob/living/M = holder.owner
-		var/datum/abilityHolder/vampire/H = holder
 
 		if (!M || !target || !ismob(target))
 			return 1
@@ -39,7 +38,6 @@
 		if (!M.sight_check(1))
 			boutput(M, SPAN_ALERT("How do you expect this to work? You can't use your eyes right now."))
 			M.visible_message(SPAN_ALERT("What was that? There's something odd about [M]'s eyes."))
-			if (istype(H)) H.blood_tracking_output(src.pointCost)
 			return 1
 
 		. = ..()
@@ -47,9 +45,6 @@
 		boutput(M, SPAN_ALERT("You have to stand still..."))
 
 		actions.start(new/datum/action/bar/icon/vamp_hypno(M,target,src), M)
-
-		if (istype(H) && src.pointCost)
-			H.blood_tracking_output(src.pointCost)
 
 		if (isliving(target))
 			target:was_harmed(M, special = "vamp")

--- a/code/modules/antagonists/vampire/abilities/plague_touch.dm
+++ b/code/modules/antagonists/vampire/abilities/plague_touch.dm
@@ -16,7 +16,6 @@
 			return 1
 
 		var/mob/living/M = holder.owner
-		var/datum/abilityHolder/vampire/H = holder
 
 		if (!M || !target || !ismob(target))
 			return 1
@@ -47,6 +46,5 @@
 		if (!(L.bioHolder && L.traitHolder.hasTrait("training_chaplain")))
 			L.contract_disease(/datum/ailment/disease/vamplague, null, null, 1) // path, name, strain, bypass resist
 
-		if (istype(H)) H.blood_tracking_output(src.pointCost)
 		logTheThing(LOG_COMBAT, M, "uses diseased touch on [constructTarget(L,"combat")] at [log_loc(M)].")
 		return 0

--- a/code/modules/antagonists/vampire/abilities/radio_jammer.dm
+++ b/code/modules/antagonists/vampire/abilities/radio_jammer.dm
@@ -16,7 +16,6 @@
 			return 1
 
 		var/mob/living/M = holder.owner
-		var/datum/abilityHolder/vampire/H = holder
 
 		if (!M)
 			return 1
@@ -37,6 +36,5 @@
 				boutput(M, SPAN_ALERT("<b>You no longer disrupt radio signals.</b>"))
 				OTHER_STOP_TRACKING_CAT(M, TR_CAT_RADIO_JAMMERS)
 
-		if (istype(H)) H.blood_tracking_output(src.pointCost)
 		logTheThing(LOG_COMBAT, M, "uses radio interference at [log_loc(M)].")
 		return 0

--- a/code/modules/antagonists/vampire/abilities/screech.dm
+++ b/code/modules/antagonists/vampire/abilities/screech.dm
@@ -19,7 +19,6 @@
 			return 1
 
 		var/mob/living/M = holder.owner
-		var/datum/abilityHolder/vampire/H = holder
 
 		if (!M)
 			return 1
@@ -27,7 +26,6 @@
 		if (M.wear_mask && istype(M.wear_mask, /obj/item/clothing/mask/muzzle))
 			boutput(M, SPAN_ALERT("How do you expect this to work? You're muzzled!"))
 			M.visible_message(SPAN_ALERT("<b>[M]</b> makes a loud noise."))
-			if (istype(H)) H.blood_tracking_output(src.pointCost)
 			return 0 // Cooldown because spam is bad.
 
 		. = ..()
@@ -79,7 +77,6 @@
 
 		sonic_attack_environmental_effect(M, 2, list("light", "window", "r_window"))
 
-		if (istype(H)) H.blood_tracking_output(src.pointCost)
 		logTheThing(LOG_COMBAT, M, "uses chiropteran screech at [log_loc(M)].")
 		return 0
 

--- a/code/modules/antagonists/vampire/abilities/vampire_bite.dm
+++ b/code/modules/antagonists/vampire/abilities/vampire_bite.dm
@@ -83,8 +83,8 @@
 			boutput(M, SPAN_ALERT("The blood of the dead provides little sustenance..."))
 
 		var/bitesize = 5 * mult
-		H.change_vampire_blood(bitesize, 1)
-		H.change_vampire_blood(bitesize, 0)
+		H.change_vampire_blood(bitesize, 1, victim = HH)
+		H.change_vampire_blood(bitesize, 0, victim = HH)
 		H.tally_bite(HH,bitesize)
 		if (HH.blood_volume < 20 * mult)
 			HH.blood_volume = 0
@@ -98,7 +98,7 @@
 			if (M.get_vampire_blood() >= 20 * mult)
 				M.change_vampire_blood(-20 * mult, 0)
 			else
-				M.change_vampire_blood(0, 0, 1)
+				M.change_vampire_blood(0, 0, 1, victim = HH)
 			M.TakeDamage("chest", 0, 30 * mult)
 
 	else
@@ -108,19 +108,19 @@
 				HH.change_vampire_blood(-bitesize, 0)
 				HH.change_vampire_blood(-bitesize, 1) // Otherwise, two vampires could perpetually feed off of each other, trading blood endlessly.
 
-				H.change_vampire_blood(bitesize, 0)
-				H.change_vampire_blood(bitesize, 1)
+				H.change_vampire_blood(bitesize, 0, victim = HH)
+				H.change_vampire_blood(bitesize, 1, victim = HH)
 				H.tally_bite(HH,bitesize)
 				if (prob(50))
 					boutput(M, SPAN_ALERT("This is the blood of a fellow vampire!"))
 			else
-				HH.change_vampire_blood(0, 0, 1)
+				HH.change_vampire_blood(0, 0, 1, victim = HH)
 				boutput(M, SPAN_ALERT("[HH] doesn't have enough blood left to drink."))
 				return 0
 		else
 			var/bitesize = 10 * mult
-			H.change_vampire_blood(bitesize, 1)
-			H.change_vampire_blood(bitesize, 0)
+			H.change_vampire_blood(bitesize, 1, victim = HH)
+			H.change_vampire_blood(bitesize, 0, victim = HH)
 			H.tally_bite(HH,bitesize)
 			if (HH.blood_volume < 20 * mult)
 				HH.blood_volume = 0
@@ -237,8 +237,8 @@
 			boutput(M, SPAN_ALERT("The blood of the rotten provides little sustenance..."))
 
 		var/bitesize = 5 * mult
-		M.change_vampire_blood(bitesize, 1)
-		M.change_vampire_blood(bitesize, 0)
+		M.change_vampire_blood(bitesize, 1, victim = HH)
+		M.change_vampire_blood(bitesize, 0, victim = HH)
 		H.tally_bite(HH,bitesize)
 		if (HH.blood_volume < 20 * mult)
 			HH.blood_volume = 0
@@ -251,7 +251,7 @@
 		if (M.get_vampire_blood() >= 20 * mult)
 			M.change_vampire_blood(-20 * mult, 0)
 		else
-			M.change_vampire_blood(0, 0, 1)
+			M.change_vampire_blood(0, 0, 1, victim = HH)
 		M.TakeDamage("chest", 0, 30 * mult)
 
 	else
@@ -261,19 +261,19 @@
 				HH.change_vampire_blood(-bitesize, 0)
 				HH.change_vampire_blood(-bitesize, 1) // Otherwise, two vampires could perpetually feed off of each other, trading blood endlessly.
 
-				M.change_vampire_blood(bitesize, 0)
-				M.change_vampire_blood(bitesize, 1)
+				M.change_vampire_blood(bitesize, 0, victim = HH)
+				M.change_vampire_blood(bitesize, 1, victim = HH)
 				H.tally_bite(HH,bitesize)
 				if (prob(50))
 					boutput(M, SPAN_ALERT("This is the blood of a fellow vampire!"))
 			else
-				HH.change_vampire_blood(0, 0, 1)
+				HH.change_vampire_blood(0, 0, 1, victim = HH)
 				boutput(M, SPAN_ALERT("[HH] doesn't have enough blood left to drink."))
 				return 0
 		else
 			var/bitesize = 10 * mult
-			M.change_vampire_blood(bitesize, 1)
-			M.change_vampire_blood(bitesize, 0)
+			M.change_vampire_blood(bitesize, 1, victim = HH)
+			M.change_vampire_blood(bitesize, 0, victim = HH)
 			H.tally_bite(HH,bitesize)
 			if (HH.blood_volume < 20 * mult)
 				HH.blood_volume = 0

--- a/code/modules/antagonists/vampire/abilities/vampire_bite.dm
+++ b/code/modules/antagonists/vampire/abilities/vampire_bite.dm
@@ -90,7 +90,6 @@
 			HH.blood_volume = 0
 		else
 			HH.blood_volume -= 20 * mult
-		if (istype(H)) H.blood_tracking_output()
 
 	else if (HH.bioHolder && HH.traitHolder.hasTrait("training_chaplain"))
 		if(istype(M))
@@ -112,8 +111,6 @@
 				H.change_vampire_blood(bitesize, 0)
 				H.change_vampire_blood(bitesize, 1)
 				H.tally_bite(HH,bitesize)
-				if (istype(H))
-					H.blood_tracking_output()
 				if (prob(50))
 					boutput(M, SPAN_ALERT("This is the blood of a fellow vampire!"))
 			else
@@ -146,8 +143,6 @@
 					if (prob(65))
 						HH.changeStatus("knockdown", 1 SECOND)
 						HH.stuttering = min(HH.stuttering + 3, 10)
-
-			if (istype(H)) H.blood_tracking_output()
 
 	if (!can_take_blood_from(HH) && (mult >= 1) && isunconscious(HH))
 		boutput(HH, SPAN_ALERT("You feel your soul slipping away..."))

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3264,8 +3264,9 @@ datum
 								if (prob(33))
 									boutput(M, SPAN_ALERT("Fresh blood would be better..."))
 								var/bloodget = volume_passed / 3
-								M.change_vampire_blood(bloodget, 1) // vamp_blood
-								M.change_vampire_blood(bloodget, 0) // vamp_blood_remaining
+								var/datum/bioHolder/bioHolder = src.data
+								M.change_vampire_blood(bloodget, 1, victim = bioHolder?.owner) // vamp_blood
+								M.change_vampire_blood(bloodget, 0, victim = bioHolder?.owner) // vamp_blood_remaining
 								V.check_for_unlocks()
 								holder.del_reagent(src.id)
 								return 0

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3266,7 +3266,6 @@ datum
 								var/bloodget = volume_passed / 3
 								M.change_vampire_blood(bloodget, 1) // vamp_blood
 								M.change_vampire_blood(bloodget, 0) // vamp_blood_remaining
-								V.blood_tracking_output()
 								V.check_for_unlocks()
 								holder.del_reagent(src.id)
 								return 0

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3264,9 +3264,9 @@ datum
 								if (prob(33))
 									boutput(M, SPAN_ALERT("Fresh blood would be better..."))
 								var/bloodget = volume_passed / 3
-								var/datum/bioHolder/bioHolder = src.data
-								M.change_vampire_blood(bloodget, 1, victim = bioHolder?.owner) // vamp_blood
-								M.change_vampire_blood(bloodget, 0, victim = bioHolder?.owner) // vamp_blood_remaining
+								var/datum/bioHolder/unlinked/bioHolder = src.data
+								M.change_vampire_blood(bloodget, 1, victim = bioHolder?.weak_owner?.deref()) // vamp_blood
+								M.change_vampire_blood(bloodget, 0, victim = bioHolder?.weak_owner?.deref()) // vamp_blood_remaining
 								V.check_for_unlocks()
 								holder.del_reagent(src.id)
 								return 0

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -390,12 +390,7 @@ this is already used where it needs to be used, you can probably ignore it.
 			B.blood_DNA = "--unidentified substance--"
 			B.blood_type = "--unidentified substance--"
 
-		var/datum/bioHolder/bloodHolder = new/datum/bioHolder(null)
-		bloodHolder.CopyOther(M.bioHolder)
-		bloodHolder.ownerName = M.real_name
-		bloodHolder.ownerType = M.type
-
-		B.add_volume(blood_color_to_pass, M.blood_id, num_amount, vis_amount, blood_reagent_data=bloodHolder)
+		B.add_volume(blood_color_to_pass, M.blood_id, num_amount, vis_amount, blood_reagent_data=M.get_blood_bioholder())
 		return
 
 	BLOOD_DEBUG("[M] begins to bleed")
@@ -449,12 +444,7 @@ this is already used where it needs to be used, you can probably ignore it.
 				M.blood_volume = 0
 				//BLOOD_DEBUG("[H]'s blood volume dropped below 0 and was reset to 0")
 
-		var/datum/bioHolder/bloodHolder = new/datum/bioHolder(null)
-		bloodHolder.CopyOther(M.bioHolder)
-		bloodHolder.ownerName = M.real_name
-		bloodHolder.ownerType = M.type
-
-		B.add_volume(blood_color_to_pass, M.blood_id, blood_to_transfer, vis_amount, blood_reagent_data = bloodHolder)
+		B.add_volume(blood_color_to_pass, M.blood_id, blood_to_transfer, vis_amount, blood_reagent_data = M.get_blood_bioholder())
 		//BLOOD_DEBUG("[H] adds volume to existing blood decal")
 
 		if (B.reagents && M.reagents?.total_volume)
@@ -488,10 +478,7 @@ this is already used where it needs to be used, you can probably ignore it.
 		blood_to_transfer = some_idiot.blood_volume
 
 	if (!A.reagents.get_reagent("bloodc") && !A.reagents.get_reagent("blood")) // if it doesn't have blood with blood bioholder data already, only then create this
-		bloodHolder = new/datum/bioHolder(null)
-		bloodHolder.CopyOther(some_idiot.bioHolder)
-		bloodHolder.ownerName = some_idiot.real_name
-		bloodHolder.ownerType = some_idiot.type
+		bloodHolder = some_idiot.get_blood_bioholder()
 
 	if (ischangeling(some_idiot))
 		A.reagents.add_reagent("bloodc", blood_to_transfer, bloodHolder)

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -1015,3 +1015,7 @@ proc/GetBioeffectResearchLevelFromGlobalListByID(var/id)
 		. = BE.research_level
 	else
 		. = 0
+
+///Bioholder type for when you need a bioholder that isn't strongly linked to an owner, uses a weakref to allow GC
+/datum/bioHolder/unlinked
+	var/datum/weakref/weak_owner = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the useless "vampire blood tracking" ability that just toggles chat messages with the suggestion from this thread: https://forum.ss13.co/showthread.php?tid=23140
A little tracker HUD arrow to track the person whose blood you last drank.

~~TODO: fix tracking by blood bioHolder data~~


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- it's cool
- encourages taking just a little sip from people in order to track them later
- gives ranged blood steal a purpose beyond hiding behind windows and staring menacingly at people


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Vampires now have a new ability to track the last person they drank blood from. It uses the same icon as the old "vampire blood tracking" button you pressed once and forgot about.
```
