### PR TITLE
Gemstones are transparent enough to be in windows/antique

### DIFF
--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -951,7 +951,7 @@ ABSTRACT_TYPE(/datum/material/crystal)
 	name = "quartz"
 	desc = "Quartz is somewhat valuable but not particularly useful."
 	color = "#BBBBBB"
-	alpha = 220
+	alpha = 180
 	var/gem_tier = 3
 
 	New()


### PR DESCRIPTION
## About the PR
Just bumps their alpha value to be the same as glass (180). That's it.

## Why's this needed?
It'd be cool if you could use them in Windows and it makes making a basic level Antique a little easier. Maybe will encourage people to mess with them a bit more, who knows!

## Changelog

```changelog
(u)444explorer
(+)Gemstones are now more transparent - Use them in windows!
```
