### PR TITLE
Rename Med/Tech/Research Assistant to Trainee

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -671,7 +671,7 @@ ABSTRACT_TYPE(/datum/job/research)
 	wiki_link = "https://wiki.ss13.co/Scientist"
 
 /datum/job/research/research_assistant
-	name = "Research Assistant"
+	name = "Research Trainee"
 	limit = 2
 	wages = PAY_UNTRAINED
 	access_string = "Scientist"
@@ -722,7 +722,7 @@ ABSTRACT_TYPE(/datum/job/research)
 			M.show_text("<b>Something has gone terribly wrong here! Search for survivors and escape together.</b>", "blue")
 
 /datum/job/research/medical_assistant
-	name = "Medical Assistant"
+	name = "Medical Trainee"
 	limit = 2
 	wages = PAY_UNTRAINED
 	access_string = "Medical Doctor"
@@ -829,7 +829,7 @@ ABSTRACT_TYPE(/datum/job/engineering)
 			M.show_text("<b>Something has gone terribly wrong here! Search for survivors and escape together.</b>", "blue")
 
 /datum/job/engineering/technical_assistant
-	name = "Technical Assistant"
+	name = "Technical Trainee"
 	limit = 2
 	wages = PAY_UNTRAINED
 	access_string = "Engineer"


### PR DESCRIPTION
## About the PR 
Renames the following jobs:
- Medical Assistant -> Medical Trainee
- Technical Assistant -> Technical Trainee
- Research Assistant -> Research Trainee

## Why's this needed?
Currently Staff Assistant and Security Assistant are so far removed from the other three Assistants that it doesn't make much sense for them to share the naming schemes. Also it keeps confusing people because of the recent changes, let's fix that!

## Changelog 

```changelog
(u)444explorer
(+)Renames Technical Assistant, Medical Assistant and Research Assistant to Technical Trainee, Medical Trainee and Research Trainee.
(+)Staff Assistant and Security Assistant are not effected by this rename.
```
