### PR TITLE
Nerf lava in NTRC to be significantly more forgiving

### DIFF
--- a/code/WorkInProgress/Azungarstuff.dm
+++ b/code/WorkInProgress/Azungarstuff.dm
@@ -110,80 +110,37 @@
 	can_burn = FALSE
 	can_break = FALSE
 
-	Entered(var/mob/M)
+	Crossed(atom/movable/AM)
 		. = ..()
-		if (istype(M,/mob/dead) || istype(M,/mob/living/intangible) || istype(M, /obj/lattice))
-			return
+		if (do_lava_burn(AM))
+			SPAWN (5 SECONDS)
+				while(AM.loc == src)
+					if (!do_lava_burn(AM))
+						break
+					sleep(5 SECONDS)
+
+	proc/do_lava_burn(mob/M)
 		if(!ismob(M))
 			return
-		return_if_overlay_or_effect(M)
-
-
-		SPAWN(0)
-			if(M.loc == src)
-				if (ishuman(M))
-					var/mob/living/carbon/human/H = M
-					M.canmove = 0
-					M.changeStatus("knockdown", 6 SECONDS)
-					boutput(M, "You get too close to the edge of the lava and spontaniously combust from the heat!")
-					visible_message(SPAN_ALERT("[M] gets too close to the edge of the lava and spontaniously combusts from the heat!"))
-					H.set_burning(500)
-					playsound(M.loc, 'sound/effects/mag_fireballlaunch.ogg', 50, 0)
-					M.emote("scream")
-				if (isrobot(M))
-					M.canmove = 0
-					M.TakeDamage("chest", pick(5,10), 0, DAMAGE_BURN)
-					M.emote("scream")
-					playsound(M.loc, 'sound/effects/mag_fireballlaunch.ogg', 50, 0)
-					boutput(M, "You get too close to the edge of the lava and spontaniously combust from the heat!")
-					visible_message(SPAN_ALERT("[M] gets too close to the edge of the lava and their internal wiring suffers a major burn!"))
-					M.changeStatus("stunned", 6 SECONDS)
-			sleep(5 SECONDS)
-			if(M.loc == src)
-				if (ishuman(M))
-					var/mob/living/carbon/human/H = M
-					M.changeStatus("knockdown", 10 SECONDS)
-					M.set_body_icon_dirty()
-					H.set_burning(1000)
-					playsound(M.loc, 'sound/effects/mag_fireballlaunch.ogg', 50, 0)
-					M.emote("scream")
-					if (H.limbs.l_leg && H.limbs.r_leg)
-						if (H.limbs.l_leg)
-							H.limbs.l_leg.delete()
-						if (H.limbs.r_leg)
-							H.limbs.r_leg.delete()
-						boutput(M, "You can feel how both of your legs melt away!")
-						visible_message(SPAN_ALERT("[M] continues to remain too close to the lava, their legs literally melting away!"))
-					else
-						boutput(M, "You can feel intense heat on the lower part of your torso.")
-						visible_message(SPAN_ALERT("[M] continues to remain too close to the lava, if they had any legs, they would have melted away!"))
-
-				if (isrobot(M))
-					var/mob/living/silicon/robot/R = M
-					R.canmove = 0
-					R.TakeDamage("chest", pick(20,40), 0, DAMAGE_BURN)
-					R.emote("scream")
-					playsound(R.loc, 'sound/effects/mag_fireballlaunch.ogg', 50, 0)
-					R.changeStatus("stunned", 10 SECONDS)
-					R.part_leg_r.holder = null
-					qdel(R.part_leg_r)
-					if (R.part_leg_r.slot == "leg_both")
-						R.part_leg_l = null
-						R.update_bodypart("l_leg")
-					R.part_leg_r = null
-					R.update_bodypart("r_leg")
-					R.part_leg_l.holder = null
-					qdel(R.part_leg_l)
-					if (R.part_leg_l.slot == "leg_both")
-						R.part_leg_r = null
-						R.update_bodypart("r_leg")
-					R.part_leg_l = null
-					R.update_bodypart("l_leg")
-					visible_message(SPAN_ALERT("[M] continues to remain too close to the lava, their legs literally melting away!"))
-					boutput(M, "You can feel how both of your legs melt away!")
-				else
-					boutput(M, "You can feel intense heat on the lower part of your torso.")
-					visible_message(SPAN_ALERT("[M] continues to remain too close to the lava, if they had any legs, they would have melted away!"))
+		if (istype(M,/mob/dead) || istype(M,/mob/living/intangible))
+			return
+		if (isdead(M))
+			return
+		if (isrobot(M))
+			M.TakeDamage("chest", pick(5,10), 0, DAMAGE_BURN)
+			M.changeStatus("stunned", 2 SECONDS)
+			M.emote("scream")
+			playsound(M.loc, 'sound/effects/mag_fireballlaunch.ogg', 50, 0)
+			boutput(M, "You get too close to the edge of the lava and spontaniously combust from the heat!")
+			visible_message(SPAN_ALERT("[M] gets too close to the edge of the lava and their internal wiring suffers a major burn!"))
+		else
+			M.changeStatus("burning", 30 SECONDS)
+			M.changeStatus("knockdown", 2 SECONDS)
+			M.emote("scream",)
+			playsound(M.loc, 'sound/effects/mag_fireballlaunch.ogg', 50, 0)
+			boutput(M, "You get too close to the edge of the lava and spontaniously combust from the heat!")
+			visible_message(SPAN_ALERT("[M] gets too close to the edge of the lava and spontaniously combusts from the heat!"))
+		return TRUE
 
 	corners
 		icon_state = "lava_corners"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Nerfs the lava edges found in the NTRC adventure zone
* Lava no longer burns off legs
* 10 second borg stun is reduced to 2 seconds
* 10 second Knockdown time is reduced to 2 seconds
* Burning duration is reduced from 100 seconds to 30 seconds
* non-edge lava turf are still instant death

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* So much as brushing against a lava edge is a death sentence in this adventure zone which is already rather difficult for new players. 
* Completing many of the puzzles without legs isn't even possible without a friend due to belt speeds


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sovexe
(+)The lava edges in the NT Retention Center adventure zone has been made much more forgiving.
```
