### PR TITLE
Rewrite AI "Emergency" Law Module

### DIFF
--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -319,11 +319,11 @@ ABSTRACT_TYPE(/obj/item/aiModule/syndicate)
 	highlight_color = rgb(32, 21, 94, 255)
 
 	update_law_text(user, lawTarget)
-		src.lawText = "There is a [lawTarget ? lawTarget : "__________"] emergency. Prioritize orders from [lawTarget ? lawTarget : "__________"] personnel and assisting the crew in remedying the situation. In the case of conflict, this law takes precedence over the Second Law.'"
+		src.lawText = "There is a station-wide emergency. Prioritize [lawTarget ? lawTarget : "__________"] in order to remedy the situation. In the case of conflict, this law takes precedence over the Second Law.'"
 		return ..()
 
 	attack_self(mob/user)
-		var/lawTarget = input_law_info(user, "Department Emergency", "Which department's orders should be prioritized?", "security")
+		var/lawTarget = input_law_info(user, "Emergency", "What should the AI prioritize?", "repairing the station")
 		if(lawTarget)
 			src.update_law_text(user, lawTarget)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Rewrites the "AI Law Module - Emergency" to have a broader use case
BEFORE:
There is a __________ emergency. Prioritize orders from __________ personnel and assisting the crew in remedying the situation. In the case of conflict, this law takes precedence over the Second Law.
AFTER:
There is a station-wide emergency. Prioritize ____________ in order to remedy the situation. In the case of conflict, this law takes precedence over the Second Law.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Before was essentially limited to just naming one department to prioritize orders from, however this rarely made a difference and I haven't really seen this law get serious use when the freeform provides more versatility if you want the AI to do something. This new law provides the means to put almost any action in the law rather than just doing one department's orders faster (which it was probably already doing)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)The AI's "Emergency" law module has been rewritten.
```
