### PR TITLE
Remove Oshan Martian prefab securitron's camera

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -14547,7 +14547,8 @@
 	control_freq = 1441;
 	desc = "A tattered and rusted security bot,  powered only by nicotine and fury at those who abandoned him here.";
 	emagged = 2;
-	name = "Mr. Beepsky"
+	name = "Mr. Beepsky";
+	no_camera = 1
 	},
 /turf/simulated/floor/plating/damaged3,
 /area/evilreaver/bar)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Varedits no_camera onto the securitron in the martian outpost on oshan


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
AI shouldnt be able to see inside the outpost
