### PR TITLE
fixes minor crime details not displaying properly in PDA security records

### DIFF
--- a/code/obj/item/device/pda2/record_progs.dm
+++ b/code/obj/item/device/pda2/record_progs.dm
@@ -54,7 +54,7 @@
 					dat += "SecHUD Flag: [src.active2["sec_flag"]]<br>"
 
 					dat += "Minor Crimes: [src.active2["mi_crim"]]<br>"
-					dat += "Details: [src.active2["mi_crim"]]<br><br>"
+					dat += "Details: [src.active2["mi_crim_d"]]<br><br>"
 
 					dat += "Major Crimes: [src.active2["ma_crim"]]<br>"
 					dat += "Details: [src.active2["ma_crim_d"]]<br><br>"


### PR DESCRIPTION
[BUG]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This fixes the PDA security records mistakenly displaying a second copy of the minor crimes entry under the minor crime details entry.
Security assistants rejoice.
![crimes](https://github.com/user-attachments/assets/0b11f04f-696b-494d-905a-230025b3f98d)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Record-keeping is extremely important.


