### PR TITLE
Give AI cores an internal camera

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -94,6 +94,7 @@ var/global/list/ai_emotions = list("Annoyed" = "ai_annoyed-dol", \
 	var/network = "SS13"
 	var/classic_move = 1 //Ordinary AI camera movement
 	var/obj/machinery/camera/current = null
+	var/obj/machinery/camera/camera = null //Our internal camera for seeing from core while in eye
 	var/list/connected_robots = list()
 	//var/list/connected_shells = list()
 	var/list/installed_modules = list()
@@ -382,6 +383,10 @@ or don't if it uses a custom topopen overlay
 		if(!isnull(src.client))
 			src.bioHolder.mobAppearance.pronouns = src.client.preferences.AH.pronouns
 			src.update_name_tag()
+
+		src.camera = new /obj/machinery/camera(src)
+		src.camera.c_tag = src.real_name
+		src.camera.network = "Robots"
 
 //Returns either the AI mainframe or the eyecam mob, depending on whther or not we are deployed
 /mob/living/silicon/ai/proc/get_message_mob()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives AI cores internal cameras so they can see what their core sees when in eyeview


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
you shouldnt need to deploy to your core to see your surroundings, these should be visible from AI view.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)AI cores now have cameras in them that AI eyes can view out of.
```
