### PR TITLE
Fix cogmap2 ranch APC wiring

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -16515,6 +16515,9 @@
 /obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grasstodirt{
 	dir = 4
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a wire underneath the front tables at the ranch to connect the Ranch APC to the power grid.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The ranch APC is not connected to the grid at roundstart.

