### PR TITLE
Fix rounds needed job logic

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -208,7 +208,7 @@
 			min = src.rounds_needed_to_play
 		if (src.rounds_allowed_to_play)
 			max = src.rounds_allowed_to_play
-		if (!min || !max)
+		if (!min && !max)
 			return TRUE
 
 		var/round_num = player.get_rounds_participated()
@@ -216,7 +216,7 @@
 			return TRUE
 		if (player.cloudSaves.getData("bypass_round_reqs")) //special flag for account transfers etc.
 			return TRUE
-		if (round_num > min && round_num <= max)
+		if (round_num >= min && (round_num <= max || !max))
 			return TRUE
 		return FALSE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix job round requirement logic by only returning early if we have neither a minimum nor maximum and dont assume all jobs have both a minimum and a maximum because no job has both


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Job logic would always return true for any job without both a minimum and a maximum (every job) when running the rounds check.
Fixes #20577
