### PR TITLE
Adds the Fishbowl Helmet, along with the Donkini, to Oshan and Nadir

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -5361,6 +5361,10 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/medical/medbay/surgery)
+"cuH" = (
+/obj/item/clothing/head/helmet/space/fishbowl,
+/turf/simulated/floor/white/grime,
+/area/abandonedmedicalship/robot_trader)
 "cuL" = (
 /obj/noticeboard/persistent{
 	name = "Chapel persistent notice board";
@@ -50046,6 +50050,17 @@
 /obj/storage/secure/closet/security/equipment,
 /turf/simulated/floor/redblack,
 /area/station/security/equipment)
+"vum" = (
+/obj/machinery/light/small/floor/cool,
+/obj/fakeobject/skeleton{
+	desc = "The head seems to be gone.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body2";
+	name = "corpse"
+	},
+/obj/item/clothing/under/gimmick/donkini,
+/turf/simulated/floor/white/grime,
+/area/abandonedmedicalship/robot_trader)
 "vuv" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/heads{
@@ -81630,8 +81645,8 @@ bzS
 bzS
 syI
 kQE
-tjr
-hvz
+cuH
+vum
 tjr
 lmL
 sdl

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -44569,6 +44569,11 @@
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/kitchen)
+"uLy" = (
+/obj/item/implant/projectile/staple,
+/obj/item/clothing/head/helmet/space/fishbowl,
+/turf/simulated/floor/white/grime,
+/area/abandonedmedicalship/robot_trader)
 "uMA" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	req_access = null
@@ -45965,6 +45970,16 @@
 /obj/table/glass/reinforced/auto,
 /turf/simulated/floor/wood,
 /area/station/science/lobby)
+"wPf" = (
+/obj/fakeobject/skeleton{
+	desc = "The head seems to be gone.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body2";
+	name = "corpse"
+	},
+/obj/item/clothing/under/gimmick/donkini,
+/turf/simulated/floor/white/grime,
+/area/abandonedmedicalship/robot_trader)
 "wPq" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 8
@@ -59843,8 +59858,8 @@ kSl
 aUm
 aUv
 aUC
-aVZ
-aUC
+uLy
+wPf
 aVZ
 aUC
 aUv


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
<!-- [mapping][Game-Objects] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the Fishbowl Helmet (#20382) and the Donkini obtainable on both Oshan and Nadir stations.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The Fishbowl Helmet and Donkini are obtainable on Space Maps, but not on both Oshan and Nadir. This change makes it so people are able to get both of these items on these maps, if they know where to look...


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Wrench
(+)The Fishbowl Helmet and Donkini have been added somewhere in the Oceans around Oshan Station and Nadir Station...
```
