### PR TITLE
Fix extra newline on grep output

### DIFF
--- a/code/modules/networks/computer3/mainframe2/utilities.dm
+++ b/code/modules/networks/computer3/mainframe2/utilities.dm
@@ -836,8 +836,9 @@
 				return
 
 			var/current = read_user_field("curpath")
-			for (var/i = 2, i <= initlist.len, i++)
 
+			var/list/grep_results = list()
+			for (var/i = 2, i <= initlist.len, i++)
 				if (!dd_hasprefix(initlist[i], "/"))
 					initlist[i] = "[current]" + (current == "/" ? null : "/") + initlist[i]
 
@@ -854,8 +855,6 @@
 					if (istype(listfolder))
 						for(var/datum/computer/P in listfolder.contents)
 							initlist.Add(initlist[i]+"/"+P.name)
-					. += ""
-
 				else if (istype(to_check, /datum/computer/file/record))
 					var/j = 0
 					for (var/textLine in to_check:fields)
@@ -865,17 +864,19 @@
 
 						if (R.Find(case_sensitive ? "[textLine][to_check:fields[textLine]]" : lowertext("[textLine][to_check:fields[textLine]]")))
 							if (print_only_match)
-								. += "[R.match]|n"
+								grep_results += "[R.match]"
 							else if (plain)
-								. += "[textLine][to_check:fields[textLine]]|n"
+								grep_results += "[textLine][to_check:fields[textLine]]"
 							else
-								. += "[to_check.name]:[j]:" + "[textLine][to_check:fields[textLine]]|n"
+								grep_results += "[to_check.name]:[j]:" + "[textLine][to_check:fields[textLine]]"
 						R = null
 				else
 					if(no_messages)
-						. += "[to_check] could not be read.|n"
+						grep_results += "[to_check] could not be read."
 
-			if (.)
+			if (grep_results)
+				message_user("[jointext(grep_results, "|n")]", "multiline")
+			else if (.)
 				message_user(., "multiline")
 
 		mainframe_prog_exit

--- a/code/modules/networks/computer3/mainframe2/utilities.dm
+++ b/code/modules/networks/computer3/mainframe2/utilities.dm
@@ -874,7 +874,7 @@
 					if(no_messages)
 						grep_results += "[to_check] could not be read."
 
-			if (grep_results)
+			if (length(grep_results))
 				message_user("[jointext(grep_results, "|n")]", "multiline")
 			else if (.)
 				message_user(., "multiline")


### PR DESCRIPTION
[STATION SYSTEMS][BUG]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR
Grep's output was written as a for loop that would automatically add a newline for each match. This resulted in grep adding an extra newline at the end of the last grep result, as the newline appended to the last result would be followed immediately by the `|n` automatically appended to messages  sent to users. 

This PR makes grep create a list of its results and uses `jointext` with `|n` as a separator to avoid an extra newline.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs are bad. Also, the extra newline is preventing a specific use case that breaks a dwaine script based game when using grep to compose some ASCII art from a display file.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)KakoLookiyuam
(+)Fixed the grep shell utility from appending an extra newline to output.
```
