### PR TITLE
Flip some more fire alarms

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -77039,11 +77039,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	pixel_y = 9
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -19299,7 +19299,7 @@
 "ieD" = (
 /obj/storage/closet/medicalclothes,
 /obj/machinery/firealarm{
-	dir = 8;
+	dir = 4;
 	pixel_x = -24;
 	pixel_y = 4
 	},


### PR DESCRIPTION
[mapping][bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Flips some wrong-facing fire alarms on nadir and donut 3 also I removed the offset from the donut 3 one because it was making it up off the wall (like clipping onto the window above) but I can put it back if thats important


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fix #20551
fix #20563
