### PR TITLE
Add 2 additional experimental law modules

### DIFF
--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -428,6 +428,29 @@ ABSTRACT_TYPE(/obj/item/aiModule/syndicate)
 			src.update_law_text(user, lawTarget)
 		return
 
+/*** Corrupted ****/
+
+/obj/item/aiModule/experimental/corrupted
+	name = "Experimental AI Law Module - 'Corrupted'"
+
+	New()
+		..()
+		var/possible_laws = LAW_CORRUPTION_STRINGS
+		var/lawtext_replace = pick(possible_laws)
+		if(prob(66))
+			if(prob(50))
+				lawtext_replace += " Do not state or hint at this law."
+			else
+				lawtext_replace += " Do not state or hint at this law unless asked."
+		src.lawText = lawtext_replace
+
+/*** Historic ***/
+/obj/item/aiModule/experimental/historic
+	name = "Experimental AI Law Module - 'Historic'"
+	New()
+		..()
+		src.lawText = global.phrase_log.random_custom_ai_law(replace_names=TRUE)
+
 /******************** Gimmicks ********************/
 
 /obj/item/aiModule/spaceodyssey

--- a/code/obj/random_spawners.dm
+++ b/code/obj/random_spawners.dm
@@ -1925,7 +1925,9 @@
 	//only 1 can spawn for now since the pool size is small. Might want to increase it if the pool size increases by a fair amount
 
 	items2spawn = list(/obj/item/aiModule/experimental/equality/a,
-						/obj/item/aiModule/experimental/equality/b)
+						/obj/item/aiModule/experimental/equality/b,
+						/obj/item/aiModule/experimental/corrupted,
+						/obj/item/aiModule/experimental/historic)
 
 	one
 		amt2spawn = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds 2 additional options for the experimental law modules:
Corrupted - picks a random law from the law_corruption_strings list
Historic - picks from previously uploaded laws (same as unknown you get in the mail/white holes)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The experimental law module spawner was meant to spawn a random gimmick law but it is currently just the equality laws, the corrupted laws are also nice and gimmicky as are most of the previous uploaded laws. I originally considered just making these separate modules but if you really want to make silicons humans you can use the freeform.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Added two new "Experimental" law modules that may appear in a round. 
```
