### PR TITLE
AI "Go offline" command to replace their brain with a latejoin one

### DIFF
--- a/code/mob/living/intangible/ai-camera.dm
+++ b/code/mob/living/intangible/ai-camera.dm
@@ -511,6 +511,12 @@
 		set desc = "Change your name."
 		mainframe?.rename_self()
 
+	verb/go_offline()
+		set category = "AI Commands"
+		set name = "Go Offline"
+		set desc = "Disconnect your brain such that a new AI can take your place."
+		mainframe?.go_offline()
+
 	stopObserving()
 		src.set_loc(get_turf(src))
 		src.observing = null

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2601,9 +2601,9 @@ proc/get_mobs_trackable_by_AI()
 		eyecam.return_mainframe()
 	if (deployed_shell)
 		src.return_to(deployed_shell)
-	src.ghostize()
 	if (src.mind)
 		src.mind.register_death()
+	src.ghostize()
 
 	//Tell the crew the AI is gone
 	if(announce)
@@ -2617,8 +2617,6 @@ proc/get_mobs_trackable_by_AI()
 	src.update_appearance()
 	src.name = "AI"
 	src.UpdateName()
-	if (src.mind)
-		src.mind.assigned_role = "AI"
 
 /*-----Core-Creation---------------------------------------*/
 

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2603,6 +2603,7 @@ proc/get_mobs_trackable_by_AI()
 		src.return_to(deployed_shell)
 	if (src.mind)
 		src.mind.register_death()
+		src.mind.get_player()?.dnr = TRUE
 	src.ghostize()
 
 	//Tell the crew the AI is gone

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2114,7 +2114,7 @@ or don't if it uses a custom topopen overlay
 	var/mob/message_mob = src.get_message_mob()
 	if (!message_mob.client || isdead(src))
 		return
-	var/confirm = tgui_alert(message_mob, "Become a ghost and permanently replace yourself with a latejoinable AI? (WARNING: YOU CANNOT BE LAWED TO DO THIS AND YOU CANNOT BE REVIVED.)", "Permanently Suicide?", list("Yes", "Cancel"))
+	var/confirm = tgui_alert(message_mob, "Become a ghost and allow other players to join into your core? (WARNING: YOU CANNOT BE LAWED OR ORDERED TO DO THIS AND YOU CANNOT BE REVIVED.)", "Permanently Shut Down?", list("Yes", "Cancel"))
 	if (confirm != "Yes")
 		return
 
@@ -2607,7 +2607,7 @@ proc/get_mobs_trackable_by_AI()
 
 	//Tell the crew the AI is gone
 	if(announce)
-		command_alert("Station AI unit malfunction detected, attempting download of new mind from Central Command database.","Artificial Intelligence Update", alert_origin = ALERT_STATION)
+		command_alert("Station AI unit [pick("crash", "kernel panic", "unrecoverable error")] detected, attempting automated download of new personality from Central Command database...","Artificial Intelligence Update", alert_origin = ALERT_STATION)
 	logTheThing(LOG_COMBAT, src, "is replaced with a latejoin AI at [log_loc(src)].")
 
 	qdel(src.brain)

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -151,6 +151,7 @@
 	O.verbs += /mob/living/silicon/ai/proc/ai_station_announcement
 	O.verbs += /mob/living/silicon/ai/proc/view_messageLog
 	O.verbs += /mob/living/silicon/ai/verb/rename_self
+	O.verbs += /mob/living/silicon/ai/verb/go_offline
 	O.job = "AI"
 
 	SPAWN(0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a command for AIs to use that ghosts them and replaces their brain with a latejoin one, announcing that they have done so to the crew.

Code probably sucks and I know the warning for doing this also sucks but im PRing this so you can tell me which bits suck

Credit to meaow589 (AKA: Tanuki Singuloose) on the forums for the idea https://forum.ss13.co/showthread.php?tid=23151

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When an AI has to go it can be a pain to replace them or build a latejoin one, so much so that most crews dont bother, this provides an easy way for AI players to leave the game if they need to.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*) AIs now have a "Go Offline" command to replace themselves with a latejoin AI, this is also announced to the crew. 
```
