### PR TITLE
Fix Atlas Engineering airless tiles

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1802,7 +1802,7 @@
 	pixel_y = 10
 	},
 /obj/item/wrench,
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "aii" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -10885,7 +10885,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "boC" = (
 /obj/machinery/door/airlock/pyro/alt{
@@ -10976,7 +10976,7 @@
 /obj/machinery/atmospherics/pipe/manifold/overfloor{
 	dir = 4
 	},
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "bwv" = (
 /obj/machinery/door/airlock/pyro/glass/command{
@@ -11081,7 +11081,7 @@
 /area/station/security/interrogation)
 "bCt" = (
 /obj/machinery/atmospherics/unary/portables_connector,
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "bCz" = (
 /obj/cable/yellow{
@@ -13841,7 +13841,7 @@
 /obj/cable/orange{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "hPY" = (
 /obj/decal/tile_edge/stripe/big{
@@ -15364,7 +15364,7 @@
 	},
 /area/listeningpost)
 "kBQ" = (
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "kCN" = (
 /obj/securearea{
@@ -15436,7 +15436,7 @@
 /obj/machinery/dispenser,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /obj/machinery/firealarm/east,
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "kNc" = (
 /obj/lattice{
@@ -16569,7 +16569,7 @@
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "nik" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -18332,7 +18332,7 @@
 /obj/cable/orange{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "ray" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -18971,7 +18971,7 @@
 /obj/cable/orange{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "szE" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
@@ -19075,7 +19075,7 @@
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "sSG" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -19733,7 +19733,7 @@
 /obj/machinery/power/reactor_stats,
 /obj/cable,
 /obj/machinery/power/data_terminal,
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "tYS" = (
 /obj/machinery/power/data_terminal,
@@ -20067,7 +20067,7 @@
 	id = "Cold Loop Gas Supply 2";
 	target_pressure = 1000
 	},
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "uLo" = (
 /obj/grille/catwalk{
@@ -20597,7 +20597,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "vLl" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -21560,7 +21560,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /obj/machinery/manufacturer/gas,
-/turf/simulated/floor/airless/darkblue/checker,
+/turf/simulated/floor/darkblue/checker,
 /area/station/engine/core)
 "xGd" = (
 /obj/table/syndicate/auto,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace the airless blue tiles with ones that have a breathable atmosphere (oops)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
(most) Engineers have lungs
