### PR TITLE
Improve the Oshan carousel

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -804,7 +804,7 @@ var/global/list/mapNames = list(
 	merchant_right_centcom = /area/shuttle/merchant_shuttle/right_centcom/cogmap
 	merchant_right_station = /area/shuttle/merchant_shuttle/right_station/cogmap
 
-	shipping_destinations = list("North", "South")
+	shipping_destinations = list("North Carousel", "South Carousel")
 
 	valid_nuke_targets = list("the fitness room" = list(/area/station/crew_quarters/fitness),
 		"the quartermaster's office" = list(/area/station/quartermaster/office),

--- a/code/obj/machinery/launcherloader.dm
+++ b/code/obj/machinery/launcherloader.dm
@@ -300,14 +300,14 @@
 /obj/machinery/cargo_router/oshan_north
 	trigger_when_no_match = 0
 	New()
-		destinations = list("North" = NORTH, "South" = EAST)
+		destinations = list("North Carousel" = NORTH, "South Carousel" = EAST)
 		default_direction = NORTH
 		..()
 
 /obj/machinery/cargo_router/oshan_south
 	trigger_when_no_match = 0
 	New()
-		destinations = list("South" = SOUTH, "North" = WEST)
+		destinations = list("South Carousel" = SOUTH, "North Carousel" = WEST)
 		default_direction = SOUTH
 		..()
 

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -20085,6 +20085,9 @@
 /area/station/mining/staff_room)
 "bvz" = (
 /obj/machinery/light/incandescent/warm,
+/obj/disposalpipe/segment/bent{
+	dir = 4
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/mining/staff_room)
 "bvA" = (
@@ -21618,6 +21621,7 @@
 /obj/cable{
 	icon_state = "5-8"
 	},
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "bAM" = (
@@ -22652,7 +22656,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/storage/cart,
+/obj/machinery/computer/barcode{
+	dir = 8
+	},
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bEk" = (
@@ -22940,10 +22946,24 @@
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bFg" = (
-/obj/storage/cart,
+/obj/machinery/floorflusher{
+	id = "carousel";
+	name = "\improper Carousel Chute"
+	},
+/obj/disposalpipe/trunk/transport{
+	dir = 4
+	},
+/obj/machinery/activation_button/flusher_button{
+	pixel_y = -22;
+	id = "carousel";
+	name = "Carousel Chute Button"
+	},
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "bFh" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
@@ -22952,12 +22972,18 @@
 /obj/cable{
 	icon_state = "2-5"
 	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
 "bFj" = (
 /obj/machinery/light/incandescent/warm,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
@@ -24313,6 +24339,12 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"bJI" = (
+/obj/disposalpipe/segment/bent{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/mining/staff_room)
 "bJJ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
@@ -32152,6 +32184,12 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"cMs" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/mining/staff_room)
 "cMy" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable,
@@ -32577,6 +32615,10 @@
 	dir = 10
 	},
 /area/station/crew_quarters/cafeteria)
+"dqX" = (
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor,
+/area/station/mining/staff_room)
 "dsi" = (
 /mob/living/critter/martian/soldier,
 /turf/simulated/floor/martian,
@@ -33215,6 +33257,16 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/north)
+"egO" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "ehi" = (
 /obj/stool/chair/couch{
 	dir = 4
@@ -35242,6 +35294,12 @@
 	},
 /turf/space/fluid,
 /area/station/com_dish/research_outpost)
+"gKM" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/mining/staff_room)
 "gKQ" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -35812,6 +35870,14 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/radio/lab)
+"hGw" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/mining/staff_room)
 "hGD" = (
 /obj/decal/cleanable/dirt,
 /obj/reagent_dispensers/watertank,
@@ -36496,6 +36562,9 @@
 "iJp" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/left{
+	dir = 4
+	},
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -37704,6 +37773,15 @@
 /obj/table/round/auto,
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
+"kBa" = (
+/obj/disposalpipe/segment/morgue,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
 "kCm" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/mapping_helper/firedoor_spawn,
@@ -38106,6 +38184,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/research_outpost/chamber)
+"lgM" = (
+/obj/disposalpipe/segment/transport,
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/staff_room)
 "lgU" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
@@ -38323,6 +38405,9 @@
 	},
 /obj/mapping_helper/access/mining,
 /obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "lzH" = (
@@ -39256,6 +39341,25 @@
 /obj/mapping_helper/access/maint,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northeast)
+"mJp" = (
+/obj/rack,
+/obj/item/clothing/shoes/magnetic{
+	pixel_x = -4;
+	pixel_y = -9
+	},
+/obj/item/clothing/suit/space/diving/engineering,
+/obj/item/clothing/head/helmet/space/engineer/diving/engineering,
+/obj/item/clothing/mask/breath{
+	pixel_x = -3
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -12
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/yellow,
+/area/station/mining/staff_room)
 "mJz" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4;
@@ -39277,6 +39381,12 @@
 /obj/window_blinds/cog2/left,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"mLd" = (
+/obj/disposalpipe/segment/bent{
+	dir = 8
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/staff_room)
 "mLx" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -39914,6 +40024,13 @@
 	},
 /turf/simulated/floor,
 /area/research_outpost/hangar)
+"nxj" = (
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "nxK" = (
 /turf/simulated/floor/grass,
 /area/station/garden/owlery)
@@ -40792,6 +40909,16 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"oIL" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	dir = 4
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/mining/staff_room)
 "oIU" = (
 /turf/simulated/floor/stairs/wide/middle,
 /area/station/hallway/secondary/exit)
@@ -42560,6 +42687,14 @@
 "rgy" = (
 /turf/simulated/wall/auto/asteroid,
 /area/station/garden/owlery)
+"rhz" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/market{
+	name = "Supply Lobby"
+	})
 "rih" = (
 /obj/stool/chair/pew/left{
 	name = "wooden bench"
@@ -43328,6 +43463,16 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
+"sBo" = (
+/obj/disposaloutlet{
+	dir = 4;
+	pixel_x = 14
+	},
+/obj/disposalpipe/trunk/transport{
+	dir = 8
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/mining/staff_room)
 "sBC" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -43826,6 +43971,7 @@
 	dir = 4
 	},
 /obj/landmark/start/job/miner,
+/obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "tlG" = (
@@ -44549,6 +44695,9 @@
 	name = "autoname - SS13";
 	pixel_x = 10;
 	tag = ""
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 6
@@ -45673,6 +45822,12 @@
 /obj/cable,
 /turf/simulated/floor/plating/random,
 /area/station/security/brig)
+"wwC" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/staff_room)
 "wwP" = (
 /obj/disposalpipe/chicken_disposal_pipe/horizontal,
 /turf/simulated/floor/white,
@@ -46460,6 +46615,12 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/shuttle/sea_elevator_room)
+"xnI" = (
+/obj/disposalpipe/segment/bent{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/mining/staff_room)
 "xnV" = (
 /obj/stool/chair/yellow,
 /obj/landmark/start/job/engineer,
@@ -46513,6 +46674,9 @@
 	pixel_x = 10;
 	pixel_y = -17;
 	tag = ""
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/mining/staff_room)
@@ -81165,7 +81329,7 @@ vhK
 vhK
 bDa
 bEp
-bDa
+rhz
 gNY
 bGV
 bHU
@@ -81467,7 +81631,7 @@ bAC
 bAC
 bDb
 oQq
-bAC
+kBa
 bGb
 bGZ
 bHX
@@ -81769,7 +81933,7 @@ bAD
 bvt
 bvt
 bEr
-bvt
+egO
 bvt
 bvt
 bHY
@@ -82071,7 +82235,7 @@ bAE
 bvu
 bvu
 aSr
-bvu
+nxj
 bGc
 bHa
 bHU
@@ -82373,7 +82537,7 @@ bAF
 bBQ
 buS
 pKj
-uZZ
+oIL
 buS
 bHb
 bHU
@@ -82675,7 +82839,7 @@ kIF
 buS
 buS
 bxH
-bxH
+mJp
 buS
 cgd
 bHU
@@ -82977,7 +83141,7 @@ bAH
 bwH
 byy
 bwH
-bwH
+hGw
 buS
 bHb
 bHU
@@ -83272,14 +83436,14 @@ aHE
 bwd
 bwb
 bwI
-bwI
-bwI
-bwI
+bJI
+dqX
+dqX
 bAI
-bwI
+dqX
 tkq
 tkq
-bwI
+xnI
 buS
 bHc
 bHU
@@ -83574,7 +83738,7 @@ bJF
 bwd
 bwb
 bwI
-bwI
+gKM
 bwI
 bzv
 bwI
@@ -83876,7 +84040,7 @@ bJH
 buS
 bwc
 bFo
-bwI
+gKM
 cnu
 bzw
 bwI
@@ -84480,7 +84644,7 @@ kyL
 feA
 bwe
 bwK
-bwK
+cMs
 byA
 bwd
 bwJ
@@ -84782,7 +84946,7 @@ buS
 jcM
 bvx
 bvx
-bvx
+wwC
 byB
 bwd
 aQG
@@ -85084,7 +85248,7 @@ cjb
 api
 bvx
 api
-bvx
+wwC
 asK
 bwd
 bAM
@@ -85686,9 +85850,9 @@ ciW
 ciW
 cjb
 bvz
-bvx
-bvx
-bvx
+lgM
+lgM
+mLd
 buS
 buS
 buS
@@ -85987,7 +86151,7 @@ nMJ
 ciW
 ciW
 buS
-buS
+sBo
 ahh
 ahh
 ahh

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -31631,15 +31631,6 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
 /area/station/storage/tools)
-"clA" = (
-/obj/machinery/conveyor/SN{
-	id = "north";
-	move_lag = 10;
-	operating = 1
-	},
-/obj/decal/stripe_delivery,
-/turf/simulated/floor,
-/area/station/storage/tools)
 "clD" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor,
@@ -37248,7 +37239,7 @@
 	move_lag = 10;
 	operating = 1
 	},
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor,
 /area/station/storage/tools)
 "jJY" = (
 /obj/table/auto,
@@ -37488,6 +37479,10 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/captain)
+"kdw" = (
+/obj/decal/stripe_caution,
+/turf/simulated/floor,
+/area/station/storage/tools)
 "kdB" = (
 /obj/shrub{
 	dir = 6
@@ -87916,7 +87911,7 @@ azt
 szI
 uES
 sIS
-aCs
+kdw
 clz
 aBG
 aig
@@ -88219,7 +88214,7 @@ ozO
 jIt
 oLQ
 nZe
-clA
+nZe
 wCt
 clH
 tKE

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -23287,7 +23287,7 @@
 	},
 /area/station/crew_quarters/market)
 "bGD" = (
-/obj/decal/stripe_delivery,
+/obj/machinery/computer/barcode,
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
 "bGF" = (
@@ -23295,8 +23295,11 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/shrub{
-	dir = 10
+/obj/railing/yellow,
+/obj/machinery/conveyor/NW{
+	id = "south";
+	operating = 1;
+	move_lag = 10
 	},
 /turf/simulated/floor/green/side{
 	dir = 1
@@ -31342,13 +31345,6 @@
 	},
 /turf/space/fluid,
 /area/space)
-"ckp" = (
-/obj/machinery/conveyor_switch{
-	id = "south";
-	position = 1
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/info)
 "ckq" = (
 /obj/machinery/light/incandescent/blueish,
 /turf/simulated/floor/grime,
@@ -31616,12 +31612,6 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
-"clE" = (
-/obj/table/reinforced/auto,
-/obj/item/wrapping_paper,
-/obj/decal/stripe_caution,
-/turf/simulated/floor,
-/area/station/crew_quarters/info)
 "clF" = (
 /obj/storage/crate,
 /obj/item/reagent_containers/food/snacks/fish_fingers,
@@ -31654,17 +31644,13 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
 "clK" = (
-/obj/stool/chair{
-	dir = 8
+/obj/machinery/conveyor/NS{
+	id = "south";
+	move_lag = 10;
+	operating = 1
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
-"clL" = (
-/obj/machinery/conveyor/EW/carousel,
-/obj/lattice,
-/obj/machinery/cargo_router/oshan_south,
-/turf/space/fluid,
-/area/space)
 "clN" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -32247,9 +32233,11 @@
 	},
 /area/station/engine/engineering)
 "cRS" = (
-/obj/machinery/computer/barcode,
 /obj/machinery/light/incandescent/netural,
-/obj/decal/stripe_caution,
+/obj/machinery/conveyor_switch{
+	id = "south";
+	position = 1
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
 "cSf" = (
@@ -34408,6 +34396,8 @@
 /obj/machinery/firealarm/west,
 /obj/machinery/light/incandescent/netural,
 /obj/decal/stripe_delivery,
+/obj/table/reinforced/auto,
+/obj/item/wrapping_paper,
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
 "fFG" = (
@@ -34957,6 +34947,20 @@
 /obj/item/raw_material/plasmastone,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/sunken_asteroid)
+"gsL" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/railing/yellow,
+/obj/machinery/conveyor/EW{
+	operating = 1;
+	move_lag = 10;
+	id = "south"
+	},
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/crew_quarters/market)
 "gti" = (
 /obj/storage/crate/rcd/CE,
 /obj/machinery/firealarm/east,
@@ -35515,6 +35519,12 @@
 /obj/item/raw_material/syreline,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/sunken_asteroid)
+"hbV" = (
+/obj/lattice,
+/obj/machinery/conveyor/NW/carousel,
+/obj/machinery/cargo_router/oshan_south,
+/turf/space/fluid,
+/area/space)
 "hcV" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Crew Lounge"
@@ -37164,8 +37174,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northeast)
 "jIt" = (
-/obj/mapping_helper/wingrille_spawn/auto,
-/obj/window_blinds/cog2/middle,
+/obj/machinery/conveyor/SW{
+	id = "north";
+	move_lag = 10;
+	operating = 1
+	},
 /turf/simulated/floor/plating/random,
 /area/station/storage/tools)
 "jJY" = (
@@ -40287,6 +40300,14 @@
 /obj/cable,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom)
+"nZe" = (
+/obj/machinery/conveyor/SN{
+	id = "north";
+	move_lag = 10;
+	operating = 1
+	},
+/turf/simulated/floor,
+/area/station/storage/tools)
 "nZg" = (
 /obj/machinery/door/airlock/pyro/alt{
 	name = "Refinery"
@@ -40615,6 +40636,13 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/darkpurple,
 /area/station/crew_quarters/data)
+"ozO" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/railing/yellow,
+/turf/simulated/floor/yellow/side,
+/area/station/hallway/primary/north)
 "oAu" = (
 /obj/machinery/disposal/mail/small/autoname{
 	dir = 1;
@@ -40830,6 +40858,15 @@
 /obj/machinery/light_switch/south,
 /turf/simulated/floor/green/side,
 /area/station/turret_protected/Zeta)
+"oLQ" = (
+/obj/machinery/conveyor/SN{
+	id = "north";
+	move_lag = 10;
+	operating = 1
+	},
+/obj/strip_door,
+/turf/simulated/floor,
+/area/station/storage/tools)
 "oLV" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -42221,6 +42258,15 @@
 /obj/landmark/bill_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
+"qKx" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/decal/stripe_delivery,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/crew_quarters/market)
 "qLc" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon19,
 /turf/simulated/floor/wood,
@@ -42353,6 +42399,15 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"qTh" = (
+/obj/machinery/conveyor/NS{
+	id = "south";
+	move_lag = 10;
+	operating = 1
+	},
+/obj/strip_door,
+/turf/simulated/floor,
+/area/station/crew_quarters/market)
 "qTt" = (
 /obj/machinery/vending/janitor,
 /turf/simulated/floor/specialroom/arcade,
@@ -43245,6 +43300,13 @@
 /obj/portrait_sneaky,
 /turf/simulated/wall/auto/reinforced/old,
 /area/evilreaver/bridge)
+"szI" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/railing/yellow,
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/north)
 "sAk" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle{
@@ -43262,6 +43324,10 @@
 /obj/item/raw_material/bohrum,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/sunken_asteroid)
+"sAW" = (
+/obj/decal/stripe_caution,
+/turf/simulated/floor,
+/area/station/crew_quarters/info)
 "sBC" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -43386,6 +43452,10 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/hallway/secondary/oshan_arrivals)
+"sIS" = (
+/obj/mapping_helper/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/storage/tools)
 "sJy" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable{
@@ -44525,6 +44595,14 @@
 	},
 /turf/space/fluid,
 /area/space)
+"uES" = (
+/obj/machinery/conveyor/EW{
+	operating = 1;
+	move_lag = 10;
+	id = "north"
+	},
+/turf/simulated/floor,
+/area/station/storage/tools)
 "uEW" = (
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -46376,11 +46454,6 @@
 /obj/machinery/door_control/podbay/security/new_walls/east,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
-"xne" = (
-/obj/mapping_helper/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/alt,
-/turf/simulated/floor,
-/area/station/storage/tools)
 "xnu" = (
 /obj/cable/reinforced{
 	icon_state = "4-8-thick"
@@ -86771,7 +86844,7 @@ atv
 ayt
 azt
 aAJ
-aBG
+sIS
 fwi
 aCs
 aCs
@@ -87073,8 +87146,8 @@ atv
 ayt
 azt
 aAI
-aBG
-aCs
+sIS
+sIS
 aCs
 clx
 wHz
@@ -87375,8 +87448,8 @@ xJL
 jCs
 vrP
 aAD
-xne
-aCs
+clv
+sIS
 aCs
 cly
 uNC
@@ -87676,9 +87749,9 @@ asc
 and
 ayt
 azt
-aAE
-aBG
-aCs
+szI
+uES
+sIS
 aCs
 clz
 aBG
@@ -87978,10 +88051,10 @@ bcG
 lnt
 aoF
 azt
-aAA
+ozO
 jIt
-clv
-clv
+oLQ
+nZe
 clA
 wCt
 clH
@@ -98905,9 +98978,9 @@ aqn
 aqn
 aqn
 ckk
-clL
-qYT
-bGD
+cjV
+bvN
+sAW
 bxf
 bxf
 fJb
@@ -99209,11 +99282,11 @@ aqn
 ckk
 cjV
 bvN
-ckp
+sAW
 bxf
 clI
 byh
-clO
+qKx
 byS
 bIm
 bJj
@@ -99515,7 +99588,7 @@ cRS
 bxf
 clJ
 iUv
-clO
+gsL
 byS
 bIm
 bJk
@@ -99811,12 +99884,12 @@ cjX
 ckg
 ckC
 cjZ
-ckA
-bvN
-clE
-bxf
+hbV
+qYT
 clK
-byh
+clK
+clK
+qTh
 bGF
 bHD
 bIm


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
An alternative to #20625, starting to improve the carousel by making the dropoff stations more accessible and adding a chute from QM onto the belt.
In future it'd be nice to add additional dropoff stations in other locations but this should go some way towards making the big belt loop a bit more practical to use.
![image](https://github.com/user-attachments/assets/8ddde7e8-f37b-4fe4-8d49-fa2667f35b50)
![image](https://github.com/user-attachments/assets/12f01c2f-c95f-4829-b6b8-a1f4fb3a539a)
![image](https://github.com/user-attachments/assets/cea8055c-da7d-4865-9193-9ce4038959cd)
![image](https://github.com/user-attachments/assets/038b1ff3-7ae7-4af6-ad71-926d273c9e92)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I like the carousel but I think some of the criticism in the removal PR is valid so I tried to improve it a bit!


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)The Oshan belt carousel stations have been improved and a chute has been added from cargo onto the belt.
```
