### PR TITLE
Increase Armory door health

### DIFF
--- a/code/obj/machinery/door/airlock_pyro.dm
+++ b/code/obj/machinery/door/airlock_pyro.dm
@@ -81,6 +81,8 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/command/syndicate)
 	hardened = FALSE
 	cant_hack = TRUE
 	aiControlDisabled = FALSE
+	health = 800
+	health_max = 800
 
 /obj/machinery/door/airlock/pyro/security
 	name = "security airlock"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases Armory door health from 600 > 800


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Big buff door should have big buff health and not just be the same as the regular door, some armories before this change had command doors and 800 is the health command doors have
Fixes #20411

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Armory door health increased from 600 to 800
```
