### PR TITLE
Latejoin Cyborg if no borgs/roboticists

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -316,6 +316,8 @@ var/global/current_state = GAME_STATE_INVALID
 	if(!countJob("AI")) // There is no roundstart AI, spawn in a Latejoin AI on the spawn landmark.
 		for(var/turf/T in job_start_locations["AI"])
 			new /mob/living/silicon/ai/latejoin(T)
+	if(!countJob("Cyborg") && !countJob("Roboticist")) //if no borgs or roboticists to make borgs, autobuild a latejoin one
+		new /mob/living/silicon/robot/spawnable/light/latejoin(pick(job_start_locations["Cyborg"]))
 	if(!processScheduler.isRunning)
 		processScheduler.start()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If there are no cyborgs or roboticists, spawn a light latejoin cyborg at a cyborg start location.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Borg is one of the only jobs you cant latejoin as if there are none of them, im not a fan of this but also didnt want to take the roboticist's job, this wont affect most rounds.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)If there are no cyborgs or roboticists, a light latejoin cyborg will spawn in robotics.
```
