### PR TITLE
Fix Engine warning announcement

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -296,22 +296,13 @@ var/global/current_state = GAME_STATE_INVALID
 		qdel(monke)
 #endif
 
-#ifdef MAP_OVERRIDE_NADIR
-	SPAWN(30 MINUTES) // special catalytic engine warning
-		for(var/obj/machinery/power/catalytic_generator/CG in machine_registry[MACHINES_POWER])
-			LAGCHECK(LAG_LOW)
-			if(CG?.gen_rate < 70000 WATTS)
-				command_alert("Reports indicate that one or more catalytic generators on [station_name()] may require replacement rods for continued operation. If catalytic rods are not replaced, this may result in sitewide power failures.", "Power Grid Warning")
-			break
-#else
 	SPAWN(10 MINUTES) // standard engine warning
-		for(var/obj/machinery/computer/power_monitor/smes/E in machine_registry[MACHINES_POWER])
+		for_by_tcl(E, /obj/machinery/computer/power_monitor/smes)
 			LAGCHECK(LAG_LOW)
 			var/datum/powernet/PN = E.get_direct_powernet()
 			if(PN?.avail <= 0)
 				command_alert("Reports indicate that the engine on-board [station_name()] has not yet been started. Setting up the engine is strongly recommended, or else stationwide power failures may occur.", "Power Grid Warning", alert_origin = ALERT_STATION)
 			break
-#endif
 
 	if(!countJob("AI")) // There is no roundstart AI, spawn in a Latejoin AI on the spawn landmark.
 		for(var/turf/T in job_start_locations["AI"])

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -109,6 +109,14 @@
 	window_tag = "smespowcomp"
 	circuit_type = /obj/item/circuitboard/powermonitor_smes
 
+/obj/machinery/computer/power_monitor/smes/New()
+	..()
+	START_TRACKING
+
+/obj/machinery/computer/power_monitor/smes/disposing()
+	STOP_TRACKING
+	..()
+
 /obj/machinery/computer/power_monitor/smes/ui_static_data(mob/user)
 	. = list(
 		"type" = "smes",

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -110,12 +110,12 @@
 	circuit_type = /obj/item/circuitboard/powermonitor_smes
 
 /obj/machinery/computer/power_monitor/smes/New()
-	..()
+	. = ..()
 	START_TRACKING
 
 /obj/machinery/computer/power_monitor/smes/disposing()
 	STOP_TRACKING
-	..()
+	. = ..()
 
 /obj/machinery/computer/power_monitor/smes/ui_static_data(mob/user)
 	. = list(


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The code was checking for /obj/machinery/computer/power_monitor/smes in the MACHINES_POWER registry, it isnt in there. now just track smes monitors and for_by_tcl them.

Also remove special Nadir announcement because nadir has an engine like every other map

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nice QOL to tell everyone the engineers are slacking BEFORE it impacts the crew.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)The automated alert for the engine not being setup has been fixed.
```
