### PR TITLE
Fix "your clothes prevent you from getting cleaner" Hygiene message

### DIFF
--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -168,23 +168,22 @@ datum
 								boutput(H, "<span class='alert'><b>The water! It[pick(" burns"," hurts","'s so terrible","'s ruining your skin"," is your true mortal enemy!")]!</b></span>", group = "aquaphobia")
 							if (!ON_COOLDOWN(H, "bingus_damage", 3 SECONDS))
 								random_burn_damage(H, clamp(0.3 * volume, 4, 20))
-						if (H.sims)
-							if (hygiene_value)
-								var/hygiene = H.sims.getValue("Hygiene")
-								var/hygiene_restore = hygiene_value
-								var/hygiene_cap = 100 - H.get_chem_protection() * 4 // Hygiene will not restore above this cap; typical minimum of 40%
-								var/hygiene_distance_from_cap = hygiene_cap - hygiene
-								var/hygiene_change = min(volume * hygiene_restore * (1 - (H.get_chem_protection() / 100)), max(hygiene_distance_from_cap, 0))
+						if (hygiene_value && H.sims?.getValue("Hygiene"))
+							var/hygiene = H.sims.getValue("Hygiene")
+							var/hygiene_restore = hygiene_value
+							var/hygiene_cap = 100 - H.get_chem_protection() * 4 // Hygiene will not restore above this cap; typical minimum of 40%
+							var/hygiene_distance_from_cap = hygiene_cap - hygiene
+							var/hygiene_change = min(volume * hygiene_restore * (1 - (H.get_chem_protection() / 100)), max(hygiene_distance_from_cap, 0))
 
-								if (H.mutantrace.aquaphobic)
-									if (istype(src, /datum/reagent/oil))
-										hygiene_restore = 3
-									else if (istype(src, /datum/reagent/water))
-										hygiene_restore = -3
-								if (hygiene_distance_from_cap == 0 && !(hygiene_cap == 100) && hygiene_change == 0)
-									if(!ON_COOLDOWN(H, "Hygiene_restoration_blocked_by_clothes", 1 MINUTE))
-										boutput(M, SPAN_ALERT("Your clothes prevent you from getting any cleaner!"))
-								H.sims.affectMotive("Hygiene", hygiene_change)
+							if (H.mutantrace.aquaphobic)
+								if (istype(src, /datum/reagent/oil))
+									hygiene_restore = 3
+								else if (istype(src, /datum/reagent/water))
+									hygiene_restore = -3
+							if (hygiene_distance_from_cap == 0 && !(hygiene_cap == 100) && hygiene_change == 0)
+								if(!ON_COOLDOWN(H, "Hygiene_restoration_blocked_by_clothes", 1 MINUTE))
+									boutput(M, SPAN_ALERT("Your clothes prevent you from getting any cleaner!"))
+							H.sims.affectMotive("Hygiene", hygiene_change)
 
 				if(INGEST)
 					var/datum/ailment_data/addiction/AD = M.addicted_to_reagent(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][rp]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevent message "Your clothes prevent you from getting any cleaner!" when touching liquids with hygiene value when hygiene motive is not enabled.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Message doesn't make sense now that hygiene is gone.
