### PR TITLE
Delete duplicate HoS locker on atlas

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -13879,7 +13879,6 @@
 /area/station/janitor/office)
 "hQG" = (
 /obj/storage/secure/closet/command/hos,
-/obj/storage/secure/closet/command/hos,
 /obj/machinery/door_control/bolter/new_walls/north{
 	id = "quarters_hos";
 	dir = 2


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Other people kept rolling hos on atlas so I only just noticed this, at least i got a double cape out of it
![image](https://github.com/user-attachments/assets/71acf32f-061e-4267-bd8e-e925f2047597)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Atlas stop having mapping bugs that i caused please