### PR TITLE
Adds a bunch more Medical Specialist names

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1399,8 +1399,27 @@ ABSTRACT_TYPE(/datum/job/special/random)
 	slot_ears = list(/obj/item/device/radio/headset/medical)
 	slot_rhan = list(/obj/item/storage/firstaid/docbag)
 	slot_poc1 = list(/obj/item/device/pda2/medical_director)
-	alt_names = list("Neurological Specialist", "Ophthalmic Specialist", "Thoracic Specialist", "Orthopaedic Specialist", "Maxillofacial Specialist",
-	  "Vascular Specialist", "Anaesthesiologist", "Acupuncturist", "Medical Director's Assistant")
+	alt_names = list(
+		"Acupuncturist",
+	  	"Anesthesiologist",
+		"Cardiologist",
+		"Dental Specialist",
+		"Dermatologist",
+		"Emergency Medicine Specialist",
+		"Hematology Specialist",
+		"Hepatology Specialist",
+		"Immunology Specialist",
+		"Internal Medicine Specialist",
+		"Maxillofacial Specialist",
+		"Medical Director's Assistant",
+		"Neurological Specialist",
+		"Ophthalmic Specialist",
+		"Orthopaedic Specialist",
+		"Otorhinolaryngology Specialist",
+		"Plastic Surgeon",
+		"Thoracic Specialist",
+		"Vascular Specialist",
+	)
 
 /datum/job/special/random/vip
 	name = "VIP"

--- a/code/lists/jobs.dm
+++ b/code/lists/jobs.dm
@@ -77,21 +77,115 @@ var/list/page_departments = list(
 	all_jobs += "Staff Assistant"
 	return all_jobs
 
-var/list/command_jobs = list("Captain", "Medical Director", "Research Director", "Head of Personnel", "Head of Security", "Chief Engineer", "Communications Officer"/*"Clown"*/)
-var/list/security_jobs = list("Head of Security", "Nanotrasen Security Consultant", "Nanotrasen Special Operative", "Security Officer", "Security Assistant", "Detective")
-var/list/engineering_jobs = list("Chief Engineer", "Engineer", "Miner", "Quartermaster")
-var/list/medical_jobs = list("Medical Director", "Medical Doctor", "Roboticist", "Geneticist")
-var/list/science_jobs = list("Research Director", "Scientist")
+var/list/command_jobs = list(
+	"Captain",
+	"Medical Director",
+	"Research Director",
+	"Head of Personnel",
+	"Head of Security",
+	"Chief Engineer",
+	"Communications Officer",
+	/*"Clown"*/
+)
+var/list/security_jobs = list(
+	"Head of Security",
+	"Nanotrasen Security Consultant",
+	"Nanotrasen Special Operative",
+	"Security Officer",
+	"Security Assistant",
+	"Detective",
+)
+var/list/engineering_jobs = list(
+	"Chief Engineer",
+	"Engineer",
+	"Miner",
+	"Quartermaster",
+)
+var/list/medical_jobs = list(
+	"Medical Director",
+	"Medical Doctor",
+	"Roboticist",
+	"Geneticist"
+)
+var/list/science_jobs = list(
+	"Research Director",
+	"Scientist",
+)
 var/list/medsci_jobs = medical_jobs + science_jobs
-var/list/service_jobs = list("Head of Personnel", "Bartender", "Chef", "Botanist", "Rancher", "Angler", "Clown", "Chaplain", "Janitor")
+var/list/service_jobs = list(
+	"Head of Personnel",
+	"Bartender",
+	"Chef",
+	"Botanist",
+	"Rancher",
+	"Angler",
+	"Clown",
+	"Chaplain",
+	"Janitor",
+)
 
 // we have to include alt names for jobs or they won't be sorted into categories correctly
-var/list/command_gimmicks = list("Head of Mining", "Nanotrasen Security Consultant" /* NTSC isn't a gimmick role, but for the sake of sorting, it practically is*/)
-var/list/security_gimmicks = list("Vice Officer", "Forensic Technician")
-var/list/engineering_gimmicks = list("Head of Mining", "Station Builder", "Atmospherish Technician", "Technical Assistant")
-var/list/medical_gimmicks = list("Medical Specialist", "Neurological Specialist", "Ophthalmic Specialist", "Thoracic Specialist", "Orthopaedic Specialist", "Maxillofacial Specialist",
-	  "Vascular Specialist", "Anaesthesiologist", "Acupuncturist", "Medical Director's Assistant", "Medical Assistant", "Pharmacist", "Psychiatrist", "Psychologist", "Psychotherapist", "Therapist", "Counselor")
-var/list/science_gimmicks = list("Toxins Researcher", "Chemist", "Research Assistant", "Test Subject")
+var/list/command_gimmicks = list(
+	"Head of Mining",
+	"Nanotrasen Security Consultant" /* NTSC isn't a gimmick role, but for the sake of sorting, it practically is*/,
+)
+var/list/security_gimmicks = list(
+	"Vice Officer",
+	"Forensic Technician",
+)
+var/list/engineering_gimmicks = list(
+	"Head of Mining",
+	"Station Builder",
+	"Atmospherish Technician",
+	"Technical Assistant",
+)
+var/list/medical_gimmicks = list(
+	"Acupuncturist",
+	"Anesthesiologist",
+	"Cardiologist",
+	"Counselor",
+	"Dental Specialist",
+	"Dermatologist",
+	"Emergency Medicine Specialist",
+	"Hematology Specialist",
+	"Hepatology Specialist",
+	"Immunology Specialist",
+	"Internal Medicine Specialist",
+	"Maxillofacial Specialist",
+	"Medical Director's Assistant",
+	"Neurological Specialist",
+	"Ophthalmic Specialist",
+	"Orthopaedic Specialist",
+	"Otorhinolaryngology Specialist",
+	"Pharmacist",
+	"Plastic Surgeon",
+	"Psychiatrist",
+	"Psychologist",
+	"Psychotherapist",
+	"Therapist",
+	"Thoracic Specialist",
+	"Vascular Specialist",
+)
+var/list/science_gimmicks = list(
+	"Toxins Researcher",
+	"Chemist",
+	"Research Assistant",
+	"Test Subject",
+)
 var/list/medsci_gimmicks = medical_gimmicks + science_gimmicks
-var/list/service_gimmicks = list("Lawyer", "Barber", "Mail Courier", "Head of Deliverying", "Mail Bringer", "Mime", "Musician", "Apiculturist", "Apiarist", "Sous-Chef", "Waiter", "Life Coach","Stowaway")
+var/list/service_gimmicks = list(
+	"Lawyer",
+	"Barber",
+	"Mail Courier",
+	"Head of Deliverying",
+	"Mail Bringer",
+	"Mime",
+	"Musician",
+	"Apiculturist",
+	"Apiarist",
+	"Sous-Chef",
+	"Waiter",
+	"Life Coach",
+	"Stowaway",
+)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MEDICAL][FEAT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Increases the pool of alternate names for the Medical Specialist.

Renames Anaesthesiologist to Anesthesiologist to reflect the correct American spelling. Retaining the "ae" would make sense if in reference to Anaesthetists (UK term).

Sorts the list of alternate names alphabetically.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Flavourful.