### PR TITLE
Stop space fungus from causing food poisoning

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1078,18 +1078,6 @@ datum
 			hygiene_value = -0.5
 			viscosity = 0.55
 
-			reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)
-				. = ..()
-				if (method == INGEST)
-					var/ranchance = rand(1,10)
-					if (ranchance == 1)
-						boutput(M, SPAN_ALERT("You feel very sick."))
-						M.reagents.add_reagent("toxin", rand(1,5))
-					else if (ranchance <= 5)
-						boutput(M, SPAN_ALERT("That tasted absolutely FOUL."))
-						M.contract_disease(/datum/ailment/disease/food_poisoning, null, null, 1) // path, name, strain, bypass resist
-					else boutput(M, SPAN_ALERT("Yuck!"))
-				return
 
 			on_plant_life(var/obj/machinery/plantpot/P, var/datum/plantgrowth_tick/growth_tick)
 				growth_tick.endurance_bonus += 0.5


### PR DESCRIPTION
[Chemistry][Removal]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR removes the space fungus INGEST effect.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Dishes made out of mushrooms provided by botany, especially mushroom pizza, caused food poisoning because of space fungus. I couldn't let this crime left unresolved, because mushrooms on pizza is fucking delicious.  

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Space fungus cannot cause food poisoning anymore.
```
