### PR TITLE
Make "Hairy" trait magic + Vanilla ignores magic genes

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1337,7 +1337,7 @@ TYPEINFO(/datum/trait/partyanimal)
 	icon_state = "hair"
 
 	onAdd(mob/owner)
-		owner.bioHolder.AddEffect("hair_growth")
+		owner.bioHolder.AddEffect("hair_growth", magical = TRUE)
 
 	onRemove(mob/owner)
 		owner.bioHolder.RemoveEffect("hair_growth")

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -2929,7 +2929,7 @@ datum
 				. = ..()
 				if ( (method==TOUCH && prob(33)) || method==INGEST)
 					if(M.bioHolder.HasAnyEffect(EFFECT_TYPE_POWER) && prob(4))
-						M.bioHolder.RemoveAllEffects(EFFECT_TYPE_POWER, TRUE)
+						M.bioHolder.RemoveAllEffects(EFFECT_TYPE_POWER)
 						boutput(M, "You feel plain.")
 				return
 

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -2929,7 +2929,7 @@ datum
 				. = ..()
 				if ( (method==TOUCH && prob(33)) || method==INGEST)
 					if(M.bioHolder.HasAnyEffect(EFFECT_TYPE_POWER) && prob(4))
-						M.bioHolder.RemoveAllEffects(EFFECT_TYPE_POWER)
+						M.bioHolder.RemoveAllEffects(EFFECT_TYPE_POWER, TRUE)
 						boutput(M, "You feel plain.")
 				return
 

--- a/code/modules/medical/genetics/baseBioeffect.dm
+++ b/code/modules/medical/genetics/baseBioeffect.dm
@@ -53,7 +53,7 @@ ABSTRACT_TYPE(/datum/bioEffect)
 	var/reclaim_mats = 10 // Materials returned when this gene is reclaimed
 	var/reclaim_fail = 5 // Chance % for a reclamation of this gene to fail
 	var/curable_by_mutadone = TRUE //! if 0/FALSE, we cant mutadone this - reinforced, magic genes and anti-toxins use this
-	var/curable_by_vanilla = TRUE //! only for magical genes like clown clumsiness or hairy trait! - we REALLY dont want to lose this
+	var/is_magical = FALSE //! only for trait genes/similar, we really dont want to lose this
 	var/stability_loss = 0
 	var/tmp/activated_from_pool = 0
 	var/altered = 0

--- a/code/modules/medical/genetics/baseBioeffect.dm
+++ b/code/modules/medical/genetics/baseBioeffect.dm
@@ -52,7 +52,8 @@ ABSTRACT_TYPE(/datum/bioEffect)
 	var/req_mut_research = null // If set, need to research the mutation before you can do anything w/ this one
 	var/reclaim_mats = 10 // Materials returned when this gene is reclaimed
 	var/reclaim_fail = 5 // Chance % for a reclamation of this gene to fail
-	var/curable_by_mutadone = 1
+	var/curable_by_mutadone = TRUE //! if 0/FALSE, we cant mutadone this - reinforced, magic genes and anti-toxins use this
+	var/curable_by_vanilla = TRUE //! only for magical genes like clown clumsiness or hairy trait! - we REALLY dont want to lose this
 	var/stability_loss = 0
 	var/tmp/activated_from_pool = 0
 	var/altered = 0

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -764,7 +764,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 				newEffect.can_reclaim = FALSE
 				newEffect.degrade_to = null
 				newEffect.can_copy = FALSE
-				newEffect.curable_by_vanilla = FALSE
+				newEffect.is_magical = TRUE
 
 			if(safety && istype(newEffect, /datum/bioEffect/power))
 				// Only powers have safety ("synced" i.e. safe for user)
@@ -865,11 +865,11 @@ var/list/datum/bioEffect/mutini_effects = list()
 		logTheThing(LOG_COMBAT, owner, "loses the [effect] mutation at [log_loc(owner)].")
 		return effects.Remove(effect.id)
 
-	proc/RemoveAllEffects(var/type = null, var/ignoreMagic = FALSE)
+	proc/RemoveAllEffects(var/type = null, var/ignoreMagic = TRUE)
 		for(var/D as anything in effects)
 			var/datum/bioEffect/BE = effects[D]
 			if(BE && (isnull(type) || BE.effectType == type))
-				if(ignoreMagic == FALSE || ignoreMagic == TRUE && BE.curable_by_vanilla == TRUE) // No removing hairy trait or job traits!
+				if(!ignoreMagic ||ignoreMagic && !BE.is_magical) // No removing hairy trait or job traits!
 					RemoveEffect(BE.id)
 					BE.owner = null
 					BE.holder = null

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -865,7 +865,8 @@ var/list/datum/bioEffect/mutini_effects = list()
 		logTheThing(LOG_COMBAT, owner, "loses the [effect] mutation at [log_loc(owner)].")
 		return effects.Remove(effect.id)
 
-	proc/RemoveAllEffects(var/type = null, var/ignoreMagic = TRUE)
+	///ignoreMagic means "do not remove magical bioeffects"
+	proc/RemoveAllEffects(var/type = null, var/ignoreMagic = FALSE)
 		for(var/D as anything in effects)
 			var/datum/bioEffect/BE = effects[D]
 			if(BE && (isnull(type) || BE.effectType == type))

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -759,7 +759,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 			if(timeleft) newEffect.timeLeft = timeleft
 			if(magical)
 				newEffect.curable_by_mutadone = FALSE
-				newEffect.stability_loss = FALSE
+				newEffect.stability_loss = 0
 				newEffect.can_scramble = FALSE
 				newEffect.can_reclaim = FALSE
 				newEffect.degrade_to = null

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -758,12 +758,13 @@ var/list/datum/bioEffect/mutini_effects = list()
 			if(power) newEffect.power = power
 			if(timeleft) newEffect.timeLeft = timeleft
 			if(magical)
-				newEffect.curable_by_mutadone = 0
-				newEffect.stability_loss = 0
-				newEffect.can_scramble = 0
-				newEffect.can_reclaim = 0
+				newEffect.curable_by_mutadone = FALSE
+				newEffect.stability_loss = FALSE
+				newEffect.can_scramble = FALSE
+				newEffect.can_reclaim = FALSE
 				newEffect.degrade_to = null
-				newEffect.can_copy = 0
+				newEffect.can_copy = FALSE
+				newEffect.curable_by_vanilla = FALSE
 
 			if(safety && istype(newEffect, /datum/bioEffect/power))
 				// Only powers have safety ("synced" i.e. safe for user)
@@ -864,17 +865,17 @@ var/list/datum/bioEffect/mutini_effects = list()
 		logTheThing(LOG_COMBAT, owner, "loses the [effect] mutation at [log_loc(owner)].")
 		return effects.Remove(effect.id)
 
-	proc/RemoveAllEffects(var/type = null)
+	proc/RemoveAllEffects(var/type = null, var/ignoreMagic = FALSE)
 		for(var/D as anything in effects)
 			var/datum/bioEffect/BE = effects[D]
 			if(BE && (isnull(type) || BE.effectType == type))
-				RemoveEffect(BE.id)
-				BE.owner = null
-				BE.holder = null
-				if(istype(BE, /datum/bioEffect/power))
-					var/datum/bioEffect/power/BEP = BE
-					BEP?.ability?.owner = null
-				//qdel(BE)
+				if(ignoreMagic == FALSE || ignoreMagic == TRUE && BE.curable_by_vanilla == TRUE) // No removing hairy trait or job traits!
+					RemoveEffect(BE.id)
+					BE.owner = null
+					BE.holder = null
+					if(istype(BE, /datum/bioEffect/power))
+						var/datum/bioEffect/power/BEP = BE
+						BEP?.ability?.owner = null
 		return 1
 
 	proc/RemoveAllPoolEffects(var/type = null)

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -869,7 +869,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 		for(var/D as anything in effects)
 			var/datum/bioEffect/BE = effects[D]
 			if(BE && (isnull(type) || BE.effectType == type))
-				if(!ignoreMagic ||ignoreMagic && !BE.is_magical) // No removing hairy trait or job traits!
+				if(!ignoreMagic || ignoreMagic && !BE.is_magical) // No removing hairy trait or job traits!
 					RemoveEffect(BE.id)
 					BE.owner = null
 					BE.holder = null


### PR DESCRIPTION
## About the PR 
Makes the mutantrace hair bioeffect magic, meaning it can't be scrambled, removed or otherwise messed with like other bioeffects from traits.
Also makes Vanilla and any other source of removealleffects unable to remove magic genes, so you can't get out of being a true Clown from it.

Tested with Clown, Mime and Lizard with the "Hairy" trait.

## Why's this needed?
Being able to reliably remove clown clumsiness and mime muteness seems like an oversight. Same with mutantrace hair for the rest of their round.  Bug/Oversight fix.

fixes #20611
fixes #20700