### PR TITLE
Improves disco stress test

### DIFF
--- a/code/modules/admin/debug.dm
+++ b/code/modules/admin/debug.dm
@@ -756,7 +756,6 @@ body
 				if(istype(T, /turf/space) || istype(T, /turf/simulated/floor/airless/plating/catwalk))
 					continue
 				qdel(door)
-
 		if ("Chemist's Delight")
 			for (var/turf/simulated/floor/T in world)
 				LAGCHECK(LAG_LOW)

--- a/code/modules/admin/debug.dm
+++ b/code/modules/admin/debug.dm
@@ -736,19 +736,27 @@ body
 	var/selected = input("Select scenario", "Do not use on a live server for the love of god", "Cancel") in list("Cancel", "Disco Inferno", "Chemist's Delight", "Viscera Cleanup Detail", "Brighter Bonanza", "Monkey Business","Monkey Chemistry","Monkey Gear","Clothing Dummies")
 	switch (selected)
 		if ("Disco Inferno")
-			for (var/turf/T in landmarks[LANDMARK_BLOBSTART])
+			for (var/turf/T as anything in landmarks[LANDMARK_BLOBSTART]+landmarks[LANDMARK_HALLOWEEN_SPAWN]+landmarks[LANDMARK_PESTSTART])
 				var/datum/gas_mixture/gas = new /datum/gas_mixture
-				gas.toxins = 10000
-				gas.oxygen = 10000
-				gas.temperature = 10000
+				gas.toxins = 33333
+				gas.oxygen = 66666
+				gas.temperature = 100000
 				T.assume_air(gas)
-			for (var/obj/machinery/door/door in by_type[/obj/machinery/door])
-				if (istype(door, /obj/machinery/door/airlock/pyro/maintenance) || istype(door, /obj/machinery/door/airlock/maintenance))
-					LAGCHECK(LAG_LOW)
-					qdel(door)
-			for (var/obj/machinery/door/firedoor/door in by_type[/obj/machinery/door])
-				LAGCHECK(LAG_LOW)
+			for_by_tcl(door, /obj/machinery/door)
+				var/turf/T = get_step(door, NORTH)
+				if(istype(T, /turf/space) || istype(T, /turf/simulated/floor/airless/plating/catwalk))
+					continue
+				T = get_step(door, SOUTH)
+				if(istype(T, /turf/space) || istype(T, /turf/simulated/floor/airless/plating/catwalk))
+					continue
+				T = get_step(door, EAST)
+				if(istype(T, /turf/space) || istype(T, /turf/simulated/floor/airless/plating/catwalk))
+					continue
+				T = get_step(door, WEST)
+				if(istype(T, /turf/space) || istype(T, /turf/simulated/floor/airless/plating/catwalk))
+					continue
 				qdel(door)
+
 		if ("Chemist's Delight")
 			for (var/turf/simulated/floor/T in world)
 				LAGCHECK(LAG_LOW)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Improves the disco inferno stress test by increasing spawn spots, improving the burn mixture, and improving door deletion selection to not open to space and to delete more doors.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
must boogie down harder