### PR TITLE
Broken disposals pipes cost 1 welding fuel to remove

### DIFF
--- a/code/modules/disposals/disposal.dm
+++ b/code/modules/disposals/disposal.dm
@@ -193,7 +193,7 @@
 	plane = PLANE_FLOOR
 	var/base_icon_state	//! Initial icon state on map
 	var/list/mail_tag = null //! Tag of mail group for switching pipes
-	var/welding_cost = 3
+	var/welding_cost = 3 //! Amount of welding fuel it costs to install/remove
 
 
 	var/image/pipeimg = null

--- a/code/modules/disposals/disposal.dm
+++ b/code/modules/disposals/disposal.dm
@@ -193,6 +193,7 @@
 	plane = PLANE_FLOOR
 	var/base_icon_state	//! Initial icon state on map
 	var/list/mail_tag = null //! Tag of mail group for switching pipes
+	var/welding_cost = 3
 
 
 	var/image/pipeimg = null
@@ -451,7 +452,7 @@
 			return		// prevent interaction with T-scanner revealed pipes
 
 		if (isweldingtool(I))
-			if (I:try_weld(user, 3, noisy = 2))
+			if (I:try_weld(user, src.welding_cost, noisy = 2))
 				// check if anything changed over 2 seconds
 				var/turf/uloc = user.loc
 				var/atom/wloc = I.loc
@@ -2003,6 +2004,7 @@ TYPEINFO(/obj/item/reagent_containers/food/snacks/einstein_loaf)
 	dpdir = 0		// broken pipes have dpdir=0 so they're not found as 'real' pipes
 					// i.e. will be treated as an empty turf
 	desc = "A broken piece of disposal pipe."
+	welding_cost = 1
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Make the cost of welding disposals pipes a variable on the pipe, and change broken pipes to only cost 1 welding fuel instead of 3.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently it costs 9 welding fuel to replace a single broken disposal pipe; removing both broken ends and then installing the new one at 3 fuel each. This is nearly half of a welding tool's capacity, making repair tedious as you must constantly refuel your welding tool. This change lowers the overall cost replacing broken pipes to 5 welding fuel; removing intact pipes still costs 3 fuel.