### PR TITLE
Remove intended loyalist headrev interaction

### DIFF
--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -82,7 +82,6 @@ var/datum/job_controller/job_controls
 		if (!valid_jobs.Find(job))
 			logTheThing(LOG_DEBUG, null, "<b>Jobs:</b> check job eligibility error - [player.ckey] requested [job.name], but it was not found in list of valid jobs! (Flag value: [valid_categories]).")
 			return
-		var/datum/preferences/P = player.client.preferences
 		// antag job exemptions
 		if(player.mind?.is_antagonist())
 			if ((!job.allow_traitors && player.mind.special_role))

--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -89,7 +89,7 @@ var/datum/job_controller/job_controls
 				return
 			else if (!job.allow_spy_theft && (player.mind.special_role == ROLE_SPY_THIEF))
 				return
-			else if (istype(ticker?.mode, /datum/game_mode/revolution) && (job.cant_spawn_as_rev || ("loyalist" in P?.traitPreferences.traits_selected)))
+			else if (istype(ticker?.mode, /datum/game_mode/revolution) && job.cant_spawn_as_rev)
 				return
 			else if ((istype(ticker?.mode, /datum/game_mode/conspiracy)) && job.cant_spawn_as_con)
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the currently broken loyalist not rolling headrev code


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I don't think traits should interact with antag rolls, you should be able to have a beret and roll headrev, it is currently broken and there are no issues as is. If you dont want to roll headrev you can disable it. (I also have the suspicion that this code is forcing me to roll staff assistant whenever I roll headrev, even when I have other valid headrev jobs higher.