### PR TITLE
Remove RD and MD inter-department radio access

### DIFF
--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -234,31 +234,27 @@
 
 /obj/item/device/radio/headset/command/rd
 	name = "research director's headset"
-	desc = "This headset can receive on the Medical channel in addition to other secure frequencies. The 'sci' part of 'medsci'."
+	desc = "This headset seems to be covered in a large variety of burns."
 	secure_frequencies = list(
 		"h" = R_FREQ_COMMAND,
 		"r" = R_FREQ_RESEARCH,
-		"m" = R_FREQ_MEDICAL,
 		)
 	secure_classes = list(
 		"h" = RADIOCL_COMMAND,
 		"r" = RADIOCL_RESEARCH,
-		"m" = RADIOCL_MEDICAL,
 		)
 	icon_override = "rd"
 	icon_tooltip = "Research Director"
 
 /obj/item/device/radio/headset/command/md
 	name = "medical director's headset"
-	desc = "This headset can receive on the Research channel in addition to other secure frequencies. The 'med' part of 'medsci'."
+	desc = "Perfect for shouting at the Chief Engineer that the reactor is killing people."
 	secure_frequencies = list(
 		"h" = R_FREQ_COMMAND,
-		"r" = R_FREQ_RESEARCH,
 		"m" = R_FREQ_MEDICAL,
 		)
 	secure_classes = list(
 		"h" = RADIOCL_COMMAND,
-		"r" = RADIOCL_RESEARCH,
 		"m" = RADIOCL_MEDICAL,
 		)
 	icon_override = "md"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the RD's medical radio access
Removes the MD's science radio access


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consistency with other (HoS/CE) command headsets, they shouldn't have access to a radio channel outside of their department. I presume this is a remnant of when the RD was in charge of medbay but this just isnt the case anymore and it feels out of place with the relationship between medical and research now, they are different departments, with different heads of staff.

Im open to better descriptions for the headsets because im not a huge fan of these

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)The RD and MD no longer have access to each other's radio channels.
```
