### PR TITLE
Fix tooltip_rebuild getting cleared before it's evaluated

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -268,7 +268,7 @@ ABSTRACT_TYPE(/obj/item)
 
 				usr.client.tooltipHolder.showHover(src, tooltipParams)
 
-			tooltip_rebuild = 0
+				tooltip_rebuild = 0
 
 		usr.moused_over(src)
 


### PR DESCRIPTION
[FIX] [OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a storage item has an item added it sets tooltip_rebuild to 1, so next time the tooltip is rendered the text is rebuilt.
Currently, if the storage item is moused over and the tooltip tip wouldn't be shown (such as it being on the floor) tooltip_rebuild is cleared without the text getting rebuilt (only done when shown). This PR moves the statement clearing it within the if statement that decides whether the tooltip is shown, meaning it always gets the chance to be rebuilt if needed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes the issue reported in #20664 as well as making sure other tooltips will update correctly.
