### PR TITLE
Changes the name of the Pickpocket Gun

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1234,7 +1234,7 @@ TYPEINFO(/obj/item/gun/energy/pickpocket)
 				"conductive_high" = 5,
 				"energy_high" = 10)
 /obj/item/gun/energy/pickpocket
-	name = "\improper Super! Grapple Friend" // based off of the foam dart gun names
+	name = "\improper Super! Grapple Friend" // like foam dart guns
 	desc = "A complicated, camoflaged claw device on a tether capable of complex and stealthy interactions. It's definitely not just a repurposed janky toy that steals shit."
 	icon_state = "pickpocket"
 	w_class = W_CLASS_SMALL

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1234,8 +1234,8 @@ TYPEINFO(/obj/item/gun/energy/pickpocket)
 				"conductive_high" = 5,
 				"energy_high" = 10)
 /obj/item/gun/energy/pickpocket
-	name = "pickpocket grapple gun" // absurdly shitty name
-	desc = "A complicated, camoflaged claw device on a tether capable of complex and stealthy interactions. It steals shit."
+	name = "\improper Super! Grapple Friend" // based off of the foam dart gun names
+	desc = "A complicated, camoflaged claw device on a tether capable of complex and stealthy interactions. It's definitely not just a repurposed janky toy that steals shit."
 	icon_state = "pickpocket"
 	w_class = W_CLASS_SMALL
 	item_state = "pickpocket"


### PR DESCRIPTION
## About the PR
Changes the name of the Pickpocket Gun to be the Super! Grapple Friend, I think it's funny to imply this is just a really shitty toy "grapple gun" used to steal shit. Also it's inline with Foam Dart guns and it has a toy-like vibe.

## Why's this needed?
The comment says its an absurdly shitty name... and I think it's neat

## Changelog 

```changelog
(u)444explorer
(+)Renamed the "pickpocket grapple gun" to the "Super! Grapple Friend", uplink entry is unchanged.
```
