### PR TITLE
Fixes button directions on Cogmap 1 and 2

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -11180,7 +11180,10 @@
 	},
 /obj/stool,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "maintpowerroom"
+	id = "maintpowerroom";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
@@ -13187,8 +13190,9 @@
 /obj/machinery/door_control{
 	id = "lockdown";
 	name = "Bridge Lockdown";
-	pixel_x = 28;
-	pixel_y = 28
+	pixel_x = 23;
+	pixel_y = 28;
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -15525,7 +15529,9 @@
 /obj/machinery/door_control{
 	id = "lockdown";
 	name = "Bridge Lockdown";
-	pixel_y = -24
+	pixel_y = -21;
+	dir = 1;
+	pixel_x = -1
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -18143,7 +18149,9 @@
 /obj/machinery/door_control{
 	id = "speedboost_crusher";
 	name = "Disposals Doors";
-	pixel_y = -24
+	pixel_y = -21;
+	dir = 1;
+	pixel_x = -1
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
@@ -19588,7 +19596,9 @@
 /obj/machinery/door_control{
 	id = "eva";
 	name = "EVA Secure Shutters";
-	pixel_x = 28
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -21835,7 +21845,9 @@
 /obj/machinery/door_control{
 	id = "hangar_main";
 	name = "Mechanic's Bay Door Control";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 0
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -23372,7 +23384,9 @@
 	},
 /obj/machinery/door_control{
 	id = "cargodock_out";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
@@ -23643,7 +23657,9 @@
 	},
 /obj/machinery/door_control{
 	id = "cargodock_in";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/decal/stripe_caution,
 /turf/simulated/floor,
@@ -24671,7 +24687,9 @@
 	desc = "A remote control switch for the cargo bay door.";
 	id = "cargosto";
 	name = "Storage Door Control";
-	pixel_x = -26
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /obj/machinery/portable_reclaimer,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -26389,7 +26407,9 @@
 /obj/machinery/door_control{
 	id = "tox_mix";
 	name = "Mixing Vent Control";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -26488,7 +26508,10 @@
 	tag = ""
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_rd"
+	id = "quarters_rd";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
@@ -26828,7 +26851,9 @@
 /obj/machinery/door_control{
 	id = "hangar_cargo";
 	name = "Cargo Hangar Door Control";
-	pixel_y = -24
+	pixel_y = -21;
+	dir = 1;
+	pixel_x = -1
 	},
 /obj/cable{
 	icon_state = "1-4"
@@ -27586,7 +27611,9 @@
 /obj/machinery/door_control{
 	id = "tox_vent1";
 	name = "Chamber One Exhaust";
-	pixel_y = -24
+	pixel_y = -21;
+	dir = 1;
+	pixel_x = -1
 	},
 /obj/machinery/atmospherics/binary/pump/active{
 	dir = 8;
@@ -28452,8 +28479,10 @@
 	},
 /obj/machinery/door_control{
 	name = "Kitchen Shutter Control";
-	pixel_x = -24;
-	id = "kitchen"
+	pixel_x = -23;
+	id = "kitchen";
+	dir = 8;
+	pixel_y = 0
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -30119,7 +30148,9 @@
 "cfb" = (
 /obj/storage/closet/wardrobe/orange,
 /obj/machinery/door_timer/minibrig{
-	pixel_y = -24
+	pixel_y = -23;
+	dir = 1;
+	pixel_x = -1
 	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/cargo)
@@ -31699,7 +31730,9 @@
 /obj/machinery/door_control{
 	id = "miningshutter";
 	name = "Ore Belt Door Switch";
-	pixel_y = -24
+	pixel_y = -21;
+	dir = 1;
+	pixel_x = -1
 	},
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
@@ -31975,8 +32008,9 @@
 	icon_state = "bedsheet-black"
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	pixel_y = 8;
-	id = "quarters_mdir"
+	pixel_y = 6;
+	id = "quarters_mdir";
+	pixel_x = 23
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
@@ -32395,14 +32429,18 @@
 	id = "medbay_front";
 	name = "Medbay Door Control";
 	pixel_x = -23;
-	pixel_y = 8
+	pixel_y = 6;
+	dir = 8
 	},
 /obj/item/clipboard,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/stamp,
 /obj/item/decoration/ashtray,
-/obj/blind_switch/area/west,
+/obj/blind_switch/area/west{
+	pixel_x = -24;
+	pixel_y = -6
+	},
 /obj/item/remote/porter/port_a_medbay,
 /obj/item/reagent_containers/food/drinks/tea,
 /obj/item/stamp/md,
@@ -32684,7 +32722,9 @@
 /obj/machinery/door_control{
 	id = "hangar_artlab";
 	name = "Science Hangar Door Control";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/simulated/floor/grey/side{
 	dir = 4
@@ -35015,7 +35055,9 @@
 /obj/machinery/door_control{
 	id = "test_chamber";
 	name = "Test Chamber Shutter Control";
-	pixel_y = -23
+	pixel_y = -21;
+	dir = 1;
+	pixel_x = -1
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 8;
@@ -36206,7 +36248,8 @@
 	},
 /obj/machinery/light_switch{
 	name = "W light switch";
-	pixel_x = -24
+	pixel_x = -24;
+	dir = 8
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -36395,7 +36438,8 @@
 "cAr" = (
 /obj/machinery/light_switch{
 	name = "W light switch";
-	pixel_x = -24
+	pixel_x = -24;
+	dir = 8
 	},
 /turf/simulated/floor/carpet/grime,
 /area/listeningpost)
@@ -37527,7 +37571,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "seccourtroom"
+	id = "seccourtroom";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "red2"
@@ -38558,7 +38605,9 @@
 /obj/machinery/door_control{
 	id = "hangar_medical";
 	name = "Medical Hangar Door Control";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /obj/machinery/light_switch/west{
 	pixel_y = -10
@@ -38573,7 +38622,9 @@
 /area/shuttle/arrival/station)
 "dGl" = (
 /obj/machinery/door_timer/solitary{
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = -1
 	},
 /turf/simulated/floor/red/corner{
 	dir = 8
@@ -42028,7 +42079,10 @@
 /area/station/medical/research)
 "gbf" = (
 /obj/machinery/door_control/bolter/new_walls/north{
-	id = "quarters_cap"
+	id = "quarters_cap";
+	dir = 2;
+	pixel_x = 0;
+	pixel_y = 26
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
@@ -42645,7 +42699,9 @@
 	dir = 8
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "medisolation"
+	id = "medisolation";
+	pixel_x = 23;
+	pixel_y = 1
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
@@ -43122,6 +43178,12 @@
 /area/station/crew_quarters/supplylobby)
 "gUl" = (
 /obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/door_control{
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	pixel_x = 11;
+	pixel_y = 24
+	},
 /turf/simulated/floor/red,
 /area/station/engine/hotloop)
 "gUN" = (
@@ -45915,7 +45977,9 @@
 /obj/machinery/door_control{
 	id = "pt_laser";
 	name = "PTL Doors";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/ptl)
@@ -50439,7 +50503,9 @@
 /obj/machinery/door_control{
 	id = "chemistry";
 	name = "Safety Shutters";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -50608,8 +50674,10 @@
 	},
 /obj/machinery/light_switch/north,
 /obj/machinery/door_control/bolter/new_walls/north{
-	pixel_x = 8;
-	id = "quarters_hop"
+	pixel_x = 9;
+	id = "quarters_hop";
+	dir = 2;
+	pixel_y = 26
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
@@ -51686,6 +51754,15 @@
 /area/station/science/gen_storage)
 "nPn" = (
 /obj/table/auto,
+/obj/item/clothing/glasses/vr/bomb{
+	pixel_x = 1;
+	pixel_y = 0;
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!"
+	},
+/obj/item/clothing/glasses/vr/bomb{
+	pixel_x = -4;
+	pixel_y = 12
+	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "nPp" = (
@@ -52325,7 +52402,9 @@
 /obj/machinery/door_control{
 	id = "ai_core";
 	name = "AI Core Shield";
-	pixel_x = -22
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 0
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -53947,8 +54026,9 @@
 	},
 /obj/machinery/firealarm/east,
 /obj/machinery/partyalarm{
-	dir = 2;
-	pixel_y = -26
+	dir = 1;
+	pixel_y = -25;
+	pixel_x = 0
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
@@ -55332,23 +55412,11 @@
 /obj/table/auto,
 /obj/item/chem_grenade/firefighting{
 	pixel_x = -9;
-	pixel_y = 14
-	},
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = 6;
-	pixel_y = 15
-	},
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = 8;
-	pixel_y = 8
+	pixel_y = 18
 	},
 /obj/item/device/audio_log{
 	pixel_x = -8;
-	pixel_y = -1
+	pixel_y = 0
 	},
 /obj/item/device/radio/intercom/medical{
 	dir = 8
@@ -55519,20 +55587,15 @@
 /area/station/crew_quarters/barber_shop)
 "qGh" = (
 /obj/machinery/door_control{
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	pixel_x = 7;
-	pixel_y = 36
-	},
-/obj/machinery/door_control{
 	id = "combustion";
 	name = "Combustion Chamber Vent";
 	pixel_x = -7;
-	pixel_y = 36
+	pixel_y = 25
 	},
 /obj/machinery/activation_button/ignition_switch{
 	id = "combustion_ignition";
-	pixel_y = 26
+	pixel_y = 26;
+	pixel_x = 6
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -58330,7 +58393,9 @@
 /obj/machinery/door_control{
 	id = "engsupply_shutter";
 	name = "Safety Shutters";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/simulated/floor/black,
 /area/station/engine/coldloop)
@@ -58759,8 +58824,10 @@
 	pixel_x = 8
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	pixel_x = -8;
-	id = "medisolation"
+	pixel_x = -7;
+	id = "medisolation";
+	dir = 1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/red,
 /area/station/medical/medbay/surgery)
@@ -58943,7 +59010,9 @@
 /obj/machinery/door_control{
 	id = "tox_vent3";
 	name = "Waste Chamber Exhaust";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor/red,
@@ -59305,10 +59374,13 @@
 	id = "brig_divide";
 	name = "Brig Divider Control";
 	pixel_x = 24;
-	pixel_y = 8
+	pixel_y = 8;
+	dir = 4
 	},
 /obj/machinery/door_timer/genpop_n{
-	pixel_x = 24
+	pixel_x = 24;
+	dir = 4;
+	pixel_y = -7
 	},
 /turf/simulated/floor,
 /area/station/security/main)
@@ -61336,11 +61408,14 @@
 /obj/machinery/door_control{
 	id = "brig_divide";
 	name = "Brig Divider Control";
-	pixel_x = 24;
-	pixel_y = 8
+	pixel_x = 23;
+	pixel_y = 7;
+	dir = 4
 	},
 /obj/machinery/door_timer/genpop_s{
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = -8
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -62410,7 +62485,9 @@
 /obj/machinery/door_control{
 	id = "dwaine_core";
 	name = "DWAINE Core Shield";
-	pixel_x = -25
+	pixel_x = -24;
+	dir = 8;
+	pixel_y = 1
 	},
 /obj/cable{
 	icon_state = "1-8"
@@ -62907,7 +62984,10 @@
 	pixel_y = 5
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_ce"
+	id = "quarters_ce";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -21
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 10
@@ -63434,7 +63514,10 @@
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
 	},
-/obj/machinery/door_control/podbay/security/new_walls/east,
+/obj/machinery/door_control/podbay/security/new_walls/east{
+	pixel_x = 23;
+	pixel_y = 1
+	},
 /obj/machinery/manufacturer/hangar,
 /obj/machinery/light{
 	dir = 4

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -631,7 +631,9 @@
 /obj/machinery/door_control{
 	id = "ai_core";
 	name = "AI Core Shield";
-	pixel_x = 28
+	pixel_x = 26;
+	dir = 4;
+	pixel_y = -1
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -2195,7 +2197,10 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/catering)
 "ahj" = (
-/obj/machinery/door_control/podbay/catering/new_walls/east,
+/obj/machinery/door_control/podbay/catering/new_walls/east{
+	pixel_x = 23;
+	pixel_y = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/catering)
 "ahk" = (
@@ -6021,7 +6026,10 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/maintenance/outer/ne)
 "atd" = (
-/obj/machinery/door_control/podbay/arrivals/new_walls/east,
+/obj/machinery/door_control/podbay/arrivals/new_walls/east{
+	pixel_x = 23;
+	pixel_y = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/maintenance/outer/ne)
 "ate" = (
@@ -9548,8 +9556,9 @@
 /obj/machinery/door_control{
 	id = "kitchen";
 	name = "Kitchen Shutter Control";
-	pixel_x = 24;
-	pixel_y = 24
+	pixel_x = 23;
+	pixel_y = 24;
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -14196,10 +14205,14 @@
 /obj/machinery/door_control{
 	id = "lockdown_checkpoint1";
 	name = "Checkpoint Lockdown";
-	pixel_x = -24;
-	pixel_y = 8
+	pixel_x = -23;
+	pixel_y = 8;
+	dir = 8
 	},
-/obj/machinery/light_switch/west,
+/obj/machinery/light_switch/west{
+	pixel_x = -23;
+	pixel_y = -4
+	},
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
 /turf/simulated/floor/specialroom/bar,
@@ -18349,7 +18362,10 @@
 "bde" = (
 /obj/storage/secure/closet/personal,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "maint_quarters1"
+	id = "maint_quarters1";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_west)
@@ -18552,7 +18568,10 @@
 /obj/item/clothing/mask/horse_mask,
 /obj/storage/crate,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "cc2"
+	id = "cc2";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA)
@@ -20520,13 +20539,17 @@
 /obj/machinery/door_control{
 	id = "lockdown_sec";
 	name = "Security Lockdown";
-	pixel_x = -24;
-	pixel_y = -8
+	pixel_x = -23;
+	pixel_y = -7;
+	dir = 8
 	},
 /obj/disposalpipe/segment/transport,
 /obj/item/device/radio/intercom/brig,
 /obj/machinery/phone,
-/obj/blind_switch/area/west,
+/obj/blind_switch/area/west{
+	pixel_x = -23;
+	pixel_y = 5
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
 "bkI" = (
@@ -20878,7 +20901,10 @@
 /area/station/hangar/sec)
 "blQ" = (
 /obj/disposalpipe/segment/mail/vertical,
-/obj/machinery/door_control/podbay/security/new_walls/west,
+/obj/machinery/door_control/podbay/security/new_walls/west{
+	pixel_x = -23;
+	pixel_y = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "blR" = (
@@ -23881,7 +23907,9 @@
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff,
 /obj/blind_switch/area{
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
@@ -25237,7 +25265,10 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_hos"
+	id = "quarters_hos";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor{
 	icon_state = "carpetS"
@@ -25363,7 +25394,10 @@
 /area/station/crew_quarters/heads)
 "byC" = (
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_hop"
+	id = "quarters_hop";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/heads)
@@ -26483,7 +26517,11 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
 "bBT" = (
-/obj/machinery/door_control/podbay/mainpod1/new_walls/south,
+/obj/machinery/door_control/podbay/mainpod1/new_walls/south{
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "bBU" = (
@@ -28843,8 +28881,9 @@
 /obj/machinery/door_control{
 	id = "lockdown";
 	name = "Bridge Lockdown";
-	pixel_x = -24;
-	pixel_y = 8
+	pixel_x = -23;
+	pixel_y = 1;
+	dir = 8
 	},
 /obj/item/storage/box/trackimp_kit,
 /turf/simulated/floor/blueblack{
@@ -29235,13 +29274,15 @@
 	id = "armory";
 	name = "Armory Window";
 	pixel_x = 24;
-	pixel_y = -8
+	pixel_y = -7;
+	dir = 4
 	},
 /obj/machinery/door_control{
 	id = "lockdown_sec";
 	name = "Security Lockdown";
 	pixel_x = 24;
-	pixel_y = 8
+	pixel_y = 7;
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -29714,12 +29755,6 @@
 /turf/simulated/floor,
 /area/station/engine/inner)
 "bJV" = (
-/obj/machinery/door_control{
-	id = "engine_observation";
-	name = "Observation Shutters";
-	pixel_x = -24;
-	pixel_y = -8
-	},
 /obj/rack,
 /obj/item/extinguisher{
 	pixel_x = 9;
@@ -29728,6 +29763,13 @@
 /obj/item/extinguisher{
 	pixel_x = -6;
 	pixel_y = 2
+	},
+/obj/machinery/door_control{
+	id = "engine_observation";
+	name = "Observation Shutters";
+	pixel_x = -23;
+	pixel_y = 0;
+	dir = 8
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -29851,7 +29893,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "quarters_ce"
+	id = "quarters_ce";
+	pixel_x = -23;
+	pixel_y = 1
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -31077,7 +31121,8 @@
 /area/station/security/checkpoint/podbay)
 "bNa" = (
 /obj/machinery/door_control/podbay/mainpod2/new_walls/north{
-	id = "hangar_sec2"
+	id = "hangar_sec2";
+	dir = 2
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/security/checkpoint/podbay)
@@ -32635,16 +32680,19 @@
 	dir = 1
 	},
 /obj/table/reinforced/auto,
-/obj/machinery/door_control{
+/obj/disposalpipe/segment/mail/bent/south,
+/obj/machinery/door_control/table{
+	id = "pt_laser";
+	pixel_x = -7;
+	pixel_y = 3;
+	name = "PTL Doors"
+	},
+/obj/machinery/door_control/table{
+	pixel_x = 5;
+	pixel_y = 3;
 	id = "lockdown_checkpoint3";
 	name = "Checkpoint Lockdown"
 	},
-/obj/machinery/door_control{
-	id = "pt_laser";
-	name = "PTL Doors";
-	pixel_y = 8
-	},
-/obj/disposalpipe/segment/mail/bent/south,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -33284,7 +33332,8 @@
 /obj/item/clothing/head/helmet/space/captain,
 /obj/item/tank/jetpack,
 /obj/machinery/door_control/bolter/new_walls/north{
-	id = "quarters_cap"
+	id = "quarters_cap";
+	dir = 2
 	},
 /turf/simulated/floor/carpet{
 	dir = 5;
@@ -34273,12 +34322,14 @@
 /obj/disposalpipe/segment/mail/vertical,
 /obj/table/reinforced/auto,
 /obj/machinery/door_timer/genpop/new_walls/north{
-	pixel_y = -5
+	pixel_y = 4;
+	pixel_x = 5
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/table{
+	pixel_x = -8;
+	pixel_y = 5;
 	id = "visitorlockdown";
-	name = "Brig Visitor Lockdown";
-	pixel_y = 7
+	name = "Brig Visitor Lockdown"
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
@@ -34361,13 +34412,16 @@
 /obj/random_item_spawner/desk_stuff,
 /obj/item/rubberduck,
 /obj/blind_switch/area{
-	pixel_x = -24
+	pixel_x = -24;
+	dir = 8;
+	pixel_y = -6
 	},
 /obj/machinery/door_control{
 	id = "lockdown";
 	name = "Bridge Lockdown";
-	pixel_x = -24;
-	pixel_y = 8
+	pixel_x = -23;
+	pixel_y = 6;
+	dir = 8
 	},
 /obj/item/stamp/cap,
 /turf/simulated/floor/carpet/arcade,
@@ -36052,7 +36106,9 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "cbP" = (
-/obj/machinery/door_control/podbay/engineering/new_walls/north,
+/obj/machinery/door_control/podbay/engineering/new_walls/north{
+	dir = 2
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "cbR" = (
@@ -38318,14 +38374,16 @@
 /obj/machinery/door_control{
 	id = "scienceteleporter";
 	name = "Pad Shutters";
-	pixel_x = 24;
-	pixel_y = 6
+	pixel_x = 23;
+	pixel_y = 6;
+	dir = 4
 	},
 /obj/machinery/door_control{
 	id = "scienceteleporter2";
 	name = "Pad Access Door";
-	pixel_x = 24;
-	pixel_y = -6
+	pixel_x = 23;
+	pixel_y = -7;
+	dir = 4
 	},
 /turf/simulated/floor/caution/corner/ne,
 /area/station/science/teleporter)
@@ -38583,7 +38641,9 @@
 /obj/machinery/door_control{
 	id = "crusher";
 	name = "Crusher Door Control";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -42901,8 +42961,9 @@
 /obj/machinery/door_control{
 	id = "lockdown_checkpoint2";
 	name = "Checkpoint Lockdown";
-	pixel_x = -24;
-	pixel_y = -8
+	pixel_x = -23;
+	pixel_y = -6;
+	dir = 8
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -44013,7 +44074,8 @@
 	id = "tox_vent2";
 	name = "Chamber Two Exhaust";
 	pixel_x = -23;
-	pixel_y = 8
+	pixel_y = 8;
+	dir = 8
 	},
 /obj/machinery/activation_button/ignition_switch{
 	id = "tox_ignition1";
@@ -46600,7 +46662,8 @@
 	id = "tox_vent1";
 	name = "Chamber One Exhaust";
 	pixel_x = -23;
-	pixel_y = 8
+	pixel_y = 5;
+	dir = 8
 	},
 /turf/simulated/floor/caution/south,
 /area/station/science/lab)
@@ -46730,7 +46793,9 @@
 	},
 /obj/blind_switch/area/north,
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "quarters_mdir"
+	id = "quarters_mdir";
+	pixel_x = -23;
+	pixel_y = 1
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/medical/head)
@@ -46835,7 +46900,9 @@
 	desc = "A remote control switch for the cargo bay door.";
 	id = "qm_tohall_shutter";
 	name = "Cargo Outlet Door Control";
-	pixel_x = -26
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 0
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/yellow/side{
@@ -47222,7 +47289,9 @@
 /obj/machinery/door_control{
 	id = "medbay_entrance";
 	name = "Medbay Door Control";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/west,
 /area/station/medical/head)
@@ -48182,7 +48251,9 @@
 /area/station/quartermaster/office)
 "cOu" = (
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "qm_crimeroom"
+	id = "qm_crimeroom";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/plating/damaged1,
 /area/station/quartermaster/office)
@@ -50603,7 +50674,9 @@
 /obj/machinery/door_control{
 	id = "test_chamber2";
 	name = "Test Chamber Shutter Control";
-	pixel_y = -24
+	pixel_y = -21;
+	dir = 1;
+	pixel_x = -1
 	},
 /obj/landmark/start/job/scientist,
 /obj/decal/stripe_caution,
@@ -51747,15 +51820,19 @@
 /turf/simulated/floor/grime,
 /area/station/storage/auxillary)
 "dbl" = (
-/obj/machinery/door_control/podbay/qm/new_walls/east,
+/obj/machinery/door_control/podbay/qm/new_walls/east{
+	pixel_x = 23;
+	pixel_y = 1
+	},
 /obj/machinery/vending/air_vendor/plasma,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/qm)
 "dbm" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door_control{
+/obj/machinery/door_control/table{
 	id = "qm_dock";
-	name = "Outer Door Toggle"
+	name = "Outer Door Toggle"pixel_x = -1;
+	pixel_y = 3
 	},
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
@@ -52596,7 +52673,10 @@
 	},
 /obj/machinery/drainage,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "maint_bathroom"
+	id = "maint_bathroom";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
@@ -53510,11 +53590,6 @@
 /area/research_outpost)
 "div" = (
 /obj/stool/chair/office,
-/obj/machinery/door_control{
-	id = "test_chamber2";
-	name = "Test Chamber Shutter Control";
-	pixel_y = -24
-	},
 /turf/simulated/floor/black,
 /area/research_outpost)
 "diw" = (
@@ -53600,17 +53675,23 @@
 /turf/simulated/floor/black,
 /area/research_outpost)
 "diI" = (
-/obj/table/reinforced/auto,
 /obj/machinery/light/lamp/green,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/table/reinforced/auto,
 /turf/simulated/floor/black,
 /area/research_outpost)
 "diJ" = (
-/obj/table/reinforced/auto,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/table/reinforced/auto,
+/obj/machinery/door_control/table{
+	pixel_x = -1;
+	pixel_y = 4;
+	name = "Test Chamber Shutter Control";
+	id = "test_chamber2"
 	},
 /turf/simulated/floor/black,
 /area/research_outpost)
@@ -53926,8 +54007,9 @@
 "djR" = (
 /obj/machinery/door_control/podbay/medsci/new_walls/east{
 	id = "hangar_research2";
-	pixel_x = 0;
-	pixel_y = 24
+	pixel_x = -1;
+	pixel_y = 25;
+	dir = 2
 	},
 /turf/simulated/floor/shuttlebay{
 	dir = 4;
@@ -54988,7 +55070,8 @@
 	},
 /obj/machinery/light_switch{
 	name = "W light switch";
-	pixel_x = -24
+	pixel_x = -24;
+	dir = 8
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -55356,7 +55439,8 @@
 "doD" = (
 /obj/machinery/light_switch{
 	name = "E light switch";
-	pixel_x = 24
+	pixel_x = 24;
+	dir = 4
 	},
 /turf/unsimulated/floor/shuttle/red{
 	dir = 4
@@ -56765,7 +56849,8 @@
 	id = "tox_heat1";
 	name = "Chamber One Heat Shield";
 	pixel_x = -23;
-	pixel_y = 8
+	pixel_y = 8;
+	dir = 8
 	},
 /turf/simulated/floor/blue,
 /area/station/science/lab)
@@ -56807,7 +56892,9 @@
 /obj/machinery/door_control{
 	id = "chemistry";
 	name = "Privacy Shutters";
-	pixel_x = 28
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/table/reinforced/chemistry/auto,
 /obj/item/storage/box/beakerbox{
@@ -57785,7 +57872,10 @@
 /obj/item/clothing/under/gimmick/trashsinglet,
 /obj/item/clothing/under/misc/flame,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "cc3"
+	id = "cc3";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA)
@@ -59893,6 +59983,12 @@
 	},
 /obj/mapping_helper/access/medical,
 /obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door_control/table{
+	name = "Medbay Door Control";
+	id = "medbay_entrance";
+	pixel_x = 5;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/reception)
 "ibc" = (
@@ -60319,7 +60415,9 @@
 /obj/machinery/door_control{
 	id = "eva";
 	name = "EVA Secure Shutters";
-	pixel_x = 28
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/item/tank/jetpack/micro,
 /obj/decal/stripe_caution,
@@ -62299,7 +62397,10 @@
 "kkO" = (
 /obj/storage/secure/closet/personal,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "maint_quarters2"
+	id = "maint_quarters2";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_west)
@@ -63837,19 +63938,17 @@
 	pixel_x = 10;
 	tag = ""
 	},
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = 2;
-	pixel_y = 5
-	},
 /obj/decal/stripe_delivery,
+/obj/item/clothing/glasses/vr/bomb{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/vr/bomb{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	pixel_x = -3;
+	pixel_y = 11
+	},
 /turf/simulated/floor,
 /area/station/science/lab)
 "lLB" = (
@@ -63964,11 +64063,13 @@
 	dir = 1;
 	icon_state = "noedge-tile1"
 	},
-/obj/machinery/door_control{
+/obj/table/reinforced/auto,
+/obj/machinery/door_control/table{
 	id = "pt_laser";
+	pixel_x = -1;
+	pixel_y = 3;
 	name = "PTL Doors"
 	},
-/obj/table/reinforced/auto,
 /turf/simulated/floor/engine,
 /area/station/hallway/primary/west)
 "lRi" = (
@@ -64695,7 +64796,8 @@
 	id = "tox_heat2";
 	name = "Chamber Two Heat Shield";
 	pixel_x = -23;
-	pixel_y = -8
+	pixel_y = -8;
+	dir = 8
 	},
 /turf/simulated/floor/blue,
 /area/station/science/lab)
@@ -68138,7 +68240,10 @@
 /area/station/medical/medbay/lobby)
 "qjA" = (
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "cc1"
+	id = "cc1";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA)
@@ -70603,7 +70708,10 @@
 	},
 /obj/item/storage/briefcase/toxins,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_rd"
+	id = "quarters_rd";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -71614,14 +71722,16 @@
 /obj/machinery/door_control{
 	id = "pt_laser";
 	name = "PTL Doors";
-	pixel_x = -24;
-	pixel_y = 8
+	pixel_x = -23;
+	pixel_y = 7;
+	dir = 8
 	},
 /obj/machinery/door_control{
 	id = "engine_observation";
 	name = "Observation Shutters";
-	pixel_x = -24;
-	pixel_y = -8
+	pixel_x = -23;
+	pixel_y = -6;
+	dir = 8
 	},
 /obj/item/extinguisher,
 /obj/decal/stripe_delivery,
@@ -71888,7 +71998,9 @@
 /obj/machinery/door_control{
 	id = "cloning";
 	name = "Cloning Door Control";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 0
 	},
 /obj/item/storage/firstaid/brain,
 /obj/item/hand_labeler,
@@ -74209,7 +74321,9 @@
 /area/station/maintenance/disposal)
 "wtX" = (
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "bridge_shower"
+	id = "bridge_shower";
+	pixel_x = 23;
+	pixel_y = 1
 	},
 /turf/simulated/floor/sanitary,
 /area/station/hallway/primary/east)
@@ -75732,11 +75846,6 @@
 	dir = 8
 	},
 /obj/landmark/start/job/medical_doctor,
-/obj/machinery/door_control{
-	id = "medbay_entrance";
-	name = "Medbay Door Control";
-	pixel_x = -24
-	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay/reception)
 "yfB" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -51831,7 +51831,8 @@
 /obj/table/reinforced/auto,
 /obj/machinery/door_control/table{
 	id = "qm_dock";
-	name = "Outer Door Toggle"pixel_x = -1;
+	name = "Outer Door Toggle";
+	pixel_x = -1;
 	pixel_y = 3
 	},
 /turf/simulated/floor/plating,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Edits Door Control Buttons and Door Timers on Cogmap 1 and 2 to use their new directionals, and fixes buttons that were facing the wrong way, pixel shifting them when needed to be in better positions.

Same with the last map PR, a fix to Science's Bomb Test VR Goggles has been bundled in to make them proper Bomb Test Goggles instead of varedits.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Implementing new directions are good, and there are a few instances where buttons were flipped in the wrong direction due to direction code inconsistency.