### PR TITLE
Moves Cog1 Catering Announcement Computer

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -41544,10 +41544,6 @@
 	icon_state = "fred2"
 	},
 /area/station/crew_quarters/cafeteria)
-"fGf" = (
-/obj/machinery/computer/announcement/station/catering,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/bar)
 "fGA" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -57987,6 +57983,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/computer/announcement/station/catering,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "sDi" = (
@@ -113497,7 +113494,7 @@ atA
 avZ
 aqP
 hbN
-fGf
+asl
 asl
 aDd
 bOP

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -49618,7 +49618,9 @@
 /obj/item/device/radio/intercom/catering{
 	dir = 8
 	},
-/obj/table/auto,
+/obj/machinery/computer/announcement/station/catering{
+	dir = 8
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "mmZ" = (
@@ -57983,7 +57985,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/computer/announcement/station/catering,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "sDi" = (


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the announcement computer from the bar counter to catering storage. Check the mapdiff under "Checks" to see the specific new location.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bartender couldn't reach the north 3 tables since the computer was in the way. 