### PR TITLE
Fix departmental trainee roles

### DIFF
--- a/code/lists/jobs.dm
+++ b/code/lists/jobs.dm
@@ -43,6 +43,7 @@ var/list/job_mailgroup_list = list(
 	"Chief Engineer" = MGD_COMMAND,
 	"Quartermaster" = MGD_CARGO,
 	"Engineer" = MGD_STATIONREPAIR,
+	"Technical Trainee" = MGD_STATIONREPAIR,
 	"Janitor" = MGD_STATIONREPAIR,
 	"Miner" = MGD_MINING,
 	"Botanist" = MGD_BOTANY,
@@ -51,6 +52,7 @@ var/list/job_mailgroup_list = list(
 	"Geneticist" = MGD_MEDRESEACH,
 	"Pathologist" = MGD_MEDRESEACH,
 	"Medical Doctor" = MGD_MEDBAY,
+	"Medical Trainee" = MGD_MEDBAY,
 	"Chaplain" = MGD_SPIRITUALAFFAIRS)
 
 //Used for PDA department paging.
@@ -100,16 +102,19 @@ var/list/engineering_jobs = list(
 	"Engineer",
 	"Miner",
 	"Quartermaster",
+	"Technical Trainee",
 )
 var/list/medical_jobs = list(
 	"Medical Director",
 	"Medical Doctor",
 	"Roboticist",
-	"Geneticist"
+	"Geneticist",
+	"Medical Trainee",
 )
 var/list/science_jobs = list(
 	"Research Director",
 	"Scientist",
+	"Research Trainee",
 )
 var/list/medsci_jobs = medical_jobs + science_jobs
 var/list/service_jobs = list(
@@ -137,7 +142,6 @@ var/list/engineering_gimmicks = list(
 	"Head of Mining",
 	"Station Builder",
 	"Atmospherish Technician",
-	"Technical Assistant",
 )
 var/list/medical_gimmicks = list(
 	"Acupuncturist",
@@ -169,7 +173,6 @@ var/list/medical_gimmicks = list(
 var/list/science_gimmicks = list(
 	"Toxins Researcher",
 	"Chemist",
-	"Research Assistant",
 	"Test Subject",
 )
 var/list/medsci_gimmicks = medical_gimmicks + science_gimmicks

--- a/code/obj/landmark.dm
+++ b/code/obj/landmark.dm
@@ -143,8 +143,8 @@ var/global/list/job_start_locations = list()
 	name = "Engineer"
 	icon_state = "engineer"
 
-/obj/landmark/start/job/technical_assistant
-	name = "Technical Assistant"
+/obj/landmark/start/job/technical_trainee
+	name = "Technical Trainee"
 	icon_state = "engineer"
 /obj/landmark/start/job/miner
 	name = "Miner"
@@ -160,8 +160,8 @@ var/global/list/job_start_locations = list()
 	name = "Medical Doctor"
 	icon_state = "medical_doctor"
 
-/obj/landmark/start/job/medical_assistant
-	name = "Medical Assistant"
+/obj/landmark/start/job/medical_trainee
+	name = "Medical Trainee"
 	icon_state = "medical_doctor"
 
 /obj/landmark/start/job/geneticist
@@ -176,8 +176,8 @@ var/global/list/job_start_locations = list()
 	name = "Scientist"
 	icon_state = "scientist"
 
-/obj/landmark/start/job/research_assistant
-	name = "Research Assistant"
+/obj/landmark/start/job/research_trainee
+	name = "Research Trainee"
 	icon_state = "scientist"
 
 // Security

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -256,7 +256,7 @@
 			return list(access_morgue, access_maint_tunnels)
 
 		///////////////////////////// Medical
-		if("Medical Doctor")
+		if("Medical Doctor", "Medical Trainee")
 			return list(access_medical, access_medical_lockers, access_morgue, access_maint_tunnels)
 		if("Geneticist")
 			return list(access_medical, access_medical_lockers, access_morgue, access_medlab, access_maint_tunnels)
@@ -267,8 +267,6 @@
 		if("Pharmacist")
 			return list(access_research,access_tech_storage, access_maint_tunnels, access_chemistry,
 						access_medical_lockers, access_medical, access_morgue, access_researchfoyer)
-		if("Medical Assistant")
-			return list(access_maint_tunnels, access_tech_storage, access_medical, access_morgue)
 		if("Psychiatrist")
 			return list(access_medical, access_maint_tunnels)
 		if("Medical Specialist")
@@ -277,20 +275,18 @@
 						access_medlab) //Mdir minus head stuff
 
 		///////////////////////////// Science
-		if("Scientist")
+		if("Scientist", "Research Trainee")
 			return list(access_tox, access_tox_storage, access_research, access_chemistry, access_researchfoyer, access_artlab, access_telesci, access_robotdepot)
 		if("Chemist")
 			return list(access_research, access_chemistry, access_researchfoyer)
 		if("Toxins Researcher")
 			return list(access_research, access_tox, access_tox_storage, access_researchfoyer)
-		if("Research Assistant")
-			return list(access_maint_tunnels, access_tech_storage, access_research, access_chemistry, access_tox, access_researchfoyer, access_artlab, access_telesci, access_robotdepot) //notably not tox_storage, which is also the sci locker access for some fucking reason
 
 		//////////////////////////// Engineering
 		if("Atmospheric Technician")
 			return list(access_maint_tunnels, access_engineering_control,
 						access_eva, access_engineering, access_engineering_storage, access_engineering_eva, access_engineering_atmos)
-		if("Engineer")
+		if("Engineer", "Technical Trainee")
 			return list(access_engineering, access_maint_tunnels, access_engineering_control,
 						access_engineering_storage, access_engineering_atmos, access_engineering_engine, access_engineering_power,
 						access_tech_storage, access_engineering_mechanic)
@@ -321,7 +317,7 @@
 			return list(access_bar, access_kitchen)
 		if("Clown", "Boxer", "Barber", "Mime", "Dungeoneer")
 			return list(access_maint_tunnels)
-		if("Assistant", "Staff Assistant", "Technical Assistant", "Radio Show Host")
+		if("Assistant", "Staff Assistant", "Radio Show Host")
 			return list(access_maint_tunnels, access_tech_storage)
 		if("Mail Courier")
 			return list(access_mail, access_heads, access_cargo, access_medical, access_researchfoyer, access_research, access_tech_storage)

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -12476,7 +12476,7 @@
 	dir = 4;
 	level = -1
 	},
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
 "eWF" = (
@@ -13859,7 +13859,7 @@
 /obj/stool/chair/blue{
 	dir = 4
 	},
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "hPj" = (
@@ -15564,7 +15564,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},
@@ -16922,7 +16922,7 @@
 /turf/simulated/floor/red,
 /area/station/security/equipment)
 "nOs" = (
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
 "nOy" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -19941,7 +19941,7 @@
 	dir = 8
 	},
 /obj/item/storage/wall/office,
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/wood/two,
 /area/station/medical/staff)
 "gXP" = (
@@ -20733,7 +20733,7 @@
 /obj/stool/chair/office{
 	dir = 1
 	},
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/carpet{
 	icon_state = "fred2"
 	},
@@ -22299,7 +22299,7 @@
 	},
 /area/station/crew_quarters/bar)
 "iDb" = (
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -28733,7 +28733,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/orangeblack/side/white,
 /area/station/engine/engineering)
 "nwl" = (
@@ -37881,7 +37881,7 @@
 /area/station/crew_quarters/quarters_west)
 "ulP" = (
 /obj/stool/chair/office,
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/carpet,
 /area/station/science/lobby)
 "ulV" = (
@@ -39241,7 +39241,7 @@
 	anchored = 0;
 	dir = 8
 	},
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellowblack"

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -40123,7 +40123,7 @@
 /area/station/security/checkpoint)
 "eFF" = (
 /obj/stool/chair/yellow,
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/elect)
 "eFK" = (
@@ -40692,7 +40692,7 @@
 /obj/stool/chair/couch{
 	dir = 4
 	},
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -44924,7 +44924,7 @@
 /area/station/security/brig)
 "ipJ" = (
 /obj/stool/chair/comfy/blue,
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/wood/two,
 /area/station/medical/staff)
 "ipZ" = (
@@ -50936,7 +50936,7 @@
 /turf/simulated/floor/green/side,
 /area/station/turret_protected/Zeta)
 "nkK" = (
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "nlf" = (
@@ -54240,7 +54240,7 @@
 /area/station/hydroponics/bay)
 "pJe" = (
 /obj/disposalpipe/segment/mail,
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "pJv" = (
@@ -65274,7 +65274,7 @@
 /area/station/storage/primary)
 "yiI" = (
 /obj/stool/chair/yellow,
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "yiM" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -69633,7 +69633,7 @@
 /area/station/chapel/sanctuary)
 "rAl" = (
 /obj/stool/chair/comfy,
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},
@@ -74079,7 +74079,7 @@
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai)
 "woU" = (
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "wpW" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -16638,7 +16638,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "bXr" = (
@@ -23318,7 +23318,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/carpet/blue,
 /area/station/medical/staff)
 "goU" = (
@@ -37269,7 +37269,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -38353,7 +38353,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/scidisposal)
 "pDG" = (
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
 "pDR" = (
@@ -38677,7 +38677,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
 "pQx" = (
@@ -45169,7 +45169,7 @@
 /area/station/maintenance/southwest)
 "tUx" = (
 /obj/stool,
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
 "tUA" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -40134,7 +40134,7 @@
 /obj/stool/chair/yellow{
 	dir = 8
 	},
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
 "mac" = (
@@ -54930,7 +54930,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm/south,
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/yellowblack,
 /area/station/engine/engineering)
 "qBc" = (
@@ -57033,7 +57033,7 @@
 "rib" = (
 /obj/stool/chair/office,
 /obj/disposalpipe/segment/mail,
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/carpet/green/fancy/narrow,
 /area/station/medical/medbay/lobby)
 "rig" = (
@@ -63514,7 +63514,7 @@
 /obj/stool/chair/comfy{
 	dir = 8
 	},
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/station/medical/breakroom)
 "tiX" = (
@@ -71391,7 +71391,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "vBq" = (
@@ -77210,7 +77210,7 @@
 /area/station/crew_quarters/quarters)
 "xhY" = (
 /obj/stool/chair/couch/purple,
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/wood,
 /area/station/science/lobby)
 "xhZ" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -30342,7 +30342,7 @@
 /obj/stool/chair/office/yellow{
 	dir = 8
 	},
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "czr" = (
@@ -34831,7 +34831,7 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment/morgue,
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -37956,7 +37956,7 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "hOA" = (
@@ -48759,7 +48759,7 @@
 /obj/machinery/atmospherics/binary/valve{
 	name = "hot reserve tank valve";
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -54404,7 +54404,7 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
 "tOr" = (
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},
@@ -58849,7 +58849,7 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "wXQ" = (
@@ -59433,7 +59433,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/white,
 /area/station/science/lobby)
 "xsj" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -11302,7 +11302,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
 "faQ" = (
@@ -20149,7 +20149,7 @@
 /obj/stool/chair/purple{
 	dir = 8
 	},
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},
@@ -33911,7 +33911,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/bent/west,
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/white,
 /area/station/medical/staff)
 "ohY" = (
@@ -44711,7 +44711,7 @@
 /obj/stool/chair/yellow{
 	dir = 4
 	},
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/black,
 /area/station/engine/engineering)
 "sZX" = (
@@ -48686,7 +48686,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/white,
 /area/station/medical/staff)
 "uMd" = (
@@ -51621,7 +51621,7 @@
 /obj/stool/chair/purple{
 	dir = 4
 	},
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/black,
 /area/station/science/hall)
 "wbj" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -34237,7 +34237,7 @@
 /area/diner/dining)
 "flf" = (
 /obj/stool/chair/yellow,
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -39673,7 +39673,7 @@
 /area/station/security/processing)
 "mXI" = (
 /obj/stool/bench/blue/auto,
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/blue/checker,
 /area/station/medical/medbay)
 "mXZ" = (
@@ -40713,7 +40713,7 @@
 	dir = 8
 	},
 /obj/machinery/light/incandescent/cool,
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/blue/corner{
 	dir = 8
 	},
@@ -42955,7 +42955,7 @@
 /obj/stool/chair/purple{
 	dir = 8
 	},
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/wood,
 /area/station/science/lobby)
 "rCV" = (
@@ -43460,7 +43460,7 @@
 /obj/stool/chair/yellow{
 	dir = 8
 	},
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "szG" = (
@@ -46835,7 +46835,7 @@
 /obj/stool/chair/office/purple{
 	dir = 4
 	},
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/wood,
 /area/station/science/lobby)
 "xOk" = (

--- a/maps/unused/ozymandias.dmm
+++ b/maps/unused/ozymandias.dmm
@@ -15810,7 +15810,7 @@
 	},
 /area/station/medical/staff)
 "emH" = (
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/greenblack{
 	dir = 5
 	},
@@ -21428,7 +21428,7 @@
 /area/station/security/equipment)
 "fIM" = (
 /obj/disposalpipe/segment/vertical,
-/obj/landmark/start/job/research_assistant,
+/obj/landmark/start/job/research_trainee,
 /turf/simulated/floor/greenblack{
 	dir = 4
 	},
@@ -25222,7 +25222,7 @@
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
 "gGI" = (
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/bluewhite/corner{
 	dir = 1
 	},
@@ -25987,7 +25987,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
 	},
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/engineering/private)
 "gPK" = (
@@ -57243,7 +57243,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/landmark/start/job/technical_assistant,
+/obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor,
 /area/station/engine/engineering/private)
 "paJ" = (
@@ -91021,7 +91021,7 @@
 /obj/submachine/chef_sink/chem_sink{
 	pixel_y = 16
 	},
-/obj/landmark/start/job/medical_assistant,
+/obj/landmark/start/job/medical_trainee,
 /turf/simulated/floor/bluewhite/corner{
 	dir = 8
 	},


### PR DESCRIPTION
[FIX] [SPAWN]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a few issues with the departmental trainee roles and brings them in line with the base role within their department:
- Fixes spawn points that were pointing to "Assistant" instead of "Trainee"
- Adds them to the `get_access(job)` proc so they are correctly allocated access rights in the HoP computer (This matches the rights they are given on spawning in)
- Added them to the relevant departmental PDA message lists

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Departmental trainee roles are a great way for newer players to learn the game. These fixes should reduce a few sticking points and make the experience even more beginner friendly.


