### PR TITLE
Buffs syndicate command armour slightly

### DIFF
--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -1062,6 +1062,7 @@ TYPEINFO(/obj/item/clothing/head/helmet/space/industrial)
 		..()
 		setProperty("meleeprot_head", 7)
 		setProperty("space_movespeed", 0)
+		setProperty("disorient_resist_eye", 100)
 
 TYPEINFO(/obj/item/clothing/head/helmet/space/industrial/salvager)
 	mats = list("metal_superdense" = 20,

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1599,6 +1599,7 @@ TYPEINFO(/obj/item/clothing/suit/space/industrial/syndicate)
 		setProperty("meleeprot", 9)
 		setProperty("rangedprot", 2)
 		setProperty("space_movespeed", 0)
+		setProperty("disorient_resist", 40)
 
 	New()
 		START_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives syndicate command armour flash protection on the helmet and some disorient resist on the body, enough to take an extra baton hit.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
For a 5TC item that looks like it should make you a tank this often feels like a noob trap and isn't actually very threatening. Giving it a little better resilience against some stuns might make it more worth using.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Syndicate command armour now offers eye protection on the helmet and some disorient resistance on the body (enough to take an extra baton hit)
```
