### PR TITLE
Adds cinnamon to 3 drinks that typically contain it

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2055,8 +2055,8 @@
 		name = "Hot Toddy"
 		id = "hottoddy"
 		result = "hottoddy"
-		required_reagents = list("sweet_tea" = 1, "bourbon" = 1, "juice_lemon" = 1)
-		result_amount = 3
+		required_reagents = list("sweet_tea" = 1, "bourbon" = 1, "juice_lemon" = 1, "cinnamon" = 1)
+		result_amount = 4
 		mix_phrase = "The drink suddenly fills the room with a festive aroma."
 		mix_sound = 'sound/misc/drinkfizz.ogg'
 		drinkrecipe = TRUE
@@ -2085,11 +2085,17 @@
 		name = "Spiced Rum"
 		id = "spicedrum"
 		result = "spicedrum"
-		required_reagents = list("rum" = 1, "capsaicin" = 1)
+		required_reagents = list("rum" = 1, "cinnamon" = 1)
 		result_amount = 2
-		mix_phrase = "You feel like you might have misunderstood the recipe."
+		mix_phrase = "The drink fills the room with the smell of cinnamon."
 		mix_sound = 'sound/misc/drinkfizz.ogg'
 		drinkrecipe = TRUE
+
+		fake
+			id = "spicedrumfake"
+			result = "spicedrumfake"
+			required_reagents = list("rum" = 1, "capsaicin" = 1)
+			mix_phrase = "You feel like you might have misunderstood the recipe."
 
 	romulale
 		name = "Romulale"
@@ -2252,8 +2258,8 @@
 		name = "Pumpkin Spice Latte"
 		id = "pumpkinspicelatte"
 		result = "pumpkinspicelatte"
-		required_reagents = list("juice_pumpkin"=1, "milk"= 2, "espresso"=1)
-		result_amount = 4
+		required_reagents = list("juice_pumpkin"=1, "milk"= 2, "espresso"=1, "cinnamon"=1)
+		result_amount = 5
 		mix_phrase = "The drink smells vaguely like artifical autumn."
 		mix_sound = 'sound/misc/drinkfizz.ogg'
 

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -4712,7 +4712,7 @@ datum
 			reagent_state = LIQUID
 			taste = "biting"
 
-		fooddrink/alcoholic/spicedrumfake
+		fooddrink/alcoholic/spicedrum
 			name = "spiced rum"
 			id = "spicedrum"
 			fluid_r = 205

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -4712,16 +4712,20 @@ datum
 			reagent_state = LIQUID
 			taste = "biting"
 
-		fooddrink/alcoholic/spicedrum
+		fooddrink/alcoholic/spicedrumfake
 			name = "spiced rum"
 			id = "spicedrum"
 			fluid_r = 205
 			fluid_g = 149
 			fluid_b = 12
 			alch_strength = 0.6
-			description = "An egregious and disgusting misinterpretation of some perfectly good rum."
+			description = "A rich, dark rum infused with the spice of cinnamon."
 			reagent_state = LIQUID
 			taste = "seasoned"
+
+			fake
+				id = "spicedrumfake"
+				description = "An egregious and disgusting misinterpretation of some perfectly good rum."
 
 		fooddrink/alcoholic/beesknees
 			name = "Bee's Knees"

--- a/code/z_adventurezones/hospital.dm
+++ b/code/z_adventurezones/hospital.dm
@@ -239,8 +239,8 @@
 	//icon = 'icons/obj/foodNdrink/bottle.dmi'
 	icon_state = "bottle-spicedrum"
 	bottle_style = "bottle-spicedrum"
-	fluid_style = "spicedrum"
-	label = "spicedrum"//"brandy"
+	fluid_style = "spicedrumfake"
+	label = "spicedrumfake"//"brandy"
 	heal_amt = 1
 	g_amt = 60
 	initial_volume = 250


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QoL] [Catering]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds `cinnamon` requirement to "Spiced Rum", "Hot Toddy", and "Pumpkin Spiced Latte".

Also adds a "fake" version of "Spiced Rum" that's still made with capsaicin.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These recipes are typically defined by their use of spice, particularly cinnamon, and were largely added before cinnamon existed. This just makes them a bit more accurate, and also adds more reasons to make cinnamon. Since we're approaching the fall season, this seemed like good timing.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(+)"Spiced Rum", "Hot Toddy", and "Pumpkin Spiced Latte" are now made with cinnamon.
```
