### PR TITLE
Booster Y/Z and Genetic Scrambling no longer removes Magical Genes

### DIFF
--- a/code/modules/medical/genetics/bioEffects/meta.dm
+++ b/code/modules/medical/genetics/bioEffects/meta.dm
@@ -45,7 +45,7 @@
 		var/mob/living/L = owner
 		var/datum/bioHolder/B = L.bioHolder
 
-		B.RemoveAllEffects()
+		B.RemoveAllEffects(null, TRUE)
 		B.BuildEffectPool()
 		return
 
@@ -70,7 +70,7 @@
 		var/mob/living/L = owner
 		var/datum/bioHolder/B = L.bioHolder
 
-		B.RemoveAllEffects()
+		B.RemoveAllEffects(null, TRUE)
 		B.RemoveAllPoolEffects()
 		return
 

--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -557,7 +557,7 @@
 				var/datum/bioEffect/mutantrace = H.mutantrace.race_mutation
 				if (mutantrace && GetBioeffectResearchLevelFromGlobalListByID(initial(mutantrace.id)) >= EFFECT_RESEARCH_ACTIVATED)
 					addEffect = initial(mutantrace.id)
-			subject.bioHolder.RemoveAllEffects()
+			subject.bioHolder.RemoveAllEffects(null, TRUE)
 			subject.bioHolder.BuildEffectPool()
 			if (addEffect) // re-mutantify if we would have been able to anyway
 				subject.bioHolder.AddEffect(addEffect)


### PR DESCRIPTION
## About the PR 
As the title says, Booster Y/Z and genetic scrambling will no longer remove magic genes like clown clumsiness or mutantrace hair

## Why's this needed?
magic genes are supposed to be irremovable aside from admin sources, so lets make sure that they do that

fixes #20776 
