### PR TITLE
Fixes button directions on Oshan and Nadir

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1006,7 +1006,9 @@
 /obj/machinery/door_control{
 	id = "nadir_bhull_ne";
 	name = "Emergency Re-Entry";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/space/fluid/acid,
 /area/space)
@@ -1097,7 +1099,10 @@
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/reagent_containers/food/drinks/bottle/fancy_beer,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "eastcc_room1"
+	id = "eastcc_room1";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/crew_quarters/quarters_east)
@@ -1951,7 +1956,9 @@
 	icon_state = "bedsheet-pink"
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_bdr2"
+	id = "cc_bdr2";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/red/standard/narrow/south,
 /area/station/crew_quarters/quarters_west)
@@ -2480,7 +2487,9 @@
 	pixel_x = -32
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "eastcc_stall3"
+	id = "eastcc_stall3";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
@@ -2720,7 +2729,9 @@
 /obj/machinery/door_control{
 	id = "nadir_diploshut";
 	name = "Quarters Shutters";
-	pixel_x = 22
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/black,
@@ -3398,7 +3409,10 @@
 "bxL" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "maint_crimeroom1"
+	id = "maint_crimeroom1";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/industrial,
 /area/station/hallway/secondary/construction{
@@ -3727,7 +3741,8 @@
 "bFf" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/door_control/bolter/new_walls/north{
-	id = "maint_shower1"
+	id = "maint_shower1";
+	dir = 2
 	},
 /turf/simulated/floor/sanitary,
 /area/station/maintenance/storage{
@@ -6473,7 +6488,9 @@
 /obj/machinery/door_control{
 	id = "ai_core";
 	name = "AI Core Shield";
-	pixel_y = -26
+	pixel_y = -21;
+	dir = 1;
+	pixel_x = -1
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -6743,7 +6760,9 @@
 	icon_state = "bedsheet-blue"
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_bdr1"
+	id = "cc_bdr1";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/blue/standard/narrow/south,
 /area/station/crew_quarters/quarters_west)
@@ -8425,7 +8444,9 @@
 /obj/machinery/door_control{
 	id = "nadir_bhull_nw";
 	name = "Emergency Re-Entry";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/space/fluid/acid,
 /area/space)
@@ -9701,7 +9722,10 @@
 /area/station/medical/medbay)
 "esW" = (
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "decon1"
+	id = "decon1";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/science/lobby{
@@ -9782,7 +9806,9 @@
 	pixel_x = -32
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_stall1"
+	id = "cc_stall1";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -10012,14 +10038,16 @@
 "ezP" = (
 /obj/machinery/light,
 /obj/blind_switch/area/east{
-	pixel_y = 6
+	pixel_y = 6;
+	pixel_x = 23
 	},
 /obj/storage/secure/closet/brig_automatic/solitary2,
 /obj/machinery/door_control{
 	id = "secfoy_out";
 	name = "Exit Control";
-	pixel_x = 24;
-	pixel_y = -6
+	pixel_x = 23;
+	pixel_y = -6;
+	dir = 4
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/checkpoint/sec_foyer{
@@ -10028,7 +10056,10 @@
 "eAk" = (
 /obj/reagent_dispensers/still,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "maint_crimeroom2"
+	id = "maint_crimeroom2";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/construction{
@@ -12866,7 +12897,9 @@
 "fHm" = (
 /obj/machinery/crema_switch{
 	id = "crematorium";
-	pixel_x = 28
+	pixel_x = 24;
+	dir = 4;
+	pixel_y = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
@@ -13942,7 +13975,9 @@
 	},
 /obj/item/clothing/suit/bedsheet,
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_bdr3"
+	id = "cc_bdr3";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/green/standard/narrow/south,
 /area/station/crew_quarters/quarters_west)
@@ -14379,7 +14414,10 @@
 	},
 /obj/stool/bench/blue/auto,
 /obj/machinery/door_control/bolter/new_walls/north{
-	id = "cc_stall3"
+	id = "cc_stall3";
+	dir = 2;
+	pixel_x = 0;
+	pixel_y = 25
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -14552,7 +14590,9 @@
 /obj/machinery/door_control{
 	id = "nadir_exnex";
 	name = "Shielding Control";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/simulated/floor/engine,
 /area/station/science/construction{
@@ -15185,7 +15225,7 @@
 /obj/machinery/door_control{
 	id = "scienceteleporter2";
 	name = "Pad Access Door";
-	pixel_x = -8;
+	pixel_x = -7;
 	pixel_y = 26
 	},
 /obj/machinery/door_control{
@@ -16103,7 +16143,9 @@
 /obj/machinery/door_control{
 	id = "nadir_bhull_sw";
 	name = "Emergency Re-Entry";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/space/fluid/acid,
 /area/space)
@@ -17445,7 +17487,9 @@
 	pixel_x = -32
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "eastcc_stall4"
+	id = "eastcc_stall4";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
@@ -21359,7 +21403,9 @@
 /obj/machinery/door_control{
 	id = "armory";
 	name = "Armory Window";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/simulated/floor/engine/caution,
 /area/station/ai_monitored/armory)
@@ -22729,7 +22775,9 @@
 "jBb" = (
 /obj/storage/secure/closet/command/hos,
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "quarters_hos"
+	id = "quarters_hos";
+	pixel_x = -23;
+	pixel_y = 1
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
@@ -23246,7 +23294,9 @@
 	},
 /obj/landmark/start/job/assistant,
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "eastcc_room2"
+	id = "eastcc_room2";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/crew_quarters/quarters_east)
@@ -25839,13 +25889,15 @@
 /area/pasiphae/crew)
 "kNA" = (
 /obj/machinery/door_timer/solitary2/new_walls/west{
-	pixel_y = -9
+	pixel_y = -10;
+	pixel_x = -22
 	},
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
 /obj/machinery/door_timer/solitary/new_walls/west{
-	pixel_y = 9
+	pixel_y = 9;
+	pixel_x = -22
 	},
 /turf/simulated/floor/redblack{
 	dir = 8
@@ -27996,7 +28048,8 @@
 /obj/machinery/door_control{
 	id = "cargo_swapabout";
 	name = "Cargo Shutters";
-	pixel_y = 26
+	pixel_y = 24;
+	pixel_x = 0
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 9
@@ -29199,7 +29252,9 @@
 	pixel_x = -32
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "eastcc_stall4"
+	id = "eastcc_stall4";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
@@ -29287,7 +29342,9 @@
 	tag = ""
 	},
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "quarters_rd"
+	id = "quarters_rd";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/black,
 /area/station/science/research_director)
@@ -35551,7 +35608,9 @@
 	pixel_x = -32
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_stall2"
+	id = "cc_stall2";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -37168,7 +37227,10 @@
 	},
 /obj/landmark/start/job/assistant,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "maint_cc2"
+	id = "maint_cc2";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/black,
 /area/station/maintenance/storage{
@@ -37994,7 +38056,8 @@
 	pixel_x = -12
 	},
 /obj/machinery/door_control/bolter/new_walls/north{
-	id = "eastcc_stall1"
+	id = "eastcc_stall1";
+	dir = 2
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
@@ -38502,7 +38565,9 @@
 	},
 /obj/machinery/drainage,
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "decon2"
+	id = "decon2";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/science/lobby{
@@ -39781,7 +39846,9 @@
 /obj/machinery/door_control{
 	id = "nadir_exnex";
 	name = "Shielding Control";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/simulated/floor/engine,
 /area/station/science/construction{
@@ -40971,7 +41038,9 @@
 "rrj" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "quarters_cap"
+	id = "quarters_cap";
+	pixel_x = 23;
+	pixel_y = 1
 	},
 /turf/simulated/floor/black,
 /area/station/bridge/captain)
@@ -41955,7 +42024,9 @@
 /obj/machinery/door_control/podbay{
 	id = "pasibay";
 	name = "Pasiphae pod bay door control";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/simulated/floor,
 /area/pasiphae/hangar)
@@ -42389,7 +42460,8 @@
 	pixel_x = -12
 	},
 /obj/machinery/door_control/bolter/new_walls/north{
-	id = "eastcc_stall2"
+	id = "eastcc_stall2";
+	dir = 2
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
@@ -43466,12 +43538,13 @@
 /obj/machinery/door_control{
 	id = "PTLDOOR";
 	name = "Transmission Laser Confinement";
-	pixel_x = -24;
-	pixel_y = -8
+	pixel_x = -23;
+	pixel_y = -7;
+	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
+	dir = 4;
+	pixel_x = -22;
 	pixel_y = 8
 	},
 /obj/table/auto,
@@ -43844,7 +43917,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_mdir"
+	id = "quarters_mdir";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/black,
 /area/station/medical/head)
@@ -45672,7 +45748,10 @@
 	},
 /area/station/crew_quarters/lounge)
 "tuT" = (
-/obj/machinery/door_control/podbay/security/new_walls/west,
+/obj/machinery/door_control/podbay/security/new_walls/west{
+	pixel_x = -23;
+	pixel_y = 1
+	},
 /turf/simulated/floor/engine/caution/west,
 /area/station/hangar/sec)
 "tvh" = (
@@ -45796,7 +45875,9 @@
 /obj/machinery/door_control{
 	id = "nadirclomp";
 	name = "Cloning Bay Door Control";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /obj/machinery/manufacturer/uniform{
 	free_resources = list(/obj/item/material_piece/cloth/cottonfabric = 5)
@@ -48580,7 +48661,9 @@
 /obj/stool/chair/red,
 /obj/disposalpipe/junction/left/east,
 /obj/machinery/door_timer/genpop/new_walls/north{
-	pixel_x = 6
+	pixel_x = 0;
+	dir = 2;
+	pixel_y = 24
 	},
 /turf/simulated/floor/redblack{
 	dir = 1
@@ -49224,7 +49307,10 @@
 /obj/item/storage/wall/random,
 /obj/landmark/start/job/assistant,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "maint_cc1"
+	id = "maint_cc1";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/black,
 /area/station/maintenance/storage{
@@ -49484,7 +49570,9 @@
 /obj/machinery/door_control{
 	id = "nadir_barchem";
 	name = "Bar Chem-Safety Shutters";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /obj/table/reinforced/chemistry/auto{
 	name = "prep counter"
@@ -50675,7 +50763,9 @@
 	},
 /obj/machinery/door_control/bolter/new_walls/north{
 	pixel_x = 8;
-	id = "quarters_hop"
+	id = "quarters_hop";
+	dir = 2;
+	pixel_y = 25
 	},
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 1
@@ -51201,7 +51291,9 @@
 /obj/machinery/door_control{
 	id = "dwaine_core";
 	name = "DWAINE Core Shield";
-	pixel_x = 25
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
@@ -51952,7 +52044,8 @@
 "wjr" = (
 /obj/machinery/light_switch/west{
 	pixel_x = -8;
-	pixel_y = 24
+	pixel_y = 24;
+	dir = 1
 	},
 /turf/simulated/floor/engine/caution/corner{
 	dir = 8
@@ -53968,7 +54061,9 @@
 /obj/machinery/door_control{
 	id = "nadir_bhull_se";
 	name = "Emergency Re-Entry";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/space/fluid/acid,
 /area/space)
@@ -55017,7 +55112,9 @@
 /obj/machinery/door_control{
 	id = "nadir_disposalock";
 	name = "Emergency Re-Entry";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/space/fluid/acid/clear,
 /area/space)
@@ -55429,7 +55526,10 @@
 	icon_state = "bedsheet-yellow"
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_ce"
+	id = "quarters_ce";
+	pixel_x = -1;
+	dir = 1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/engine/engineering/ce)
@@ -55652,7 +55752,9 @@
 /obj/machinery/door_control{
 	id = "nadirmed";
 	name = "Medbay Door Control";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 0
 	},
 /turf/simulated/floor/blueblack/corner{
 	dir = 1

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -1978,25 +1978,28 @@
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/psychiatrist)
 "agH" = (
-/obj/table/wood/auto/desk{
-	pixel_y = -2
-	},
 /obj/shrub{
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant";
-	pixel_y = 20
-	},
-/obj/machinery/door_control{
-	id = "hallway_door";
-	name = "Medbay Door Control";
-	pixel_y = -2
+	pixel_y = 18;
+	pixel_x = -8
 	},
 /obj/item/reagent_containers/vape{
 	pixel_x = 10;
 	pixel_y = 10
 	},
 /obj/item/reagent_containers/pill/methamphetamine{
-	pixel_y = 11
+	pixel_y = 8;
+	pixel_x = -8
+	},
+/obj/table/wood/auto/desk{
+	pixel_y = -2
+	},
+/obj/machinery/door_control/table{
+	id = "hallway_door";
+	name = "Medbay Door Control";
+	pixel_x = -1;
+	pixel_y = 1
 	},
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/psychiatrist)
@@ -2291,7 +2294,8 @@
 	},
 /obj/machinery/crema_switch{
 	id = "crematorium";
-	pixel_y = 28
+	pixel_y = 25;
+	pixel_x = 0
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -5300,7 +5304,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "quarters_rd"
+	id = "quarters_rd";
+	pixel_x = 23;
+	pixel_y = 1
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
@@ -5840,7 +5846,9 @@
 /obj/machinery/door_control{
 	id = "cloning_door";
 	name = "Cloning Door Control";
-	pixel_x = -22
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
@@ -5879,8 +5887,9 @@
 /obj/machinery/door_control{
 	id = "medbay_front";
 	name = "Medbay Door Control";
-	pixel_x = 23;
-	pixel_y = 8
+	pixel_x = 24;
+	pixel_y = 8;
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -7566,7 +7575,9 @@
 /obj/machinery/door_control{
 	id = "test_chamber";
 	name = "Test Chamber Blast Door Control";
-	pixel_y = -24
+	pixel_y = -22;
+	dir = 1;
+	pixel_x = -1
 	},
 /turf/simulated/floor/engine,
 /area/research_outpost/chamber)
@@ -7652,7 +7663,9 @@
 /obj/machinery/door_control{
 	id = "chemistry";
 	name = "Privacy Shutters Control";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
@@ -12406,7 +12419,9 @@
 /obj/machinery/door_control{
 	id = "diner";
 	name = "Diner Pod Bay Blast Door Control";
-	pixel_x = -22
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/diner/hangar)
@@ -12480,7 +12495,10 @@
 /area/listeningpost)
 "aQz" = (
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_ce"
+	id = "quarters_ce";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/ce)
@@ -15255,7 +15273,9 @@
 /obj/machinery/door_control{
 	id = "research_outpost";
 	name = "Research Outpost Blast Door Control";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/research_outpost/hangar)
@@ -15422,10 +15442,14 @@
 	pixel_y = 6
 	},
 /obj/machinery/door_timer/solitary/new_walls/south{
-	pixel_x = 8
+	pixel_x = 8;
+	dir = 1;
+	pixel_y = -21
 	},
 /obj/machinery/door_timer/solitary2/new_walls/south{
-	pixel_x = -8
+	pixel_x = -9;
+	dir = 1;
+	pixel_y = -21
 	},
 /obj/item/storage/firstaid/regular{
 	pixel_x = -6
@@ -18981,7 +19005,9 @@
 	pixel_y = 8
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "eng_bathroom"
+	id = "eng_bathroom";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/station/engine/engineering/restroom)
@@ -19195,7 +19221,9 @@
 /area/station/crew_quarters/showers)
 "bsv" = (
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "gym_bath1"
+	id = "gym_bath1";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -20000,7 +20028,9 @@
 /obj/machinery/door_control{
 	id = "podbay";
 	name = "Pod Bay Blast Door Control";
-	pixel_x = -22
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /obj/machinery/vending/air_vendor/plasma,
 /turf/simulated/floor,
@@ -20286,7 +20316,9 @@
 /area/station/crew_quarters/captain)
 "bwi" = (
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "quarters_cap"
+	id = "quarters_cap";
+	pixel_x = 23;
+	pixel_y = 1
 	},
 /turf/simulated/floor/carpet/purple/standard/narrow/ne,
 /area/station/crew_quarters/captain)
@@ -20325,7 +20357,9 @@
 /obj/machinery/door_control{
 	id = "lockdown";
 	name = "Bridge Lockdown";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
@@ -20818,7 +20852,9 @@
 	icon_state = "2-5"
 	},
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "quarters_hop"
+	id = "quarters_hop";
+	pixel_x = -23;
+	pixel_y = 1
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
@@ -24746,7 +24782,9 @@
 /obj/machinery/door_control{
 	id = "cargo_inbound";
 	name = "Cargo Inbound Door Control";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
@@ -24977,7 +25015,9 @@
 "bML" = (
 /obj/stool/chair/comfy,
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "radiohost"
+	id = "radiohost";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/purple/fancy/narrow/T_west,
 /area/station/crew_quarters/radio/lab)
@@ -25927,7 +25967,9 @@
 /obj/machinery/door_control{
 	id = "cargo_outbound";
 	name = "Cargo Outbound Door Control";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
@@ -26043,7 +26085,10 @@
 /area/station/security/processing)
 "bQA" = (
 /obj/machinery/door_timer/genpop/new_walls/north{
-	layer = 29
+	layer = 29;
+	dir = 2;
+	pixel_x = 0;
+	pixel_y = 25
 	},
 /turf/simulated/floor,
 /area/station/security/processing)
@@ -27346,7 +27391,9 @@
 /obj/machinery/door_control{
 	id = "crusher";
 	name = "Disposals Doors";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 0
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
@@ -28970,7 +29017,9 @@
 /obj/machinery/door_control{
 	id = "diner";
 	name = "Pod Door Control";
-	pixel_x = 22
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/simulated/floor/caution/north,
 /area/diner/hangar)
@@ -29469,7 +29518,9 @@
 /obj/machinery/door_control{
 	id = "tech";
 	name = "Tech Outpost Pod Bay Blast Door Control";
-	pixel_x = 22
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/tech_outpost)
@@ -31311,7 +31362,9 @@
 /obj/machinery/door_control{
 	id = "podbay";
 	name = "Pod Bay Blast Door Control";
-	pixel_x = 22
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/machinery/conveyor/NS/carousel,
 /obj/lattice,
@@ -33482,8 +33535,9 @@
 /obj/machinery/door_control{
 	id = "medbay_front";
 	name = "Medbay Door Control";
-	pixel_x = -23;
-	pixel_y = 8
+	pixel_x = -24;
+	pixel_y = 8;
+	dir = 8
 	},
 /obj/machinery/navbeacon/mule/medbay_north,
 /obj/decal/stripe_caution,
@@ -34095,7 +34149,9 @@
 /obj/machinery/door_control{
 	id = "mining_podbay";
 	name = "Mining Pod Bay Blast Door Control";
-	pixel_x = -22
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/mining/staff_room)
@@ -35101,7 +35157,9 @@
 /obj/machinery/door_control{
 	id = "catering_podbay";
 	name = "Catering Pod Bay Blast Door Control";
-	pixel_x = -22
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/catering{
@@ -36152,7 +36210,10 @@
 /area/station/bridge)
 "hVJ" = (
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_mdir"
+	id = "quarters_mdir";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "fblue2"
@@ -36868,7 +36929,10 @@
 	pixel_y = 32
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "cc_room3"
+	id = "cc_room3";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/green,
 /area/station/crew_quarters/quartersA)
@@ -37331,7 +37395,10 @@
 	pixel_y = 32
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "cc_room1"
+	id = "cc_room1";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/purple,
 /area/station/crew_quarters/quartersA)
@@ -40136,7 +40203,9 @@
 /obj/machinery/door_control{
 	id = "research_podbay";
 	name = "Research Pod Bay Blast Door Control";
-	pixel_x = -22
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
@@ -40213,7 +40282,10 @@
 	pixel_y = 32
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "cc_room5"
+	id = "cc_room5";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/red,
 /area/station/crew_quarters/quartersA)
@@ -43951,12 +44023,14 @@
 /area/station/hallway/primary/east)
 "tlG" = (
 /obj/machinery/door_control/bolter/new_walls/west{
-	pixel_y = -8;
-	id = "treatment1"
+	pixel_y = -7;
+	id = "treatment1";
+	pixel_x = -23
 	},
 /obj/machinery/door_control/bolter/new_walls/west{
-	pixel_y = 8;
-	id = "treatment2"
+	pixel_y = 7;
+	id = "treatment2";
+	pixel_x = -23
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -43986,7 +44060,10 @@
 	pixel_y = 32
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "cc_room2"
+	id = "cc_room2";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/quartersA)
@@ -44575,7 +44652,9 @@
 /area/station/crew_quarters/cafeteria)
 "uon" = (
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "gym_bath2"
+	id = "gym_bath2";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -46522,7 +46601,10 @@
 /area/station/storage/warehouse)
 "xmS" = (
 /obj/machinery/light/incandescent/greenish,
-/obj/machinery/door_control/podbay/security/new_walls/east,
+/obj/machinery/door_control/podbay/security/new_walls/east{
+	pixel_x = 23;
+	pixel_y = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "xnu" = (
@@ -46598,7 +46680,9 @@
 /obj/machinery/door_control{
 	id = "ai_core";
 	name = "AI Core Shield";
-	pixel_x = 28
+	pixel_x = 25;
+	dir = 4;
+	pixel_y = 0
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/camera{
@@ -46954,7 +47038,10 @@
 	pixel_y = 32
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "cc_room4"
+	id = "cc_room4";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/yellow,
 /area/station/crew_quarters/quartersA)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Edits Door Control Buttons and Door Timers on Oshan Laboratory and Nadir Extraction Site to use their new directionals, and fixes buttons that were facing the wrong way, pixel shifting them when needed to be in better positions. A few light switches, cremation switches and fire alarms have also been tweaked to be in the right direction or be in a better position on a wall.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Implementing new directions are good, and there are a few instances where buttons were flipped in the wrong direction due to direction code inconsistency.