### PR TITLE
Add training to trainees

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -655,6 +655,7 @@ ABSTRACT_TYPE(/datum/job/research)
 	name = "Research Trainee"
 	limit = 2
 	wages = PAY_UNTRAINED
+	trait_list = list("training_scientist")
 	access_string = "Scientist"
 	rounds_allowed_to_play = ROUNDS_MAX_RESASS
 	slot_back = list(/obj/item/storage/backpack/research)
@@ -706,6 +707,7 @@ ABSTRACT_TYPE(/datum/job/research)
 	name = "Medical Trainee"
 	limit = 2
 	wages = PAY_UNTRAINED
+	trait_list = list("training_medical")
 	access_string = "Medical Doctor"
 	rounds_allowed_to_play = ROUNDS_MAX_MEDASS
 	slot_back = list(/obj/item/storage/backpack/medic)
@@ -813,6 +815,7 @@ ABSTRACT_TYPE(/datum/job/engineering)
 	name = "Technical Trainee"
 	limit = 2
 	wages = PAY_UNTRAINED
+	trait_list = list("training_engineer")
 	access_string = "Engineer"
 	rounds_allowed_to_play = ROUNDS_MAX_TECHASS
 	slot_back = list(/obj/item/storage/backpack/engineering)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QoL] [Traits]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds `training_engineer`, `training_medical` and `training_scientist` to the three trainee jobs respectively.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There's a couple of things such as artifact hints that are tied to scientist training that might be confusing for trainees if they're told to expect messages there. Same for brains and medical training. And then engineering training just to round it off between all of them. Now that the jobs are limited to new players, they can be a little closer to actual jobs.
