### PR TITLE
Biodome/Icemoon Disks use their actual planet names

### DIFF
--- a/code/modules/networks/computer3/disks.dm
+++ b/code/modules/networks/computer3/disks.dm
@@ -120,8 +120,8 @@
 		src.root.add_file( place )
 
 	icemoon
-		name = "galactic coordinate disk - 'Moon X15'"
-		target_name = "Moon X15"
+		name = "galactic coordinate disk - 'Senex'"
+		target_name = "Senex"
 
 	solarium
 		name = "galactic coordinate disk - 'Sol'"
@@ -129,8 +129,8 @@
 		target_name = "Sol"
 
 	biodome
-		name = "galactic coordinate disk - 'Moon X05'"
-		target_name = "Moon X05"
+		name = "galactic coordinate disk - 'Fatuus'"
+		target_name = "Fatuus"
 
 	mars_outpost
 		name = "galactic coordinate disk - 'Mars'"

--- a/code/obj/landmark.dm
+++ b/code/obj/landmark.dm
@@ -510,13 +510,13 @@ var/global/list/job_start_locations = list()
 	name = "Void Diner"
 
 /obj/landmark/lrt/icemoon
-	name = "Moon X15"
+	name = "Senex"
 
 /obj/landmark/lrt/solarium
 	name = "Sol"
 
 /obj/landmark/lrt/biodome
-	name = "Moon X05"
+	name = "Fatuus"
 
 /obj/landmark/lrt/mars_outpost
 	name = "Mars"


### PR DESCRIPTION
## About the PR
Moon x15 and Moon x05 are outdated names for the planets their respective Adventure Zones take place on, so this changes them to the current ones - Senex and Fatuus respectively.

## Why's this needed?
The odd bits of "concrete" lore we have should be accurate.

## Changelog
```changelog
(u)444explorer
(+)Renamed the Telescience Disks "Moon x15" and "Moon x05" to "Senex" and "Fatuus" respectively
```
