### PR TITLE
CE Locker Puzzle contains the CE's PDA

### DIFF
--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -381,7 +381,7 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 		/obj/item/extinguisher,
 		/obj/item/clothing/suit/space/light/engineer,
 		/obj/item/clothing/head/helmet/space/light/engineer,
-		/obj/item/device/pda2/chiefengineer,
+		/obj/item/device/pda2/chiefengineer
 	)
 
 /* ==================== */

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -381,6 +381,7 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 		/obj/item/extinguisher,
 		/obj/item/clothing/suit/space/light/engineer,
 		/obj/item/clothing/head/helmet/space/light/engineer,
+		/obj/item/device/pda2/chiefengineer,
 	)
 
 /* ==================== */


### PR DESCRIPTION
## About the PR
That one prefab in the aestroid field that has the Chief Engineer's locker? yeah let's give it the PDA since the actual CE locker has it too, yayyy

## Why's this needed?
I think it makes sense and should't be too big of a deal, make the reward ever so slightly more  rewarding 
