### PR TITLE
Allows Flocktraces the ability to jump to flock speak links.

### DIFF
--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -295,7 +295,7 @@
 	return src.compute
 
 //moved from flockmind to allow traces to teleport
-/mob/living/intangible/flock/flockmind/Topic(href, href_list)
+/mob/living/intangible/flock/Topic(href, href_list)
 	if(href_list["origin"])
 		var/atom/movable/origin = locate(href_list["origin"])
 		if(!QDELETED(origin))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The code comment says this was supposed to be the case, but the author forgot to actually remove the `/flockmind` part of the path.

- [x] Did not test my code
- [x] Did not even compile my code
- [x] Code probably works as intended

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kapu1178
(+)Flocktraces can now use flockchat links to jump to targets like the Flockmind.
```
