### PR TITLE
Move Oshan HoS medal

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -27709,6 +27709,10 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/decal/poster/wallsign/framed_award/hos_medal{
+	pixel_x = -28;
+	pixel_y = -4
+	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bWb" = (
@@ -45047,9 +45051,6 @@
 /area/station/security/interrogation)
 "vex" = (
 /obj/machinery/weapon_stand/rifle_rack/recharger,
-/obj/decal/poster/wallsign/framed_award/hos_medal{
-	pixel_y = 28
-	},
 /obj/machinery/light/incandescent/harsh/very,
 /turf/simulated/floor/redblack,
 /area/station/ai_monitored/armory)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the Oshan Head Of Security medal from their armory to their office.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consistent with other maps. Medal is a spy target and armory is higher risk.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Flappybat
(+)Oshan HoS medal moved from armory to HoS office.
```
