### PR TITLE
Adds a syndie ground base area that doesn't block Hadars for trench warfare

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -4204,6 +4204,16 @@ ABSTRACT_TYPE(/area/mining)
 	teleport_blocked = 1
 	icon_state = "purple"
 
+/// Syndicate base that is radproof and not Hadar-blocked, for Trench Warfare
+
+/area/syndicate_base
+	name = "Syndicate Base"
+	icon_state = "yellow"
+	requires_power = 0
+	sound_environment = 2
+	teleport_blocked = 1
+	do_not_irradiate = TRUE
+
 /// For Devtest testing purposes
 /area/station/devzone
 	name = "Dev Zone"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Mapping][Internal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
A tiny change for @cogwerks adding an area for the Caer Vedwyd that doesnt block the included Hadars from working


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Needed for event map