### PR TITLE
Replace Swedish Meatball lunchbox 

### DIFF
--- a/code/obj/item/storage/lunchboxes.dm
+++ b/code/obj/item/storage/lunchboxes.dm
@@ -63,11 +63,11 @@
 		/obj/item/paper/lunchbox_note)
 
 	food7
-		spawn_contents = list(/obj/item/reagent_containers/food/snacks/swedishmeatball,\
-		/obj/item/reagent_containers/food/snacks/stroopwafel,\
-		/obj/item/reagent_containers/food/snacks/swedish_fish,\
+		spawn_contents = list(/obj/item/reagent_containers/food/snacks/bagel/lox,\
+		/obj/item/reagent_containers/food/snacks/bagel/creamcheese,\
+		/obj/item/reagent_containers/food/snacks/ingredient/cheese,\
+		/obj/item/reagent_containers/food/snacks/plant/apple,\
 		/obj/item/reagent_containers/food/drinks/water,\
-		/obj/item/kitchen/utensil/fork,\
 		/obj/item/paper/lunchbox_note)
 
 	food8


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This just swaps the contents of the Swedish Meatball lunchbox with one that has two bagel variants, a wedge of cheese, and an apple. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Accent food is fun, but it showed up a bit too often due to being in the lunchbox.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Jan.antilles
(+)Swedish Meatball lunchbox contents replaced with an assortment of bagels.
```
