### PR TITLE
Fixes Button Directions on Clarion and Kondaru

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -2258,8 +2258,9 @@
 	},
 /obj/machinery/crema_switch{
 	id = "crematorium";
-	pixel_x = -20;
-	pixel_y = 26
+	pixel_x = -23;
+	pixel_y = 28;
+	dir = 8
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
@@ -4107,7 +4108,8 @@
 /obj/machinery/door_control{
 	id = "disposals_door";
 	name = "Disposals Safety Shutters";
-	pixel_y = 28
+	pixel_y = 24;
+	pixel_x = 8
 	},
 /obj/machinery/manufacturer/general,
 /turf/simulated/floor,
@@ -6587,8 +6589,14 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/item/decoration/flower_vase,
-/obj/item/disk/data/floppy/read_only/communications,
+/obj/item/decoration/flower_vase{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/obj/item/disk/data/floppy/read_only/communications{
+	pixel_x = 5;
+	pixel_y = 3
+	},
 /obj/machinery/light_switch/east{
 	dir = 4;
 	pixel_y = 5
@@ -6661,8 +6669,10 @@
 	dir = 1
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	pixel_x = -8;
-	id = "res_bathroom"
+	pixel_x = -7;
+	id = "res_bathroom";
+	dir = 1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/sanitary,
 /area/station/science/lobby)
@@ -6916,7 +6926,9 @@
 /obj/machinery/door_control{
 	id = "lockdown";
 	name = "Bridge Lockdown Control";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /obj/cable{
 	icon_state = "0-4"
@@ -8619,14 +8631,16 @@
 /obj/machinery/door_control{
 	id = "scienceteleporter2";
 	name = "Pad Public-Access Lockdown";
-	pixel_x = 24;
-	pixel_y = -8
+	pixel_x = 23;
+	pixel_y = -7;
+	dir = 4
 	},
 /obj/machinery/door_control{
 	id = "scienceteleporter";
 	name = "Pad Control-Access Lockdown";
-	pixel_x = 24;
-	pixel_y = 8
+	pixel_x = 23;
+	pixel_y = 7;
+	dir = 4
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/science/teleporter)
@@ -8945,11 +8959,13 @@
 	},
 /obj/machinery/door_timer/solitary/new_walls/north{
 	layer = 3.1;
-	pixel_x = -8
+	pixel_x = -8;
+	dir = 2
 	},
 /obj/machinery/door_timer/solitary2/new_walls/north{
 	layer = 3.1;
-	pixel_x = 8
+	pixel_x = 8;
+	dir = 2
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -9044,15 +9060,26 @@
 /area/station/science/lab)
 "bgY" = (
 /obj/table/reinforced/auto,
-/obj/item/clipboard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/stamp,
-/obj/item/clothing/glasses/vr{
+/obj/item/clipboard{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/paper_bin{
+	pixel_x = -7;
+	pixel_y = 0
+	},
+/obj/item/pen{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/stamp{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/vr/bomb{
 	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = 2;
-	pixel_y = 5
+	pixel_x = -6;
+	pixel_y = 16
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
@@ -9556,14 +9583,16 @@
 /obj/machinery/door_control{
 	id = "tox_one";
 	name = "Chamber Exhaust";
-	pixel_x = -24;
-	pixel_y = 8
+	pixel_x = -23;
+	pixel_y = 7;
+	dir = 8
 	},
 /obj/machinery/door_control{
 	id = "tox_hs_one";
 	name = "Chamber Heat Shield";
-	pixel_x = -24;
-	pixel_y = -8
+	pixel_x = -23;
+	pixel_y = -7;
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
@@ -11178,15 +11207,22 @@
 	dir = 4
 	},
 /obj/table/reinforced/auto,
-/obj/machinery/light/lamp/green{
-	pixel_x = -6;
-	pixel_y = 4;
-	switchon = 1
+/obj/item/deconstructor{
+	pixel_x = 3;
+	pixel_y = 10
 	},
-/obj/machinery/cell_charger,
-/obj/item/cell/supercell/charged,
-/obj/item/deconstructor,
-/obj/item/device/radio/headset/engineer,
+/obj/item/device/radio/headset/engineer{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/obj/machinery/cell_charger{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/cell/supercell/charged{
+	pixel_x = 0;
+	pixel_y = 0
+	},
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
 	},
@@ -11337,11 +11373,6 @@
 /obj/stool/chair/comfy{
 	dir = 1;
 	name = "worn brown chair"
-	},
-/obj/machinery/door_control{
-	id = "engineshield";
-	name = "Engine Room Heat Shield";
-	pixel_y = 20
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "fblue2"
@@ -14012,7 +14043,9 @@
 /obj/machinery/door_control{
 	id = "cloning_exit";
 	name = "Cloning Exit Door Control";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 0
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 5
@@ -14160,7 +14193,9 @@
 /obj/storage/closet/dresser/random,
 /obj/landmark/bill_spawn,
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "cc_room1"
+	id = "cc_room1";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/crew_quarters/quarters_west)
@@ -17632,6 +17667,9 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/item/rocko{
+	pixel_x = -12
+	},
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
 	},
@@ -19193,7 +19231,8 @@
 "gqa" = (
 /obj/storage/closet/dresser/random,
 /obj/machinery/door_control/bolter/new_walls/north{
-	id = "cc_room3"
+	id = "cc_room3";
+	dir = 2
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/crew_quarters/quarters_west)
@@ -22055,8 +22094,9 @@
 /obj/machinery/door_control{
 	id = "engineshield";
 	name = "Engine Room Heat Shield";
-	pixel_x = 24;
-	pixel_y = 8
+	pixel_x = 23;
+	pixel_y = 1;
+	dir = 4
 	},
 /obj/machinery/networked/printer{
 	print_id = "Engineering"
@@ -22597,7 +22637,8 @@
 "iMu" = (
 /obj/storage/closet/dresser/random,
 /obj/machinery/door_control/bolter/new_walls/north{
-	id = "cc_room4"
+	id = "cc_room4";
+	dir = 2
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/crew_quarters/quarters_west)
@@ -23860,6 +23901,13 @@
 	pixel_x = -10
 	},
 /obj/disposalpipe/segment,
+/obj/machinery/door_control{
+	id = "cargo_swapabout";
+	name = "Cargo Shutters";
+	pixel_x = -24;
+	dir = 8;
+	pixel_y = 0
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -23892,7 +23940,9 @@
 	pixel_x = 12
 	},
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "cc_shower_2"
+	id = "cc_shower_2";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -24345,7 +24395,10 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/escape)
 "kkr" = (
-/obj/machinery/door_control/podbay/security/new_walls/west,
+/obj/machinery/door_control/podbay/security/new_walls/west{
+	pixel_x = -23;
+	pixel_y = 1
+	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 5;
@@ -29598,13 +29651,36 @@
 	dir = 4
 	},
 /obj/table/reinforced/auto,
-/obj/item/clipboard,
-/obj/item/paper_bin,
-/obj/item/pen/fancy,
-/obj/item/stamp/ce,
-/obj/item/reagent_containers/food/drinks/mug/random_color,
-/obj/item/rocko{
-	pixel_x = -12
+/obj/item/reagent_containers/food/drinks/mug/random_color{
+	pixel_x = 16;
+	pixel_y = 1
+	},
+/obj/machinery/door_control/table{
+	pixel_x = -8;
+	pixel_y = 0;
+	name = "Engine Room Heat Shield";
+	id = "engineshield"
+	},
+/obj/machinery/light/lamp/green{
+	pixel_x = 16;
+	pixel_y = 17;
+	switchon = 1
+	},
+/obj/item/clipboard{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/paper_bin{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/stamp/ce{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/item/pen/fancy{
+	pixel_x = 5;
+	pixel_y = 1
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
@@ -31164,7 +31240,9 @@
 "pnZ" = (
 /obj/machinery/door_control{
 	id = "market_2";
-	pixel_y = -24
+	pixel_y = -21;
+	dir = 1;
+	pixel_x = -1
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/market)
@@ -31986,7 +32064,9 @@
 /obj/machinery/shower,
 /obj/machinery/drainage,
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "med_bathroom"
+	id = "med_bathroom";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/white,
 /area/station/medical/staff)
@@ -33501,11 +33581,6 @@
 	pixel_x = -5
 	},
 /obj/disposalpipe/trunk,
-/obj/machinery/door_control{
-	id = "cargo_swapabout";
-	name = "Cargo Shutters";
-	pixel_x = -26
-	},
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/yellow/side{
 	dir = 9
@@ -33523,7 +33598,9 @@
 /obj/machinery/door_control{
 	id = "ai_core";
 	name = "AI Core Shield";
-	pixel_y = -21
+	pixel_y = -21;
+	dir = 1;
+	pixel_x = -1
 	},
 /obj/item/device/radio/intercom/AI{
 	dir = 4
@@ -33968,7 +34045,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door_control/podbay/mainpod1/new_walls/west,
+/obj/machinery/door_control/podbay/mainpod1/new_walls/west{
+	pixel_x = -23;
+	pixel_y = 0
+	},
 /turf/simulated/floor/stairs{
 	dir = 1
 	},
@@ -34075,7 +34155,6 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/item/decoration/flower_vase,
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -34085,8 +34164,21 @@
 	pixel_x = -10;
 	pixel_y = -5
 	},
-/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 0;
+	pixel_y = 10
+	},
 /obj/blind_switch/area/west,
+/obj/item/decoration/flower_vase{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/machinery/door_control/table{
+	name = "Bridge Lockdown Control";
+	id = "lockdown";
+	pixel_x = -1;
+	pixel_y = 2
+	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "blue2"
@@ -34407,14 +34499,14 @@
 /obj/machinery/door_control{
 	id = "cargodock_out";
 	name = "Outlet Door Control";
-	pixel_x = -8;
-	pixel_y = 22
+	pixel_x = -7;
+	pixel_y = 24
 	},
 /obj/machinery/door_control{
 	id = "cargodock_in";
 	name = "Intake Door Control";
-	pixel_x = 8;
-	pixel_y = 22
+	pixel_x = 7;
+	pixel_y = 24
 	},
 /obj/machinery/conveyor_switch{
 	id = "cargobelt_out";
@@ -34974,7 +35066,9 @@
 /obj/storage/closet/dresser/random,
 /obj/landmark/bill_spawn,
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "cc_room2"
+	id = "cc_room2";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/crew_quarters/quarters_west)
@@ -37298,17 +37392,21 @@
 	c_tag = "autotag";
 	dir = 8;
 	name = "autoname  - SS13";
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 1
 	},
 /obj/blind_switch/area/east{
-	dir = 4
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 2
 	},
 /obj/machinery/chem_heater/chemistry,
 /obj/machinery/door_control{
 	id = "chemblast";
 	name = "Chemistry Blast Shield Control";
 	pixel_x = 24;
-	pixel_y = -8
+	pixel_y = -11;
+	dir = 4
 	},
 /turf/simulated/floor/purpleblack{
 	dir = 4
@@ -37993,7 +38091,9 @@
 "upO" = (
 /obj/machinery/door_control{
 	id = "market_3";
-	pixel_y = -24
+	pixel_y = -21;
+	dir = 1;
+	pixel_x = -1
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/market)
@@ -38620,7 +38720,10 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/door_timer/minibrig/new_walls/east,
+/obj/machinery/door_timer/minibrig/new_walls/east{
+	pixel_x = 22;
+	pixel_y = -1
+	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/escape)
 "uKc" = (
@@ -39037,11 +39140,13 @@
 /obj/machinery/door_control{
 	id = "lockdown";
 	name = "Bridge Lockdown Control";
-	pixel_x = -24;
-	pixel_y = -8
+	pixel_x = -23;
+	pixel_y = -8;
+	dir = 8
 	},
 /obj/machinery/firealarm/west{
-	pixel_y = 5
+	pixel_y = 6;
+	pixel_x = -23
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -39618,7 +39723,8 @@
 	dir = 1
 	},
 /obj/item/decoration/flower_vase{
-	pixel_y = 24
+	pixel_y = 18;
+	pixel_x = -14
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -41731,7 +41837,9 @@
 	pixel_x = -12
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_shower_1"
+	id = "cc_shower_1";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -41826,7 +41934,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "n_bathroom"
+	id = "n_bathroom";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
@@ -42257,11 +42367,6 @@
 /obj/item/device/radio/intercom/science{
 	dir = 4
 	},
-/obj/machinery/door_control{
-	id = "lockdown";
-	name = "Bridge Lockdown Control";
-	pixel_y = 28
-	},
 /obj/machinery/computer/security{
 	dir = 4
 	},
@@ -42376,11 +42481,18 @@
 "xOE" = (
 /obj/machinery/firealarm/east,
 /obj/table/reinforced/auto,
-/obj/item/device/audio_log,
-/obj/item/audio_tape{
-	pixel_y = 5
+/obj/item/device/audio_log{
+	pixel_x = -9;
+	pixel_y = 8
 	},
-/obj/item/wrench,
+/obj/item/audio_tape{
+	pixel_y = -6;
+	pixel_x = 5
+	},
+/obj/item/wrench{
+	pixel_x = 1;
+	pixel_y = 3
+	},
 /turf/simulated/floor,
 /area/station/science/lab)
 "xOU" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -1508,7 +1508,10 @@
 /obj/item/crowbar,
 /obj/item/hand_labeler,
 /obj/item/device/multitool,
-/obj/machinery/door_control/podbay/mainpod1/new_walls/west,
+/obj/machinery/door_control/podbay/mainpod1/new_walls/west{
+	pixel_x = -23;
+	pixel_y = 0
+	},
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
@@ -2309,13 +2312,16 @@
 	desc = "Someone scratched off the old label and plastered over it with a hand labeler. What the hell was this before?";
 	id = "clowntainment";
 	name = "CONTAIN honk";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 6
 	},
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/light_switch{
 	name = "W light switch";
-	pixel_x = -24;
-	pixel_y = -9
+	pixel_x = -23;
+	pixel_y = -7;
+	dir = 8
 	},
 /obj/cable{
 	icon_state = "2-5"
@@ -2734,7 +2740,10 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "business2"
+	id = "business2";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA)
@@ -3280,7 +3289,8 @@
 	},
 /obj/machinery/crema_switch{
 	id = "crematorium";
-	pixel_y = 28
+	pixel_y = 24;
+	pixel_x = 0
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
@@ -3488,7 +3498,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/door_timer/minibrig2/new_walls/north,
+/obj/machinery/door_timer/minibrig2/new_walls/north{
+	dir = 2
+	},
 /obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -3860,7 +3872,10 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "business1"
+	id = "business1";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersB)
@@ -7321,7 +7336,9 @@
 "aBF" = (
 /obj/machinery/door_control{
 	id = "det_entry";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/grime,
@@ -8177,14 +8194,16 @@
 /obj/machinery/door_control{
 	id = "fireshield";
 	name = "Heat Shield";
-	pixel_x = -24;
-	pixel_y = 8
+	pixel_x = -23;
+	pixel_y = 7;
+	dir = 8
 	},
 /obj/machinery/door_control{
 	id = "combustion";
 	name = "Chamber Exhaust";
-	pixel_x = -24;
-	pixel_y = -8
+	pixel_x = -23;
+	pixel_y = -7;
+	dir = 8
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -8713,7 +8732,9 @@
 /obj/machinery/door_control{
 	id = "crusher";
 	name = "Crusher Door Control";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 0
 	},
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/grime,
@@ -9340,7 +9361,10 @@
 /obj/item/clipboard,
 /obj/item/pen,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_mdir"
+	id = "quarters_mdir";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /obj/item/mdlicense,
 /turf/simulated/floor/black,
@@ -9411,7 +9435,9 @@
 /obj/machinery/door_control{
 	id = "ai_core";
 	name = "AI Core Shield";
-	pixel_y = -26
+	pixel_y = -21;
+	dir = 1;
+	pixel_x = -1
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -10616,7 +10642,9 @@
 "aQe" = (
 /obj/stool/chair,
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room7"
+	id = "cc_room7";
+	pixel_x = 23;
+	pixel_y = 1
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/station/crew_quarters/quarters_north)
@@ -11681,12 +11709,16 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/power/apc/autoname_west,
+/obj/machinery/power/apc/autoname_west{
+	pixel_x = -20;
+	pixel_y = -3
+	},
 /obj/machinery/door_control{
 	id = "clone_begone";
 	name = "Exit Door Control";
-	pixel_x = -24;
-	pixel_y = 15
+	pixel_x = -23;
+	pixel_y = 13;
+	dir = 8
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 1
@@ -11891,7 +11923,9 @@
 /obj/machinery/door_control{
 	id = "clone_begone";
 	name = "Exit Door Control";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/storage/secure/closet/medical/cloning,
 /turf/simulated/floor/white,
@@ -12421,7 +12455,10 @@
 /area/station/crew_quarters/quarters_north)
 "aXe" = (
 /obj/disposalpipe/segment/vertical,
-/obj/machinery/door_control/podbay/escape/new_walls/west,
+/obj/machinery/door_control/podbay/escape/new_walls/west{
+	pixel_x = -23;
+	pixel_y = 1
+	},
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -13858,7 +13895,9 @@
 /obj/machinery/door_control{
 	id = "eva";
 	name = "EVA Secure Shutters";
-	pixel_x = 28
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
@@ -16240,7 +16279,9 @@
 /area/station/mining/refinery)
 "bob" = (
 /obj/disposalpipe/segment/horizontal,
-/obj/machinery/door_control/podbay/mining/new_walls/north,
+/obj/machinery/door_control/podbay/mining/new_walls/north{
+	dir = 2
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -16765,12 +16806,16 @@
 	},
 /obj/item/pen,
 /obj/machinery/door_control/bolter/new_walls/south{
-	pixel_x = 8;
-	id = "treatment2"
+	pixel_x = 6;
+	id = "treatment2";
+	dir = 1;
+	pixel_y = -21
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
 	pixel_x = -8;
-	id = "treatment1"
+	id = "treatment1";
+	dir = 1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
@@ -17378,11 +17423,14 @@
 /obj/machinery/door_control{
 	id = "unlode";
 	name = "Unloading Door Control";
-	pixel_x = 25
+	pixel_x = 24;
+	dir = 4;
+	pixel_y = -3
 	},
 /obj/machinery/manufacturer/hangar,
 /obj/machinery/light_switch/east{
-	pixel_y = 11
+	pixel_y = 9;
+	pixel_x = 24
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -22056,7 +22104,10 @@
 /obj/machinery/phone,
 /obj/item/pen/crayon/golden,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_hop"
+	id = "quarters_hop";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/black,
 /area/station/bridge/hos)
@@ -22629,7 +22680,9 @@
 /obj/machinery/door_control{
 	id = "cargo_swapabout";
 	name = "Cargo Shutters";
-	pixel_x = -26
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 0
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -23924,7 +23977,10 @@
 	dir = 4
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_hos"
+	id = "quarters_hos";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
@@ -25534,6 +25590,14 @@
 	pixel_y = 21
 	},
 /obj/table/reinforced/chemistry/auto/basicsup,
+/obj/item/device/analyzer/atmospheric{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/device/analyzer/atmospheric{
+	pixel_x = 3;
+	pixel_y = 4
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
@@ -25544,7 +25608,12 @@
 	desc = null
 	},
 /obj/item/device/audio_log{
-	pixel_y = 7
+	pixel_y = 2;
+	pixel_x = -1
+	},
+/obj/item/device/analyzer/atmospheric{
+	pixel_x = -24;
+	pixel_y = 4
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
@@ -25679,8 +25748,9 @@
 /obj/machinery/door_control{
 	id = "tox_vent2";
 	name = "Chamber Two Exhaust";
-	pixel_x = -24;
-	pixel_y = -8
+	pixel_x = -23;
+	pixel_y = -9;
+	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
@@ -25798,7 +25868,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/door_timer/minibrig3/new_walls/north,
+/obj/machinery/door_timer/minibrig3/new_walls/north{
+	dir = 2
+	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -26160,42 +26232,29 @@
 /area/station/science/lab)
 "ccX" = (
 /obj/table/auto,
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = 8;
-	pixel_y = 10
-	},
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = -8;
-	pixel_y = 12
-	},
-/obj/item/device/analyzer/atmospheric,
-/obj/item/device/analyzer/atmospheric{
-	pixel_x = -8;
-	pixel_y = -2
-	},
-/obj/item/device/analyzer/atmospheric{
-	pixel_x = 9;
-	pixel_y = -1
-	},
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/clothing/glasses/vr{
-	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
-	network = "bombtest";
-	pixel_x = -8;
-	pixel_y = 7
-	},
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
+	},
+/obj/item/clothing/glasses/vr/bomb{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/clothing/glasses/vr/bomb{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/clothing/glasses/vr/bomb{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	pixel_x = 8;
+	pixel_y = -7
+	},
+/obj/item/clothing/glasses/vr/bomb{
+	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
+	pixel_x = 8;
+	pixel_y = 5
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
@@ -26440,8 +26499,9 @@
 /obj/machinery/door_control{
 	id = "tox_mix";
 	name = "Mixing Vent Control";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -23;
+	pixel_y = 1;
+	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
@@ -28044,7 +28104,9 @@
 /obj/machinery/door_control{
 	id = "ppap";
 	name = "Facility Door Control";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/caution/north,
@@ -28075,7 +28137,9 @@
 /obj/machinery/door_control{
 	id = "test_chamber2";
 	name = "Test Chamber Shutter Control";
-	pixel_y = -24
+	pixel_y = -21;
+	dir = 1;
+	pixel_x = -1
 	},
 /obj/item/storage/firstaid/fire,
 /turf/simulated/floor/purplewhite,
@@ -29644,7 +29708,9 @@
 "coL" = (
 /obj/stool/chair,
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "cc_room2"
+	id = "cc_room2";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/west,
 /area/station/crew_quarters/quarters_north)
@@ -33695,7 +33761,9 @@
 	pixel_y = -3
 	},
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "cc_room1"
+	id = "cc_room1";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/crew_quarters/quarters_south)
@@ -33900,13 +33968,14 @@
 /obj/machinery/door_control{
 	id = "kondaru_medexit";
 	name = "Medbay Door Control";
-	pixel_x = 24;
-	pixel_y = -9
+	pixel_x = 23;
+	pixel_y = -8;
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24;
-	pixel_y = 7
+	pixel_x = 23;
+	pixel_y = 6
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
@@ -34093,7 +34162,9 @@
 /obj/table/wood/auto,
 /obj/random_item_spawner/medicine,
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room10"
+	id = "cc_room10";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
@@ -34191,7 +34262,9 @@
 "fdH" = (
 /obj/stool/chair,
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room5"
+	id = "cc_room5";
+	pixel_x = 23;
+	pixel_y = 1
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/station/crew_quarters/quarters_north)
@@ -34717,17 +34790,6 @@
 /obj/machinery/vehicle/pod_smooth/industrial,
 /turf/simulated/floor/engine,
 /area/station/hangar/qm)
-"fxg" = (
-/obj/machinery/door_control{
-	id = "imports_door";
-	name = "Import Door Control";
-	pixel_x = -26
-	},
-/obj/machinery/conveyor/SN{
-	id = "qmin"
-	},
-/turf/simulated/floor/caution/westeast,
-/area/station/quartermaster/cargobay)
 "fxh" = (
 /obj/lattice,
 /obj/warp_beacon/security,
@@ -34920,7 +34982,9 @@
 	pixel_y = 10
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room11"
+	id = "cc_room11";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
@@ -35025,7 +35089,9 @@
 /obj/machinery/door_control{
 	id = "PTLDOOR";
 	name = "Transmission Laser Confinement";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/cable/blue{
 	icon_state = "0-8"
@@ -35041,7 +35107,10 @@
 /turf/simulated/floor/green,
 /area/station/crew_quarters/quarters_south)
 "fLU" = (
-/obj/machinery/door_control/podbay/research/new_walls/west,
+/obj/machinery/door_control/podbay/research/new_walls/west{
+	pixel_x = -23;
+	pixel_y = 0
+	},
 /obj/storage/secure/crate/plasma{
 	desc = "A secure crate designed for transport of hazardous research materials.";
 	name = "Hazard Transport Crate";
@@ -37010,7 +37079,8 @@
 	id = "tox_vent1";
 	name = "Chamber One Exhaust";
 	pixel_x = 9;
-	pixel_y = 9
+	pixel_y = 8;
+	dir = 8
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
@@ -37897,7 +37967,9 @@
 "hKQ" = (
 /obj/stool/chair,
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room6"
+	id = "cc_room6";
+	pixel_x = 23;
+	pixel_y = 1
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/station/crew_quarters/quarters_north)
@@ -38756,7 +38828,10 @@
 	pixel_x = -2
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_rd"
+	id = "quarters_rd";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/black,
 /area/station/science/research_director)
@@ -39588,7 +39663,8 @@
 /area/station/engine/gas)
 "iUC" = (
 /obj/machinery/door_timer/solitary2/new_walls/north{
-	layer = 3.1
+	layer = 3.1;
+	dir = 2
 	},
 /obj/machinery/atmospherics/unary/outlet_injector/active{
 	dir = 8
@@ -39609,7 +39685,9 @@
 /area/station/security/brig/solitary)
 "iVD" = (
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room12"
+	id = "cc_room12";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/damaged5,
 /area/station/crew_quarters/quarters_south)
@@ -39826,7 +39904,10 @@
 /obj/item/clipboard,
 /obj/item/pen,
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_ce"
+	id = "quarters_ce";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/yellowblack,
 /area/station/crew_quarters/ce)
@@ -40531,7 +40612,8 @@
 	pixel_x = 12
 	},
 /obj/machinery/door_control/bolter/new_walls/north{
-	id = "n_bathroom2"
+	id = "n_bathroom2";
+	dir = 2
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom{
@@ -41029,6 +41111,16 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
+"jWc" = (
+/obj/machinery/door_control{
+	id = "dwaine_core";
+	name = "DWAINE Core Shield";
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/Zeta)
 "jWx" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -41596,7 +41688,8 @@
 	dir = 8
 	},
 /obj/machinery/door_timer/solitary/new_walls/north{
-	layer = 3.1
+	layer = 3.1;
+	dir = 2
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -41990,14 +42083,16 @@
 /obj/machinery/door_control{
 	id = "fireshield";
 	name = "Heat Shield";
-	pixel_x = -24;
-	pixel_y = 8
+	pixel_x = -23;
+	pixel_y = 7;
+	dir = 8
 	},
 /obj/machinery/door_control{
 	id = "combustion";
 	name = "Chamber Exhaust";
-	pixel_x = -24;
-	pixel_y = -8
+	pixel_x = -23;
+	pixel_y = -7;
+	dir = 8
 	},
 /obj/decal/poster/wallsign/space{
 	layer = 2;
@@ -44438,8 +44533,14 @@
 "mxp" = (
 /obj/machinery/light,
 /obj/table/reinforced/auto,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/paper_bin{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = 3;
+	pixel_y = 5
+	},
 /turf/simulated/floor/grey,
 /area/station/quartermaster/cargobay)
 "mxv" = (
@@ -44956,7 +45057,9 @@
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
 "mSD" = (
-/obj/machinery/door_control/podbay/security/new_walls/north,
+/obj/machinery/door_control/podbay/security/new_walls/north{
+	dir = 2
+	},
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
@@ -45149,18 +45252,6 @@
 	dir = 0;
 	name = "autoname - SS13";
 	pixel_y = 20
-	},
-/obj/machinery/door_control{
-	id = "qm_dock";
-	name = "Import Hatch Override";
-	pixel_x = -2;
-	pixel_y = 28
-	},
-/obj/machinery/door_control{
-	id = "manualshipping";
-	name = "Export Hatch Override";
-	pixel_x = 9;
-	pixel_y = 28
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/cargobay)
@@ -47798,7 +47889,9 @@
 	},
 /obj/item/pen/fancy,
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "cc_diplo"
+	id = "cc_diplo";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/crew_quarters/heads{
@@ -47915,7 +48008,9 @@
 /turf/space,
 /area/station/maintenance/southwest)
 "phz" = (
-/obj/machinery/door_control/podbay/engineering/new_walls/north,
+/obj/machinery/door_control/podbay/engineering/new_walls/north{
+	dir = 2
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -48449,11 +48544,6 @@
 	pixel_y = 6
 	},
 /obj/item/device/multitool,
-/obj/machinery/door_control{
-	id = "dwaine_core";
-	name = "DWAINE Core Shield";
-	pixel_x = 25
-	},
 /turf/simulated/floor/greenblack,
 /area/station/turret_protected/Zeta)
 "pzN" = (
@@ -48758,8 +48848,7 @@
 	},
 /obj/machinery/atmospherics/binary/valve{
 	name = "hot reserve tank valve";
-	dir = 1;
-
+	dir = 1
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -52208,7 +52297,9 @@
 "sjX" = (
 /obj/stool/chair,
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "cc_room4"
+	id = "cc_room4";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/west,
 /area/station/crew_quarters/quarters_north)
@@ -52468,7 +52559,9 @@
 	pixel_x = 8
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room9"
+	id = "cc_room9";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
@@ -52809,7 +52902,8 @@
 	},
 /obj/machinery/firealarm/east,
 /obj/machinery/door_control/bolter/new_walls/north{
-	id = "quarters_cap"
+	id = "quarters_cap";
+	dir = 2
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
@@ -52998,7 +53092,9 @@
 /obj/machinery/door_control{
 	id = "boomroom";
 	name = "Test Chamber Shutters";
-	pixel_x = -24
+	pixel_x = -23;
+	dir = 8;
+	pixel_y = 1
 	},
 /obj/table/reinforced/auto,
 /obj/item/clothing/glasses/sunglasses{
@@ -55477,13 +55573,13 @@
 /turf/simulated/floor/black/grime,
 /area/station/routing/depot)
 "uCJ" = (
+/obj/machinery/deep_fryer,
 /obj/machinery/door_control{
 	id = "kitchen";
 	name = "Kitchen Shutter Control";
-	pixel_x = 10;
+	pixel_x = 0;
 	pixel_y = 24
 	},
-/obj/machinery/deep_fryer,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/kitchen)
 "uDm" = (
@@ -55625,8 +55721,20 @@
 /area/space)
 "uHA" = (
 /obj/table/reinforced/auto,
-/obj/item/hand_labeler,
-/obj/item/hand_labeler,
+/obj/item/hand_labeler{
+	pixel_x = 17;
+	pixel_y = 9
+	},
+/obj/item/hand_labeler{
+	pixel_x = 17;
+	pixel_y = 9
+	},
+/obj/machinery/door_control/table{
+	name = "Import Door Control";
+	id = "imports_door";
+	pixel_x = -1;
+	pixel_y = 4
+	},
 /turf/simulated/floor/grey,
 /area/station/quartermaster/cargobay)
 "uIb" = (
@@ -55978,6 +56086,20 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door_control{
+	id = "manualshipping";
+	name = "Export Hatch Override";
+	pixel_x = 31;
+	pixel_y = -21;
+	dir = 1
+	},
+/obj/machinery/door_control{
+	id = "qm_dock";
+	name = "Import Hatch Override";
+	pixel_x = -1;
+	pixel_y = -21;
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/cargobay)
@@ -56916,7 +57038,9 @@
 "vAN" = (
 /obj/stool/chair,
 /obj/machinery/door_control/bolter/new_walls/west{
-	id = "cc_room3"
+	id = "cc_room3";
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/west,
 /area/station/crew_quarters/quarters_north)
@@ -57808,7 +57932,9 @@
 /obj/machinery/door_control{
 	id = "cable_partition";
 	name = "Cable Partition Control";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /turf/simulated/floor/engine{
 	dir = 4;
@@ -58929,7 +59055,9 @@
 	pixel_y = 10
 	},
 /obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room8"
+	id = "cc_room8";
+	pixel_x = 23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
@@ -59833,7 +59961,10 @@
 	pixel_x = 12
 	},
 /obj/machinery/door_control/bolter/new_walls/south{
-	id = "n_bathroom1"
+	id = "n_bathroom1";
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -21
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom{
@@ -59930,7 +60061,9 @@
 /obj/machinery/door_control{
 	id = "mports_door";
 	name = "Cargo Export";
-	pixel_x = 24
+	pixel_x = 23;
+	dir = 4;
+	pixel_y = 1
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -107199,7 +107332,7 @@ ejV
 qIn
 uUX
 qIn
-fxg
+qIn
 iIL
 eob
 fXD
@@ -127421,7 +127554,7 @@ saq
 wIv
 ujq
 edU
-lSk
+jWc
 pzj
 bHl
 cxa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Edits Door Control Buttons and Door Timers on Clarion and Kondaru to use their new directionals, and fixes buttons that were facing the wrong way, pixel shifting them when needed to be in better positions. A few light switches, cremation switches and fire alarms have also been tweaked to be in the right direction or be in a better position on a wall. A few tables also had things moved a bit apart to give space to buttons.

This is the last PR for the main maps, though PR's for extra places (Mining Level, Asteroid Field, Random Rooms, etc...) will likely be coming up to close up most of the common places you can see buttons that need proper directionals.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Implementing new directions are good, and there are a few instances where buttons were flipped in the wrong direction due to direction code inconsistency. A couple buttons on tables were/would also be covered by table junk and needed space.