### PR TITLE
Move Some Plantmaster Data to Regular Data

### DIFF
--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -493,7 +493,7 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 				qdel(seed1)
 				qdel(seed2)
 				src.mode = "seedlist"
-				. = TRUE
+				update_static_data(ui.user, ui)
 
 
 

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -24,38 +24,11 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 	attack_ai(var/mob/user as mob)
 		return attack_hand(user)
 
-	ui_static_data(mob/user)
-		var/exlist = list()
-		var/seedlist = list()
-		var/geneout = null//tmp var for storing analysis results
+	ui_data(mob/user)
+		var/list/thisContainerData = null
 		var/splice_chance = 100
 		var/splice1_geneout
 		var/splice2_geneout
-
-		if (src.splicing1 && src.splicing2)
-			splice_chance = src.SpliceChance(src.splicing1, src.splicing2)
-
-		switch(src.mode)
-			if("extractables")
-				for(var/exItem in src.extractables)
-					if (istype(exItem, /obj/item/seed))
-						var/obj/item/seed/S = exItem
-						geneout = QuickAnalysisRow(S, S.planttype, S.plantgenes)
-					else if (istype(exItem, /obj/item/reagent_containers/food/snacks/plant))
-						var/obj/item/reagent_containers/food/snacks/plant/S = exItem
-						geneout = QuickAnalysisRow(S, S.planttype, S.plantgenes)
-					exlist += list(geneout)
-
-			if("seedlist")
-				for (var/obj/item/seed/S in src.seeds)
-					if((S == src.splicing1) || (S == src.splicing2)) continue;
-					geneout = QuickAnalysisRow(S, S.planttype, S.plantgenes)
-					geneout["damage"] = list(S.seeddamage, FALSE)
-					geneout["splicing"] = list("splicing", (S == src.splicing1) || (S == src.splicing2))
-					geneout["allow_infusion"]= list("allow_infusion", src.inserted?.reagents?.total_volume > 0)
-					seedlist += list(geneout)
-
-		var/list/thisContainerData = null
 
 		if (src.inserted)
 			var/obj/item/reagent_containers/glass/thisContainer = src.inserted
@@ -85,6 +58,9 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 							volume = current_reagent.volume
 						)))
 
+		if (src.splicing1 && src.splicing2)
+			splice_chance = src.SpliceChance(src.splicing1, src.splicing2)
+
 		if(src.splicing1)
 			splice1_geneout = QuickAnalysisRow(src.splicing1, src.splicing1.planttype, src.splicing1.plantgenes)
 			splice1_geneout["damage"] = list(src.splicing1.seeddamage, FALSE)
@@ -97,8 +73,6 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 			splice2_geneout["allow_infusion"]= list("allow_infusion", src.inserted?.reagents?.total_volume > 0)
 
 		return list(
-			"extractables" = exlist,
-			"seeds" = seedlist,
 			"category" = src.mode,
 			"category_lengths" = list(length(src.extractables),length(src.seeds)),
 			"inserted" =  src.inserted ? "[src.inserted.reagents.total_volume]/[src.inserted.reagents.maximum_volume] [src.inserted.name]" : "No reagent vessel",
@@ -109,6 +83,36 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 			"splice_seeds" = list(splice1_geneout, splice2_geneout),
 			"sortBy" = src.sort,
 			"sortAsc" = src.sortAsc,
+		)
+
+	ui_static_data(mob/user)
+		var/exlist = list()
+		var/seedlist = list()
+		var/geneout = null//tmp var for storing analysis results
+
+		switch(src.mode)
+			if("extractables")
+				for(var/exItem in src.extractables)
+					if (istype(exItem, /obj/item/seed))
+						var/obj/item/seed/S = exItem
+						geneout = QuickAnalysisRow(S, S.planttype, S.plantgenes)
+					else if (istype(exItem, /obj/item/reagent_containers/food/snacks/plant))
+						var/obj/item/reagent_containers/food/snacks/plant/S = exItem
+						geneout = QuickAnalysisRow(S, S.planttype, S.plantgenes)
+					exlist += list(geneout)
+
+			if("seedlist")
+				for (var/obj/item/seed/S in src.seeds)
+					if((S == src.splicing1) || (S == src.splicing2)) continue;
+					geneout = QuickAnalysisRow(S, S.planttype, S.plantgenes)
+					geneout["damage"] = list(S.seeddamage, FALSE)
+					geneout["splicing"] = list("splicing", (S == src.splicing1) || (S == src.splicing2))
+					geneout["allow_infusion"]= list("allow_infusion", src.inserted?.reagents?.total_volume > 0)
+					seedlist += list(geneout)
+
+		return list(
+			"extractables" = exlist,
+			"seeds" = seedlist,
 		)
 
 	Exited(Obj, newloc)
@@ -152,7 +156,7 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 					else
 						I.set_loc(src.loc) // causes Exited proc to be called
 						usr.put_in_hand_or_eject(I) // try to eject it into the users hand, if we can
-				update_static_data(ui.user, ui)
+				. = TRUE
 
 			if("insertbeaker")
 				if (src.inserted)
@@ -169,7 +173,7 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 					ui.user.drop_item()
 					inserting.set_loc(src)
 					boutput(ui.user, SPAN_NOTICE("You add [inserted] to the machine!"))
-					update_static_data(ui.user, ui)
+					. = TRUE
 
 			if("ejectseeds")
 				for (var/obj/item/seed/S in src.seeds)
@@ -203,7 +207,7 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 			if("sort")
 				src.sort = params["sortBy"]
 				src.sortAsc = text2num(params["asc"])
-				update_static_data(ui.user, ui)
+				. = TRUE
 
 			if("analyze")
 				var/obj/item/I = locate(params["analyze_ref"]) in src
@@ -227,7 +231,7 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 
 			if("outputmode")
 				src.seedoutput = !src.seedoutput
-				update_static_data(ui.user, ui)
+				. = TRUE
 
 			if("label")
 				var/obj/item/I = locate(params["label_ref"]) in src
@@ -489,7 +493,7 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 				qdel(seed1)
 				qdel(seed2)
 				src.mode = "seedlist"
-				update_static_data(ui.user, ui)
+				. = TRUE
 
 
 
@@ -502,7 +506,6 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 			user.drop_item()
 			W.set_loc(src)
 			boutput(user, SPAN_NOTICE("You add [W] to the machine!"))
-			src.update_static_data_for_all_viewers()
 			tgui_process.update_uis(src)
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that *some* of the Plantmaster data is passed as regular data in lieu of static data.
The seed list and the extractable list remains as static data.
Regular data:
![image](https://github.com/user-attachments/assets/d81772d8-d3ac-4eac-9337-75a4a91a132a)
Static data:
![image](https://github.com/user-attachments/assets/cf815b8b-25b3-4d7a-9917-e5111abc510c)

This is a different take on #20607


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Static data wasn't appropriate for some the data. Static data is appropriate for "large data that should be sent infrequently." Many properties were small.
This has a nice upside of not needing to recalculate the large lists when: shuffling beakers around, sorting the list or toggling the Output Internally button.

[UI][Performance]