### PR TITLE
Access implant for admin mice

### DIFF
--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -4129,6 +4129,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		src.fur_color = "#be5a53"
 		// true when making the mob to not make the respawn timer reset...false here to allow for crime
 		ghost_spawned = FALSE
+		new /obj/item/implant/access/infinite/head_of_security(src)
 
 	setup_hands()
 		..()

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -4129,7 +4129,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		src.fur_color = "#be5a53"
 		// true when making the mob to not make the respawn timer reset...false here to allow for crime
 		ghost_spawned = FALSE
-		new /obj/item/implant/access/infinite/head_of_security(src)
+		new /obj/item/implant/access/infinite/admin_mouse(src)
 
 	setup_hands()
 		..()

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1710,11 +1710,10 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 				..()
 				access.access = get_access("Chef")
 
-		head_of_security
-
+		admin_mouse
 			New()
 				..()
-				access.access = get_access("Head of Security")
+				access.access = get_access("Captain") + get_access("Head of Security") + access_centcom
 
 
 /* ============================================================ */

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1713,7 +1713,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		admin_mouse
 			New()
 				..()
-				access.access = get_access("Captain") + get_access("Head of Security") + access_centcom
+				access.access = get_access("Admin")
 
 
 /* ============================================================ */

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1710,6 +1710,12 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 				..()
 				access.access = get_access("Chef")
 
+		head_of_security
+
+			New()
+				..()
+				access.access = get_access("Head of Security") + access_centcom
+
 
 /* ============================================================ */
 /* --------------------- Artifact Implants -------------------- */

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1714,7 +1714,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 
 			New()
 				..()
-				access.access = get_access("Head of Security") + access_centcom
+				access.access = get_access("Head of Security")
 
 
 /* ============================================================ */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives admin mice a new infinite implant equivalent to Captain + HoS + Centcom.
As far as I can see in testing implants don't drop and can't be removed from critters.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Admin mice couldn't interact with everything, particularly consoles.
They still have issues with things requiring ID cards but such is life when you are a small amaranth rodent.