### PR TITLE
Extends the bartender's alcohol intuition

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -855,7 +855,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	alias_names = list("Barman")
 	limit = 1
 	wages = PAY_UNTRAINED
-	trait_list = list("training_drinker")
+	trait_list = list("training_drinker", "training_bartender")
 	access_string = "Bartender"
 	slot_belt = list(/obj/item/device/pda2/bartender)
 	slot_jump = list(/obj/item/clothing/under/rank/bartender)

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -747,6 +747,11 @@ ABSTRACT_TYPE(/datum/trait/job)
 	desc = "Subject is experienced in foodstuffs and their effects."
 	id = "training_chef"
 
+/datum/trait/job/bartender
+	name = "Bartender Training"
+	desc = "Subject has a keen mind for all things alcoholic."
+	id = "training_bartender"
+
 // bartender, detective, HoS
 /datum/trait/job/drinker
 	name = "Professional Drinker"

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -31,8 +31,8 @@
 			. = "<br>[src.bioHolder.mobAppearance.flavor_text]"
 
 	// crappy hack because you can't do \his[src] etc
-	var/t_his  = his_or_her(src)
-	var/t_him  = him_or_her(src)
+	var/t_his = his_or_her(src)
+	var/t_him = him_or_her(src)
 
 	. +=  "<br>[SPAN_NOTICE("*---------*")]"
 	var/datum/ailment_data/found = src.find_ailment_by_type(/datum/ailment/disability/memetic_madness)
@@ -414,8 +414,6 @@
 		var/et_amt = src.reagents.get_reagent_amount("ethanol")
 		var/drunk_assess = ""
 		if (!isalcoholresistant(src) || src.reagents.has_reagent("moonshine"))
-			if (src.reagents.has_reagent("moonshine"))
-				et_amt *= 7
 			switch (et_amt)
 				if (0 to 10)
 					drunk_assess = "[capitalize("[he_or_she(src)]")] seem[blank_or_s(src)] <b>buzzed.</b>"

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -31,8 +31,8 @@
 			. = "<br>[src.bioHolder.mobAppearance.flavor_text]"
 
 	// crappy hack because you can't do \his[src] etc
-	var/t_his = his_or_her(src)
-	var/t_him = him_or_her(src)
+	var/t_his  = his_or_her(src)
+	var/t_him  = him_or_her(src)
 
 	. +=  "<br>[SPAN_NOTICE("*---------*")]"
 	var/datum/ailment_data/found = src.find_ailment_by_type(/datum/ailment/disability/memetic_madness)
@@ -409,6 +409,30 @@
 			items += ", [O]"
 		items = copytext(items, 3)
 		. += "<br>[SPAN_NOTICE("[src] is juggling [items]!")]"
+
+	if (src.reagents.has_reagent("ethanol"))
+		if (usr.mind && usr.mind.assigned_role == "Bartender")
+			var/et_amt = src.reagents.get_reagent_amount("ethanol")
+			var/drunk_assess = ""
+			if (!isalcoholresistant(src) || src.reagents.has_reagent("moonshine"))
+				if (src.reagents.has_reagent("moonshine"))
+					et_amt *= 7
+				switch (et_amt)
+					if (0 to 10)
+						drunk_assess = "[capitalize("[he_or_she(src)]")] seem[blank_or_s(src)] <b>buzzed.</b>"
+					if (10 to 20)
+						drunk_assess = "[capitalize("[he_or_she(src)]")] look[blank_or_s(src)] a little <b>tipsy.</b>"
+					if (20 to 40)
+						drunk_assess = "[capitalize("[hes_or_shes(src)]")] pretty <b>[prob(10)? "stewed" : "drunk"].</b>"
+					if (40 to 70)
+						drunk_assess = "[capitalize("[hes_or_shes(src)]")] totally <b>smashed.</b>"
+					if (70 to 100)
+						drunk_assess = SPAN_ALERT("[capitalize("[hes_or_shes(src)]")] <b>[prob(3)? " zonked</b> off [his_or_her(src)] <b>rocker" : "badly inebriated"].</b>")
+					if (100 to INFINITY)
+						drunk_assess = SPAN_ALERT("[capitalize("[hes_or_shes(src)]")] <b>dying of drink.</b>")
+			else
+				drunk_assess = "[capitalize("[his_or_her(src)]")] inebriaton is almost <b>imperceptible</b> to you."
+			. += "<br> [drunk_assess]"
 
 	. += "<br>[SPAN_NOTICE("*---------*")]"
 

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -411,28 +411,27 @@
 		. += "<br>[SPAN_NOTICE("[src] is juggling [items]!")]"
 
 	if (src.reagents.has_reagent("ethanol"))
-		if (usr.mind && usr.mind.assigned_role == "Bartender")
-			var/et_amt = src.reagents.get_reagent_amount("ethanol")
-			var/drunk_assess = ""
-			if (!isalcoholresistant(src) || src.reagents.has_reagent("moonshine"))
-				if (src.reagents.has_reagent("moonshine"))
-					et_amt *= 7
-				switch (et_amt)
-					if (0 to 10)
-						drunk_assess = "[capitalize("[he_or_she(src)]")] seem[blank_or_s(src)] <b>buzzed.</b>"
-					if (10 to 20)
-						drunk_assess = "[capitalize("[he_or_she(src)]")] look[blank_or_s(src)] a little <b>tipsy.</b>"
-					if (20 to 40)
-						drunk_assess = "[capitalize("[hes_or_shes(src)]")] pretty <b>[prob(10)? "stewed" : "drunk"].</b>"
-					if (40 to 70)
-						drunk_assess = "[capitalize("[hes_or_shes(src)]")] totally <b>smashed.</b>"
-					if (70 to 100)
-						drunk_assess = SPAN_ALERT("[capitalize("[hes_or_shes(src)]")] <b>[prob(3)? " zonked</b> off [his_or_her(src)] <b>rocker" : "badly inebriated"].</b>")
-					if (100 to INFINITY)
-						drunk_assess = SPAN_ALERT("[capitalize("[hes_or_shes(src)]")] <b>dying of drink.</b>")
-			else
-				drunk_assess = "[capitalize("[his_or_her(src)]")] inebriaton is almost <b>imperceptible</b> to you."
-			. += "<br> [drunk_assess]"
+		var/et_amt = src.reagents.get_reagent_amount("ethanol")
+		var/drunk_assess = ""
+		if (!isalcoholresistant(src) || src.reagents.has_reagent("moonshine"))
+			if (src.reagents.has_reagent("moonshine"))
+				et_amt *= 7
+			switch (et_amt)
+				if (0 to 10)
+					drunk_assess = "[capitalize("[he_or_she(src)]")] seem[blank_or_s(src)] <b>buzzed.</b>"
+				if (10 to 20)
+					drunk_assess = "[capitalize("[he_or_she(src)]")] look[blank_or_s(src)] a little <b>tipsy.</b>"
+				if (20 to 40)
+					drunk_assess = "[capitalize("[hes_or_shes(src)]")] pretty <b>[prob(10)? "stewed" : "drunk"].</b>"
+				if (40 to 70)
+					drunk_assess = "[capitalize("[hes_or_shes(src)]")] totally <b>smashed.</b>"
+				if (70 to 100)
+					drunk_assess = SPAN_ALERT("[capitalize("[hes_or_shes(src)]")] <b>[prob(3)? " zonked</b> off [his_or_her(src)] <b>rocker" : "badly inebriated"].</b>")
+				if (100 to INFINITY)
+					drunk_assess = SPAN_ALERT("[capitalize("[hes_or_shes(src)]")] <b>dying of drink.</b>")
+		else
+			drunk_assess = "[capitalize("[his_or_her(src)]")] inebriaton is almost <b>imperceptible</b> to you."
+		. += "<br> [drunk_assess]"
 
 	. += "<br>[SPAN_NOTICE("*---------*")]"
 

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -971,6 +971,12 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 			for(var/current_id in reagent_list)
 				var/datum/reagent/current_reagent = reagent_list[current_id]
 				. += "<br>[SPAN_ALERT("[current_reagent.volume] units of [current_reagent.name]")]"
+
+			if (iscarbon(user) || ismobcritter(user))
+				if (user.mind && user.mind.assigned_role == "Bartender")
+					var/eth_eq = get_ethanol_equivalent(user, src)
+					if (eth_eq)
+						. += "<br> [SPAN_REGULAR("You estimate there's the equivalent of <b>[eth_eq] units of ethanol</b> here.")]"
 		return
 
 	proc/get_reagents_fullness()
@@ -1096,11 +1102,12 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 		for (var/i in 1 to num_val)
 			.[result_name[i]] = result_amount[i]
 
-	/// Gets a string of what something tastes like (as shown to the drinker/eater/whatever)
+	/// Gets a string of what something tastes like (as shown to the drinker/eater/whate ver)
 	proc/get_taste_string(mob/taster)
 		if (iscarbon(taster) || ismobcritter(taster))
 			if (taster.mind && taster.mind.assigned_role == "Bartender")
 				var/reag_list = ""
+				var/eth_eq = get_ethanol_equivalent(taster, src)
 				for (var/current_id in src.reagent_list)
 					var/datum/reagent/current_reagent = src.reagent_list[current_id]
 					if (length(src.reagent_list) > 1 && src.reagent_list[src.reagent_list.len] == current_id)
@@ -1109,6 +1116,8 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 					reag_list += ", [current_reagent.name]"
 				reag_list = copytext(reag_list, 3)
 				. = "Tastes like there might be some [reag_list] in this. "
+				if (eth_eq)
+					. += "[SPAN_REGULAR("This should be about <b>[eth_eq / src.total_volume * 100]% ethanol by volume.</b> <br>")]"
 			var/tastes = src.get_prevalent_tastes(3)
 			switch (length(tastes))
 				if (0)

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -972,11 +972,10 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 				var/datum/reagent/current_reagent = reagent_list[current_id]
 				. += "<br>[SPAN_ALERT("[current_reagent.volume] units of [current_reagent.name]")]"
 
-			if (iscarbon(user) || ismobcritter(user))
-				if (user.mind && user.mind.assigned_role == "Bartender")
-					var/eth_eq = get_ethanol_equivalent(user, src)
-					if (eth_eq)
-						. += "<br> [SPAN_REGULAR("You estimate there's the equivalent of <b>[eth_eq] units of ethanol</b> here.")]"
+			if (user.traitHolder.hasTrait("training_bartender"))
+				var/eth_eq = get_ethanol_equivalent(user, src)
+				if (eth_eq)
+					. += "<br> [SPAN_REGULAR("You estimate there's the equivalent of <b>[eth_eq] units of ethanol</b> here.")]"
 		return
 
 	proc/get_reagents_fullness()
@@ -1102,32 +1101,31 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 		for (var/i in 1 to num_val)
 			.[result_name[i]] = result_amount[i]
 
-	/// Gets a string of what something tastes like (as shown to the drinker/eater/whate ver)
+	/// Gets a string of what something tastes like (as shown to the drinker/eater/whatever)
 	proc/get_taste_string(mob/taster)
-		if (iscarbon(taster) || ismobcritter(taster))
-			if (taster.mind && taster.mind.assigned_role == "Bartender")
-				var/reag_list = ""
-				var/eth_eq = get_ethanol_equivalent(taster, src)
-				for (var/current_id in src.reagent_list)
-					var/datum/reagent/current_reagent = src.reagent_list[current_id]
-					if (length(src.reagent_list) > 1 && src.reagent_list[src.reagent_list.len] == current_id)
-						reag_list += " and [current_reagent.name]"
-						continue
-					reag_list += ", [current_reagent.name]"
-				reag_list = copytext(reag_list, 3)
-				. = "Tastes like there might be some [reag_list] in this. "
-				if (eth_eq)
-					. += "[SPAN_REGULAR("This should be about <b>[eth_eq / src.total_volume * 100]% ethanol by volume.</b> <br>")]"
-			var/tastes = src.get_prevalent_tastes(3)
-			switch (length(tastes))
-				if (0)
-					. += "Tastes pretty bland."
-				if (1)
-					. += "Tastes kind of [tastes[1]]."
-				if (2)
-					. += "Tastes kind of [tastes[1]] and [tastes[2]]."
-				else
-					. += "Tastes kind of [tastes[1]], [tastes[2]], and a little bit [tastes[3]]."
+		if (taster.traitHolder.hasTrait("training_bartender"))
+			var/reag_list = ""
+			var/eth_eq = get_ethanol_equivalent(taster, src)
+			for (var/current_id in src.reagent_list)
+				var/datum/reagent/current_reagent = src.reagent_list[current_id]
+				if (length(src.reagent_list) > 1 && src.reagent_list[src.reagent_list.len] == current_id)
+					reag_list += " and [current_reagent.name]"
+					continue
+				reag_list += ", [current_reagent.name]"
+			reag_list = copytext(reag_list, 3)
+			. = "Tastes like there might be some [reag_list] in this. "
+			if (eth_eq)
+				. += "[SPAN_REGULAR("This should be about <b>[eth_eq / src.total_volume * 100]% ethanol by volume.</b> <br>")]"
+		var/tastes = src.get_prevalent_tastes(3)
+		switch (length(tastes))
+			if (0)
+				. += "Tastes pretty bland."
+			if (1)
+				. += "Tastes kind of [tastes[1]]."
+			if (2)
+				. += "Tastes kind of [tastes[1]] and [tastes[2]]."
+			else
+				. += "Tastes kind of [tastes[1]], [tastes[2]], and a little bit [tastes[3]]."
 
 	/// returns whether reagents are solid, liquid, gas, or mixture
 	proc/get_state_description()

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -609,9 +609,9 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 					return
 			if(src.is_sealed)
 				return
-			if(user.mind.assigned_role == "Bartender")
+			if(user.traitHolder.hasTrait("training_bartender"))
 				. = ("You deftly [pick("spin", "twirl")] [src] managing to keep all the contents inside.")
-				if(!ON_COOLDOWN(user, "bartender spinning xp", 180 SECONDS)) //only for real cups
+				if(user.mind.assigned_role == "Bartender" && !ON_COOLDOWN(user, "bartender spinning xp", 180 SECONDS)) //only for real cups
 					JOB_XP(user, "Bartender", 1)
 			else
 				user.visible_message(SPAN_ALERT("<b>[user] spills the contents of [src] all over [him_or_her(user)]self!</b>"))
@@ -1087,11 +1087,11 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 		var/success_prob = 25
 		var/hurt_prob = 50
 
-		if (user.reagents && user.reagents.has_reagent("ethanol") && user.mind && user.mind.assigned_role == "Bartender")
+		if (user.reagents && user.reagents.has_reagent("ethanol") && user.traitHolder.hasTrait("training_bartender"))
 			success_prob = 75
 			hurt_prob = 25
 
-		else if (user.mind && user.mind.assigned_role == "Bartender")
+		else if (user.traitHolder.hasTrait("training_bartender"))
 			success_prob = 50
 			hurt_prob = 10
 

--- a/code/obj/item/device/pda2/scanners.dm
+++ b/code/obj/item/device/pda2/scanners.dm
@@ -65,9 +65,15 @@
 		size = 6
 
 		scan_atom(atom/A)
+			var/mob/user = usr
 			if (..())
 				return
 			. = scan_reagents(A, visible = TRUE)
+			if (iscarbon(user) || ismobcritter(user))
+				if (user.mind && user.mind.assigned_role == "Bartender")
+					var/eth_eq = get_ethanol_equivalent(user, A.reagents)
+					if (eth_eq)
+						. += "<br> [SPAN_REGULAR("You estimate there's the equivalent of <b>[eth_eq] units of ethanol</b> here.")]"
 
 	//Plant scanner
 	plant_scan

--- a/code/obj/item/device/pda2/scanners.dm
+++ b/code/obj/item/device/pda2/scanners.dm
@@ -69,11 +69,10 @@
 			if (..())
 				return
 			. = scan_reagents(A, visible = TRUE)
-			if (iscarbon(user) || ismobcritter(user))
-				if (user.mind && user.mind.assigned_role == "Bartender")
-					var/eth_eq = get_ethanol_equivalent(user, A.reagents)
-					if (eth_eq)
-						. += "<br> [SPAN_REGULAR("You estimate there's the equivalent of <b>[eth_eq] units of ethanol</b> here.")]"
+			if (user.traitHolder.hasTrait("training_bartender"))
+				var/eth_eq = get_ethanol_equivalent(user, A.reagents)
+				if (eth_eq)
+					. += "<br> [SPAN_REGULAR("You estimate there's the equivalent of <b>[eth_eq] units of ethanol</b> here.")]"
 
 	//Plant scanner
 	plant_scan

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -531,11 +531,10 @@ TYPEINFO(/obj/item/device/reagentscanner)
 			boutput(user, SPAN_ALERT("\The [src] encounters an error and crashes!"))
 		else
 			var/scan_output = "[src.scan_results]"
-			if (iscarbon(user) || ismobcritter(user))
-				if (user.mind && user.mind.assigned_role == "Bartender")
-					var/eth_eq = get_ethanol_equivalent(user, A.reagents)
-					if (eth_eq)
-						scan_output += "<br> [SPAN_REGULAR("You estimate there's the equivalent of <b>[eth_eq] units of ethanol</b> here.")]"
+			if (user.traitHolder.hasTrait("training_bartender"))
+				var/eth_eq = get_ethanol_equivalent(user, A.reagents)
+				if (eth_eq)
+					scan_output += "<br> [SPAN_REGULAR("You estimate there's the equivalent of <b>[eth_eq] units of ethanol</b> here.")]"
 			boutput(user, scan_output)
 
 	attack_self(mob/user as mob) // no eth_eq here cuz then we'd have to save how the reagent container used to be

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -530,9 +530,15 @@ TYPEINFO(/obj/item/device/reagentscanner)
 		if (isnull(src.scan_results))
 			boutput(user, SPAN_ALERT("\The [src] encounters an error and crashes!"))
 		else
-			boutput(user, "[src.scan_results]")
+			var/scan_output = "[src.scan_results]"
+			if (iscarbon(user) || ismobcritter(user))
+				if (user.mind && user.mind.assigned_role == "Bartender")
+					var/eth_eq = get_ethanol_equivalent(user, A.reagents)
+					if (eth_eq)
+						scan_output += "<br> [SPAN_REGULAR("You estimate there's the equivalent of <b>[eth_eq] units of ethanol</b> here.")]"
+			boutput(user, scan_output)
 
-	attack_self(mob/user as mob)
+	attack_self(mob/user as mob) // no eth_eq here cuz then we'd have to save how the reagent container used to be
 		if (isnull(src.scan_results))
 			boutput(user, SPAN_NOTICE("No previous scan results located."))
 			return

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -522,6 +522,21 @@
 
 	return data
 
+/proc/get_ethanol_equivalent(mob/user, datum/reagents/R)
+	var/eth_eq = 0
+	var/should_we_output = FALSE //looks bad if we output this when it's just ethanol in there
+	for (var/current_id in R.reagent_list)
+		var/datum/reagent/current_reagent = R.reagent_list[current_id]
+		if (istype(current_reagent, /datum/reagent/fooddrink/alcoholic))
+			var/datum/reagent/fooddrink/alcoholic/alch_reagent = current_reagent
+			eth_eq += alch_reagent.alch_strength * alch_reagent.volume
+			should_we_output = TRUE
+		if (current_reagent.id == "ethanol")
+			eth_eq += current_reagent.volume
+	if (should_we_output == FALSE)
+		eth_eq = 0
+	return eth_eq
+
 // Should make it easier to maintain the detective's scanner and PDA program (Convair880).
 /proc/scan_forensic(var/atom/A as turf|obj|mob, visible = 0)
 	if (istype(A, /obj/ability_button)) // STOP THAT


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Whenever a bartender uses any of the scanning items I could think of (reagent scanner, spectroscopic goggles, PDA app), they will do quick mental math to estimate how much ethanol is in the container. Pictured below is a 1:1 mix of Screwdriver and Martini in a cocktail glass:
![image](https://github.com/user-attachments/assets/05f604ce-55d5-432b-95a4-e66a0374bc64)

Additionally, whenever a bartender tastes a drink, their keen sense of taste will give them an estimate of the drink's composition, in percent ethanol by volume (AKA %ABV). Here's how that same mixture tastes to the trained tastes of a bartender:
![image](https://github.com/user-attachments/assets/299f4678-b8e9-4b7e-9ba9-6d8c8a17c50c)

Finally, everyone can get some idea of the level of pure ethanol in someone's body just by looking at them. Here's what someone with 50u of ethanol looks like:
![image](https://github.com/user-attachments/assets/fabfb401-3682-4c89-8081-d9e67cc98202)

This PR also implements Bartender Training, which determines if someone can twirl drinks without spilling it, affects bottle shatter success chance, and affects access to the bartender abilities listed above.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A bartender's job is to provide drinks to a customer, and ostensibly to ensure their customers don't get drunker than they want to from their drinks. This change gives relevant information to the player that can help them achieve the latter goal.


## Changelog 
```changelog
(u)Mintyphresh
(+)Bartenders can now intuit much more about the alcohol contents of drinks.
```
