### PR TITLE
removes underage drinking crime

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -291,23 +291,6 @@ datum
 				..()
 				return
 
-			on_add()
-				if(!istype(holder) || !istype(holder.my_atom) || !ishuman(holder.my_atom))
-					return
-				var/mob/living/carbon/human/H = holder.my_atom
-				if(seen_by_camera(H))
-					// determine the name of the perp (goes by ID if wearing one)
-					var/perpname = H.name
-					if(H:wear_id && H:wear_id:registered)
-						perpname = H:wear_id:registered
-					var/datum/db_record/gen_record = data_core.general.find_record("name", perpname)
-					var/datum/db_record/sec_record = data_core.security.find_record("name", perpname)
-					// Yes. Its 21. This is Space America. That is canon now.
-					if(gen_record && sec_record && text2num(gen_record["age"]) < 21 && sec_record["criminal"] != ARREST_STATE_ARREST)
-						sec_record["criminal"] = ARREST_STATE_ARREST
-						sec_record["mi_crim"] = "Underage drinking."
-						H.update_arrest_icon()
-
 		fooddrink/alcoholic/hard_punch
 			name = "hard punch"
 			id = "hard_punch"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
as title says, removes the automatic arrest status gained from drinking while below age 21 (so one age. 20)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
conceptually, keeping an american standard for drinking age doesn't make sense when the setting is in the middle of space. while nt may be based out of america, i dont think sticking to this one specific law fits the setting well, even if it is a joke.

practically, the way underage drinking goes usually boils down to one of two things: 1, a person is aware of the underage drinking auto setting, and sets their age to 20 while slamming shots at the bar because ha ha funny arrest status. jailbird lite, basically. 2, a person who is unaware of the drinking age due to being from another country or just not thinking about it, ends up confused and frustrated because they keep getting stunned and cuffed by the securitron who keeps doing loops around the bar. 


not putting a changelog since i dont think it really needs one, but if it does i'll make one