### PR TITLE
Unhides handkerchiefs from Uniform manufacturers

### DIFF
--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -448,12 +448,12 @@
 		/datum/manufacture/satchel,
 		/datum/manufacture/satchel_red,
 		/datum/manufacture/satchel_green,
-		/datum/manufacture/satchel_blue)
+		/datum/manufacture/satchel_blue,
+		/datum/manufacture/handkerchief)
 
 	hidden = list(/datum/manufacture/breathmask,
 		/datum/manufacture/patch,
 		/datum/manufacture/towel,
-		/datum/manufacture/handkerchief,
 		/datum/manufacture/tricolor,
 		/datum/manufacture/hat_ltophat)
 

--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -548,7 +548,8 @@
 		/datum/manufacture/hat_green,
 		/datum/manufacture/hat_blue,
 		/datum/manufacture/hat_purple,
-		/datum/manufacture/hat_tophat)
+		/datum/manufacture/hat_tophat,
+		/datum/manufacture/handkerchief,)
 
 	hidden = list(/datum/manufacture/id_card_gold,
 		/datum/manufacture/implant_access_infinite,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] [clothing] [QoL] [-->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As simple as that; Unhides the handkerchiefs usually only found in the uniform manu's hidden menu. This also adds them to the HoP's uniform fab, as is reqested by the code comments.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
~Someone told me "When you code it"~
It's a neat item! Who on a space station doesn't need a handkerchief? It's got fun little interactios, such as being able to be turned into a mask. Now in the code, @cogwerks left a comment saying that the manu "should be for regular uniforms [...], not tons of gimmicks, which I also understand. I simply want to make these more available, and if the uniform manu isn't the intended way, I'll try and find another way.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
It's a small change, I don't think it needs a changelog as is.