### PR TITLE
Nukie masks get built-in voice changers

### DIFF
--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -24,7 +24,7 @@
 
 	New()
 		..()
-		src.vchange = new(src) // Built-in voice changer (Convair880).
+		src.vchange = new /obj/item/voice_changer/permanent(src) // Built-in voice changer (Convair880).
 		if(istype(src.loc, /mob/living))
 			var/mob/M = src.loc
 			src.AddComponent(/datum/component/self_destruct, M)

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -47,6 +47,9 @@
 			return
 	else if (issnippingtool(W))
 		if (src.vchange)
+			if (src.vchange.permanent)
+				user.show_text("[src]'s [src.vchange.name] cannot be removed!", "red")
+				return
 			user.show_text("You begin removing [src.vchange] from [src].", "blue")
 			if (!do_after(user, 2 SECONDS))
 				user.show_text("You were interrupted!", "red")
@@ -235,7 +238,7 @@ TYPEINFO(/obj/item/clothing/mask/moustache)
 		New()
 			START_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
 			..()
-			src.vchange = new(src)
+			src.vchange = new /obj/item/voice_changer/permanent(src)
 
 		disposing()
 			STOP_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
@@ -273,7 +276,11 @@ TYPEINFO(/obj/item/voice_changer)
 	desc = "This voice-modulation device will dynamically disguise your voice to that of whoever is listed on your identification card, via incredibly complex algorithms. Discretely fits inside most masks, and can be removed with wirecutters."
 	icon_state = "voicechanger"
 	is_syndicate = 1
+	var/permanent = FALSE
 	HELP_MESSAGE_OVERRIDE({"Use the voice changer on a face-concealing mask to fit it inside. You will speak as and appear in chat as the name of your worn ID, or as "unknown" if you aren't wearing your ID. Use wirecutters on the mask to remove the voice changer."})
+
+/obj/item/voice_changer/permanent
+	permanent = TRUE
 
 TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 	mats = 12	// 2x voice changer cost. It's complicated ok

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -224,7 +224,7 @@ TYPEINFO(/obj/item/clothing/mask/moustache)
 
 	syndicate
 		name = "syndicate field protective mask"
-		desc = "A tight-fitting mask designed to protect syndicate operatives from all manner of toxic inhalants. Worn with a buckle around the back of the head."
+		desc = "A tight-fitting mask designed to protect syndicate operatives from all manner of toxic inhalants. Has a built-in voice changer."
 		icon_state = "gas_mask_syndicate"
 		item_state = "gas_mask_syndicate"
 		color_r = 0.8 //this one's also green
@@ -235,6 +235,7 @@ TYPEINFO(/obj/item/clothing/mask/moustache)
 		New()
 			START_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
 			..()
+			src.vchange = new(src)
 
 		disposing()
 			STOP_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a built in voice changer to syndicate masks
Also adds support for voice changers that cannot be removed and uses this for the built in voice changers of the syndicate and hunter masks.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Less chat clog when "BlastCo Operative Lima (as John Syndicate) says "Im gonna blow you up""
This isn't that huge a buff as far as I can tell for infiltrating as its still your syndicate mask and you are going to want other infilling gear anyway (infil comes with a loose voice changer you can put in a normal mask) though this may require blacklisting syndicate field masks from both the SWAT and respirator medal rewards.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Nuclear Operative gasmasks now come with built-in voice changers.
```
