### PR TITLE
Require harm intent to adjust shape of table with screwdriver

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -37,7 +37,7 @@ TYPEINFO_NEW(/obj/table)
 	var/drawer_locked = FALSE
 	/// id for key checks, keys with the same id can lock it
 	var/lock_id = null
-	HELP_MESSAGE_OVERRIDE({"You can use a <b>wrench</b> on <span class='harm'>harm</span> intent to disassemble it."})
+	HELP_MESSAGE_OVERRIDE({""})
 
 	New(loc)
 		..()
@@ -69,6 +69,13 @@ TYPEINFO_NEW(/obj/table)
 		var/area/Ar = get_area(src)
 		if (Ar)
 			Ar.sims_score = min(Ar.sims_score + bonus, 100)
+
+	get_help_message(dist, mob/user)
+		. = ..()
+		. += "You can use a <b>wrench</b> on <span class='harm'>harm</span> intent to disassemble it. \
+		You can also use a <b>screwdriver</b> on <span class='harm'>harm</span> intent to \
+		[(src.has_drawer && src.drawer_locked) ? "pick the drawer's lock." : "adjust the shape of it."]"
+
 
 	proc/xmasify()
 		var/in_cafeteria = istype(get_area(src), /area/station/crew_quarters/cafeteria)
@@ -246,7 +253,7 @@ TYPEINFO_NEW(/obj/table)
 		else if (istype(W, /obj/item/paint_can))
 			return
 
-		else if (isscrewingtool(W))
+		else if (isscrewingtool(W) && user.a_intent == INTENT_HARM)
 			if (src.has_drawer && src.drawer_locked)
 				actions.start(new /datum/action/bar/icon/table_tool_interact(src, W, TABLE_LOCKPICK), user)
 				return
@@ -254,7 +261,7 @@ TYPEINFO_NEW(/obj/table)
 				actions.start(new /datum/action/bar/icon/table_tool_interact(src, W, TABLE_ADJUST), user)
 				return
 
-		else if (iswrenchingtool(W) && !src.status && user.a_intent == "harm") // shouldn't have status unless it's reinforced, maybe? hopefully?
+		else if (iswrenchingtool(W) && !src.status && user.a_intent == INTENT_HARM) // shouldn't have status unless it's reinforced, maybe? hopefully?
 			if (istype(src, /obj/table/folding))
 				actions.start(new /datum/action/bar/icon/fold_folding_table(src, W), user)
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes table code to require you be on harm intent to use a screwdriver to adjust the shape of the table, like how you need harm intent to disassemble it with a wrench (this also changes it for the screwdriver drink too). Update help message to reflect this change. Also change wrench part of code to use intent macro instead of string.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Trying to place a screwdriver on a table is frustrating so we can give it parity with how the wrench does it

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TealSeer
(+)Using a screwdriver on a table now requires you be on harm intent.
```
