### PR TITLE
Allow 3 Security Officers to revoke armory access

### DIFF
--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -117,11 +117,11 @@
 
 	get_help_message()
 		if (src.authed)
-			. = "The Head of Security can unauthorize armory access."
+			. = "Three security personnel, or the Head of Security can revoke armory access."
 			if(!authdisk_authorized)
 				. += "<br>You can also use the <b>Authentication Disk</b> to issue an emergency revocation."
 		else
-			. = "Three security personnel, or the Head of Security, can authorize access."
+			. = "Three security personnel, or the Head of Security, can authorize armory access."
 			if(!authdisk_authorized)
 				. += "<br>You can also use the <b>Authentication Disk</b> to issue an emergency override."
 
@@ -137,7 +137,7 @@
 		src.icon_state = "drawbr-alert"
 		src.UpdateIcon()
 
-		ON_COOLDOWN(src, "unauth", 5 MINUTES)
+		ON_COOLDOWN(src, "unauth", 30 SECONDS)
 
 		src.authorized = null
 		src.authorized_registered = null
@@ -174,6 +174,9 @@
 			icon_state = "drawbr"
 			src.UpdateIcon()
 
+			src.authorized = null
+			src.authorized_registered = null
+
 			SEND_GLOBAL_SIGNAL(COMSIG_GLOBAL_ARMORY_UNAUTH)
 
 			for (var/obj/machinery/door/airlock/D in armory_area)
@@ -193,10 +196,10 @@
 	proc/print_auth_needed(var/mob/author)
 		if (author)
 			for (var/mob/O in hearers(src, null))
-				O.show_message(SPAN_SUBTLE(SPAN_SAY("[SPAN_NAME("[src]")] beeps, \"[author] request accepted. [src.auth_need - src.authorized.len] authorizations needed until Armory is opened.\"")), 2)
+				O.show_message(SPAN_SUBTLE(SPAN_SAY("[SPAN_NAME("[src]")] beeps, \"[author] request accepted. [src.auth_need - src.authorized.len] authorizations needed until Armory is [src.authed ? "closed" : "opened"].\"")), 2)
 		else
 			for (var/mob/O in hearers(src, null))
-				O.show_message(SPAN_SUBTLE(SPAN_SAY("[SPAN_NAME("[src]")] beeps, \"[src.auth_need - src.authorized.len] authorizations needed until Armory is opened.\"")), 2)
+				O.show_message(SPAN_SUBTLE(SPAN_SAY("[SPAN_NAME("[src]")] beeps, \"[src.auth_need - src.authorized.len] authorizations needed until Armory is [src.authed ? "closed" : "opened"].\"")), 2)
 
 
 /obj/machinery/computer/riotgear/attack_hand(mob/user)
@@ -217,7 +220,7 @@
 			boutput(user, SPAN_ALERT("Emergency armory authorizations cannot be cleared or reissued!"))
 			return
 		if(src.authed)
-			src.manual_unauthorize(user)
+			src.manual_unauthorize(user, null, TRUE)
 			return
 		var/emergency_auth = tgui_alert(user, "This cannot be undone by Authentication Disk!", "Authentication Warning", list("Emergency Authorization", "Cancel"))
 		if(emergency_auth == "Emergency Authorization" && in_interact_range(src, user) && equipped_or_holding(W, user))
@@ -248,17 +251,13 @@
 		boutput(user, "The access level of [W] is not high enough.")
 		return
 
-	if(authed && (!(access_armory in W:access)))
-		boutput(user, "Armory has already been authorized!")
-		return
-
-	if(authed && (access_armory in W:access))
-		src.manual_unauthorize(user)
-		return
-
 	if (!src.authorized)
 		src.authorized = list()
 		src.authorized_registered = list()
+
+	if(authed)
+		src.manual_unauthorize(user, W)
+		return
 
 	var/choice = tgui_alert(user, "Would you like to authorize access to riot gear? [src.auth_need - length(src.authorized)] authorization\s are still needed.", "Armory Auth", list("Authorize", "Repeal"))
 	if(BOUNDS_DIST(user, src) > 0 || src.authed)
@@ -306,15 +305,63 @@
 			print_auth_needed(user)
 
 /// Handles unauthorization from armory computer interaction
-/obj/machinery/computer/riotgear/proc/manual_unauthorize(mob/user)
-	var/choice = tgui_alert(user, "Would you like to unauthorize security's access to riot gear?", "Armory Unauthorization", list("Unauthorize", "No"))
-	if(!in_interact_range(src, user)) return
+/obj/machinery/computer/riotgear/proc/manual_unauthorize(mob/user, var/obj/item/W, var/is_auth_disk = FALSE)
+	if(GET_COOLDOWN(src, "unauth"))
+		boutput(user, SPAN_ALERT(" The armory computer cannot take your commands at the moment! Wait [GET_COOLDOWN(src, "unauth")/10] seconds!"))
+		playsound( src.loc, 'sound/machines/airlock_deny.ogg', 10, 0 )
+		return
+
+	// Basically the same as authing
+	var/choice = tgui_alert(user, "Would you like to revoke security's access to riot gear? [src.auth_need - length(src.authorized)] unauthorization\s are still needed.", "Armory Unauthorization", list("Unauthorize", "Repeal"))
+	if(BOUNDS_DIST(user, src) > 0 || !src.authed)
+		return
 	src.add_fingerprint(user)
-	if (choice == "Unauthorize")
-		if(GET_COOLDOWN(src, "unauth"))
-			boutput(user, SPAN_ALERT(" The armory computer cannot take your commands at the moment! Wait [GET_COOLDOWN(src, "unauth")/10] seconds!"))
-			playsound( src.loc, 'sound/machines/airlock_deny.ogg', 10, 0 )
-			return
-		unauthorize()
-		playsound(src.loc, 'sound/machines/chime.ogg', 10, 1)
-		boutput(user,SPAN_NOTICE(" The armory's equipments have returned to having their default access!"))
+	if (!choice)
+		return
+	switch(choice)
+		if("Unauthorize")
+			if (is_auth_disk)
+				unauthorize()
+				playsound(src.loc, 'sound/machines/chime.ogg', 10, 1)
+				boutput(user,SPAN_NOTICE(" The armory's equipments have returned to having their default access!"))
+				return
+			if (user in src.authorized)
+				boutput(user, "You have already unauthorized! [src.auth_need - src.authorized.len] unauthorizations from others are still needed.")
+				return
+			if (W:registered in src.authorized_registered)
+				boutput(user, "This ID has already issued an unauthorization! [src.auth_need - src.authorized.len] unauthorizations from others are still needed.")
+				return
+			if (access_armory in W:access)
+				unauthorize()
+				playsound(src.loc, 'sound/machines/chime.ogg', 10, 1)
+				boutput(user,SPAN_NOTICE(" The armory's equipments have returned to having their default access!"))
+				return
+
+			if (ishuman(user))
+				var/mob/living/carbon/human/H = user
+				if (H.bioHolder.Uid in src.authorized)
+					boutput(user, "You have already unauthorized - fingerprints on file! [src.auth_need - src.authorized.len] unauthorizations from others are still needed.")
+					return
+				src.authorized += H.bioHolder.Uid
+			else
+				src.authorized += user
+			src.authorized_registered += W:registered
+
+			if (length(src.authorized) < auth_need)
+				logTheThing(LOG_STATION, user, "added an approval for revoking armory access using [W]. [length(src.authorized)] total approvals.")
+				print_auth_needed(user)
+			else
+				unauthorize()
+				playsound(src.loc, 'sound/machines/chime.ogg', 10, 1)
+				boutput(user,SPAN_NOTICE(" The armory's equipments have returned to having their default access!"))
+
+		if("Repeal")
+
+			if (ishuman(user))
+				var/mob/living/carbon/human/H = user
+				src.authorized -= H.bioHolder.Uid
+			else
+				src.authorized -= user
+			src.authorized_registered -= W:registered
+			logTheThing(LOG_STATION, user, "removed an approval for revoking armory access using [W]. [length(src.authorized)] total approvals.")
+			print_auth_needed(user)

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -137,7 +137,7 @@
 		src.icon_state = "drawbr-alert"
 		src.UpdateIcon()
 
-		ON_COOLDOWN(src, "unauth", 30 SECONDS)
+		ON_COOLDOWN(src, "unauth", 5 MINUTES)
 
 		src.authorized = null
 		src.authorized_registered = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows 3 people with security locker access to deauthorize armory

Code probably sucks but I wanted dev opinion before putting effort into cleaning it considering the last one was closed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This PR was previously closed (#18330)  (Forum Thread: https://forum.ss13.co/showthread.php?tid=22461) under the reasoning "Nah - armory auth should be treated as a last resort, not an additional gear locker". Since a cooldown is now required to pass before you can deauth (5 minutes) this will discourage using it as a "gear locker". In addition its far more likely one captain would use it this way than 3 officers (I have never seen 3 officers auth without good reason, I have seen many captains do it, then requiring me to use packets to lock it.) This allows 3 officers to unauthorize the armory in the case they dont want it open, e.g. rogue captain, someone stole the auth disk. This change seemed pretty liked in the thread.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Three people with Security Equipment access can now revoke armory access.
```
