### PR TITLE
Increases maximum number of unboxed pills/patches chemmaster can create

### DIFF
--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -491,7 +491,7 @@ TYPEINFO(/obj/machinery/chem_shaker/large)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define CHEMMASTER_MINIMUM_REAGENT 5 //!mininum reagent for pills, bottles and patches
-#define CHEMMASTER_NO_CONTAINER_MAX 20 //!maximum number of unboxed pills/patches
+#define CHEMMASTER_NO_CONTAINER_MAX 24 //!maximum number of unboxed pills/patches
 #define CHEMMASTER_ITEMNAME_MAXSIZE 16 //!chosen by fair dice roll
 #define CHEMMASTER_MAX_PILL 22 //!22 pill icons
 #define CHEMMASTER_MAX_CANS 26 //!26 flavours of cans

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -491,7 +491,7 @@ TYPEINFO(/obj/machinery/chem_shaker/large)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define CHEMMASTER_MINIMUM_REAGENT 5 //!mininum reagent for pills, bottles and patches
-#define CHEMMASTER_NO_CONTAINER_MAX 10 //!maximum number of unboxed pills/patches
+#define CHEMMASTER_NO_CONTAINER_MAX 20 //!maximum number of unboxed pills/patches
 #define CHEMMASTER_ITEMNAME_MAXSIZE 16 //!chosen by fair dice roll
 #define CHEMMASTER_MAX_PILL 22 //!22 pill icons
 #define CHEMMASTER_MAX_CANS 26 //!26 flavours of cans
@@ -1072,7 +1072,7 @@ TYPEINFO(/obj/machinery/chem_master)
 				var/obj/item/item_box/medical_patches/patch_box = null
 				if(use_box || patchcount > CHEMMASTER_NO_CONTAINER_MAX)
 					if(!use_box && patchcount > CHEMMASTER_NO_CONTAINER_MAX)
-						src.visible_message("The [src]'s output limit beeps sternly, and a patch box is automatically dispensed!")
+						src.visible_message(SPAN_ALERT("The [src]'s output limit beeps sternly, and a patch box is automatically dispensed!"))
 					patch_box = new(src)
 					patch_box.name = "box of [item_name] patches"
 					if (is_medical_patch)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label[game objects][qol] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Increases CHEMMASTER_NO_CONTAINER_MAX to 24, from 10.

Fixes the warning message for creating too many boxless patches. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

There are three issues open which seem to refer to a Chemmaster mechanic which prevents too many unboxed pills/patches from being created at once. 

The maximum amount of unboxed items being at 24 means that the large beaker and the watering can can be used with the no-box setting even with minimum pill/patch size. So it should make it less likely that people are negatively affected by a mechanic ostensibly just meant to reduce item spam.

fixes #19644
fixes #15166
fixes #14275