### PR TITLE
Alters Tetrodotoxin behavior and changes pufferfish availability slightly

### DIFF
--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1949,7 +1949,7 @@ datum
 			fluid_g = 180
 			fluid_b = 240
 			transparency = 10
-			depletion_rate = 0.3
+			depletion_rate = 0.1
 			var/progression_speed = 1
 			var/counter = 1
 

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1949,7 +1949,7 @@ datum
 			fluid_g = 180
 			fluid_b = 240
 			transparency = 10
-			depletion_rate = 0.1
+			depletion_rate = 0.2
 			var/progression_speed = 1
 			var/counter = 1
 
@@ -1957,7 +1957,7 @@ datum
 				if (!M) M = holder.my_atom
 
 				switch(src.counter+= (mult * src.progression_speed))
-					if (10 to 27) // Small signs of trouble
+					if (10 to 28) // Small signs of trouble
 						if (prob(15))
 							M.change_misstep_chance(15 * mult)
 						if (probmult(13))
@@ -1966,7 +1966,7 @@ datum
 						if (probmult(13))
 							M.emote(pick("twitch","drool","tremble"))
 							M.change_eye_blurry(2, 2)
-					if (27 to 47) // Effects ramp up, breathlessness, early paralysis signs and heartache
+					if (28 to 40) // Effects ramp up, breathlessness, early paralysis signs and heartache
 						M.change_eye_blurry(5, 5)
 						M.stuttering = max(M.stuttering, 5)
 						M.setStatusMin("slowed", 40 SECONDS)
@@ -1977,7 +1977,7 @@ datum
 							M.change_misstep_chance(15 * mult)
 						if (!ON_COOLDOWN(M, "heartbeat_hallucination", 30 SECONDS))
 							M.playsound_local(get_turf(M), 'sound/effects/HeartBeatLong.ogg', 30, 1, pitch = 2)
-					if (47 to INFINITY) // Heart effects kick in
+					if (40 to INFINITY) // Heart effects kick in
 						M.setStatusMin("slowed", 40 SECONDS)
 						M.change_eye_blurry(15, 15)
 						M.losebreath = max(5, M.losebreath + (5 * mult))

--- a/code/modules/fishing/fish.dm
+++ b/code/modules/fishing/fish.dm
@@ -289,7 +289,6 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/fish)
 	name = "pufferfish"
 	desc = "Adorable. Quite poisonous."
 	icon_state = "pufferfish"
-	initial_volume = 60 // 20 fish oil and 40 tetrodotoxin
 	inhand_color = "#8d754e"
 	slice_product = /obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet/pufferfish
 	category = FISH_CATEGORY_AQUARIUM
@@ -315,7 +314,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/fish)
 
 	make_reagents()
 		..() //it still contains fish oil
-		src.reagents.add_reagent("tetrodotoxin",40) // REALLY don't eat raw pufferfish
+		src.reagents.add_reagent("tetrodotoxin",20) // REALLY don't eat raw pufferfish
 
 	onSlice(var/mob/user) // Don't eat pufferfish the staff assistant made
 		if (user.traitHolder?.hasTrait("training_chef"))
@@ -328,7 +327,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/fish)
 		else
 			if (prob(25)) // Don't try doing it if you don't know what you're doing
 				boutput(user, SPAN_NOTICE("You prick yourself trying to cut [src], and feel a bit numb."))
-				src.reagents.trans_to(user, 20)
+				src.reagents.trans_to(user, 5)
 			else if (prob(30)) // 30% of 75%(slightly more than 22%) chance of still being safe to eat
 				src.reagents.remove_reagent("tetrodotoxin",src.reagents.get_reagent_amount("tetrodotoxin"))
 

--- a/code/modules/fishing/fishing_lootpools.dm
+++ b/code/modules/fishing/fishing_lootpools.dm
@@ -66,6 +66,11 @@
 	if(!(user.bioHolder.HasEffect("clumsy")))
 		return FALSE
 
+///minimum T2 to get pufferfish from exotic sources
+/datum/fishing_lootpool/pufferfish
+	minimum_rod_tier = 2
+	fish_available = list(/obj/item/reagent_containers/food/fish/pufferfish = 25)
+
 ///tiny junk items you can find in vending machines and others.
 /datum/fishing_lootpool/tiny_junk
 	fish_available = list(/obj/item/reagent_containers/food/snacks/burger/moldy = 5, \

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -301,7 +301,6 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/damselfish = 10,\
 	/obj/item/reagent_containers/food/fish/green_chromis = 10,\
 	/obj/item/reagent_containers/food/fish/cardinalfish = 5,\
-	/obj/item/reagent_containers/food/fish/pufferfish = 10,\
 	/obj/item/reagent_containers/food/fish/royal_gramma = 10,\
 	/obj/item/reagent_containers/food/fish/bc_angelfish = 5,\
 	/obj/item/reagent_containers/food/fish/blue_tang = 15,\
@@ -311,6 +310,10 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/betta = 30,\
 	/obj/item/reagent_containers/food/fish/mandarin_fish = 5)
 
+/datum/fishing_spot/fluid/New()
+	..()
+	src.fishing_lootpools += new /datum/fishing_lootpool/pufferfish(src)
+
 /datum/fishing_spot/water_cooler
 	fishing_atom_type = /obj/reagent_dispensers/watertank/fountain
 	rod_tier_required = 1
@@ -318,7 +321,6 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/damselfish = 30,\
 	/obj/item/reagent_containers/food/fish/green_chromis = 20,\
 	/obj/item/reagent_containers/food/fish/cardinalfish = 15,\
-	/obj/item/reagent_containers/food/fish/pufferfish = 15,\
 	/obj/item/reagent_containers/food/fish/royal_gramma = 10,\
 	/obj/item/reagent_containers/food/fish/bc_angelfish = 10,\
 	/obj/item/reagent_containers/food/fish/blue_tang = 15,\
@@ -327,6 +329,10 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/lionfish = 15,\
 	/obj/item/reagent_containers/food/fish/betta = 30,\
 	/obj/item/reagent_containers/food/fish/mandarin_fish = 5)
+
+/datum/fishing_spot/water_cooler/New()
+	..()
+	src.fishing_lootpools += new /datum/fishing_lootpool/pufferfish(src)
 
 /datum/fishing_spot/kitchen_sink
 	fishing_atom_type = /obj/submachine/chef_sink
@@ -395,7 +401,6 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/damselfish = 30,\
 	/obj/item/reagent_containers/food/fish/green_chromis = 20,\
 	/obj/item/reagent_containers/food/fish/cardinalfish = 15,\
-	/obj/item/reagent_containers/food/fish/pufferfish = 15,\
 	/obj/item/reagent_containers/food/fish/royal_gramma = 10,\
 	/obj/item/reagent_containers/food/fish/bc_angelfish = 10,\
 	/obj/item/reagent_containers/food/fish/blue_tang = 15,\
@@ -404,6 +409,10 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/mandarin_fish = 5,\
 	/obj/item/reagent_containers/food/fish/lionfish = 15,\
 	/obj/item/reagent_containers/food/fish/betta = 30)
+
+/datum/fishing_spot/watertank/New()
+	..()
+	src.fishing_lootpools += new /datum/fishing_lootpool/pufferfish(src)
 
 /datum/fishing_spot/fueltank
 	fishing_atom_type = /obj/reagent_dispensers/fueltank
@@ -483,7 +492,6 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/damselfish = 30,\
 	/obj/item/reagent_containers/food/fish/green_chromis = 20,\
 	/obj/item/reagent_containers/food/fish/cardinalfish = 15,\
-	/obj/item/reagent_containers/food/fish/pufferfish = 10,\
 	/obj/item/reagent_containers/food/fish/royal_gramma = 10,\
 	/obj/item/reagent_containers/food/fish/bc_angelfish = 10,\
 	/obj/item/reagent_containers/food/fish/blue_tang = 15,\
@@ -493,6 +501,10 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/betta = 30,\
 	/obj/item/reagent_containers/food/fish/mandarin_fish = 5)
 
+/datum/fishing_spot/janitor_bucket/New()
+	..()
+	src.fishing_lootpools += new /datum/fishing_lootpool/pufferfish(src)
+
 /datum/fishing_spot/bucket
 	fishing_atom_type = /obj/item/reagent_containers/glass/bucket
 	rod_tier_required = 1
@@ -500,7 +512,6 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/damselfish = 30,\
 	/obj/item/reagent_containers/food/fish/green_chromis = 20,\
 	/obj/item/reagent_containers/food/fish/cardinalfish = 15,\
-	/obj/item/reagent_containers/food/fish/pufferfish = 10,\
 	/obj/item/reagent_containers/food/fish/royal_gramma = 10,\
 	/obj/item/reagent_containers/food/fish/bc_angelfish = 10,\
 	/obj/item/reagent_containers/food/fish/blue_tang = 15,\
@@ -509,6 +520,10 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/lionfish = 15,\
 	/obj/item/reagent_containers/food/fish/betta = 30,\
 	/obj/item/reagent_containers/food/fish/mandarin_fish = 5)
+
+/datum/fishing_spot/bucket/New()
+	..()
+	src.fishing_lootpools += new /datum/fishing_lootpool/pufferfish(src)
 
 /datum/fishing_spot/drain
 	fishing_atom_type = /obj/machinery/drainage
@@ -835,7 +850,6 @@ datum/fishing_spot/golden_toilet
 	/obj/item/reagent_containers/food/fish/damselfish = 30,\
 	/obj/item/reagent_containers/food/fish/green_chromis = 20,\
 	/obj/item/reagent_containers/food/fish/cardinalfish = 15,\
-	/obj/item/reagent_containers/food/fish/pufferfish = 15,\
 	/obj/item/reagent_containers/food/fish/royal_gramma = 10,\
 	/obj/item/reagent_containers/food/fish/bc_angelfish = 10,\
 	/obj/item/reagent_containers/food/fish/blue_tang = 15,\

--- a/code/modules/status_system/statusFoodBuffs.dm
+++ b/code/modules/status_system/statusFoodBuffs.dm
@@ -286,7 +286,7 @@
 	id = "food_fireburp"
 	name = "Food (Fire Burps)"
 	desc = "Your stomach is flaming hot!"
-	icon_state = "foodbuff"
+	icon_state = "fireburp"
 	exclusiveGroup = "Food"
 	maxDuration = 6000
 	unique = 1


### PR DESCRIPTION
[LABEL][balance][catering][chemistry]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR first and foremost reduces both Tetrodotoxin's depletion, and the amount of it that come in each pufferfish, it also makes it so you need at least a tier 2 rod to actually catch pufferfish under most circumstances, with a few minor fishing spot exceptions. This PR also alters the timings of TTX slighly to try and make the progression less immediately obvious and forgiving.

(I intend to change the rod tier requirement to a bait requirement once the system is properly implemented, so the rod tier is a bit of a stop gap intended for the moment.)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've been looking at how TTX plays in game for a while, and what i've noticed is it really doesn't see much use at all. While i never intended for it to be some meta poison, i think the high dose until it does any damage, and somewhat forgiving nature of the damage windup, while coupled with the ease to treat and very inconsistent availability makes it feel quite underwhelming, even for a gimmick poison. As for the progression change, it's an attempt at making the poison a bit more dangerous, since at the moment the very loud heartbeats and sizeable alloted time do make this a pretty undertuned chem, especially for the acquisition effort.

The change in depletion is supposed to do two things:
1- make obtaining any usable dose through ??? pills an actual possibility(3 units of impurity means you'd need to get lucky in 5 pills for any effect).
2- make smaller amounts as additives to food have some way of happening, since even spiking a drink feels near impossible with the 15 unit lethal dose.

Stacking does not seem like it will be a concern, since i find it difficult to think of most things that could complement this well at 0.2 depletion, that weren't already options, once most loud poisons just defeat tetrodotoxin's main thing, as mentioned before, what this does the most is make it existing in the ??? pills pool not as irrelevant as it currently is.
This, not to mention we've since veered away from things like scalpel dipping and other easy ways to pass on poisons in small doses directly to people, which already mostly only worked with very fast acting chems like old 11 cycle depletion pancuronium.


## Changelog
```changelog
(u)Colossus
(+)Tetrodotoxin now has a smaller(0.2) depletion, and slightly altered timing, but pufferfish only carry half the amount in them, and can only be caught by tier 2 rods or higher.
```
