### PR TITLE
Makes the ectoplasmic destabilizer shoot through walls

### DIFF
--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -224,7 +224,8 @@ toxic - poisons
 	//With what % do we hit mobs laying down
 	hit_ground_chance = 0
 	//Can we pass windows
-	window_pass = 0
+	window_pass = 1
+	goes_through_walls = 1
 	brightness = 0.8
 	color_red = 0.2
 	color_green = 0.8


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes shots from the ghostbuster's ectoplasmic destabilizer so that they pass through walls and windows.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Ghosts have made it a habit of hovering on top of projectile-blocking objects to avoid getting busted. In previous Spooktobers, I have had ghost buster rounds where every ghost I found did this. This PR was meant to prevent that.

Seeing as the projectile does negligible stun damage, has a short range, and does not hurt wraiths, this PR should have minimal impacts on game balance. It can be used to destroy transposed particle fields, but the utility of being able to shoot them through walls is limited.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)The ectoplasmic destabilizer can now bust ghosts through walls..
```
