### PR TITLE
Red Chainsaw TGUI Arm Replace popup

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -338,7 +338,7 @@
 		if (the_item.temp_flags & IS_LIMB_ITEM)
 			boutput(usr, SPAN_ALERT("The saw is already attached as an arm."))
 			return
-		switch (alert(usr, "Which arm would you like to replace with [the_item]?",,"Left","Right","Cancel"))
+		switch (tgui_alert(usr, "Which arm would you like to replace with [the_item]?", "Replace Arm", list("Left", "Right", "Cancel"), theme = "syndicate"))
 			if ("Cancel")
 				return
 			if ("Right")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Upgrades the item arm syndie chainsaw popup from a byond default to a themed tgui one
![image](https://github.com/user-attachments/assets/3957943d-61bb-4cfc-b77d-b965f20946e8)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
**RED**

[ui][QoL][Feature]