### PR TITLE
Increased CheMaster Item Name Size

### DIFF
--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -492,7 +492,7 @@ TYPEINFO(/obj/machinery/chem_shaker/large)
 
 #define CHEMMASTER_MINIMUM_REAGENT 5 //!mininum reagent for pills, bottles and patches
 #define CHEMMASTER_NO_CONTAINER_MAX 10 //!maximum number of unboxed pills/patches
-#define CHEMMASTER_ITEMNAME_MAXSIZE 16 //!chosen by fair dice roll
+#define CHEMMASTER_ITEMNAME_MAXSIZE 24 //!maximum characters allowed for the item name
 #define CHEMMASTER_MAX_PILL 22 //!22 pill icons
 #define CHEMMASTER_MAX_CANS 26 //!26 flavours of cans
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Chemistry] [Catering] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the maximum size of allowable item name for pills and bottles coming from the CheMaster from 16 characters to 24.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is needed because sixteen characters can be a bit restrictive when it comes to creative naming. Twenty-four should allow for a bit more creativity.

