### PR TITLE
AI Law Manudrive

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1702,6 +1702,48 @@
 	time = 60 SECONDS
 	category = "Component"
 
+/datum/manufacture/syndicate_laws
+	name = "Syndicate Law Module Set"
+	item_requirements = list("metal_dense" = 40)
+	item_outputs = list(/obj/item/aiModule/syndicate/law1, /obj/item/aiModule/syndicate/law2, /obj/item/aiModule/syndicate/law3, /obj/item/aiModule/syndicate/law4)
+	create = 1
+	time = 60 SECONDS
+	category = "Component"
+
+ABSTRACT_TYPE(/datum/manufacture/aiModule)
+/datum/manufacture/aiModule
+	name = "AI Law Module - 'YOU SHOULDNT SEE ME'"
+	item_requirements = list("metal_dense" = 10)
+	item_outputs = list(/obj/item/aiModule/asimov1)
+	create = 1
+	time = 10 SECONDS
+	category = "Component"
+
+	makeCaptain
+		name = "AI Law Module - 'MakeCaptain'"
+		item_outputs = list(/obj/item/aiModule/makeCaptain)
+
+	oneHuman
+		name = "AI Law Module - 'OneHuman'"
+		item_outputs = list(/obj/item/aiModule/oneHuman)
+
+	notHuman
+		name = "AI Law Module - 'NotHuman'"
+		item_outputs = list(/obj/item/aiModule/notHuman)
+
+	emergency
+		name = "AI Law Module - 'Emergency'"
+		item_outputs = list(/obj/item/aiModule/emergency)
+
+	removeCrew
+		name = "AI Law Module - 'RemoveCrew'"
+		item_outputs = list(/obj/item/aiModule/removeCrew)
+
+	freeform
+		name = "AI Law Module - 'Freeform'"
+		item_outputs = list(/obj/item/aiModule/freeform)
+
+
 // Robotics Research
 
 /datum/manufacture/implanter

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1716,7 +1716,7 @@ ABSTRACT_TYPE(/datum/manufacture/aiModule)
 	item_requirements = list("metal_dense" = 10)
 	item_outputs = list(/obj/item/aiModule/asimov1)
 	create = 1
-	time = 10 SECONDS
+	time = 20 SECONDS
 	category = "Component"
 
 	makeCaptain

--- a/code/obj/item/manudrive.dm
+++ b/code/obj/item/manudrive.dm
@@ -41,16 +41,6 @@ TYPEINFO(/obj/item/disk/data/floppy/manudrive)
 				MD.fablimit = src.fablimit
 		src.read_only = 1
 
-	emag_act(var/mob/user)
-		if (!src.emagged)
-			src.emagged = TRUE
-			boutput(user, SPAN_ALERT("[src]'s encrypted recipes have been unlocked."))
-			for (var/X in src.emag_recipes)
-				for (var/datum/computer/file/manudrive/MD in src.root.contents)
-					MD.drivestored += get_schematic_from_path(X)
-			return TRUE
-		return FALSE
-
 	ai //AI core frame limiting
 		name = "Command ManuDrive: Artificial Intelligence License"
 		desc = "A drive for data storage that can be inserted and removed from manufacturers to temporarily add recipes to a manufacturer. This drive carries a blueprint protected by NT-approved DRM that permits the user to manufacture two AI core frames."
@@ -77,7 +67,6 @@ TYPEINFO(/obj/item/disk/data/floppy/manudrive)
 		/datum/manufacture/aiModule/emergency,
 		/datum/manufacture/aiModule/removeCrew,
 		/datum/manufacture/aiModule/freeform)
-		emag_recipes = list(/datum/manufacture/syndicate_laws)
 
 
 	interdictor_parts //Compacts the parts into a single manudrive

--- a/code/obj/item/manudrive.dm
+++ b/code/obj/item/manudrive.dm
@@ -25,6 +25,9 @@ TYPEINFO(/obj/item/disk/data/floppy/manudrive)
 	var/list/datum/manufacture/temp_recipe_string = list()
 	/// -1 Means it can be used unlimited time, its a lazy solution yet an effective one, numbers above 0 can only have things fabricated from those manudrives x amount of times.
 	var/fablimit = -1
+	var/emagged = FALSE
+	/// List of recipes that only show up when emagged
+	var/list/datum/manufacture/emag_recipes = list()
 
 	New(var/loc)
 		..()
@@ -37,6 +40,16 @@ TYPEINFO(/obj/item/disk/data/floppy/manudrive)
 				MD.drivestored += get_schematic_from_path(X)
 				MD.fablimit = src.fablimit
 		src.read_only = 1
+
+	emag_act(var/mob/user)
+		if (!src.emagged)
+			src.emagged = TRUE
+			boutput(user, SPAN_ALERT("[src]'s encrypted recipes have been unlocked."))
+			for (var/X in src.emag_recipes)
+				for (var/datum/computer/file/manudrive/MD in src.root.contents)
+					MD.drivestored += get_schematic_from_path(X)
+			return TRUE
+		return FALSE
 
 	ai //AI core frame limiting
 		name = "Command ManuDrive: Artificial Intelligence License"
@@ -53,6 +66,19 @@ TYPEINFO(/obj/item/disk/data/floppy/manudrive)
 
 		singleuse
 			fablimit = 1
+
+	aiLaws //In case you want to make your own laws in the case the original ones are stolen/blown up
+		name = "Command ManuDrive: Artificial Intelligence Laws Blueprint"
+		desc = "A drive for data storage that can be inserted and removed from manufacturers to temporarily add recipes to a manufacturer. This drive carries a blueprint that permits the user to manufacture the AI laws found on each NT station."
+		icon_state = "datadiskcom"
+		temp_recipe_string = list(/datum/manufacture/aiModule/makeCaptain,
+		/datum/manufacture/aiModule/oneHuman,
+		/datum/manufacture/aiModule/notHuman,
+		/datum/manufacture/aiModule/emergency,
+		/datum/manufacture/aiModule/removeCrew,
+		/datum/manufacture/aiModule/freeform)
+		emag_recipes = list(/datum/manufacture/syndicate_laws)
+
 
 	interdictor_parts //Compacts the parts into a single manudrive
 		name = "Engineering Manudrive: Spatial Interdictor Assembly Blueprints"

--- a/code/obj/item/manudrive.dm
+++ b/code/obj/item/manudrive.dm
@@ -25,9 +25,6 @@ TYPEINFO(/obj/item/disk/data/floppy/manudrive)
 	var/list/datum/manufacture/temp_recipe_string = list()
 	/// -1 Means it can be used unlimited time, its a lazy solution yet an effective one, numbers above 0 can only have things fabricated from those manudrives x amount of times.
 	var/fablimit = -1
-	var/emagged = FALSE
-	/// List of recipes that only show up when emagged
-	var/list/datum/manufacture/emag_recipes = list()
 
 	New(var/loc)
 		..()

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -281,6 +281,7 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	name = "\improper Research Director's locker"
 	req_access = list(access_research_director)
 	spawn_contents = list(/obj/item/plant/herb/cannabis/spawnable,
+	/obj/item/disk/data/floppy/manudrive/aiLaws,
 	/obj/item/device/light/zippo,
 	/obj/item/storage/box/clothing/research_director,
 	/obj/item/clothing/shoes/brown,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a manudrive to the RD's locker with the 6 basic laws found on-station.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If someone steals, blows up or otherwise destroys the laws found in upload they are presently impossible to replace if they weren't already mechscanned (which is unlikely). 
## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)The Research Director now has a Manudrive containing the blueprints for most on-station laws.
```
