### PR TITLE
Fix clarion tech-storage door access

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -16026,7 +16026,7 @@
 	name = "Technical Storage"
 	},
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/maint,
+/obj/mapping_helper/access/tech_storage,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "dPw" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix the tech storage door in clarion having the wrong access (was maint, now tech storage)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Too easy to get into tech storage on Clarion; map consistency