### PR TITLE
reassign ambience sound channels

### DIFF
--- a/_std/defines/sound.dm
+++ b/_std/defines/sound.dm
@@ -1,7 +1,7 @@
 //Reserved Area Ambience sound channels
-#define SOUNDCHANNEL_LOOPING 123
-#define SOUNDCHANNEL_FX_1 124
-#define SOUNDCHANNEL_FX_2 125
+#define SOUNDCHANNEL_LOOPING 990
+#define SOUNDCHANNEL_FX_1 991
+#define SOUNDCHANNEL_FX_2 992
 #define SOUNDCHANNEL_RADIO 1013
 #define SOUNDCHANNEL_ADMIN_LOW 1014 // lower end of the range of admin channels
 #define SOUNDCHANNEL_ADMIN_HIGH 1024 // upper end


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Reassigns the three reserved ambience channels to `990` `991` and `992`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Ambience sound often breaks when other sounds play. My current suspicion is the the proc `generate_sound` which can play between channel `1` and `900` is the cause, or at least "a cause", with the original ambience channels falling in that range having been `123` `124` and `125`


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sovexe
(+)Attempt at preventing ambient sound loops from breaking
```
