### PR TITLE
adds bar access to a door which should have it

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -43390,6 +43390,7 @@
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
 	},
+/obj/mapping_helper/access/bar,
 /turf/simulated/floor/marble/black,
 /area/station/crew_quarters/catering)
 "ssc" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![image](https://github.com/user-attachments/assets/5bdac900-6878-4e2d-a6a5-d1d3b89f8291)
adds bar access to this door which had only kitchen access, its the way between bar and the cafe floor, also they have access to the room anyway through other doors


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix mistake


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->


