### PR TITLE
"Fix" staggered still letting you sprint

### DIFF
--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -941,9 +941,13 @@
 
 		onAdd(optional=null)
 			.=..()
+			APPLY_ATOM_PROPERTY(src.owner, PROP_MOB_CANTSPRINT, src)
 			if (ishuman(owner))
 				var/mob/living/carbon/human/H = owner
 				H.sustained_moves = 0
+		onRemove()
+			REMOVE_ATOM_PROPERTY(src.owner, PROP_MOB_CANTSPRINT, src)
+			. = ..()
 
 	blocking
 		id = "blocking"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [BALANCE] [GUH]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The description of the "staggered" status effect you get when you hit someone or get hit reads: `"You have been staggered by a melee attack.<br>Slowed slightly, unable to sprint."` but currently it doesn't do that.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Might make fights a little less wacky clickfests and make it easier to catch someone who is sprinting away from you?
I'm very open to being told this is a bad idea or was removed for a reason etc.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Getting staggered by a melee attack now makes you unable to sprint for a short time.
```
