### PR TITLE
Getting hit by a heavy thrown object applies hit stagger

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -2193,6 +2193,8 @@
 			. = 'sound/impact_sounds/Flesh_Stab_3.ogg'
 			if(thr?.user)
 				src.was_harmed(thr.user, AM)
+	if (AM.throwforce > 5) //number
+		src.changeStatus("staggered", 5 SECONDS)
 	..()
 
 /mob/living/proc/check_singing_prefix(var/message)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just applies the melee hit stagger slow effect to anyone hit with a thrown object with throwforce > 5.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Make chases that don't involve stuns or guns a little more interesting?


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Getting hit by a heavy thrown object now applies melee hit stagger.
```
