### PR TITLE
Clean up item burning variables and use define for burnt item remains

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -34,6 +34,7 @@
 #include "defines\atom.dm"
 #include "defines\bioeffect.dm"
 #include "defines\blocking.dm"
+#include "defines\burning.dm"
 #include "defines\camera_coverage.dm"
 #include "defines\chemicompiler.dm"
 #include "defines\chemistry.dm"

--- a/_std/defines/burning.dm
+++ b/_std/defines/burning.dm
@@ -1,0 +1,8 @@
+// Burning /obj/item
+
+/// Leaves nothing behind when burned
+#define BURN_REMAINS_NONE 0
+/// Leaves an ash pile behind when burned
+#define BURN_REMAINS_ASH 1
+/// Leaves a molten mess behind when burned
+#define BURN_REMAINS_MELT 2

--- a/code/datums/abilities/kudzumen.dm
+++ b/code/datums/abilities/kudzumen.dm
@@ -681,7 +681,7 @@
 	throwforce = 5
 	throw_range = 5
 	hit_type = DAMAGE_BLUNT
-	burn_type = 1
+	burn_remains = BURN_REMAINS_MELT
 	stamina_damage = 30
 	stamina_cost = 15
 	stamina_crit_chance = 50

--- a/code/datums/gamemodes/pod_wars/pw_weapons.dm
+++ b/code/datums/gamemodes/pod_wars/pw_weapons.dm
@@ -205,7 +205,7 @@ TYPEINFO(/obj/item/gun/energy/blaster_pod_wars)
 	w_class = W_CLASS_SMALL
 	flags = TABLEPASS | NOSHIELD | USEDELAY
 	tool_flags = TOOL_CUTTING
-	burn_type = 1
+	burn_remains = BURN_REMAINS_MELT
 	stamina_damage = 25
 	stamina_cost = 10
 	stamina_crit_chance = 40

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -771,7 +771,7 @@ this is already used where it needs to be used, you can probably ignore it.
 	throwforce = 0
 	throw_range = 16
 	flags = TABLEPASS | NOSHIELD
-	burn_type = 1
+	burn_remains = BURN_REMAINS_MELT
 
 	New()
 		..()

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -30,15 +30,15 @@ ABSTRACT_TYPE(/obj/item)
 	/*_______*/
 	/*Burning*/
 	/*‾‾‾‾‾‾‾*/
-	var/burn_possible = TRUE //cogwerks fire project - can object catch on fire - let's have all sorts of shit burn at hellish temps
+
+	var/burn_possible = TRUE //!Is this item burnable
 	var/burning = null
-	/// How long an item takes to burn (or be consumed by other means), based on the weight class if no value is set
-	var/health = null
-	var/burn_point = 15000  //this already exists but nothing uses it???
-	var/burn_output = 1500 //how hot should it burn
-	var/burn_type = 0 //0 = ash, 1 = melt
+	var/health = null //!How long an item takes to burn (or be consumed by other means), based on the weight class if no value is set
+	var/burn_point = 15000 KELVIN //!Ambient temperature at which the item may spontaneously ignite
+	var/burn_output = 1500 KELVIN //!How hot does the item burn once on fire
+	var/burn_remains = BURN_REMAINS_ASH	///!What is left when it's burnt up
 	var/burning_last_process = 0
-	var/firesource = FALSE //TRUE or FALSE : dictates whether or not the item can be used as a valid source of fire
+	var/firesource = FALSE //! Is this a valid source for lighting fires
 
 	/*______*/
 	/*Combat*/
@@ -283,9 +283,9 @@ ABSTRACT_TYPE(/obj/item)
 		if (istype(src.material))
 			burn_possible = src.material.getProperty("flammable") > 1 ? TRUE : FALSE
 			if (src.material.getMaterialFlags() & (MATERIAL_METAL | MATERIAL_CRYSTAL | MATERIAL_RUBBER))
-				burn_type = 1
+				burn_remains = BURN_REMAINS_MELT
 			else
-				burn_type = 0
+				burn_remains = BURN_REMAINS_ASH
 
 		if (src.material.countTriggers(TRIGGERS_ON_LIFE))
 			src.AddComponent(/datum/component/loctargeting/mat_triggersonlife)
@@ -963,10 +963,12 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 
 		if (src.health <= 0)
 			STOP_TRACKING_CAT(TR_CAT_BURNING_ITEMS)
-			if (burn_type == 1)
-				make_cleanable( /obj/decal/cleanable/molten_item,get_turf(src))
-			else
-				make_cleanable( /obj/decal/cleanable/ash,get_turf(src))
+			switch(src.burn_remains)
+				if(BURN_REMAINS_ASH)
+					make_cleanable(/obj/decal/cleanable/ash, get_turf(src))
+				if(BURN_REMAINS_MELT)
+					make_cleanable(/obj/decal/cleanable/molten_item, get_turf(src))
+
 
 			if (istype(src,/obj/item/parts/human_parts))
 				src:holder = null

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -36,7 +36,7 @@ ABSTRACT_TYPE(/obj/item)
 	var/health = null //!How long an item takes to burn (or be consumed by other means), based on the weight class if no value is set
 	var/burn_point = 15000 KELVIN //!Ambient temperature at which the item may spontaneously ignite
 	var/burn_output = 1500 KELVIN //!How hot does the item burn once on fire
-	var/burn_remains = BURN_REMAINS_ASH	///!What is left when it's burnt up
+	var/burn_remains = BURN_REMAINS_ASH	//!What is left when it's burnt up
 	var/burning_last_process = 0
 	var/firesource = FALSE //! Is this a valid source for lighting fires
 

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -32,12 +32,12 @@ ABSTRACT_TYPE(/obj/item)
 	/*‾‾‾‾‾‾‾*/
 
 	var/burn_possible = TRUE //!Is this item burnable
-	var/burning = null
+	var/burning = null //!Are we currently burning
 	var/health = null //!How long an item takes to burn (or be consumed by other means), based on the weight class if no value is set
 	var/burn_point = 15000 KELVIN //!Ambient temperature at which the item may spontaneously ignite
 	var/burn_output = 1500 KELVIN //!How hot does the item burn once on fire
 	var/burn_remains = BURN_REMAINS_ASH	//!What is left when it's burnt up
-	var/burning_last_process = 0
+	var/burning_last_process = 0 //!Keep track of last burning state
 	var/firesource = FALSE //! Is this a valid source for lighting fires
 
 	/*______*/

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -13,7 +13,7 @@ GAUNTLET CARDS
 	wear_image_icon = 'icons/mob/clothing/card.dmi'
 	w_class = W_CLASS_TINY
 	object_flags = NO_GHOSTCRITTER
-	burn_type = 1
+	burn_remains = BURN_REMAINS_MELT
 	stamina_damage = 0
 	stamina_cost = 0
 	var/list/files = list("tools" = 1)

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -332,7 +332,7 @@ TYPEINFO(/obj/item/device/radio/intercom)
 	device_color = "#3983C6" // for chat color
 
 	// burning stuff
-	burn_type = 1 // burn down to a glob
+	burn_remains = BURN_REMAINS_MELT // burn down to a glob
 	burn_possible = TRUE
 	burn_point = 300
 	health = 50 // same as a plank

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -13,7 +13,7 @@
 	var/crystal = 0
 	var/powersource = 0
 	var/scoopable = 1
-	burn_type = 1
+	burn_remains = BURN_REMAINS_MELT
 	var/wiggle = 6 // how much we want the sprite to be deviated fron center
 	max_stack = 50
 	event_handler_flags = USE_FLUID_ENTER
@@ -542,7 +542,7 @@
 	force = 5
 	throwforce = 5
 	g_amt = 3750
-	burn_type = 1
+	burn_remains = BURN_REMAINS_MELT
 	stamina_damage = 5
 	stamina_cost = 5
 	stamina_crit_chance = 35

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -532,7 +532,7 @@ TYPEINFO(/obj/item/sword/pink/angel)
 	flags = TABLEPASS | NOSHIELD | USEDELAY
 	tool_flags = TOOL_CUTTING
 	desc = "Gets the blood to run out juuuuuust right. Looks like this could be nasty when thrown."
-	burn_type = 1
+	burn_remains = BURN_REMAINS_MELT
 	stamina_damage = 15
 	stamina_cost = 5
 	stamina_crit_chance = 50
@@ -737,7 +737,7 @@ TYPEINFO(/obj/item/sword/pink/angel)
 	w_class = W_CLASS_SMALL
 	flags = TABLEPASS | NOSHIELD | USEDELAY
 	desc = "An ancient and questionably effective weapon."
-	burn_type = 0
+	burn_remains = BURN_REMAINS_ASH
 	stamina_damage = 45
 	stamina_cost = 20
 	stamina_crit_chance = 60

--- a/code/obj/item/storage/toolbox.dm
+++ b/code/obj/item/storage/toolbox.dm
@@ -20,7 +20,7 @@ ABSTRACT_TYPE(/obj/item/storage/toolbox)
 	//cogwerks - burn vars
 	burn_point = 4500
 	burn_output = 4800
-	burn_type = 1
+	burn_remains = BURN_REMAINS_MELT
 	stamina_damage = 50
 	stamina_cost = 20
 	stamina_crit_chance = 10

--- a/code/obj/retribution/makeshift_signaller.dm
+++ b/code/obj/retribution/makeshift_signaller.dm
@@ -14,7 +14,7 @@ TYPEINFO(/obj/item/makeshift_signaller_frame)
 	throw_speed = 4
 	throw_range = 20
 	m_amt = 500
-	burn_type = 1
+	burn_remains = BURN_REMAINS_MELT
 	var/build_stage = 0
 	desc = "A disemboweled remote signaller, ready for further modifications."
 	stamina_damage = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[internal][cleanup]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Use doc-comments for various item burning-related variables
* Replace `burn_type` with `burn_remains` as the variable name that tracks what items should melt into when burnt up. 
* Create a new burnable define `BURN_REMAINS_*` for clarity on what stuff will burn into.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Clearer variable names/doccomments. Atomizing work on burning component. Allows for additional types of burn remains to be easily added in the future, as well as no remains.