### PR TITLE
Removes examine range from intangibles

### DIFF
--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -17,7 +17,7 @@
 	if (isalive(usr))
 		. += "<br>[SPAN_NOTICE("You look closely at <B>[src.name] ([src.get_pronouns()])</B>.")]"
 
-	if (!istype(usr, /mob/dead/target_observer) && !istype(usr, /mob/living/intangible))
+	if (!isobserver(usr) && !isintangible(usr))
 		if (!ignore_checks && (GET_DIST(usr.client.eye, src) > 7 && (!usr.client || !usr.client.eye || !usr.client.holder || usr.client.holder.state != 2)))
 			return "[jointext(., "")]<br>[SPAN_ALERT("<B>[src.name]</B> is too far away to see clearly.")]"
 

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -17,7 +17,7 @@
 	if (isalive(usr))
 		. += "<br>[SPAN_NOTICE("You look closely at <B>[src.name] ([src.get_pronouns()])</B>.")]"
 
-	if (!istype(usr, /mob/dead/target_observer))
+	if (!istype(usr, /mob/dead/target_observer) && !istype(usr, /mob/living/intangible))
 		if (!ignore_checks && (GET_DIST(usr.client.eye, src) > 7 && (!usr.client || !usr.client.eye || !usr.client.holder || usr.client.holder.state != 2)))
 			return "[jointext(., "")]<br>[SPAN_ALERT("<B>[src.name]</B> is too far away to see clearly.")]"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SILICONS][QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Intangibles no longer get the "is too far away to see clearly." message for trying to examine people far from their eye.
Mostly affects AIs (as they can now examine people from viewports), but wraiths, poltergeists, flockmind/trace, blobs, zoldorf manifests and brain things (whatever they are) are also affected


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The eye is mostly an abstraction right? Their ability to see people clearly should not depend on where it is.
I am open to changing this to not include intangibles that can't move freely (wraith, poltergeist, zoldorf manifest)
