### PR TITLE
Delete /obj/item/acesscomputerunfolder

### DIFF
--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -37,30 +37,6 @@
 /obj/machinery/computer/card/console_lower
 	icon = 'icons/obj/computerpanel.dmi'
 	icon_state = "id2"
-/obj/item/acesscomputerunfolder
-	icon = 'icons/obj/items/storage.dmi'
-	item_state = "hopcaseC"
-	icon_state = "hopcaseC"
-
-	force = 8
-	throw_speed = 1
-	throw_range = 4
-	w_class = W_CLASS_BULKY
-	stamina_damage = 40
-	stamina_cost = 17
-	stamina_crit_chance = 10
-
-	burn_point = 2500
-	burn_output = 2500
-	burn_possible = TRUE
-	health = 10
-
-	New(var/loc, var/obj/object)
-		..(loc)
-		src.set_loc(loc)
-		src.name = "foldable portable identification computer"
-		src.desc = "A briefcase with an identification computer inside. A breakthrough in briefcase technology!"
-		BLOCK_SETUP(BLOCK_BOOK)
 
 /obj/machinery/computer/card/portable
 	name = "portable identification computer"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Deletes /obj/item/acesscomputerunfolder


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As far as I can tell this item does nothing, its not the foldable ID computer, and doesnt seem to "unfold" a folded one when instantiated on the same loc, its not used anywhere in actual foldable ID computer functionality and isnt made at any point by other code (unless in secret) and it just serves to confuse anyone trying to add portable machinery (me). It just looks exactly like the portable ID computer without actually being one and just being a useless item.

Looking at the original PR for this, it seems like it used to have functionality but it has since been moved elsewhere, leaving this object doing nothing. #8692 is what seems to have left this item with no functionality.