### PR TITLE
Pumpkin products retain their sprite size when carved, lantern'd, or hollowed

### DIFF
--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -1080,12 +1080,14 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 			src.carving_message(W, user)
 			var/obj/item/clothing/head/result = new src.carving_result(user.loc)
 			result.name = "carved [src.name]"
+			result.transform = src.transform
 			qdel(src)
 		else if (isspooningtool(W))
 			src.spoon_message(W, user)
 			var/obj/item/reagent_containers/result = new src.spoon_result(user.loc)
 			result.reagents.maximum_volume = max(result.reagents.maximum_volume, src.reagents.total_volume)
 			src.reagents.trans_to(result, src.reagents.maximum_volume)
+			result.transform = src.transform
 			qdel(src)
 
 	proc/carving_message(obj/item/knife, mob/user)

--- a/code/obj/item/clothing/plants.dm
+++ b/code/obj/item/clothing/plants.dm
@@ -97,6 +97,7 @@
 			W.icon = 'icons/misc/halloween.dmi'
 			W.icon_state = "flight[W:on]"
 			W.item_state = "lantern"
+			W.transform = src.transform
 			qdel(src)
 		else
 			..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label [hydroponics][feature] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Carved pumpkins, pumpkin lanterns, and pumpkin bowls copy across the transform of their base product when created, meaning their sprites will be the same size as the pumpkins they were created from.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's more immersive to feel as if you're carving the pumpkin you are holding; and it's quite disappointing to grow a huge pumpkin only to have it shrink to a standard size when you carve it. 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Egregorious
(+)Pumpkins will now retain their size when carved.
```
