### PR TITLE
Apply disease resistance as a percentage modifier to virulence

### DIFF
--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -417,7 +417,7 @@
 
 		if (istype(A,/datum/ailment/disease/))
 			var/datum/ailment/disease/D = A
-			resist_prob = ((100 - resist_prob) / 100) * D.virulence
+			resist_prob = 100 - (((100 - resist_prob) / 100) * D.virulence)
 
 	if (prob(resist_prob))
 		return 0

--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -417,7 +417,7 @@
 
 		if (istype(A,/datum/ailment/disease/))
 			var/datum/ailment/disease/D = A
-			resist_prob -= D.virulence
+			resist_prob = (100 - resist_prob) * D.virulence
 
 	if (prob(resist_prob))
 		return 0

--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -417,12 +417,12 @@
 
 		if (istype(A,/datum/ailment/disease/))
 			var/datum/ailment/disease/D = A
-			resist_prob = ((100 - resist_prob) / 100) * D.virulence
+			resist_prob = 100 - ((resist_prob / 100) * D.virulence)
 
 	if (prob(resist_prob))
-		return 1 // you caught the virus! do you want to give the captured virus a nickname? virus has been recorded in lurgydex
-	else
 		return 0
+	else
+		return 1 // you caught the virus! do you want to give the captured virus a nickname? virus has been recorded in lurgydex
 
 /// Contract the specified disease.
 /// @param ailment_path Path of the ailment to add. If both ailment_path and ailment_name are passed, this is used.

--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -417,7 +417,7 @@
 
 		if (istype(A,/datum/ailment/disease/))
 			var/datum/ailment/disease/D = A
-			resist_prob = 100 - ((resist_prob / 100) * D.virulence)
+			resist_prob = ((100 - resist_prob) / 100) * D.virulence
 
 	if (prob(resist_prob))
 		return 0

--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -417,12 +417,12 @@
 
 		if (istype(A,/datum/ailment/disease/))
 			var/datum/ailment/disease/D = A
-			resist_prob = (100 - resist_prob) * D.virulence
+			resist_prob = ((100 - resist_prob) / 100) * D.virulence
 
 	if (prob(resist_prob))
-		return 0
-	else
 		return 1 // you caught the virus! do you want to give the captured virus a nickname? virus has been recorded in lurgydex
+	else
+		return 0
 
 /// Contract the specified disease.
 /// @param ailment_path Path of the ailment to add. If both ailment_path and ailment_name are passed, this is used.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][medical]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Apply disease resistance as a percentage modifier to the virulence of the disease before modifying the resistance probability.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
100% Disease resistance isn't 100% resistance.

Interactive graph of current/proposed behavior:
https://www.desmos.com/calculator/j4gq8ogod6

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Disease resistance scales based on a percentage of the disease's virulence.
```
