### PR TITLE
More atlas fixes

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -9911,6 +9911,7 @@
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/tox,
 /turf/simulated/floor/purple,
 /area/research_outpost/hangar)
 "bXo" = (
@@ -13922,6 +13923,7 @@
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/tox,
 /turf/simulated/floor/purple,
 /area/station/science/storage)
 "iiP" = (

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -9206,7 +9206,7 @@
 /obj/decal/stripe_delivery,
 /obj/machinery/computer/airbr{
 	density = 0;
-	id = "ai2medbay";
+	id = "sciship";
 	pixel_x = 32;
 	starts_established = 1
 	},
@@ -13918,7 +13918,6 @@
 	dir = 4
 	},
 /obj/mapping_helper/access/tox_storage,
-/obj/mapping_helper/access/tox,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -16395,7 +16394,7 @@
 "lEi" = (
 /obj/machinery/computer/airbr{
 	density = 0;
-	id = "ai2medbay";
+	id = "sciship";
 	pixel_x = -32;
 	dir = 2
 	},
@@ -20235,6 +20234,9 @@
 /obj/machinery/light_switch/south{
 	pixel_x = 6
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 10
 	},
@@ -22601,7 +22603,7 @@
 /area/station/mining/magnet)
 "vjI" = (
 /obj/airbridge_controller{
-	id = "ai2medbay"
+	id = "sciship"
 	},
 /turf/space,
 /area/space)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
3 minor atlas fixes:
Change ID of sci airbridge to "sciship" from "ai2medbay" (copypasted from cogmap according to original PR)
Add a missing wire in sci ship
Adds a normal toxins access spawner to the storage room because to reach normal toxins you have to go through storage (and the other door into tox storage has both)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix good
