### PR TITLE
Datumize Clothing Stains

### DIFF
--- a/code/WorkInProgress/laundry.dm
+++ b/code/WorkInProgress/laundry.dm
@@ -78,8 +78,8 @@ TYPEINFO(/obj/submachine/laundry_machine)
 			for (var/obj/item/I in src.contents)
 				if (istype(I, /obj/item/clothing))
 					var/obj/item/clothing/C = I
-					C.stains = list("damp")
-					C.UpdateName()
+					C.clean_stains()
+					C.add_stain(/datum/stain/damp)
 				I.clean_forensic()
 			if (src.occupant && ishuman(src.occupant))
 				H.sims?.affectMotive("Hygiene", 100)
@@ -94,7 +94,7 @@ TYPEINFO(/obj/submachine/laundry_machine)
 			for (var/obj/item/item in src.contents)
 				if (istype(item, /obj/item/clothing))
 					var/obj/item/clothing/clothing = item
-					clothing.stains = null
+					clothing.clean_stains()
 					clothing.delStatus("freshly_laundered") // ...and this is the price we pay for being cheeky
 					clothing.changeStatus("freshly_laundered", rand(2,4) MINUTES)
 					clothing.UpdateName()

--- a/code/datums/stain.dm
+++ b/code/datums/stain.dm
@@ -1,0 +1,57 @@
+ABSTRACT_TYPE(/datum/stain)
+/datum/stain
+	var/name = "stained"
+
+/datum/stain/proc/add_to_clothing(obj/item/clothing/worn)
+	return
+
+/datum/stain/proc/remove_from_clothing(obj/item/clothing/worn)
+	return
+
+/datum/stain/blood
+	name = "blood-stained"
+
+/datum/stain/sparkly
+	name = "sparkly"
+
+/datum/stain/damp
+	name = "damp"
+
+/datum/stain/puke
+	name = "puke-coated"
+
+/datum/stain/puke/green
+	name = "green-puke-coated"
+
+/datum/stain/dirt
+	name = "dirty"
+
+/datum/stain/slime
+	name = "slimy"
+
+/datum/stain/oil
+	name = "oily"
+
+/datum/stain/paint
+	name = "painted"
+
+/datum/stain/flock
+	name = "teal-stained"
+
+#define LAUNDERED_COLDPROT_AMOUNT 2 //!Amount of coldprot(%) given to each item of wearable clothing
+
+/datum/stain/laundered
+	name = "freshly-laundred"
+
+/datum/stain/laundered/add_to_clothing(obj/item/clothing/worn)
+	. = ..()
+	worn.setProperty("coldprot", worn.getProperty("coldprot") + LAUNDERED_COLDPROT_AMOUNT)
+
+/datum/stain/laundered/remove_from_clothing(obj/item/clothing/worn)
+	. = ..()
+	worn.setProperty("coldprot", worn.getProperty("coldprot") - LAUNDERED_COLDPROT_AMOUNT)
+
+#undef LAUNDERED_COLDPROT_AMOUNT
+
+/datum/stain/singed
+	name = "singed"

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1915,7 +1915,7 @@
 			for (var/obj/item/W in src)
 				if (istype(W, /obj/item/clothing))
 					var/obj/item/clothing/C = W
-					C.add_stain("singed")
+					C.add_stain(/datum/stain/singed)
 			unequip_all()
 
 	if (drop_equipment)

--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -146,7 +146,7 @@
 		I.forensics_blood_color = blood_color
 		if (istype(I, /obj/item/clothing))
 			var/obj/item/clothing/C = src
-			C.add_stain("blood-stained")
+			C.add_stain(/datum/stain/blood)
 	else if (istype(src, /turf/simulated))
 		if (istype(source, /mob/living))
 			var/mob/living/L = source

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2381,8 +2381,6 @@
 		. = ..()
 		owner.remove_filter("gnesis_tint")
 
-#define LAUNDERED_COLDPROT_AMOUNT 2 /// Amount of coldprot(%) given to each item of wearable clothing
-#define LAUNDERED_STAIN_TEXT "freshly-laundered" /// Name of the "stain" given to wearable clothing
 /datum/statusEffect/freshly_laundered
 	id = "freshly_laundered"
 	name = "Freshly Laundered"
@@ -2396,20 +2394,13 @@
 		. = ..()
 		if (istype(owner, /obj/item/clothing/))
 			var/obj/item/clothing/C = owner
-			C.add_stain(LAUNDERED_STAIN_TEXT) // we just cleaned them so this is cheeky...
-			C.setProperty("coldprot", C.getProperty("coldprot") + LAUNDERED_COLDPROT_AMOUNT)
+			C.add_stain(/datum/stain/laundered)
 
 	onRemove()
 		. = ..()
 		if (istype(owner, /obj/item/clothing/))
 			var/obj/item/clothing/C = owner
-			C.setProperty("coldprot", C.getProperty("coldprot") - LAUNDERED_COLDPROT_AMOUNT)
-			if (C.stains)
-				C.stains -= LAUNDERED_STAIN_TEXT
-				C.UpdateName()
-
-#undef LAUNDERED_COLDPROT_AMOUNT
-#undef LAUNDERED_STAIN_TEXT
+			C.remove_stain(/datum/stain/laundered)
 
 /datum/statusEffect/quickcharged
 	id = "quick_charged"

--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -23,7 +23,7 @@ proc/make_cleanable(var/type,var/loc)
 	var/slipped_in_blood = 0 // self explanitory hopefully
 	var/can_dry = 0
 	var/dry = 0 // if it's slippery to start, is it dry now?
-	var/stain = null // clothing will be stained with this message if the decal is created in the same tile as them
+	var/datum/stain/stain = null //! Stain to apply to clothing if it is on the same turf as the cleanable when spawned
 	var/last_color = null
 
 	var/can_fluid_absorb = 1
@@ -257,7 +257,7 @@ proc/make_cleanable(var/type,var/loc)
 	can_sample = 1
 	sample_reagent = "blood"
 	can_dry = 1
-	stain = "blood-stained"
+	stain = /datum/stain/blood
 	var/can_track = 1
 	var/reagents_max = 10
 
@@ -622,7 +622,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	can_sample = 1
 	sample_reagent = "glitter"
 	sample_verb = "scrape"
-	stain = "sparkly"
+	stain = /datum/stain/sparkly
 
 /obj/decal/cleanable/glitter/harmless //updated to not be lethal
     sample_reagent = "sparkles"
@@ -824,7 +824,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	can_sample = 1
 	sample_reagent = "water"
 	sample_amt = 5
-	stain = "damp"
+	stain = /datum/stain/damp
 
 	Crossed(atom/movable/O)
 		if (istype(O, /obj/item/clothing/under/towel))
@@ -846,7 +846,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	sample_amt = 5
 	sample_reagent = "vomit"
 	sample_verb = "scrape"
-	stain = "puke-coated"
+	stain = /datum/stain/puke
 
 	Dry(var/time = rand(200,500))
 		if (!src.can_dry || src.dry)
@@ -932,7 +932,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	sample_amt = 5
 	sample_reagent = "gvomit"
 	sample_verb = "scrape"
-	stain = "green-puke-coated"
+	stain = /datum/stain/puke/green
 
 	Dry(var/time = rand(200,500))
 		if (!src.can_dry)
@@ -1004,7 +1004,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	can_sample = 1
 	sample_reagent = "ash"
 	sample_verb = "scrape"
-	stain = "dirty"
+	stain = /datum/stain/dirt
 
 	Sample(var/obj/item/W as obj, var/mob/user as mob)
 		..()
@@ -1032,7 +1032,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	can_dry = 1
 	can_sample = 1
 	sample_reagent = "badgrease"
-	stain = "slimy"
+	stain = /datum/stain/slime
 
 	Dry(var/time = rand(100,200))
 		if (!src.can_dry)
@@ -1061,7 +1061,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	icon = 'icons/obj/decals/cleanables.dmi'
 	icon_state = "dirt"
 	random_dir = NORTH
-	stain = "dirty"
+	stain = /datum/stain/dirt
 	can_sample = 1
 	sample_reagent = "carbon"
 
@@ -1216,7 +1216,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	random_icon_states = list("fluid1", "fluid2", "fluid3")
 	anchored = ANCHORED
 	slippery = 50
-	stain = "teal-stained"
+	stain = /datum/stain/flock
 
 /obj/decal/cleanable/machine_debris
 	name = "twisted shrapnel"
@@ -1290,7 +1290,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	slippery = 70
 	can_sample = 1
 	sample_reagent = "oil"
-	stain = "oily"
+	stain = /datum/stain/oil
 
 /obj/decal/cleanable/oil/streak
 	random_icon_states = list("streak1", "streak2", "streak3", "streak4", "streak5")
@@ -1305,7 +1305,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	can_dry = 0
 	can_sample = 0
 	sample_reagent = "juice_orange"
-	stain = "painted"
+	stain = /datum/stain/paint
 
 /obj/decal/cleanable/greenglow
 	name = "green glow"

--- a/code/obj/item/clothing.dm
+++ b/code/obj/item/clothing.dm
@@ -65,16 +65,16 @@ ABSTRACT_TYPE(/obj/item/clothing)
 		src.name = "[name_prefix(null, 1)][src.get_stain_names()][src.name][name_suffix(null, 1)]"
 
 	///Add a stain to this clothing piece
-	proc/add_stain(datum/stain/stn)
-		stn = get_singleton(stn)
-		if (!stn || !src.can_stain)
+	proc/add_stain(stain_type)
+		var/datum/stain/stain = get_singleton(stain_type)
+		if (!istype(stain) || !src.can_stain)
 			return
 		if (!islist(src.stains))
 			src.stains = list()
-		else if (stn in src.stains)
+		else if (stain in src.stains)
 			return
-		src.stains.Add(stn)
-		stn.add_to_clothing(src)
+		src.stains.Add(stain)
+		stain.add_to_clothing(src)
 		src.UpdateName()
 
 	///Returns a space-concatenated string of stain names
@@ -84,19 +84,18 @@ ABSTRACT_TYPE(/obj/item/clothing)
 				. += stn.name + " "
 
 	///Removes a stain from this clothing piece. Returns 1/TRUE if stain removed.
-	proc/remove_stain(datum/stain/stain)
-		stain = get_singleton(stain)
-		if(islist(src.stains))
-			for(var/datum/stain/stn in src.stains)
-				if (stn == stain)
-					stn.remove_from_clothing(src)
-					. = src.stains.Remove(stn)
+	proc/remove_stain(stain_type)
+		var/datum/stain/stain = get_singleton(stain_type)
+		if(stain in src.stains)
+			stain.remove_from_clothing(src)
+			. = src.stains.Remove(stain)
+			src.UpdateName()
 
 	///Removes all stains from this clothing piece
 	proc/clean_stains()
 		if (islist(src.stains) && length(src.stains))
-			for (var/datum/stain/stn in src.stains)
-				stn.remove_from_clothing(src)
+			for (var/datum/stain/stain in src.stains)
+				stain.remove_from_clothing(src)
 			src.stains = list()
 			src.UpdateName()
 

--- a/code/obj/item/clothing.dm
+++ b/code/obj/item/clothing.dm
@@ -37,7 +37,7 @@ ABSTRACT_TYPE(/obj/item/clothing)
 	stamina_crit_chance = 0
 
 	var/can_stain = 1
-	var/list/stains = null
+	var/list/datum/stain/stains = null
 
 	New()
 		..()
@@ -62,25 +62,41 @@ ABSTRACT_TYPE(/obj/item/clothing)
 		src.name = src.real_name || initial(src.name)
 		if(src.material?.usesSpecialNaming())
 			src.name = src.material.specialNaming(src)
-		src.name = "[name_prefix(null, 1)][src.get_stains()][src.name][name_suffix(null, 1)]"
+		src.name = "[name_prefix(null, 1)][src.get_stain_names()][src.name][name_suffix(null, 1)]"
 
-	proc/add_stain(var/stn)
+	///Add a stain to this clothing piece
+	proc/add_stain(datum/stain/stn)
+		stn = get_singleton(stn)
 		if (!stn || !src.can_stain)
 			return
 		if (!islist(src.stains))
 			src.stains = list()
 		else if (stn in src.stains)
 			return
-		src.stains += stn
+		src.stains.Add(stn)
+		stn.add_to_clothing(src)
 		src.UpdateName()
 
-	proc/get_stains()
+	///Returns a space-concatenated string of stain names
+	proc/get_stain_names()
 		if (src.can_stain && islist(src.stains) && length(src.stains))
-			for (var/i in src.stains)
-				. += i + " "
+			for (var/datum/stain/stn in src.stains)
+				. += stn.name + " "
 
+	///Removes a stain from this clothing piece. Returns 1/TRUE if stain removed.
+	proc/remove_stain(datum/stain/stain)
+		stain = get_singleton(stain)
+		if(islist(src.stains))
+			for(var/datum/stain/stn in src.stains)
+				if (stn == stain)
+					stn.remove_from_clothing(src)
+					. = src.stains.Remove(stn)
+
+	///Removes all stains from this clothing piece
 	proc/clean_stains()
 		if (islist(src.stains) && length(src.stains))
+			for (var/datum/stain/stn in src.stains)
+				stn.remove_from_clothing(src)
 			src.stains = list()
 			src.UpdateName()
 

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -125,6 +125,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\sims.dm"
 #include "code\datums\spawn_rules.dm"
 #include "code\datums\special_r.dm"
+#include "code\datums\stain.dm"
 #include "code\datums\sun.dm"
 #include "code\datums\syndicate_buylist.dm"
 #include "code\datums\teg_transform.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[internal][feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Switch clothing stains from strings to a datum singleton pattern. Freshly-laundered's cold resistance behavior has been moved to the stain itself.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More easily add behavior to clothing based on stain application. 