### PR TITLE
Hacked Mining Charges no Longer Guarantee a Nuclear Generator Meltdown

### DIFF
--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1402,7 +1402,7 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 						if (src)
 							src.boom()
 							if (target)
-								if (istype(target, /obj/machinery))
+								if (istype(target, /obj/machinery) && !istype(target, /obj/machinery/atmospherics/binary/nuclear_reactor))
 									target.ex_act(1) // Reliably blasts through doors.
 						return
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that mining charges do not enact the `ex_act(1)` they normally would if the target is a nuclear reactor. Because of the explosion, it still causes harm, but at least the reactor can be repaired.

(First explosion is slower because it had breakpoints)

https://github.com/user-attachments/assets/3d345a9d-0eca-4a21-b159-d8c7feb311f0



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Old behaviour sucked because of a combination of 2 things:
There's very little counterplay for engineers against the hit and run tactics of a wizard teleporting in or a miner breaching in.
It runins the whole round for the engineer since destroyed reactors can't be repaired.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Garash
(+)Hacked charges no longer guarantee a nuclear generator meltdown. They still make lots of radioactive rods and debris fly around though!
```
[Game Objects][Balance]
