### PR TITLE
Minor improvements to trenchmap

### DIFF
--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -43,14 +43,14 @@
 		solid = rgb(0, 0, 50),
 		station = rgb(255, 153, 58),
 		other = rgb(120, 200, 120),
-		transparant = rgb(0, 0, 0, 0))
+		transparant = null)
 	#else
 	var/list/map_colors = list(
 		empty = rgb(30, 30, 45),
 		solid = rgb(180,180,180),
 		station = rgb(27, 163, 186),
 		other = rgb(186, 0, 60),
-		transparant = rgb(0, 0, 0, 0))
+		transparant = null)
 	#endif
 
 	proc/generate_map()

--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -39,16 +39,18 @@
 
 	#ifdef UNDERWATER_MAP
 	var/list/map_colors = list(
-		empty = rgb(0, 0, 50),
-		solid = rgb(0, 0, 255),
+		empty = rgb(0, 0, 255),
+		solid = rgb(0, 0, 50),
 		station = rgb(255, 153, 58),
-		other = rgb(120, 200, 120))
+		other = rgb(120, 200, 120),
+		transparant = rgb(0, 0, 0, 0))
 	#else
 	var/list/map_colors = list(
 		empty = rgb(30, 30, 45),
 		solid = rgb(180,180,180),
 		station = rgb(27, 163, 186),
-		other = rgb(186, 0, 60))
+		other = rgb(186, 0, 60),
+		transparant = rgb(0, 0, 0, 0))
 	#endif
 
 	proc/generate_map()
@@ -56,25 +58,28 @@
 			Z_LOG_DEBUG("Mining Map", "Generating map ...")
 			map = icon('icons/misc/trenchMapEmpty.dmi', "template")
 			var/turf_color = null
+			var/size_mult = 2
 			for (var/x in 1 to world.maxx)
 				for (var/y in 1 to world.maxy)
 					var/turf/T = locate(x,y,MINING_Z)
 					if (istype(T, /turf/simulated/wall/auto/asteroid) || istype(T, /turf/simulated/floor/plating/airless/asteroid))
 						turf_color = "solid"
 					else if (istype(T, /turf/space))
-						turf_color = "empty"
+						turf_color = "transparant"
 					else
 						if (T.loc && istype(T.loc, /area/shuttle/sea_elevator) || istype(T.loc, /area/mining) || istype(T.loc, /area/prefab/sea_mining) || istype(T.loc, /area/station/solar/small_backup3))
 							turf_color = "station"
 						else
 							turf_color = "other"
 
-					map.DrawBox(map_colors[turf_color], x * 2, y * 2, x * 2 + 1, y * 2 + 1)
+					var/mx = x * size_mult - 1
+					var/my = y * size_mult - 1
+					map.DrawBox(map_colors[turf_color], mx, my, mx + 1, my + 1)
 
 			for (var/beacon in by_type[/obj/warp_beacon])
 				if (istype(beacon, /obj/warp_beacon/miningasteroidbelt))
 					var/turf/T = get_turf(beacon)
-					map.DrawBox(map_colors["station"], T.x * 2 - 2, T.y * 2 - 2, T.x * 2 + 2, T.y * 2 + 2)
+					map.DrawBox(map_colors["station"], T.x * size_mult - 3, T.y * size_mult - 3, T.x * size_mult + 2, T.y * size_mult + 2)
 
 			Z_LOG_DEBUG("Mining Map", "Map generation complete")
 			generate_map_html()
@@ -116,6 +121,7 @@
 			width: 600px;
 			overflow: hidden;
 			margin: 0 auto;
+			background-color: [map_colors["empty"]]
 		}
 		#map img {
 			position: absolute;

--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -42,15 +42,13 @@
 		empty = rgb(0, 0, 255),
 		solid = rgb(0, 0, 50),
 		station = rgb(255, 153, 58),
-		other = rgb(120, 200, 120),
-		transparant = null)
+		other = rgb(120, 200, 120))
 	#else
 	var/list/map_colors = list(
 		empty = rgb(30, 30, 45),
 		solid = rgb(180,180,180),
 		station = rgb(27, 163, 186),
-		other = rgb(186, 0, 60),
-		transparant = null)
+		other = rgb(186, 0, 60))
 	#endif
 
 	proc/generate_map()
@@ -65,7 +63,7 @@
 					if (istype(T, /turf/simulated/wall/auto/asteroid) || istype(T, /turf/simulated/floor/plating/airless/asteroid))
 						turf_color = "solid"
 					else if (istype(T, /turf/space))
-						turf_color = "transparant"
+						continue
 					else
 						if (T.loc && istype(T.loc, /area/shuttle/sea_elevator) || istype(T.loc, /area/mining) || istype(T.loc, /area/prefab/sea_mining) || istype(T.loc, /area/station/solar/small_backup3))
 							turf_color = "station"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects][bug][Code Quality]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1. Inverts Wall&Ground colors on Oshan maps
2. Fixes pixel gap on the bottom left of maps
3. Uses transparency for Space/Seafloor tiles (Filled in via css)
4. Andd I got rid of a magic number

The pixel gap
![image](https://github.com/user-attachments/assets/b70628b6-f930-44a8-a412-cae16bacd3fd)

Tested on both ocean and space maps:
![image](https://github.com/user-attachments/assets/d2dfb3e6-c6f8-424c-bd1b-cf8e9b7a4d26)
![image](https://github.com/user-attachments/assets/4cd76462-7d62-49b2-b9e4-236a1056008a)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
1. Something impassable should be darker than a passable area
2. Cuts off the right side of the map, and is annoying
3. Marginal filesize improvement, and brings it inline with goonhub images
 

