### PR TITLE
Adds a vision overlay to gas masks

### DIFF
--- a/code/modules/overlays/OverlayManager.dm
+++ b/code/modules/overlays/OverlayManager.dm
@@ -387,6 +387,16 @@
 
 		return ..()
 
+/datum/overlayComposition/gasmask
+	New()
+		var/datum/overlayDefinition/dither = new()
+		dither.d_icon = 'icons/effects/overlays/weldingmask.dmi'
+		dither.d_icon_state = "steelmask"
+		dither.d_blend_mode = 2
+		dither.d_mouse_opacity = 0
+		definitions.Add(dither)
+
+		return ..()
 
 // temporary blindness overlay until the other one is fixed
 /datum/overlayComposition/limited_sight

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -111,12 +111,25 @@
 	color_r = 0.8 // green tint
 	color_g = 1
 	color_b = 0.8
+	var/low_visibility = TRUE
 
 	setupProperties()
 		..()
 		setProperty("coldprot", 7)
 		setProperty("heatprot", 7)
 		setProperty("disorient_resist_eye", 10)
+
+	equipped(mob/user, slot)
+		. = ..()
+		if (low_visibility)
+			user.addOverlayComposition(/datum/overlayComposition/gasmask)
+			user.updateOverlaysClient(user.client)
+
+	unequipped(mob/user)
+		. = ..()
+		if (low_visibility)
+			user.removeOverlayComposition(/datum/overlayComposition/gasmask)
+			user.updateOverlaysClient(user.client)
 
 /obj/item/clothing/mask/gas/NTSO
 	name = "NT gas mask"
@@ -126,6 +139,7 @@
 	color_r = 0.8 // cool blueberry nanotrasen tint provides disorientation resist
 	color_g = 0.8
 	color_b = 1
+	low_visibility = FALSE
 
 	setupProperties()
 		..()
@@ -186,6 +200,7 @@ TYPEINFO(/obj/item/clothing/mask/moustache)
 		icon_state = "slasher_mask"
 		item_state = "slasher_mask"
 		item_function_flags = IMMUNE_TO_ACID
+		low_visibility = FALSE
 		see_face = TRUE
 		setupProperties()
 			..()
@@ -234,6 +249,7 @@ TYPEINFO(/obj/item/clothing/mask/moustache)
 		color_g = 1
 		color_b = 0.8
 		item_function_flags = IMMUNE_TO_ACID
+		low_visibility = FALSE
 
 		New()
 			START_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
@@ -411,6 +427,7 @@ TYPEINFO(/obj/item/clothing/mask/monkey_translator)
 	icon_state = "clown"
 	item_state = "clown_hat"
 	item_function_flags = IMMUNE_TO_ACID
+	low_visibility = FALSE
 	burn_possible = FALSE
 	color_r = 1
 	color_g = 1

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -235,6 +235,7 @@ TYPEINFO(/obj/item/clothing/mask/moustache)
 	color_r = 1
 	color_g = 0.8
 	color_b = 0.8
+	low_visibility = FALSE // Listening post only item seems fair to have this
 
 	New()
 		. = ..()
@@ -268,6 +269,7 @@ TYPEINFO(/obj/item/clothing/mask/moustache)
 	color_r = 0.8
 	color_g = 0.8
 	color_b = 1
+	low_visibility = TRUE // medal reward mask shouldn't be better than standard mask
 
 TYPEINFO(/obj/item/clothing/mask/gas/voice)
 	mats = 6


### PR DESCRIPTION
[LABEL][Clothing][Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a overlay to gas masks, the same size as welded sheet masks, that restricts longer range visibility when worn. This does not affect slasher masks, NTSO/NTSC or listening post/nukie masks.(please let me know if i made any mistakes in which masks to apply this to)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There have been multiple discussions related to the addition of SOME drawback to gas masks (for example this forum post https://forum.ss13.co/showthread.php?tid=23206) and more often than not the general aggreement is they could use something to balance them, since at the moment they offer lots of benefits and no drawback to wearing all the time. This would bring masks in line with other protection equipment that has added descentive not to be worn at all times such as hazard suits and space suits, and cut down on the amount of players rushing to get one at roundstart + never taking them off at any moment.

With this overlay, the mask's visibility is not impacted nearly enough to stop regular use at chemistry, nor it's emergency use to traverse smoke, but would make a case for actually taking it off when you go to the bar get a drink.

EDIT: from just doing chemistry with the mask on all the time as testing i can attest to it not really getting in the way of your actual job, everything is visible enough that i can just play as normal if i'm in science doing science stuff.

![image](https://github.com/user-attachments/assets/00793270-8f2a-42c2-b4c7-8649ca867756)

```changelog
(u)Colossus
(*) Regular station gas masks now have a visibility penalty.
```
