### PR TITLE
No eating/drinking/pills with gas masks

### DIFF
--- a/_std/defines/clothing.dm
+++ b/_std/defines/clothing.dm
@@ -67,6 +67,8 @@ var/list/all_slots = list(SLOT_BACK, SLOT_WEAR_MASK, SLOT_L_HAND, SLOT_R_HAND, S
 #define ONBACK						(1<<17)
 /// can be work on the belt
 #define ONBELT						(1<<18)
+/// stops the person from eating, drinking and swallowing pills
+#define BLOCKEATING					(1<<19)
 
 
 //Suit blood flags

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -271,7 +271,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			return 0
 		if (M == user)
 			//can this person eat this food?
-			if(M.wear_mask?.c_flags & BLOCKSMOKE) // eating with other masks is fine as QoL
+			if(M.wear_mask?.c_flags & BLOCKEATING) // eating with other masks is fine as QoL
 				boutput(M, SPAN_ALERT("You can't eat with that mask in the way!"))
 				return 0
 			if(!M.can_eat(src))
@@ -649,7 +649,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			boutput(C, SPAN_ALERT("You can't seem to chug from [src.name]! How odd."))
 			return
 
-		if(C?.wear_mask?.c_flags & BLOCKSMOKE)
+		if(C?.wear_mask?.c_flags & BLOCKEATING)
 			boutput(C, SPAN_ALERT("You can't chug with that mask in the way."))
 			return
 
@@ -707,7 +707,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			if(!target.can_drink(src))
 				boutput(target, SPAN_ALERT("You can't drink [src]!"))
 				return 0
-			if(target.wear_mask?.c_flags & BLOCKSMOKE)
+			if(target.wear_mask?.c_flags & BLOCKEATING)
 				boutput(target, SPAN_ALERT("You can't drink [src] with that mask in the way!"))
 				return 0
 			src.take_a_drink(target, user)

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -347,11 +347,6 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 		if (check_target_immunity(M))
 			user.visible_message(SPAN_ALERT("[user] tries to feed [M] [src], but fails!"), SPAN_ALERT("You try to feed [M] [src], but fail!"))
 			return 0
-		else if(H?.wear_mask.c_flags & COVERSMOUTH | BLOCKSMOKE) // eating with other masks is fine as QoL
-			user.tri_message(M, SPAN_ALERT("<b>[user]</b> tries to feed [M] [src], but [he_or_she(M)] can't eat with that mask in the way!"),\
-			SPAN_ALERT("You try to feed [M] [src], but [he_or_she(M)] can't eat with that mask in the way!"),\
-			SPAN_ALERT("<b>[user]</b> tries to feed you [src], but you can't eat with that mask in the way!"))
-			return 0
 		else if(!M.can_eat(src))
 			user.tri_message(M, SPAN_ALERT("<b>[user]</b> tries to feed [M] [src], but [he_or_she(M)] can't eat that!"),\
 				SPAN_ALERT("You try to feed [M] [src], but [he_or_she(M)] can't eat that!"),\
@@ -713,9 +708,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 				boutput(target, SPAN_ALERT("You can't drink [src]!"))
 				return 0
 			if(H?.wear_mask.c_flags & COVERSMOUTH | BLOCKSMOKE)
-				SETUP_GENERIC_PRIVATE_ACTIONBAR(user, src, 2 SECONDS, src.take_a_drink, list(target, user), src.icon, src.icon_state, NONE,
-				 INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ATTACKED)
-				return 1
+				boutput(target, SPAN_ALERT("You can't drink [src] with that mask in the way!"))
+				return 0
 			src.take_a_drink(target, user)
 			return 1
 		else

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -271,7 +271,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			return 0
 		if (M == user)
 			//can this person eat this food?
-			if(H?.wear_mask.c_flags & COVERSMOUTH | BLOCKSMOKE) // eating with other masks is fine as QoL
+			if(M.wear_mask?.c_flags & BLOCKSMOKE) // eating with other masks is fine as QoL
 				boutput(M, SPAN_ALERT("You can't eat with that mask in the way!"))
 				return 0
 			if(!M.can_eat(src))
@@ -649,7 +649,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			boutput(C, SPAN_ALERT("You can't seem to chug from [src.name]! How odd."))
 			return
 
-		if(C?.wear_mask.c_flags & COVERSMOUTH | BLOCKSMOKE)
+		if(C?.wear_mask?.c_flags & BLOCKSMOKE)
 			boutput(C, SPAN_ALERT("You can't chug with that mask in the way."))
 			return
 
@@ -707,7 +707,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			if(!target.can_drink(src))
 				boutput(target, SPAN_ALERT("You can't drink [src]!"))
 				return 0
-			if(H?.wear_mask.c_flags & COVERSMOUTH | BLOCKSMOKE)
+			if(target.wear_mask?.c_flags & BLOCKSMOKE)
 				boutput(target, SPAN_ALERT("You can't drink [src] with that mask in the way!"))
 				return 0
 			src.take_a_drink(target, user)

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -271,6 +271,9 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			return 0
 		if (M == user)
 			//can this person eat this food?
+			if(H?.wear_mask.c_flags & COVERSMOUTH | BLOCKSMOKE) // eating with other masks is fine as QoL
+				boutput(M, SPAN_ALERT("You can't eat with that mask in the way!"))
+				return 0
 			if(!M.can_eat(src))
 				boutput(M, SPAN_ALERT("You can't eat [src]!"))
 				return 0
@@ -344,9 +347,14 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 		if (check_target_immunity(M))
 			user.visible_message(SPAN_ALERT("[user] tries to feed [M] [src], but fails!"), SPAN_ALERT("You try to feed [M] [src], but fail!"))
 			return 0
+		else if(H?.wear_mask.c_flags & COVERSMOUTH | BLOCKSMOKE) // eating with other masks is fine as QoL
+			user.tri_message(M, SPAN_ALERT("<b>[user]</b> tries to feed [M] [src], but [he_or_she(M)] can't eat with that mask in the way!"),\
+			SPAN_ALERT("You try to feed [M] [src], but [he_or_she(M)] can't eat with that mask in the way!"),\
+			SPAN_ALERT("<b>[user]</b> tries to feed you [src], but you can't eat with that mask in the way!"))
+			return 0
 		else if(!M.can_eat(src))
-			user.tri_message(M, SPAN_ALERT("<b>[user]</b> tries to feed [M] [src], but they can't eat that!"),\
-				SPAN_ALERT("You try to feed [M] [src], but they can't eat that!"),\
+			user.tri_message(M, SPAN_ALERT("<b>[user]</b> tries to feed [M] [src], but [he_or_she(M)] can't eat that!"),\
+				SPAN_ALERT("You try to feed [M] [src], but [he_or_she(M)] can't eat that!"),\
 				SPAN_ALERT("<b>[user]</b> tries to feed you [src], but you can't eat that!"))
 			return 0
 		else
@@ -645,6 +653,11 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 		if(!can_chug)
 			boutput(C, SPAN_ALERT("You can't seem to chug from [src.name]! How odd."))
 			return
+
+		if(C?.wear_mask.c_flags & COVERSMOUTH | BLOCKSMOKE)
+			boutput(C, SPAN_ALERT("You can't chug with that mask in the way."))
+			return
+
 		if(C.bioHolder)
 			maybe_too_clumsy = C.bioHolder.HasEffect("clumsy") && prob(50)
 		if(C.reagents.reagent_list["ethanol"])
@@ -699,6 +712,10 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			if(!target.can_drink(src))
 				boutput(target, SPAN_ALERT("You can't drink [src]!"))
 				return 0
+			if(H?.wear_mask.c_flags & COVERSMOUTH | BLOCKSMOKE)
+				SETUP_GENERIC_PRIVATE_ACTIONBAR(user, src, 2 SECONDS, src.take_a_drink, list(target, user), src.icon, src.icon_state, NONE,
+				 INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ATTACKED)
+				return 1
 			src.take_a_drink(target, user)
 			return 1
 		else
@@ -708,8 +725,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 				user.visible_message(SPAN_ALERT("[user] attempts to force [target] to drink from [src], but fails!."), SPAN_ALERT("You try to force [target] to drink [src], but fail!"))
 				return 0
 			else if(!target.can_drink(src))
-				user.tri_message(target, SPAN_ALERT("<b>[user]</b> tries to make [target] drink [src], but they can't drink that!"),\
-					SPAN_ALERT("You try to make [target] drink [src], but they can't drink that!"),\
+				user.tri_message(target, SPAN_ALERT("<b>[user]</b> tries to make [target] drink [src], but [he_or_she(target)] can't drink that!"),\
+					SPAN_ALERT("You try to make [target] drink [src], but [he_or_she(target)] can't drink that!"),\
 					SPAN_ALERT("<b>[user]</b> tries to give you a drink of [src], but you can't drink that!"))
 				return 0
 			if (!src.reagents || !src.reagents.total_volume)

--- a/code/modules/chemistry/tools/pills.dm
+++ b/code/modules/chemistry/tools/pills.dm
@@ -100,6 +100,9 @@
 	proc/pill_action(mob/user, mob/target)
 		if (iscarbon(target) || ismobcritter(target))
 			if (target == user)
+				if(C?.wear_mask.c_flags & COVERSMOUTH | BLOCKSMOKE)
+					boutput(C, SPAN_ALERT("You can't swallow [src] with that mask in the way."))
+					return
 				user.visible_message("[user] swallows [src].",\
 				SPAN_NOTICE("You swallow [src]."))
 			else if(check_target_immunity(target))

--- a/code/modules/chemistry/tools/pills.dm
+++ b/code/modules/chemistry/tools/pills.dm
@@ -100,8 +100,8 @@
 	proc/pill_action(mob/user, mob/target)
 		if (iscarbon(target) || ismobcritter(target))
 			if (target == user)
-				if(C?.wear_mask.c_flags & COVERSMOUTH | BLOCKSMOKE)
-					boutput(C, SPAN_ALERT("You can't swallow [src] with that mask in the way."))
+				if(target.wear_mask?.c_flags & BLOCKSMOKE)
+					boutput(target, SPAN_ALERT("You can't swallow [src] with that mask in the way."))
 					return
 				user.visible_message("[user] swallows [src].",\
 				SPAN_NOTICE("You swallow [src]."))

--- a/code/modules/chemistry/tools/pills.dm
+++ b/code/modules/chemistry/tools/pills.dm
@@ -100,7 +100,7 @@
 	proc/pill_action(mob/user, mob/target)
 		if (iscarbon(target) || ismobcritter(target))
 			if (target == user)
-				if(target.wear_mask?.c_flags & BLOCKSMOKE)
+				if(target.wear_mask?.c_flags & BLOCKEATING)
 					boutput(target, SPAN_ALERT("You can't swallow [src] with that mask in the way."))
 					return
 				user.visible_message("[user] swallows [src].",\

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -104,7 +104,7 @@
 	name = "gas mask"
 	desc = "A close-fitting mask that can filter some environmental toxins or be connected to an air supply."
 	icon_state = "gas_mask"
-	c_flags =  COVERSMOUTH | COVERSEYES | MASKINTERNALS | BLOCKSMOKE
+	c_flags =  COVERSMOUTH | COVERSEYES | MASKINTERNALS | BLOCKSMOKE | BLOCKEATING
 	w_class = W_CLASS_NORMAL
 	see_face = FALSE
 	item_state = "gas_mask"
@@ -227,13 +227,14 @@ TYPEINFO(/obj/item/clothing/mask/moustache)
 
 	syndicate
 		name = "syndicate field protective mask"
-		desc = "A tight-fitting mask designed to protect syndicate operatives from all manner of toxic inhalants. Has a built-in voice changer."
+		desc = "A tight-fitting mask designed to protect syndicate operatives from all manner of toxic inhalants while still allowing the user to eat. Has a built-in voice changer."
 		icon_state = "gas_mask_syndicate"
 		item_state = "gas_mask_syndicate"
 		color_r = 0.8 //this one's also green
 		color_g = 1
 		color_b = 0.8
 		item_function_flags = IMMUNE_TO_ACID
+		c_flags =  COVERSMOUTH | COVERSEYES | MASKINTERNALS | BLOCKSMOKE // doesn't prevent eating
 
 		New()
 			START_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects][Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents eating, drinking and swallowing pills while wearing a gas mask.
Does not apply to nukie masks
Does not prevent others from force feeding you as that is arguably a buff.

oh also adds pronouns to some messages near the changes
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's mostly to make some reason not to wear one, even if a quite small one.
Should make people take off the gas mask sometimes, at least on rp.
Needing an extra hand to take a pill might do something on classic.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Valtsu0
(+) You can no longer eat, drink or swallow pills while wearing a non-syndicate gas mask
```
