### PR TITLE
Split every access from I WANNA BE THE JOB

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -44,6 +44,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //////--- CONVENIENCE OPTIONS FOR TESTING ETC ---//
 //#define DISABLE_DEVFILE // Don't load things defined in '__local.development.dm'. Use if you have some breaking changes in there or whatnot
 //#define DEBUG_EVERYONE_GETS_CAPTAIN_ID // all IDs are captain rank, kept separate from below options to avoid disrupting access-related tests
+//#define I_MEAN_ALL_ACCESS // Captain level ID's have EVERY access
 //#define NO_COOLDOWNS // disables all /datum/targetable cooldowns
 //#define BONUS_POINTS // gives a bunch of starting points to various abilities/uplinks/weapon vendors
 //#define SHUT_UP_AND_GIVE_ME_MEDAL_STUFF // causes has_medal to always return true - good for testing medal rewards etc.

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -200,11 +200,7 @@
 	switch(job)
 		// --------------------------- Heads of staff
 		if("Captain")
-#if defined(I_WANNA_BE_THE_JOB)
-			return access_all_actually
-#else
 			return get_all_accesses()
-#endif
 		if("Head of Personnel")
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_forensics_lockers,
 						access_tox, access_tox_storage, access_chemistry, access_medical, access_medlab,
@@ -347,6 +343,9 @@
 			return list()
 
 /proc/get_all_accesses()  // not adding the special stuff to this
+#if defined(I_MEAN_ALL_ACCESS)
+			return access_all_actually
+#else
 	return list(access_security, access_brig, access_forensics_lockers,
 				access_medical, access_medlab, access_morgue, access_securitylockers,
 				access_tox, access_tox_storage, access_chemistry, access_carrypermit, access_contrabandpermit,
@@ -360,6 +359,7 @@
 				access_engineering_control, access_engineering_mechanic, access_engineering_chief, access_mining, access_mining_outpost,
 				access_research, access_research_director, access_dwaine_superuser, access_engineering_atmos, access_medical_director, access_special_club,
 				access_researchfoyer, access_telesci, access_artlab, access_robotdepot, access_money)
+#endif
 
 /proc/syndicate_spec_ops_access() //syndie spec ops need to get out of the listening post.
 	return list(access_security, access_brig, access_forensics_lockers,

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -344,7 +344,7 @@
 
 /proc/get_all_accesses()  // not adding the special stuff to this
 #if defined(I_MEAN_ALL_ACCESS)
-			return access_all_actually
+	return access_all_actually
 #else
 	return list(access_security, access_brig, access_forensics_lockers,
 				access_medical, access_medlab, access_morgue, access_securitylockers,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Splits captain access returning real all access from I_WANNA_BE_THE_JOB into its own define of I_MEAN_ALL_ACCESS


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sometimes you wanna be the job captain without every access, though it could be on EVERYONE_GETS_CAPTAIN_ID which would be perfectly reasonable