### PR TITLE
fixes cyber-kidneys being un-emaggable through damage

### DIFF
--- a/code/obj/item/organs/kidney.dm
+++ b/code/obj/item/organs/kidney.dm
@@ -97,6 +97,7 @@ TYPEINFO(/obj/item/organ/kidney/cyber)
 	desc = "A fancy robotic kidney to replace one that someone's lost!"
 	icon_state = "cyber-kidney-L"
 	// item_state = "heart_robo1"
+	organ_name = "cyber_kidney"
 	default_material = "pharosium"
 	robotic = 1
 	created_decal = /obj/decal/cleanable/oil


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

not sure how long this has been broken, but cyber kidneys have the same organ_name as flesh kidneys currently and can't be damage emagged because of it (since the global variable that handles organ damage looks for cyber_kidney)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

idk seems like it would be a cool feature to fix

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)gus
(+)cyberkidneys can be emagged through damage again
```
