### PR TITLE
give cog1 bar a sink

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -57629,6 +57629,13 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/routing/sortingRoom)
+"slD" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 4;
+	pixel_x = -4
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/bar)
 "slQ" = (
 /obj/machinery/firealarm/west,
 /obj/machinery/light{
@@ -114483,7 +114490,7 @@ erD
 auO
 ask
 ayR
-asl
+slD
 asl
 aBU
 mQx


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

let that sink in
![image](https://github.com/user-attachments/assets/017ecb94-1996-45a5-9496-d3d1fea20f6c)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

bars typically have a sink in them, for all bartender's water needs. cog 1 lost theirs at some point, so have it back

