### PR TITLE
Prevent shooting guns at null target

### DIFF
--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -363,6 +363,13 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	if (isghostdrone(user))
 		user.show_text("<span class='combat bold'>Your internal law subroutines kick in and prevent you from using [src]!</span>")
 		return FALSE
+
+	if(!isturf(target))
+		target = get_turf(target)
+
+	if(isnull(target))
+		return FALSE
+
 	if (!canshoot(user))
 		if (ismob(user) && src.click_sound)
 			user.show_text(src.click_msg, "red") // No more attack messages for empty guns (Convair880).
@@ -375,9 +382,6 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 		return FALSE
 	if (!istype(src.current_projectile,/datum/projectile/))
 		return FALSE
-
-	if(!isturf(target))
-		target = get_turf(target)
 
 	if (src.muzzle_flash)
 		if (isturf(user.loc))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a null target check to gun_parent to prevent shooting if we have a null target. Moves the isturf check up higher to also catch this if it ever returns null.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Shooting at null doesn't do anything but still causes the gun to use ammo and runtime.
Specifically we error on shooting at /obj/jobxprewardbutton. 