### PR TITLE
Fix pills not correctly tipping onto the floor

### DIFF
--- a/code/obj/item/chem_pill_bottle.dm
+++ b/code/obj/item/chem_pill_bottle.dm
@@ -99,10 +99,11 @@
 
 	proc/tip_out(var/mob/user as mob, atom/location, var/skip_messages = FALSE)
 		var/obj/item/reagent_containers/pill/P = src.create_pill()
+		if (!istype(location, /turf)) location = location.loc
 		if (istype(P))
 			var/i = rand(3,8)
 			while(istype(P) && i > 0)
-				P.set_loc(location.loc)
+				P.set_loc(location)
 				P = src.create_pill()
 				i--
 			if (!skip_messages)

--- a/code/obj/item/chem_pill_bottle.dm
+++ b/code/obj/item/chem_pill_bottle.dm
@@ -99,7 +99,6 @@
 
 	proc/tip_out(var/mob/user as mob, atom/location, var/skip_messages = FALSE)
 		var/obj/item/reagent_containers/pill/P = src.create_pill()
-		if (!istype(location, /turf)) location = location.loc
 		if (istype(P))
 			var/i = rand(3,8)
 			while(istype(P) && i > 0)

--- a/code/obj/item/chem_pill_bottle.dm
+++ b/code/obj/item/chem_pill_bottle.dm
@@ -103,7 +103,7 @@
 		if (istype(P))
 			var/i = rand(3,8)
 			while(istype(P) && i > 0)
-				P.set_loc(location)
+				P.set_loc(get_turf(location))
 				P = src.create_pill()
 				i--
 			if (!skip_messages)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label [bug][game objects]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Pills from Chemaster pill bottles will correctly fall to the floor when tipped out.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I made a mistake with #20872 and pills were being sent to the aether instead of the turf when tipped out.

fixes #21109