### PR TITLE
Lethal .38 obtainability rebalance

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1499,12 +1499,11 @@ TYPEINFO(/obj/machinery/vending/medical)
 		product_list += new/datum/data/vending_product(/obj/item/clothing/head/helmet/hardhat/security, 4)
 		product_list += new/datum/data/vending_product(/obj/item/device/pda2/security, 2)
 		product_list += new/datum/data/vending_product(/obj/item/sec_tape/vended, 3)
-		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38/stun, 2)
+		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38/stun, 3)
 		product_list += new/datum/data/vending_product(/obj/item/implantcase/counterrev, 3)
 		product_list += new/datum/data/vending_product(/obj/item/implanter, 1)
 		product_list += new/datum/data/vending_product(/obj/item/paper/book/from_file/space_law, 3)
 		product_list += new/datum/data/vending_product(/obj/item/device/flash/turbo, rand(1, 6), hidden=1)
-		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38, rand(1, 2), hidden=1) // Obtaining a backpack full of lethal ammo required no effort whatsoever, hence why nobody ordered AP speedloaders from the Syndicate (Convair880).
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/snacks/donut, rand(2, 4), hidden=1) // emergency snack
 
 /obj/machinery/vending/security_ammo //shitsec time yes
@@ -1523,7 +1522,7 @@ TYPEINFO(/obj/machinery/vending/medical)
 	create_products(restocked)
 		..()
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/abg, 6)
-		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38, 2)
+		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38, 6)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38/stun, 3)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/nine_mm_NATO,3)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/flare, 3)

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -57,7 +57,7 @@
 	desc = "A box containing a .38 caliber revolver and ammunition."
 	// Reduced the amount of ammo. The detective had four lethal and five stun speedloaders total in his closet, perhaps a bit too much (Convair880).
 	spawn_contents = list(/obj/item/gun/kinetic/detectiverevolver,\
-	/obj/item/ammo/bullets/a38 = 3,\
+	/obj/item/ammo/bullets/a38 = 2,\
 	/obj/item/ammo/bullets/a38/stun = 2)
 
 /obj/item/storage/box/akm // cogwerks, terrorism update
@@ -106,8 +106,7 @@
 	name = ".38 AP ammo box"
 	icon_state = "revolver"
 	desc = "A box containing a couple of AP speedloaders for a .38 Special revolver."
-	spawn_contents = list(/obj/item/ammo/bullets/a38/AP = 3,\
-	/obj/item/ammo/bullets/a38 = 2)
+	spawn_contents = list(/obj/item/ammo/bullets/a38/AP = 3)
 
 /obj/item/storage/box/flaregun // For surplus crates (Convair880).
 	name = "flare gun box"

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -57,7 +57,7 @@
 	desc = "A box containing a .38 caliber revolver and ammunition."
 	// Reduced the amount of ammo. The detective had four lethal and five stun speedloaders total in his closet, perhaps a bit too much (Convair880).
 	spawn_contents = list(/obj/item/gun/kinetic/detectiverevolver,\
-	/obj/item/ammo/bullets/a38 = 2,\
+	/obj/item/ammo/bullets/a38 = 3,\
 	/obj/item/ammo/bullets/a38/stun = 2)
 
 /obj/item/storage/box/akm // cogwerks, terrorism update
@@ -106,7 +106,8 @@
 	name = ".38 AP ammo box"
 	icon_state = "revolver"
 	desc = "A box containing a couple of AP speedloaders for a .38 Special revolver."
-	spawn_contents = list(/obj/item/ammo/bullets/a38/AP = 3)
+	spawn_contents = list(/obj/item/ammo/bullets/a38/AP = 3,\
+	/obj/item/ammo/bullets/a357 = 2)
 
 /obj/item/storage/box/flaregun // For surplus crates (Convair880).
 	name = "flare gun box"

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -107,7 +107,7 @@
 	icon_state = "revolver"
 	desc = "A box containing a couple of AP speedloaders for a .38 Special revolver."
 	spawn_contents = list(/obj/item/ammo/bullets/a38/AP = 3,\
-	/obj/item/ammo/bullets/a357 = 2)
+	/obj/item/ammo/bullets/a38 = 2)
 
 /obj/item/storage/box/flaregun // For surplus crates (Convair880).
 	name = "flare gun box"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes lethal .38 ammo from sectechs
Increases .38 lethal ammo in ammotech from 2->6
Increases .38 stun ammo in sectech from 2->3

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I often see detectives (on classic at least) just play it like a secoff with lethals, and with them being able to print infinite lethal ammo at sectechs by restocking them this allows them to lethal without needing to think about it. This aims to force detectives to think more carefully about using the 3 lethal rounds they can obtain without Armory, down from the map dependent approximately 5-6 without cargo restock cartridges.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*) Lethal .38 rounds removed from sectechs. Increased lethal .38 rounds in armory. Increased stun .38 rounds in sectechs.
```
