### PR TITLE
Fix barbed wire affecting ghosts

### DIFF
--- a/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
+++ b/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
@@ -858,13 +858,16 @@ ABSTRACT_TYPE(/obj/deployable_turret/pod_wars)
 			target.TakeDamageAccountArmor("All", rand(1,2), 0, 0, DAMAGE_CUT)
 
 	Crossed(atom/movable/mover)
+		. = ..()
+		// This change prevents ghosts from being affected by barbed wire
+		if (HAS_ATOM_PROPERTY(mover, PROP_ATOM_FLOATING))
+			return
 		if(ismob(mover))
 			var/mob/M = mover
 			if(M.m_intent != "walk")
 				pokey(M, 98)
 			else
 				pokey(M, 30)
-		. = ..()
 
 //barricade deployer
 


### PR DESCRIPTION
Fixes #21106

Modify the `Crossed` proc for `/obj/barricade/barbed/wire` to prevent ghosts from being affected by barbed wire.

* Adds a check to see if the `mover` has the `PROP_ATOM_FLOATING` property and return if true


made this using AI lol https://copilot-workspace.githubnext.com/goonstation/goonstation/issues/21106?shareId=1805e7cb-9d70-4752-a816-7b366d0a29d6
i had to manually do the ..() crap but i don't expect ai to get that