### PR TITLE
Fixes unintentional misplaced tile in Donut2 Kitchen

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -43391,7 +43391,7 @@
 	icon_state = "line1"
 	},
 /obj/mapping_helper/access/bar,
-/turf/simulated/floor/marble/black,
+/turf/simulated/bar,
 /area/station/crew_quarters/catering)
 "ssc" = (
 /obj/cable{


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
A tile under the door between the Cafeteria and the shared Kitchen backroom had the wrong style. This PR fixes that single tile.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It looks stupid like it is now, and I know it wasn't intentional because I was the one that placed it there.