### PR TITLE
Fixes pufferfish bag pricking

### DIFF
--- a/code/modules/fishing/fish.dm
+++ b/code/modules/fishing/fish.dm
@@ -307,10 +307,11 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/fish)
 			var/mob/living/carbon/human/H = src.loc
 			if (src.spikes_protected(H))
 				return
-			boutput(H, SPAN_ALERT("YOWCH! You prick yourself on [src]'s spikes! Maybe you should've used gloves..."))
-			random_brute_damage(H, 3)
-			H.setStatusMin("stunned", 2 SECONDS)
-			take_bleeding_damage(H, null, 3, DAMAGE_STAB)
+			if (H.l_hand == src || H.r_hand == src)
+				boutput(H, SPAN_ALERT("YOWCH! You prick yourself on [src]'s spikes! Maybe you should've used gloves..."))
+				random_brute_damage(H, 3)
+				H.setStatusMin("stunned", 2 SECONDS)
+				take_bleeding_damage(H, null, 3, DAMAGE_STAB)
 
 	make_reagents()
 		..() //it still contains fish oil


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #21105 by having the fish check if it's in hands, rather than just in the mob, before pricking the poor sod.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
idk. bugfixes and shit.
