### PR TITLE
Fixes Shitty Grill typo

### DIFF
--- a/code/obj/machinery/shitty_grill.dm
+++ b/code/obj/machinery/shitty_grill.dm
@@ -166,7 +166,7 @@ TYPEINFO(/obj/machinery/shitty_grill)
 		if (!src.grillitem)
 			on = !on
 			cooktime = 0
-			boutput(user, SPAN_ALERT("You [on ? "light" : "turn off"] the [src] ."))
+			boutput(user, SPAN_ALERT("You [on ? "light" : "turn off"] the [src]."))
 			if (on)
 				icon_state = "shittygrill_on"
 				light.enable()


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When lighting the grill, the message would say "You light the shitty grill ." I'm getting rid of the space between "grill" and "."