### PR TITLE
Improves descriptions for 3 hats

### DIFF
--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -479,19 +479,19 @@ proc/filter_trait_hats(var/type)
 
 /obj/item/clothing/head/powdered_wig
 	name = "powdered wig"
-	desc = "A powdered wig"
+	desc = "A judicial-looking wig, covered with a starchy powder to reflect the inner stiffness of those who wear it. Or to make it white."
 	icon_state = "pwig"
 	item_state = "pwig"
 
 /obj/item/clothing/head/that
 	name = "hat"
-	desc = "An stylish looking hat"
+	desc = "A stylish, flat-topped hat often worn as formalwear. Rumored to inhibit lying in those that wear it."
 	icon_state = "tophat"
 	item_state = "that"
 
 /obj/item/clothing/head/that/purple
 	name = "purple hat"
-	desc = "A purple tophat."
+	desc = "A stylish, flat-topped hat often worn as formalwear. This one is a daring shade of purple."
 	icon_state = "ptophat"
 	item_state = "pthat"
 	protective_temperature = 500


### PR DESCRIPTION
## About the PR
Expands the descriptions of the black & purple top hats, as well as the powdered wig, to include a little more detail, as well as -- gasp -- punctuation.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #21057. Lack of punctuation at the end of descriptions can be funny, but it just looked sloppy here.