### PR TITLE
Add admin save art build mode

### DIFF
--- a/code/modules/admin/buildmodes/save_art.dm
+++ b/code/modules/admin/buildmodes/save_art.dm
@@ -1,0 +1,40 @@
+/datum/buildmode/save_art
+	name = "Save Art"
+	desc = {"***********************************************************<br>
+Left Mouse Button      = Mark corners of area with two clicks<br>
+Right Mouse Button     = Cancel the first corner<br>
+***********************************************************"}
+	icon_state = "buildmode5"
+	var/turf/A = null
+
+	click_left(atom/object, var/ctrl, var/alt, var/shift)
+		if (!A)
+			A = get_turf(object)
+			boutput(usr, SPAN_NOTICE("Corner set!"))
+			blink(A)
+		else
+			var/turf/B = get_turf(object)
+			blink(B)
+			if (!B || A.z != B.z)
+				boutput(usr, SPAN_ALERT("Corners must be on the same Z-level!"))
+				return
+			var/x_size = (abs(A.x - B.x) + 1)
+			var/y_size = (abs(A.y - B.y) + 1)
+			if(alert("Are you sure you want to save the art in an area of size [x_size]x[y_size]?",,"Yes","No") != "Yes")
+				boutput(usr, SPAN_ALERT("Saving cancelled!"))
+				A = null
+				return
+			var/icon/I = icon('icons/misc/flatBlank.dmi')
+			I.Crop(1, 1, x_size * world.icon_size, y_size * world.icon_size)
+			for (var/turf/T in block(A, B))
+				var/x_offset = (T.x - min(A.x, B.x)) * world.icon_size
+				var/y_offset = (T.y - min(A.y, B.y)) * world.icon_size
+				for (var/obj/decal/cleanable/writing/W in T.contents)
+					I.Blend(getFlatIcon(W), ICON_OVERLAY, x= x_offset + W.pixel_x, y= y_offset + W.pixel_y)
+			usr.client << ftp(I, "art_save_[world.timeofday].png")
+			boutput(usr, SPAN_NOTICE("Art saved."))
+			A = null
+
+	click_right(atom/object, var/ctrl, var/alt, var/shift)
+		A = null
+		boutput(usr, SPAN_NOTICE("Corner cancelled!"))

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -669,6 +669,7 @@
 #include "code\modules\admin\buildmodes\projectile.dm"
 #include "code\modules\admin\buildmodes\reagents.dm"
 #include "code\modules\admin\buildmodes\revert_turf_visuals.dm"
+#include "code\modules\admin\buildmodes\save_art.dm"
 #include "code\modules\admin\buildmodes\save_map.dm"
 #include "code\modules\admin\buildmodes\spawn_gift.dm"
 #include "code\modules\admin\buildmodes\spawn_inside.dm"

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)mon oct 21 24
+(u)Flourish
+(*)Added a save art build mode for saving floor art. It specifically looks for /obj/decal/cleanable/writing. Please report any issues, ty.
 (t)mon oct 07 24
 (u)Sovexe
 (*)Added a new build mode tool Visual Mirror Setup to aid in the setup of adhoc visual mirror zones for advanced gimmicks. Use with care.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds a save art build mode for saving floor art. It specifically looks for `/obj/decal/cleanable/writing` and then saves to a png. I'm making this a PR mostly cuz I haven't coded in a long time and would like another person to review it and make sure I'm not accidentally doing something terrible with icons and overlays and stuff. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

People make lots of super cool floor art and it'd be nice for admins to be able to save it. Maybe in the future we could also integrate this with MedAss and the Discord #art channel? 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

Admin changelog only.
