### PR TITLE
Eject contents of recharger when it loses power

### DIFF
--- a/code/obj/machinery/recharger.dm
+++ b/code/obj/machinery/recharger.dm
@@ -165,6 +165,7 @@ TYPEINFO(/obj/machinery/recharger)
 /obj/machinery/recharger/process(mult)
 	if(status & NOPOWER)
 		src.icon_state = sprite_empty
+		src.remove_charging()
 		UpdateIcon()
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game-objects][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When the recharger has no power, eject its contents.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The icon for rechargers visually open up when the power goes off, but it can still have a recharging object inside. It kind of looks like your recharging item just disappears, and when the power comes back on it doesn't necessarily fix itself. This makes the state in sync with the current visuals.