### PR TITLE
AI players receive atmos alerts

### DIFF
--- a/code/obj/machinery/alarm.dm
+++ b/code/obj/machinery/alarm.dm
@@ -23,6 +23,7 @@
 	/// keeps track of last alarm status
 	var/last_safe = ALARM_NOPOWER
 	var/datum/gas_mixture/environment
+	var/alertingAI = FALSE // Does this alarm currently have an AI alarm active
 
 	/// this is a list of safe & good partial pressures of each gas. If all gasses are in the good range, the alarm will show green. If any gas is outside the safe range, the alarm will show alert. Otherwise caution.
 	/// most of these values are taken from lung.dm
@@ -157,6 +158,18 @@
 	light_ov.plane = PLANE_SELFILLUM
 	src.UpdateOverlays(light_ov, "light")
 
+	var/list/cameras = list()
+	for_by_tcl(C, /obj/machinery/camera)
+		if(get_area(C) == get_area(src))
+			cameras += C
+
+	for_by_tcl(aiPlayer, /mob/living/silicon/ai)
+		if ((safe == ALARM_GOOD) && src.alertingAI)
+			aiPlayer.cancelAlarm("Atmosphere", get_area(src), src)
+			src.alertingAI = FALSE
+		else
+			aiPlayer.triggerAlarm("Atmosphere", get_area(src), cameras, src)
+			src.alertingAI = TRUE
 
 	if(alarm_frequency)
 		post_alert(safe)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
While not a "good" level atmosphere, air alarms will send an alarm to AI units.

2 minor known issues:
- Air alarms only seem to start processing status a few seconds after spawning, meaning all new alarms built/initialized will send an alert to the AI that is cleared when it catches up a few seconds later, though there shouldnt be any AIs to receive these messages before the map air alarms initialize.
- ![image](https://github.com/user-attachments/assets/236f3ce5-d4b3-411f-a0b4-8b5495443864) all the AI trigger alarm code uses single or double letter vars and I can't be bothered spending the time right now to figure out what is causing this or if its just aa dev zone thing.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes air alarms more useful, the more useful they are the more we will realise where they are missing.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)AIs now receive atmospheric alerts from air alarms.
```
