### PR TITLE
Add bullet interactions for barricades

### DIFF
--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -1,5 +1,6 @@
 obj/structure
 	icon = 'icons/obj/structures.dmi'
+	var/projectile_passthrough_chance = 0
 
 	girder
 		icon_state = "girder"
@@ -7,7 +8,7 @@ obj/structure
 		density = 1
 		material_amt = 0.2
 		var/state = 0
-		var/projectile_passthrough_chance = 50
+		projectile_passthrough_chance = 50
 		desc = "A metal support for an incomplete wall."
 		HELP_MESSAGE_OVERRIDE({"
 			You can use a <b>crowbar</b> to displace it,
@@ -348,6 +349,7 @@ TYPEINFO(/obj/structure/woodwall)
 	density = 1
 	opacity = 1
 	material_amt = 0.5
+	projectile_passthrough_chance = 30
 	var/health = 30
 	var/health_max = 30
 	var/builtby = null
@@ -370,14 +372,18 @@ TYPEINFO(/obj/structure/woodwall)
 			qdel(src)
 			return
 		else if (src.health <= 5)
+			src.projectile_passthrough_chance = 90
 			icon_state = "woodwall4"
 			set_opacity(0)
 		else if (src.health <= 10)
 			icon_state = "woodwall3"
+			src.projectile_passthrough_chance = 70
 			set_opacity(0)
 		else if (src.health <= 20)
+			src.projectile_passthrough_chance = 50
 			icon_state = "woodwall2"
 		else
+			src.projectile_passthrough_chance = 30
 			icon_state = "woodwall"
 
 	attack_hand(mob/user)
@@ -421,6 +427,33 @@ TYPEINFO(/obj/structure/woodwall)
 		src.health -= W.force
 		checkhealth()
 		return
+
+/obj/structure/woodwall/Cross(obj/projectile/mover)
+	if (istype(mover) && !mover.proj_data.always_hits_structures && prob(src.projectile_passthrough_chance))
+		src.checkhealth()
+		return TRUE
+	return (!density)
+
+/obj/structure/woodwall/bullet_act(var/obj/projectile/P)
+	var/damage = 0
+	if (!P || !istype(P.proj_data,/datum/projectile/))
+		return
+	damage = round((P.power*P.proj_data.ks_ratio), 1.0)
+	if (damage < 1)
+		return
+
+	src.material_trigger_on_bullet(src, P)
+
+	switch(P.proj_data.damage_type)
+		if(D_KINETIC)
+			src.health -= (round(damage * 1.5))
+		if(D_PIERCING)
+			src.health -= (damage * 2)
+		if(D_ENERGY)
+			src.health -= damage
+		if(D_BURNING)
+			src.health -= damage
+	return
 
 /datum/action/bar/icon/wood_repair_wall
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Balance] [Game Objects]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Defines `bullet_act` and `Cross` for `obj/structure/woodwall`, as well as adding `var/projectile_passthrough_chance = 0` to all structures, and setting it to a default 30 for barricades.

Also adjusts `projectile_passthrough_chance` on barricades depending on how damaged they are.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wood is not particularly good at stopping bullets, and I think the idea of being able to shoot through wooden walls is kind of neat and sort of an action movie classic. Also I felt like it'd be make sense for these to be damaged by projectiles in general.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(+)Wooden barricades no longer always stop kinetic bullets, and can also be shot down.
```
