### PR TITLE
Lower amount it takes to uncuff with weak cuffs

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -886,10 +886,7 @@
 
 	onStart()
 		..()
-		if(owner != null && ishuman(owner) && owner.hasStatus("handcuffed"))
-			var/mob/living/carbon/human/H = owner
-			duration = round(duration * src.cuffs.remove_self_multiplier)
-
+		duration = round(duration * src.cuffs.remove_self_multiplier)
 		owner.visible_message(SPAN_ALERT("<B>[owner] attempts to remove the handcuffs!</B>"))
 
 	onUpdate()

--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -747,7 +747,7 @@
 						target.internal.add_fingerprint(owner)
 
 /datum/action/bar/icon/handcuffSet //This is used when you try to handcuff someone.
-	duration = 40
+	duration = 4 SECONDS
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "handcuff"
@@ -821,7 +821,7 @@
 			O.show_message(SPAN_ALERT("<B>[owner] handcuffs [target]!</B>"), 1)
 
 /datum/action/bar/icon/handcuffRemovalOther //This is used when you try to remove someone elses handcuffs.
-	duration = 70
+	duration = 7 SECONDS
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "handcuff"
@@ -871,22 +871,21 @@
 			logTheThing(LOG_COMBAT, owner, "removes [constructTarget(target,"combat")]'s handcuffs at [log_loc(owner)].")
 
 /datum/action/bar/private/icon/handcuffRemoval //This is used when you try to resist out of handcuffs.
-	duration = 600
+	duration = 60 SECONDS
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "handcuff"
-	var/obj/item/handcuffs/cuffs
 
-	New(var/dur, var/Cuffs)
+	New(var/dur)
 		duration = dur
-		src.cuffs = Cuffs
-		if (src.cuffs.strength < 2) // weak cuffs are easier to remove
-			REMOVE_FLAG(src.interrupt_flags, INTERRUPT_MOVE)
 		..()
 
 	onStart()
 		..()
-		duration = round(duration * src.cuffs.remove_self_multiplier)
+		if(owner != null && ishuman(owner) && owner.hasStatus("handcuffed"))
+			var/mob/living/carbon/human/H = owner
+			duration = round(duration * H.handcuffs.remove_self_multiplier)
+
 		owner.visible_message(SPAN_ALERT("<B>[owner] attempts to remove the handcuffs!</B>"))
 
 	onUpdate()
@@ -905,7 +904,7 @@
 		..()
 		if(owner != null && ishuman(owner) && owner.hasStatus("handcuffed"))
 			var/mob/living/carbon/human/H = owner
-			src.cuffs.drop_handcuffs(H)
+			H.handcuffs.drop_handcuffs(H)
 			H.visible_message(SPAN_ALERT("<B>[H] attempts to remove the handcuffs!</B>"))
 			boutput(H, SPAN_NOTICE("You successfully remove your handcuffs."))
 			logTheThing(LOG_COMBAT, H, "removes their own handcuffs at [log_loc(H)].")

--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -875,16 +875,20 @@
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "handcuff"
+	var/obj/item/handcuffs/cuffs
 
-	New(var/dur)
+	New(var/dur, var/Cuffs)
 		duration = dur
+		src.cuffs = Cuffs
+		if (src.cuffs.strength < 2) // weak cuffs are easier to remove
+			REMOVE_FLAG(src.interrupt_flags, INTERRUPT_MOVE)
 		..()
 
 	onStart()
 		..()
 		if(owner != null && ishuman(owner) && owner.hasStatus("handcuffed"))
 			var/mob/living/carbon/human/H = owner
-			duration = round(duration * H.handcuffs.remove_self_multiplier)
+			duration = round(duration * src.cuffs.remove_self_multiplier)
 
 		owner.visible_message(SPAN_ALERT("<B>[owner] attempts to remove the handcuffs!</B>"))
 
@@ -904,7 +908,7 @@
 		..()
 		if(owner != null && ishuman(owner) && owner.hasStatus("handcuffed"))
 			var/mob/living/carbon/human/H = owner
-			H.handcuffs.drop_handcuffs(H)
+			src.cuffs.drop_handcuffs(H)
 			H.visible_message(SPAN_ALERT("<B>[H] attempts to remove the handcuffs!</B>"))
 			boutput(H, SPAN_NOTICE("You successfully remove your handcuffs."))
 			logTheThing(LOG_COMBAT, H, "removes their own handcuffs at [log_loc(H)].")

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2538,7 +2538,7 @@
 				calcTime *= 1.5
 			boutput(src, SPAN_ALERT("You attempt to remove your handcuffs. (This will take around [round(calcTime / 10)] seconds and you need to stand still)"))
 			src.handcuffs.material_trigger_when_attacked(src, src, 1)
-			actions.start(new/datum/action/bar/private/icon/handcuffRemoval(calcTime), src)
+			actions.start(new/datum/action/bar/private/icon/handcuffRemoval(calcTime, src.handcuffs), src)
 	return 0
 
 /mob/living/carbon/human/proc/spidergib()

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2538,7 +2538,7 @@
 				calcTime *= 1.5
 			boutput(src, SPAN_ALERT("You attempt to remove your handcuffs. (This will take around [round(calcTime / 10)] seconds and you need to stand still)"))
 			src.handcuffs.material_trigger_when_attacked(src, src, 1)
-			actions.start(new/datum/action/bar/private/icon/handcuffRemoval(calcTime, src.handcuffs), src)
+			actions.start(new/datum/action/bar/private/icon/handcuffRemoval(calcTime, src.handcuffs))
 	return 0
 
 /mob/living/carbon/human/proc/spidergib()

--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -478,7 +478,7 @@
 			return
 		if(ismonkey(theft_target))
 			if(theft_target.handcuffs)
-				actions.start(new/datum/action/bar/icon/handcuffRemovalOther(theft_target), src)
+				actions.start(new/datum/action/bar/icon/handcuffRemovalOther(theft_target))
 				return
 			for(var/obj/item/thing in theft_target)
 				if(IS_NPC_HATED_ITEM(thing) && thing.equipped_in_slot)

--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -208,7 +208,7 @@
 		ai_target = null
 		ai_set_state(AI_PASSIVE)
 		if(src.canmove && !ai_busy)
-			actions.start(new/datum/action/bar/private/icon/handcuffRemoval(1 MINUTE + rand(-10 SECONDS, 10 SECONDS), src.handcuffs), src)
+			actions.start(new/datum/action/bar/private/icon/handcuffRemoval(1 MINUTE + rand(-10 SECONDS, 10 SECONDS)), src)
 	ai_move()
 
 	if(ai_target)

--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -208,7 +208,7 @@
 		ai_target = null
 		ai_set_state(AI_PASSIVE)
 		if(src.canmove && !ai_busy)
-			actions.start(new/datum/action/bar/private/icon/handcuffRemoval(1 MINUTE + rand(-10 SECONDS, 10 SECONDS)), src)
+			actions.start(new/datum/action/bar/private/icon/handcuffRemoval(1 MINUTE + rand(-10 SECONDS, 10 SECONDS), src.handcuffs), src)
 	ai_move()
 
 	if(ai_target)

--- a/code/obj/item/handcuffs.dm
+++ b/code/obj/item/handcuffs.dm
@@ -162,7 +162,7 @@
 	c_flags = ONBELT
 	m_amt = 200
 	amount = 10
-	remove_self_multiplier = 0.25
+	remove_self_multiplier = 0.75
 	delete_on_last_use = TRUE
 
 /obj/item/handcuffs/tape_roll/crappy

--- a/code/obj/item/handcuffs.dm
+++ b/code/obj/item/handcuffs.dm
@@ -162,6 +162,7 @@
 	c_flags = ONBELT
 	m_amt = 200
 	amount = 10
+	remove_self_multiplier = 0.25
 	delete_on_last_use = TRUE
 
 /obj/item/handcuffs/tape_roll/crappy
@@ -178,5 +179,6 @@
 	name = "ziptie cuffs"
 	desc = "A wrist-binding tie made from a durable synthetic material.  Weaker than traditional handcuffs, but much more comfortable."
 	icon_state = "buddycuff"
+	remove_self_multiplier = 0.25
 	m_amt = 0
 	strength = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects] [Balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the `remove_self_multiplier` to `0.25` for `/obj/item/handcuffs/guardbot` and `/obj/item/handcuffs/tape_roll`.

Normal cuffs take `60 SECONDS` to uncuff, ziptie and tape now take `20 SECONDS` each.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Came to be from a thread stating frustration regarding self-uncuffing. Albeit necessary from a design standpoint, it seems okay (to me) to make an exception for weaker cuffs both from a balance standpoint and realism standpoint. It still takes a decent amount of time to uncuff, but this should make Beepsky cuffing at least less overbearing.

Relevant thread:
https://forum.ss13.co/showthread.php?tid=23302

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(*)Weak cuffs, such as ziptie or tape, can now be removed faster.
```
