### PR TITLE
Puts cooking time on the oven interface

### DIFF
--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -526,9 +526,14 @@ table#cooktime a#start {
 
 					if (ispath(possible.output))
 						var/atom/item_path = possible.output
-						dat += "<b>Result:</b><br>[bicon(possible.output)] [initial(item_path.name)]</b>"
+						dat += "<b>Result:</b><br>[bicon(possible.output)] [initial(item_path.name)]</b><br>"
 					else
-						dat += "<b>Result:</b><br>???"
+						dat += "<b>Result:</b><br>???<br>"
+
+					if (possible.cookbonus < 10)
+						dat += "<b>Cooking time:</b><br>[possible.cookbonus] seconds low"
+					else
+						dat += "<b>Cooking time:</b><br>[floor(possible.cookbonus/2)] seconds high"
 
 
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The possible recipe display now shows the required time to cook the thing too.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is the last thing really forcing chef to be a cross-eyed wiki-reading job and frankly I don't think having to look up the Magic Number for each recipe adds much other than frustrating new players.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Ovens now display the required time to cook their recipe.
```
