### PR TITLE
Mind Protection implants block wraith possession

### DIFF
--- a/code/modules/antagonists/wraith/abilties/trickster/possess.dm
+++ b/code/modules/antagonists/wraith/abilties/trickster/possess.dm
@@ -36,6 +36,9 @@
 		if (H.traitHolder.hasTrait("training_chaplain"))
 			boutput(src.holder.owner, SPAN_ALERT("As you try to reach inside this creature's mind, it instantly kicks you back into the aether!"))
 			return CAST_ATTEMPT_FAIL_CAST_FAILURE
+		for(var/obj/item/implant/health/security/anti_mindhack/AM in H.implant)
+			boutput(src.holder.owner, SPAN_ALERT("As you try to reach inside this creature's mind, \an [AM.name] forces you out!"))
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
 		AH.possession_points = 0
 		actions.start(new/datum/action/bar/icon/trickster_possession(H), holder.owner)
 		return CAST_ATTEMPT_SUCCESS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents wraiths from possessing anyone with a mind protection health implant.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It is super easy right now to just possess a secoff/hos/ntsc/cap into killing another sec and then themselves if they didnt already have silver cuffs on hand, now you will have to kill them first to possess them.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Trickster wraith possession can no longer be used on those with Mind protection health implants.
```
