### PR TITLE
Player Piano Song Length Check Bugfix

### DIFF
--- a/code/modules/items/instruments/playable_piano.dm
+++ b/code/modules/items/instruments/playable_piano.dm
@@ -233,7 +233,7 @@ TYPEINFO(/obj/player_piano)
 		src.piano_notes = list()
 //		src.visible_message(SPAN_NOTICE("\The [src] starts humming and rattling as it processes!"))
 		var/list/split_input = splittext("[note_input]", "|")
-		if (split_input > MAX_NOTE_INPUT)
+		if (length(split_input) > MAX_NOTE_INPUT)
 			return FALSE
 		for (var/string in split_input)
 			if (string)
@@ -256,6 +256,7 @@ TYPEINFO(/obj/player_piano)
 			timing = text2num(timing) / 100
 			if (timing < MIN_TIMING || timing > MAX_TIMING)
 				src.visible_message(SPAN_ALERT("\The [src] makes a loud grinding noise, followed by a boop and a beep!"))
+				src.is_busy = FALSE
 				return
 			src.timing = timing
 
@@ -384,6 +385,7 @@ TYPEINFO(/obj/player_piano)
 
 		if (!src.clean_input())
 			src.note_input = ""
+			src.is_busy = FALSE
 			return FALSE
 
 		src.build_notes(src.piano_notes)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[GAME OBJECTS] [BUG] [MAJOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes note-length-checking bug from PR #21051, which makes it unplayable.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I can't play the piano anymore.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CodeDude
(+)Fixed Player Piano note-checking bug.
```
