### PR TITLE
Adds a CHECK_MORE_RUNTIMES check for req_access not being a list

### DIFF
--- a/code/obj.dm
+++ b/code/obj.dm
@@ -30,6 +30,10 @@
 			var/turf/T = get_turf(src)
 			T?.UpdateDirBlocks()
 		src.update_access_from_txt()
+#ifdef CHECK_MORE_RUNTIMES
+		if (src.req_access && !islist(src.req_access))
+			stack_trace("[src] ([src.type]) initialized at [log_loc(src)] with non-list req_access >:(")
+#endif
 
 	Move(NewLoc, direct)
 		if(usr==0) usr = null

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -32,7 +32,7 @@
 		src.update_access_from_txt()
 #ifdef CHECK_MORE_RUNTIMES
 		if (src.req_access && !islist(src.req_access))
-			stack_trace("[src] ([src.type]) initialized at [log_loc(src)] with non-list req_access >:(")
+			stack_trace("[src] ([src.type]) initialized at \[[src.x], [src.y], [src.z]\] with non-list req_access >:(")
 #endif
 
 	Move(NewLoc, direct)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
See title


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is an otherwise silent error state, see #21191