### PR TITLE
Adds fishing bait requirements to lootpools

### DIFF
--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -31,6 +31,12 @@
 		UnregisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE)
 		. = ..()
 
+	//get the kind of lure currently being used by the fishing rod
+	proc/get_lure()
+		if (length(src.storage.stored_items))
+			return src.storage.stored_items[1]
+		else return null
+
 	//todo: attack particle?? some sort of indicator of where we're fishing
 	proc/attackby_pre(source, atom/target, mob/user)
 		if (target && user && (src.last_fished < TIME + src.fishing_delay))

--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -23,7 +23,9 @@
 
 	New()
 		..()
-		RegisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE, PROC_REF(attackby_pre))
+		RegisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE, PROC_REF(attackby_pre))  // Storage for a single lure item
+		var/list/fishing_rods = list(/obj/item/fishing_rod, /obj/item/fishing_rod/basic, /obj/item/fishing_rod/upgraded, /obj/item/fishing_rod/master)
+		src.create_storage(/datum/storage, max_wclass = W_CLASS_NORMAL, slots = 1, prevent_holding = fishing_rods)
 
 	disposing()
 		UnregisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE)
@@ -128,6 +130,10 @@
 
 		if (src.fishing_spot.try_fish(src.user, src.rod, target)) //if it returns one we successfully fished, otherwise lets restart the loop
 			..()
+			if (length(src.rod.storage.stored_items))
+				var/obj/item/lure = src.rod.storage.stored_items[1]
+				boutput(user, SPAN_NOTICE("The [lure] was bit and is no longer stuck to the [src.rod]."))
+				qdel(lure)
 			src.rod.is_fishing = FALSE
 			src.rod.UpdateIcon()
 			src.user.update_inhands()

--- a/code/modules/fishing/fishing_lootpools.dm
+++ b/code/modules/fishing/fishing_lootpools.dm
@@ -13,12 +13,20 @@
 	var/minimum_rod_tier = 0
 	/// what tier of rod is the highest to have access to the lootable?
 	var/maximum_rod_tier = INFINITY
+	/// what kind of item is needed as a lure
+	var/obj/item/required_lure = null
 
 /// This proc checks for all the conditionals that could apply to a fishing spot. Modify that for special conditions.
 /datum/fishing_lootpool/proc/check_conditionals(var/mob/user, var/obj/item/fishing_rod/fishing_rod)
 	. = TRUE
 	if(fishing_rod.tier < src.minimum_rod_tier || fishing_rod.tier > src.maximum_rod_tier)
 		return FALSE
+	if (required_lure != null)
+		var/obj/item/lure = null
+		if (length(fishing_rod.storage.stored_items))
+			lure = fishing_rod.storage.stored_items[1]
+		else return FALSE // if this requires a lure, you need to have one
+		if (!istype(lure, required_lure)) return FALSE
 
 /// This proc generates a new loottable out of a given current one
 /datum/fishing_lootpool/proc/generate_loot(var/list/current_loottable, var/mob/user, var/obj/item/fishing_rod/fishing_rod)
@@ -70,6 +78,11 @@
 /datum/fishing_lootpool/pufferfish
 	minimum_rod_tier = 2
 	fish_available = list(/obj/item/reagent_containers/food/fish/pufferfish = 25)
+
+///test for fishing lures
+/datum/fishing_lootpool/luretest
+	required_lure = /obj/item/reagent_containers/food/fish
+	fish_available = list(/obj/item/reagent_containers/food/fish/sardine = 2005)
 
 ///tiny junk items you can find in vending machines and others.
 /datum/fishing_lootpool/tiny_junk

--- a/code/modules/fishing/fishing_lootpools.dm
+++ b/code/modules/fishing/fishing_lootpools.dm
@@ -74,15 +74,15 @@
 	if(!(user.bioHolder.HasEffect("clumsy")))
 		return FALSE
 
-///minimum T2 to get pufferfish from exotic sources
+///requires meat to get pufferfish from exotic sources
 /datum/fishing_lootpool/pufferfish
-	minimum_rod_tier = 2
+	required_lure = /obj/item/reagent_containers/food/snacks/ingredient/meat
 	fish_available = list(/obj/item/reagent_containers/food/fish/pufferfish = 25)
 
-///test for fishing lures
-/datum/fishing_lootpool/luretest
-	required_lure = /obj/item/reagent_containers/food/fish
-	fish_available = list(/obj/item/reagent_containers/food/fish/sardine = 2005)
+///REAL goldfish will eat the FAKE goldfish
+/datum/fishing_lootpool/real_goldfish
+	required_lure = /obj/item/reagent_containers/food/fish/goldfish
+	fish_available = list(/obj/item/reagent_containers/food/fish/real_goldfish = 10)
 
 ///tiny junk items you can find in vending machines and others.
 /datum/fishing_lootpool/tiny_junk

--- a/code/modules/fishing/fishing_lootpools.dm
+++ b/code/modules/fishing/fishing_lootpools.dm
@@ -22,10 +22,7 @@
 	if(fishing_rod.tier < src.minimum_rod_tier || fishing_rod.tier > src.maximum_rod_tier)
 		return FALSE
 	if (required_lure != null)
-		var/obj/item/lure = null
-		if (length(fishing_rod.storage.stored_items))
-			lure = fishing_rod.storage.stored_items[1]
-		else return FALSE // if this requires a lure, you need to have one
+		var/obj/item/lure = fishing_rod.get_lure()
 		if (!istype(lure, required_lure)) return FALSE
 
 /// This proc generates a new loottable out of a given current one

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -413,6 +413,7 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 /datum/fishing_spot/watertank/New()
 	..()
 	src.fishing_lootpools += new /datum/fishing_lootpool/pufferfish(src)
+	src.fishing_lootpools += new /datum/fishing_lootpool/luretest(src)
 
 /datum/fishing_spot/fueltank
 	fishing_atom_type = /obj/reagent_dispensers/fueltank

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -161,6 +161,10 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/real_goldfish = 5,\
 	/obj/item/reagent_containers/food/fish/red_herring = 1)
 
+/datum/fishing_spot/drain/New()
+	..()
+	src.fishing_lootpools += new /datum/fishing_lootpool/real_goldfish(src)
+
 /datum/fishing_spot/clown_shoes
 	fishing_atom_type = /obj/item/clothing/shoes/clown_shoes
 	rod_tier_required = 1
@@ -413,7 +417,6 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 /datum/fishing_spot/watertank/New()
 	..()
 	src.fishing_lootpools += new /datum/fishing_lootpool/pufferfish(src)
-	src.fishing_lootpools += new /datum/fishing_lootpool/luretest(src)
 
 /datum/fishing_spot/fueltank
 	fishing_atom_type = /obj/reagent_dispensers/fueltank
@@ -486,6 +489,10 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/real_goldfish = 5,\
 	/obj/item/light/bulb/yellow/broken = 20)
 
+/datum/fishing_spot/disposal_chute/New()
+	..()
+	src.fishing_lootpools += new /datum/fishing_lootpool/real_goldfish(src)
+
 /datum/fishing_spot/janitor_bucket
 	fishing_atom_type = /obj/mopbucket
 	rod_tier_required = 1
@@ -545,6 +552,10 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/bass = 30,\
 	/obj/item/reagent_containers/food/fish/real_goldfish = 5,\
 	/obj/item/reagent_containers/food/fish/salmon = 20)
+
+/datum/fishing_spot/drain/New()
+	..()
+	src.fishing_lootpools += new /datum/fishing_lootpool/real_goldfish(src)
 
 // Alien/mutant fishing spots
 /datum/fishing_spot/meatzone_acid
@@ -774,6 +785,10 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	fish_available = list(/obj/item/coin = 25,\
 	/obj/item/reagent_containers/food/fish/real_goldfish = 5,\
 	/obj/item/currency/spacecash/really_small = 20)
+
+/datum/fishing_spot/vending/New()
+	..()
+	src.fishing_lootpools += new /datum/fishing_lootpool/real_goldfish(src)
 
 //Arc electroplater
 /datum/fishing_spot/arc_electroplater


### PR DESCRIPTION
[LABEL][catering][feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds support for custom fishing baits/lures, as well as implement the lure requirement for pufferfish i've mentioned in the pufferfish PR. It also makes it so you're more likely to acquire REAL GOLDFISH whilst using regular goldfish as bait.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While this doesn't add much in the way of content at the moment, it does make it easier to implement different bait requirement for fishing in the future.


## Changelog 
```changelog
(u)Colossus
(+)Added support for fishing bait, you are more likely to catch real goldfish with regular goldfish, and pufferfish need meat as bait.
```
