### PR TITLE
Remove stacked-rack in Kondaru armory

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -33711,7 +33711,6 @@
 	pixel_x = 5;
 	pixel_y = -4
 	},
-/obj/rack,
 /turf/simulated/floor/engine{
 	allows_vehicles = 0
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There is a spot in kondaru armory with two racks on top of each other

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
stacked racks when there should only be one