### PR TITLE
Mindhack cloners only message syndicate PDAs

### DIFF
--- a/_std/defines/jobs.dm
+++ b/_std/defines/jobs.dm
@@ -40,6 +40,7 @@
 #define MGA_CRISIS "Crisis Alert"
 #define MGA_RADIO "Radio Alert"
 #define MGA_TRACKING "Tracking Alert"
+#define MGA_SYNDICATE "Syndicate Alert"
 
 // Job categories
 #define JOB_SPECIAL "special"

--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -71,8 +71,10 @@
 		knockoff
 			name = "ThoughtOS 1.2"
 			note = "Congratulation! You have chosen the ElecTek 5 Personnel Data Actuator!"
-			message_on = 0
 			knockoff = TRUE
+
+			mess_off
+				message_on = 0
 
 		disposing()
 			if (detected_pdas)

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -65,7 +65,7 @@
 		// Other
 		MGO_STAFF, MGO_AI, MGO_SILICON, MGO_JANITOR, MGO_ENGINEER,
 		// Alerts
-		MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_ENGINE, MGA_RKIT, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST, MGA_CRISIS, MGA_TRACKING,
+		MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CLONER, MGA_ENGINE, MGA_RKIT, MGA_SALES, MGA_SHIPPING, MGA_CARGOREQUEST, MGA_CRISIS, MGA_TRACKING, MGA_SYNDICATE
 	)
 	var/alertgroups = list(MGA_MAIL, MGA_RADIO) // What mail groups that we're not a member of should we be able to mute?
 	var/bombproof = 0 // can't be destroyed with detomatix
@@ -349,6 +349,7 @@
 		name = "Military PDA"
 		desc = "A cheap knockoff looking portable microcomputer claiming to be made by ElecTek LTD. It has a slot for an ID card, and a hole to put a pen into."
 		setup_system_os_path = /datum/computer/file/pda_program/os/main_os/knockoff
+		mailgroups = list(MGA_SYNDICATE)
 		locked_bg_color = TRUE
 		bg_color = "#A33131"
 		r_tone = /datum/ringtone/basic/ring10
@@ -357,6 +358,7 @@
 
 		nuclear
 			owner = "John Doe"
+			setup_system_os_path = /datum/computer/file/pda_program/os/main_os/knockoff/mess_off
 			setup_default_cartridge = /obj/item/disk/data/cartridge/nuclear
 
 			New()

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -133,7 +133,10 @@ TYPEINFO(/obj/machinery/clonepod)
 		newsignal.data["message"] = "[msg]"
 
 		newsignal.data["address_1"] = "00000000"
-		newsignal.data["group"] = mailgroups + MGA_CLONER
+		if(src.clonehack)
+			newsignal.data["group"] = list(MGA_SYNDICATE)
+		else
+			newsignal.data["group"] = mailgroups + MGA_CLONER
 		newsignal.data["sender"] = src.net_id
 
 		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, newsignal, null, "pda")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a syndicate mailgroup only on the syndicate PDA, mindhack cloners send to this mailgroup rather than their usual selection
Turns messenger on by default for non-nukie syndicate PDAs

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Saw the idea in this thread https://forum.ss13.co/showthread.php?tid=23329 and thought it made sense
If you have a stealthy cloner somewhere you dont want it broadcasting to all of medical that you have one

Messenger only needs to be off for the nuclear PDA as other ones are specifically scanned by players and it will only show in the messenger list that they have multiple PDAs, not that one is a syndicate one, unlike the nuclear one that starts scanned and normally would have nobody to message.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Non-nuclear syndicate PDAs start with messenger on.
(+)Mindhack cloners now only send messages to syndicate PDAs.
```
