### PR TITLE
unlink oshan booth door from medbay button

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -32236,7 +32236,6 @@
 /area/station/garden/owlery)
 "dlG" = (
 /obj/machinery/door/airlock/pyro/glass{
-	id = "medbay_front";
 	name = "Medical Booth";
 	req_access_txt = "5"
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
accidentally left an id on the medbooth door so it opens and closes whenever someone hits the button in medical. lol


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

fix the bug


