### PR TITLE
ghosts see arthints

### DIFF
--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -37,7 +37,7 @@
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
-		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist"))))
+		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist")) || isobserver(usr) || isobserver(usr)))
 			. += SPAN_ARTHINT(A.examine_hint)
 
 	UpdateName()

--- a/code/obj/artifacts/artifact_items/gun_cell.dm
+++ b/code/obj/artifacts/artifact_items/gun_cell.dm
@@ -31,7 +31,7 @@
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
-		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist"))))
+		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist")) || isobserver(usr)))
 			. += SPAN_ARTHINT(A.examine_hint)
 
 	UpdateName()

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -27,7 +27,7 @@
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
-		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist"))))
+		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist")) || isobserver(usr)))
 			. += SPAN_ARTHINT(A.examine_hint)
 
 	UpdateName()

--- a/code/obj/artifacts/artifacts.dm
+++ b/code/obj/artifacts/artifacts.dm
@@ -50,7 +50,7 @@
 		if (!src.ArtifactSanityCheck())
 			return
 		var/datum/artifact/A = src.artifact
-		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist"))))
+		if (istext(A.examine_hint) && (usr && (usr.traitHolder?.hasTrait("training_scientist")) || isobserver(usr)))
 			. += SPAN_ARTHINT(A.examine_hint)
 
 	ex_act(severity)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets ghosts see scientist training artifact hints.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ghosts can already see chem mixes, and this means in things like science white holes or just observing they can see what's gonna do something funny.

