### PR TITLE
Force the AI station map to initialize on creation

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -295,6 +295,7 @@ or don't if it uses a custom topopen overlay
 	APPLY_ATOM_PROPERTY(src, PROP_MOB_EXAMINE_ALL_NAMES, src)
 
 	ai_station_map = new /obj/minimap/ai
+	ai_station_map.initialise_minimap()
 	AddComponent(/datum/component/minimap_marker/minimap, MAP_AI | MAP_SYNDICATE, "ai")
 	SPAWN(0)
 		if (bought_hat || prob(5))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][silicons]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Force the AI map to initialize after a new AI unit is created.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
AI map is consistently not working on live, this fixes it on local.
Fixes #21103
Fixes #21101
Fixes #21050
