### PR TITLE
Add "Licensed Archaeologist" medal

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -676,8 +676,9 @@ ABSTRACT_TYPE(/datum/objective/crew/researchdirector)
 /datum/objective/crew/researchdirector/artifact
 	explanation_text = "Research and activate 10 artifacts by the end of the shift."
 	medal_name = "Licensed Archaeologist"
+	var/artifacts_activated = 0
 	check_completion()
-		if (src.owner?.artifacts_activated >= 10)
+		if (src.artifacts_activated >= 10)
 			return TRUE
 
 /datum/objective/crew/researchdirector/onfire
@@ -728,8 +729,9 @@ ABSTRACT_TYPE(/datum/objective/crew/scientist)
 /datum/objective/crew/scientist/artifact
 	explanation_text = "Research and activate 10 artifacts by the end of the shift."
 	medal_name = "Licensed Archaeologist"
+	var/artifacts_activated = 0
 	check_completion()
-		if (src.owner?.artifacts_activated >= 10)
+		if (src.artifacts_activated >= 10)
 			return TRUE
 
 ABSTRACT_TYPE(/datum/objective/crew/medicaldirector)

--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -672,6 +672,14 @@ ABSTRACT_TYPE(/datum/objective/crew/researchdirector)
 		for_by_tcl(F, /obj/dfissure_to)
 			if(F.z == Z_LEVEL_STATION) return 1
 		return 0
+
+/datum/objective/crew/researchdirector/artifact
+	explanation_text = "Research and activate 10 artifacts by the end of the shift."
+	medal_name = "Licensed Archaeologist"
+	check_completion()
+		if (src.owner?.artifacts_activated >= 10)
+			return TRUE
+
 /datum/objective/crew/researchdirector/onfire
 	explanation_text = "Escape on the shuttle alive while on fire with silver sulfadiazine in your bloodstream."
 	medal_name = "Better to burn out, than fade away"
@@ -717,12 +725,12 @@ ABSTRACT_TYPE(/datum/objective/crew/scientist)
 			if(in_centcom(H) && H.getStatusDuration("burning") > 1 && owner.current.reagents.has_reagent("silver_sulfadiazine")) return 1
 			else return 0
 
-	/*artifact // This is going to be really fucking awkward to do so disabling for now
-		explanation_text = "Activate at least one artifact on the station z level by the end of the round, excluding the test artifact."
-		check_completion()
-			for(var/obj/machinery/artifact/A in machines)
-				if(A.z == Z_LEVEL_STATION && A.activated == 1 && A.name != "Test Artifact") return 1 //someone could label it I guess but I don't want to go adding an istestartifact var just for this..
-			return 0*/
+/datum/objective/crew/scientist/artifact
+	explanation_text = "Research and activate 10 artifacts by the end of the shift."
+	medal_name = "Licensed Archaeologist"
+	check_completion()
+		if (src.owner?.artifacts_activated >= 10)
+			return TRUE
 
 ABSTRACT_TYPE(/datum/objective/crew/medicaldirector)
 // so much copy/pasted stuff  :(

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -59,6 +59,8 @@ datum/mind
 
 	var/show_respawn_prompts = TRUE
 
+	var/artifacts_activated = 0
+
 	New(mob/M)
 		..()
 		if (M)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -59,8 +59,6 @@ datum/mind
 
 	var/show_respawn_prompts = TRUE
 
-	var/artifacts_activated = 0
-
 	New(mob/M)
 		..()
 		if (M)

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -162,6 +162,9 @@
 	else
 		A.show_fx(src)
 	A.effect_activate(src)
+	for (var/mob/living/L in range(5, src))
+		if (ishuman(L) || isrobot(L))
+			L.mind.artifacts_activated++
 
 /obj/proc/ArtifactDeactivated()
 	if (!src.ArtifactSanityCheck())

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -163,8 +163,15 @@
 		A.show_fx(src)
 	A.effect_activate(src)
 	for (var/mob/living/L in range(5, src))
-		if (ishuman(L) || isrobot(L))
-			L.mind.artifacts_activated++
+		for(var/datum/objective/objective in L.mind?.objectives)
+			if (istype(objective, /datum/objective/crew/scientist/artifact))
+				var/datum/objective/crew/scientist/artifact/art_obj = objective
+				art_obj.artifacts_activated++
+				break
+			if (istype(objective, /datum/objective/crew/researchdirector/artifact))
+				var/datum/objective/crew/researchdirector/artifact/art_obj = objective
+				art_obj.artifacts_activated++
+				break
 
 /obj/proc/ArtifactDeactivated()
 	if (!src.ArtifactSanityCheck())


### PR DESCRIPTION
[SCIENCE][MEDAL][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new medal tied to a new scientist objective of having activated 10 artifacts at the end of the shift. You count towards this if you are in range of 5 tiles of an artifact when it's activated

Name: "Licensed Archaeologist"
Pic:
![artmedal](https://github.com/user-attachments/assets/d18c078b-268d-4f82-8cda-0868985337df)
Desc: "Complete the Scientist or Research Director objective of activating 10 artifacts in a single shift."
Other: Medal is visible on the medals page before earned (not secret)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Artlab doesn't have any medals with it right now


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(*)Added a new Scientist/Research Director objective to activate 10 artifacts in a single shift, with a medal tied to it
```
