### PR TITLE
Replaces the empty IV bag in the atlas OR with a filled one

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -4369,7 +4369,7 @@
 /area/station/hydroponics/bay)
 "ayD" = (
 /obj/iv_stand,
-/obj/item/reagent_containers/iv_drip,
+/obj/item/reagent_containers/iv_drip/blood,
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/surgery)
 "ayE" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This replaces the empty IV bag that spawns on the IV stand in the Atlas OR with an IV bag filled with blood.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
On every other map the IV bags that start on the stands are either filled with blood or saline-glucose. Atlas is the only map where this bag is empty, which seems to be a mistake. Making this consistent with all the other maps saves doctors the two seconds it takes to replace the empty bag with one from the fridge.