### PR TITLE
Change info maps to use native HUD rendering rather than going via ByondUI

### DIFF
--- a/_std/color.dm
+++ b/_std/color.dm
@@ -82,6 +82,13 @@
 																		0.00,  0.00,  0.00,  1.00,\
 																		0.00,  0.00,  0.00,  0.00)
 
+#define COLOR_MATRIX_SHADE_LABEL "shade"
+#define COLOR_MATRIX_SHADE list(0.4,0,0,0,\
+								0,0.4,0,0,\
+								0,0,0.4,0,\
+								0,0,0,1,\
+								0,0,0,0)
+
 /// Takes two 20-length lists, turns them into 5x4 matrices, multiplies them together, and returns a 20-length list
 /proc/mult_color_matrix(var/list/Mat1, var/list/Mat2) // always 5x4 please
 	if (length(Mat1) != 20 || length(Mat2) != 20)

--- a/code/modules/gps/gps.dm
+++ b/code/modules/gps/gps.dm
@@ -67,7 +67,7 @@
 	if(target)
 		gpsToTurf(target, param = ID)
 
-/mob/proc/gpsToTurf(var/turf/dest, var/doText = 1, param = null, cardinal_only=FALSE, all_access = FALSE)
+/mob/proc/gpsToTurf(var/turf/dest, var/doText = 1, param = null, cardinal_only=FALSE, all_access = FALSE, timeout = 0)
 	removeGpsPath(doText)
 	var/turf/start = get_turf(src)
 	if(dest.z != start.z)
@@ -77,7 +77,7 @@
 	var/obj/item/card/id/id = all_access ? get_singleton(/obj/item/card/id/captains_spare) : src.get_id()
 	client.GPS_Path = get_path_to(src, dest, max_distance = 120, id=id, skip_first=FALSE, cardinal_only=cardinal_only)
 	if(length(client.GPS_Path))
-		if(doText)
+		if(doText && !timeout)
 			boutput( usr, "Path located! Use the GPS verb again to clear the path!" )
 	else
 		if(doText)
@@ -126,6 +126,9 @@
 			animate(alpha = 0, time = 2 SECONDS, loop = -1, easing = CUBIC_EASING | EASE_OUT )
 			animate(alpha = 80, time = 1 SECONDS, loop = -1, easing = BACK_EASING | EASE_OUT )
 			sleep(0.1 SECONDS)
+		if (timeout > 0)
+			sleep(timeout)
+			src.removeGpsPath(FALSE)
 
 /mob/proc/removeGpsPath(doText = 1)
 	if( client.GPS_Path )

--- a/code/modules/minimap/markers/_minimap_marker_parent.dm
+++ b/code/modules/minimap/markers/_minimap_marker_parent.dm
@@ -13,7 +13,7 @@ ABSTRACT_TYPE(/datum/minimap_marker)
 	. = ..()
 
 	src.marker = new /atom/movable()
-	src.marker.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
+	src.marker.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER | VIS_INHERIT_PLANE
 	src.marker.mouse_opacity = 0
 
 	src.target = target

--- a/code/modules/minimap/minimap_objects/objects/_minimap_object_parent.dm
+++ b/code/modules/minimap/minimap_objects/objects/_minimap_object_parent.dm
@@ -38,3 +38,8 @@
 		click_overlay_icon.ChangeOpacity(0)
 		src.icon = click_overlay_icon
 		src.mouse_opacity = 2
+
+/obj/minimap/proc/get_turf_at_screen_coords(screen_x,screen_y)
+	var/x = round((screen_x - src.map.minimap_render.pixel_x) / (src.map.zoom_coefficient * src.map.map_scale))
+	var/y = round((screen_y - src.map.minimap_render.pixel_y) / (src.map.zoom_coefficient * src.map.map_scale))
+	return locate(x, y, map.z_level)

--- a/code/modules/minimap/minimap_objects/objects/ai_map.dm
+++ b/code/modules/minimap/minimap_objects/objects/ai_map.dm
@@ -10,9 +10,7 @@
 	var/list/param_list = params2list(params)
 	if ("left" in param_list)
 		// Convert from screen (x, y) to map (x, y) coordinates.
-		var/x = round((text2num(param_list["icon-x"]) - src.map.minimap_render.pixel_x) / (src.map.zoom_coefficient * src.map.map_scale))
-		var/y = round((text2num(param_list["icon-y"]) - src.map.minimap_render.pixel_y) / (src.map.zoom_coefficient * src.map.map_scale))
-		var/turf/clicked = locate(x, y, map.z_level)
+		var/turf/clicked = src.get_turf_at_screen_coords(text2num(param_list["icon-x"]), text2num(param_list["icon-y"]))
 		if (isAIeye(usr))
 			usr.set_loc(clicked)
 		else

--- a/code/modules/minimap/minimap_objects/objects/info_map.dm
+++ b/code/modules/minimap/minimap_objects/objects/info_map.dm
@@ -37,6 +37,7 @@ TYPEINFO(/obj/machinery/info_map)
 	if (!hud)
 		return
 	hud.add_object(src.infomap, HUD_LAYER, "CENTER,CENTER-3")
+	user.apply_color_matrix(COLOR_MATRIX_SHADE, COLOR_MATRIX_SHADE_LABEL)
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(user_moved))
 
 /obj/machinery/info_map/proc/user_moved(mob/user, atom/previous_loc, direction)
@@ -52,10 +53,13 @@ TYPEINFO(/obj/machinery/info_map)
 	name = "Information Map"
 	map_path = /datum/minimap/area_map/transparent
 	map_type = MAP_INFO
-	alpha = 200
 	plane = PLANE_HUD
 	layer = HUD_LAYER
 	var/obj/machinery/info_map/display = null
+
+	New()
+		. = ..()
+		src.appearance_flags |= NO_CLIENT_COLOR
 
 	initialise_minimap()
 		. = ..()
@@ -74,6 +78,7 @@ TYPEINFO(/obj/machinery/info_map)
 
 	proc/close(mob/user)
 		display.UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
+		user.remove_color_matrix(COLOR_MATRIX_SHADE_LABEL)
 		var/datum/hud/hud = user.get_hud()
 		hud.remove_object(src)
 

--- a/code/modules/minimap/minimap_objects/objects/info_map.dm
+++ b/code/modules/minimap/minimap_objects/objects/info_map.dm
@@ -33,9 +33,10 @@ TYPEINFO(/obj/machinery/info_map)
 	. = ..()
 	if(.)
 		return
-	if(!src.minimap_ui)
-		src.minimap_ui = new(src, minimap=src.infomap, tgui_title="Information Map")
-	src.minimap_ui.ui_interact(user)
+	var/datum/hud/hud = user.get_hud()
+	if (!hud)
+		return
+	hud.add_object(src.infomap, HUD_LAYER, "CENTER,CENTER-3")
 
 
 /obj/machinery/info_map/disposing()
@@ -47,5 +48,27 @@ TYPEINFO(/obj/machinery/info_map)
 
 /obj/minimap/info
 	name = "Information Map"
-	map_path = /datum/minimap/area_map
+	map_path = /datum/minimap/area_map/transparent
 	map_type = MAP_INFO
+	alpha = 200
+	plane = PLANE_HUD
+	layer = HUD_LAYER
+
+	initialise_minimap()
+		. = ..()
+		src.map.map.plane = src.plane
+		src.map.map.layer = src.layer
+
+	Click(location, control, params)
+		var/list/param_list = params2list(params)
+		if ("left" in param_list)
+			var/turf/clicked = src.get_turf_at_screen_coords(text2num(param_list["icon-x"]), text2num(param_list["icon-y"]))
+			if (!istype(clicked.loc, /area/space))
+				usr.gpsToTurf(clicked)
+			else
+				usr.removeGpsPath()
+
+		//now remove the map from their hud
+		var/datum/hud/hud = usr.get_hud()
+		hud.remove_object(src)
+

--- a/code/modules/minimap/minimap_objects/objects/info_map.dm
+++ b/code/modules/minimap/minimap_objects/objects/info_map.dm
@@ -64,9 +64,9 @@ TYPEINFO(/obj/machinery/info_map)
 		if ("left" in param_list)
 			var/turf/clicked = src.get_turf_at_screen_coords(text2num(param_list["icon-x"]), text2num(param_list["icon-y"]))
 			if (!istype(clicked.loc, /area/space))
-				usr.gpsToTurf(clicked)
+				usr.gpsToTurf(clicked, TRUE, timeout = 40 SECONDS)
 			else
-				usr.removeGpsPath()
+				usr.removeGpsPath(FALSE)
 
 		//now remove the map from their hud
 		var/datum/hud/hud = usr.get_hud()

--- a/code/modules/minimap/minimap_objects/objects/info_map.dm
+++ b/code/modules/minimap/minimap_objects/objects/info_map.dm
@@ -18,6 +18,7 @@ TYPEINFO(/obj/machinery/info_map)
 /obj/machinery/info_map/New()
 	. = ..()
 	src.infomap = new()
+	src.infomap.display = src
 	src.infomap.initialise_minimap()
 	src.infomap.map.create_minimap_marker(src, 'icons/obj/minimap/minimap_markers.dmi', "pin")
 
@@ -41,7 +42,6 @@ TYPEINFO(/obj/machinery/info_map)
 /obj/machinery/info_map/proc/user_moved(mob/user, atom/previous_loc, direction)
 	if (BOUNDS_DIST(user, src) > 0)
 		src.infomap.close(user)
-		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 
 /obj/machinery/info_map/disposing()
 	. = ..()
@@ -55,6 +55,7 @@ TYPEINFO(/obj/machinery/info_map)
 	alpha = 200
 	plane = PLANE_HUD
 	layer = HUD_LAYER
+	var/obj/machinery/info_map/display = null
 
 	initialise_minimap()
 		. = ..()
@@ -72,6 +73,11 @@ TYPEINFO(/obj/machinery/info_map)
 		src.close(usr)
 
 	proc/close(mob/user)
+		display.UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 		var/datum/hud/hud = user.get_hud()
 		hud.remove_object(src)
+
+	disposing()
+		src.display = null
+		. = ..()
 

--- a/code/modules/minimap/minimap_objects/objects/info_map.dm
+++ b/code/modules/minimap/minimap_objects/objects/info_map.dm
@@ -13,7 +13,6 @@ TYPEINFO(/obj/machinery/info_map)
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL
 	power_usage = 5 WATTS
 	plane = PLANE_NOSHADOW_ABOVE
-	var/atom/movable/minimap_ui_handler/minimap_ui
 	var/obj/minimap/info/infomap
 
 /obj/machinery/info_map/New()
@@ -46,8 +45,6 @@ TYPEINFO(/obj/machinery/info_map)
 
 /obj/machinery/info_map/disposing()
 	. = ..()
-	qdel(src.minimap_ui)
-	src.minimap_ui = null
 	qdel(src.infomap)
 	src.infomap = null
 

--- a/code/modules/minimap/minimap_objects/objects/info_map.dm
+++ b/code/modules/minimap/minimap_objects/objects/info_map.dm
@@ -37,7 +37,12 @@ TYPEINFO(/obj/machinery/info_map)
 	if (!hud)
 		return
 	hud.add_object(src.infomap, HUD_LAYER, "CENTER,CENTER-3")
+	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(user_moved))
 
+/obj/machinery/info_map/proc/user_moved(mob/user, atom/previous_loc, direction)
+	if (BOUNDS_DIST(user, src) > 0)
+		src.infomap.close(user)
+		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 
 /obj/machinery/info_map/disposing()
 	. = ..()
@@ -67,8 +72,9 @@ TYPEINFO(/obj/machinery/info_map)
 				usr.gpsToTurf(clicked, TRUE, timeout = 40 SECONDS)
 			else
 				usr.removeGpsPath(FALSE)
+		src.close(usr)
 
-		//now remove the map from their hud
-		var/datum/hud/hud = usr.get_hud()
+	proc/close(mob/user)
+		var/datum/hud/hud = user.get_hud()
 		hud.remove_object(src)
 

--- a/code/modules/minimap/minimaps/__minimap_parent.dm
+++ b/code/modules/minimap/minimaps/__minimap_parent.dm
@@ -5,11 +5,11 @@ ABSTRACT_TYPE(/datum/minimap)
  */
 /datum/minimap
 	/// The holder for the render of the minimap, allowing for offsets and other effects to be applied to the render without modifying the render itself.
-	var/atom/movable/minimap_holder
+	var/atom/movable/minimap_render_object/minimap_holder
 	/// The minimap render to be displayed, containing both the map, dynamic area overlays, and markers.
-	var/atom/movable/minimap_render
+	var/atom/movable/minimap_render_object/minimap_render
 	/// The minimap, without minimap markers. Kept separate for the purpose of scaling the minimap without scaling the markers.
-	var/atom/movable/map
+	var/atom/movable/minimap_render_object/map
 	/// An associative list of all minimap markers the minimap is currently tracking and displaying, indexed by their target.
 	var/list/datum/minimap_marker/minimap/minimap_markers
 
@@ -45,7 +45,6 @@ ABSTRACT_TYPE(/datum/minimap)
 	. = ..()
 
 	src.minimap_holder = new
-	src.minimap_holder.vis_flags = VIS_INHERIT_LAYER
 	src.minimap_holder.appearance_flags = KEEP_TOGETHER | PIXEL_SCALE
 	src.minimap_holder.mouse_opacity = 0
 
@@ -157,7 +156,9 @@ ABSTRACT_TYPE(/datum/minimap)
 	qdel(marker)
 
 
-
+/// Just a helper type to ensure all minimap render parts have the correct vis_flags set
+/atom/movable/minimap_render_object
+	vis_flags = VIS_INHERIT_LAYER | VIS_INHERIT_PLANE
 
 
 #ifndef LIVE_SERVER

--- a/code/modules/minimap/minimaps/_area_minimap.dm
+++ b/code/modules/minimap/minimaps/_area_minimap.dm
@@ -41,12 +41,11 @@
 
 	src.map = new()
 	src.map.icon = src.map_icons_by_z_level["[src.z_level]"]
-	src.map.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
+	src.map.vis_flags |= VIS_INHERIT_ID
 	src.map.mouse_opacity = 0
 	src.map.vis_contents += src.dynamic_areas_overlays_by_z_level["[src.z_level]"]
 
 	src.minimap_render = new()
-	src.minimap_render.vis_flags = VIS_INHERIT_LAYER
 	src.minimap_render.appearance_flags = KEEP_TOGETHER | PIXEL_SCALE
 	src.minimap_render.mouse_opacity = 0
 
@@ -129,3 +128,10 @@
 	for (var/atom/target as anything in src.minimap_markers)
 		var/datum/minimap_marker/minimap/minimap_marker = src.minimap_markers[target]
 		src.set_marker_position(minimap_marker, minimap_marker.target.x, minimap_marker.target.y, minimap_marker.target.z)
+
+/datum/minimap/area_map/transparent
+	initialise_minimap_render()
+		. = ..()
+		var/icon/icon = new(src.map.icon)
+		icon.SwapColor(rgb(0, 0, 0), rgb(0, 0, 0, 0))
+		src.map.icon = icon

--- a/code/modules/minimap/minimaps/_radar_minimap.dm
+++ b/code/modules/minimap/minimaps/_radar_minimap.dm
@@ -2,12 +2,11 @@
 
 /datum/minimap/radar_map/initialise_minimap_render()
 	src.map = new()
-	src.map.vis_flags = VIS_INHERIT_ID | VIS_INHERIT_LAYER
+	src.map.vis_flags |= VIS_INHERIT_ID
 	src.map.mouse_opacity = 0
 	src.map.vis_contents += global.minimap_renderer.radar_minimap_objects_by_z_level["[src.z_level]"]
 
 	src.minimap_render = new()
-	src.minimap_render.vis_flags = VIS_INHERIT_LAYER
 	src.minimap_render.appearance_flags = KEEP_TOGETHER | PIXEL_SCALE
 	src.minimap_render.mouse_opacity = 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![image](https://github.com/user-attachments/assets/c39b7467-b3e7-4bcf-8311-667e1e2d4f39)
Makes the new info maps open as an overlay with a background tint instead of a full TGUI window, also adds point and click GPS functionality to them because it was only a few lines and I should probably atomize that but shrug.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A lot less janky, maybe looks better?
