### PR TITLE
Fix roundstart infomaps

### DIFF
--- a/code/modules/minimap/minimap_objects/objects/info_map.dm
+++ b/code/modules/minimap/minimap_objects/objects/info_map.dm
@@ -14,13 +14,14 @@ TYPEINFO(/obj/machinery/info_map)
 	power_usage = 5 WATTS
 	plane = PLANE_NOSHADOW_ABOVE
 	var/obj/minimap/info/infomap
+#ifdef IN_MAP_EDITOR
+	pixel_y = 29
+#endif
 
 /obj/machinery/info_map/New()
 	. = ..()
 	src.infomap = new()
 	src.infomap.display = src
-	src.infomap.initialise_minimap()
-	src.infomap.map.create_minimap_marker(src, 'icons/obj/minimap/minimap_markers.dmi', "pin")
 
 	// reposition onto wall
 	if(pixel_y == 0 && pixel_x == 0)
@@ -28,6 +29,15 @@ TYPEINFO(/obj/machinery/info_map)
 			pixel_y = 32
 		else
 			pixel_y = 29
+
+/obj/machinery/info_map/initialize()
+	. = ..()
+	src.infomap.initialise_minimap()
+	src.infomap.map.create_minimap_marker(src, 'icons/obj/minimap/minimap_markers.dmi', "pin")
+
+/obj/machinery/info_map/was_built_from_frame(mob/user, newly_built)
+	. = ..()
+	src.initialize()
 
 /obj/machinery/info_map/attack_hand(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Move minimap initialization to `initialize` and ensure it's called when built from frame.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Minimaps cause a crash if placed via mapeditor currently.