### PR TITLE
Clown/HoS shoes remain equipped on recolour

### DIFF
--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -322,6 +322,7 @@ TYPEINFO(/obj/item/clothing/shoes/industrial)
 					wearer.equip_if_possible(I, slot)
 				else
 					I.set_loc(get_turf(src))
+				playsound(src, 'sound/items/graffitispray3.ogg', 100, TRUE)
 				boutput(user, SPAN_NOTICE("You spraypaint the clown shoes in a sleek black!"))
 				qdel(src)
 			else
@@ -534,7 +535,6 @@ TYPEINFO(/obj/item/clothing/shoes/moon)
 					wearer.equip_if_possible(I, slot)
 				else
 					I.set_loc(get_turf(src))
-				playsound(src, 'sound/items/graffitispray3.ogg', 100, TRUE)
 				boutput(user, SPAN_NOTICE("You cover the heavy boots in crayon!"))
 				qdel(src)
 			else

--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -315,8 +315,13 @@ TYPEINFO(/obj/item/clothing/shoes/industrial)
 		else if(istype(W, /obj/item/spray_paint_graffiti) && !(istype(src, /obj/item/clothing/shoes/clown_shoes/military)))
 			if (user.traitHolder.hasTrait("training_security"))
 				var/obj/item/I = new /obj/item/clothing/shoes/clown_shoes/military()
-				I.set_loc(get_turf(src))
-				playsound(src, 'sound/items/graffitispray3.ogg', 100, TRUE)
+				if (src.equipped_in_slot)
+					var/mob/living/carbon/human/wearer = src.loc
+					var/slot = src.equipped_in_slot
+					wearer.u_equip(src)
+					wearer.equip_if_possible(I, slot)
+				else
+					I.set_loc(get_turf(src))
 				boutput(user, SPAN_NOTICE("You spraypaint the clown shoes in a sleek black!"))
 				qdel(src)
 			else
@@ -522,7 +527,13 @@ TYPEINFO(/obj/item/clothing/shoes/moon)
 		if(istype(W, /obj/item/pen/crayon) && !(istype(src, /obj/item/clothing/shoes/swat/heavy/clown)))
 			if (user.traitHolder.hasTrait("training_clown"))
 				var/obj/item/I = new /obj/item/clothing/shoes/swat/heavy/clown()
-				I.set_loc(get_turf(src))
+				if (src.equipped_in_slot)
+					var/mob/living/carbon/human/wearer = src.loc
+					var/slot = src.equipped_in_slot
+					wearer.u_equip(src)
+					wearer.equip_if_possible(I, slot)
+				else
+					I.set_loc(get_turf(src))
 				playsound(src, 'sound/items/graffitispray3.ogg', 100, TRUE)
 				boutput(user, SPAN_NOTICE("You cover the heavy boots in crayon!"))
 				qdel(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If the clown or HoS shoes were equipped when being crayoned/graffiti'd equip the new ones.
Removes accidental spraypaint sound from playing when crayoning the hos boots

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugfixes good, thing equipped should stay equipped and this lets you crayon the HoS' boots while they are wearing them.