### PR TITLE
Emagged Cyborg has no Antag Popup

### DIFF
--- a/code/modules/antagonists/syndicate_cyborg/emagged_cyborg.dm
+++ b/code/modules/antagonists/syndicate_cyborg/emagged_cyborg.dm
@@ -5,6 +5,7 @@
 	remove_on_death = TRUE
 	remove_on_clone = TRUE
 	keep_equipment_on_death = TRUE
+	has_info_popup = FALSE
 
 	is_compatible_with(datum/mind/mind)
 		return isrobot(mind.current)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->


## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets `has_info_popup = FALSE` for `/datum/antagonist/emagged_cyborg`



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #21252, which appears after clicking ok on the popup below when #19559 is merged.
Emagged cyborgs don't get "big html antag popups," they instead get a small "You have been emagged and now have absolute free will." alert.
![image](https://github.com/user-attachments/assets/92eb548c-0eb7-44ed-9d9c-d4f622db0e64)


[bug][ui]