### PR TITLE
No UI Needed for Wizard's Teleport Scrolls

### DIFF
--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -17,6 +17,9 @@
 	throw_range = 20
 	desc = "This isn't that old, you just spilled mugwort tea on it the other day."
 
+/obj/item/teleportation_scroll/get_desc()
+	. = ..() + " Charges left: [src.uses]."
+
 /obj/item/teleportation_scroll/attack_self(mob/user as mob)
 	if (!iswizard(user))
 		boutput(user, SPAN_ALERT("<b>The text is illegible!</b>"))
@@ -32,6 +35,7 @@
 	if ((usr.contents.Find(src) || (in_interact_range(src, usr) && istype(src.loc, /turf))))
 		if (src.uses >= 1 && usr.teleportscroll(1, 1, src, null, TRUE) == 1)
 			src.uses -= 1
+			tooltip_rebuild = TRUE
 
 	if (!src.uses)
 		boutput(user, SPAN_NOTICE("<b>The depleted scroll vanishes in a puff of smoke!</b>"))

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -18,44 +18,25 @@
 	desc = "This isn't that old, you just spilled mugwort tea on it the other day."
 
 /obj/item/teleportation_scroll/attack_self(mob/user as mob)
-	src.add_dialog(user)
-	var/dat = ""
 	if (!iswizard(user))
-		src.remove_dialog(user)
 		boutput(user, SPAN_ALERT("<b>The text is illegible!</b>"))
 		return
-	if (!src.uses)
-		boutput(user, SPAN_NOTICE("<b>The depleted scroll vanishes in a puff of smoke!</b>"))
-		src.remove_dialog(user)
-		user.Browse(null,"window=scroll")
-		qdel(src)
-		return
-	dat += "<b>Teleportation Scroll:</b><br><br>"
-	dat += "Charges left: [src.uses]<br><hr><br>"
-	dat += "<A href='byond://?src=\ref[src];spell_teleport=1'>Teleport</A><br><br><hr>"
-	user.Browse(dat,"window=scroll")
-	onclose(user, "scroll")
-	return
 
-/obj/item/teleportation_scroll/Topic(href, href_list)
-	..()
 	if (usr.getStatusDuration("unconscious") || !isalive(usr) || usr.restrained())
 		return
+
 	var/mob/living/carbon/human/H = usr
 	if (!( ishuman(H)))
 		return 1
+
 	if ((usr.contents.Find(src) || (in_interact_range(src, usr) && istype(src.loc, /turf))))
-		src.add_dialog(usr)
-		if (href_list["spell_teleport"])
-			if (src.uses >= 1 && usr.teleportscroll(1, 1, src, null, TRUE) == 1)
-				src.uses -= 1
-		if (ismob(src.loc))
-			src.AttackSelf(src.loc)
-		else
-			for(var/mob/M in viewers(1, src))
-				if (M.client)
-					src.AttackSelf(M)
-	return
+		if (src.uses >= 1 && usr.teleportscroll(1, 1, src, null, TRUE) == 1)
+			src.uses -= 1
+
+	if (!src.uses)
+		boutput(user, SPAN_NOTICE("<b>The depleted scroll vanishes in a puff of smoke!</b>"))
+		qdel(src)
+
 
 ////////////////////////////////////////////////////// Staves /////////////////////////////////////////////////////
 

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -18,7 +18,7 @@
 	desc = "This isn't that old, you just spilled mugwort tea on it the other day."
 
 /obj/item/teleportation_scroll/get_desc()
-	. = ..() + " Charges left: [src.uses]."
+	. = "Charges left: [src.uses]."
 
 /obj/item/teleportation_scroll/attack_self(mob/user as mob)
 	if (!iswizard(user))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that `usr.teleportscroll` is called directly after using a Teleportation Scroll. The scroll's description now indicates the amount of charges left.

![image](https://github.com/user-attachments/assets/3a55d525-c7b0-40ae-bb59-3d8b73ef966c)




## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previously, using the scroll would open a window containing a link to call the teleport method which opens a location list. Much like in #15613, we can just call that teleport method straight away.
Old window:
![image](https://github.com/user-attachments/assets/4dd21418-05b6-48ff-bd2f-8547a9912bb4)



[ui][qol]