### PR TITLE
Zoldorf Notes Normalization

### DIFF
--- a/code/datums/abilities/zoldorfabilities.dm
+++ b/code/datums/abilities/zoldorfabilities.dm
@@ -511,15 +511,15 @@
 					if(!pz.notes.len)
 						boutput(user,SPAN_ALERT("<b>You have no saved notes!</b>"))
 						return
+
 					var/aaa //modified list data
 					for(var/i=1,i<=pz.notes.len,i++)
 						var/yeet = "<span>"
 						yeet+=pz.notes[i]
 						yeet+="<br><br></span>"
 						aaa+=yeet
-					var/sizex = 0
-					var/sizey = 0
-					usr << browse("<HTML><HEAD><TITLE>Notes</TITLE></HEAD><BODY><TT>[aaa]</TT></BODY></HTML>", "window=Notes[(sizex || sizey) ? {";size=[sizex]x[sizey]"} : ""]")
+					tgui_message(usr, "[aaa]", "Notes")
+
 				if("Add Note")
 					var/note
 					note = input("Note") as null|text


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes zoldorf notes use the same system as player notes (`mob/proc/show_memory(...)`)
![image](https://github.com/user-attachments/assets/9a2e1d16-2ab5-4dfa-a791-3ddb43de4519)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Down with `browse(...)`s
Here was the old notes popup:
![261894850-ed133c74-34d0-4c70-8587-c637272783ff](https://github.com/user-attachments/assets/4e48750b-b79e-48cf-aac2-f55e3d4c965f)

[ui][qol]