### PR TITLE
tgui_message for Memorial Stats (nukies and podwars)

### DIFF
--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -519,17 +519,7 @@ var/syndicate_name = null
 		if (..(user))
 			return
 
-		var/wins = world.load_intra_round_value("nukie_win")
-		var/losses = world.load_intra_round_value("nukie_loss")
-		if(isnull(wins))
-			wins = 0
-		if(isnull(losses))
-			losses = 0
-
-		src.add_dialog(user)
-		user.Browse(src.desc, "title=Mission Memorial;window=cairngorm_stats_[src];size=300x300")
-		onclose(user, "cairngorm_stats_[src]")
-		return
+		tgui_message(user, src.desc, "Mission Memorial", theme = "syndicate")
 
 
 /obj/New()

--- a/code/datums/gamemodes/pod_wars.dm
+++ b/code/datums/gamemodes/pod_wars.dm
@@ -1008,16 +1008,7 @@ proc/setup_pw_crate_lists()
 		if (..(user))
 			return
 
-		var/nt_wins = world.load_intra_round_value("nt_win")
-		var/nt_deaths = world.load_intra_round_value("nt_death")
-		if(isnull(nt_wins))
-			nt_wins = 0
-		if(isnull(nt_deaths))
-			nt_deaths = 0
-
-		src.add_dialog(user)
-		user.Browse(src.desc, "title=Mission Log;window=pod_war_stats_[src];size=300x300")
-		onclose(user, "pod_war_stats_[src]")
+		tgui_message(user, src.desc, "Mission Log", theme = "ntos")
 
 /obj/decoration/memorial/pod_war_stats_sy/
 	name = "Syndicate Mission Log"
@@ -1043,16 +1034,7 @@ proc/setup_pw_crate_lists()
 		if (..(user))
 			return
 
-		var/sy_wins = world.load_intra_round_value("sy_win")
-		var/sy_deaths = world.load_intra_round_value("sy_death")
-		if(isnull(sy_wins))
-			sy_wins = 0
-		if(isnull(sy_deaths))
-			sy_deaths = 0
-
-		src.add_dialog(user)
-		user.Browse(src.desc, "title=Mission Log;window=pod_war_stats_[src];size=300x300")
-		onclose(user, "pod_war_stats_[src]")
+		tgui_message(user, src.desc, "Mission Log", theme = "syndicate")
 
 /obj/decoration/memorial/memorial_left
 	name = "Memorial Inscription"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Converts the old browse window for these stats to a themed `tgui_message(...)`
Also deletes useless recalculation of wins/losses in `attack_hand(...)`
![image](https://github.com/user-attachments/assets/e74283a4-b0a9-4e1f-abe3-faaab90a7c3b)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I wasn't sure it'd look nice so I tested them all in the same batch, turns out imo they do.
old popups:
![261896301-4cad43d9-f3fa-4e63-8b3a-993c011f5905](https://github.com/user-attachments/assets/2ad71fa5-6f0d-4159-9b4f-10139157b165) ![261896333-b89a2fcf-373e-451d-8bf8-1b50161232e5](https://github.com/user-attachments/assets/4cdb3fed-cdd9-43f9-9e4b-5e70dd25ccb0)

[ui][qol]
