### PR TITLE
Portable Reagent Extractor TGUI

### DIFF
--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -1166,9 +1166,9 @@ TYPEINFO(/obj/machinery/chem_master)
 			src.UpdateIcon()
 			global.tgui_process.update_uis(src)
 
-	ui_status(mob/user, datum/ui_state/state)
+	ui_status()
 		if (src.parent_item)
-			return src.parent_item.ui_status(user, state)
+			return src.parent_item.ui_status(arglist(args))
 		else
 			return ..()
 

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -526,9 +526,9 @@ TYPEINFO(/obj/machinery/chem_master)
 		/obj/item/reagent_containers/patch // 30u
 	)
 
-	var/obj/item/robot_chemaster/prototype2/parent_item = null
+	var/obj/item/robot_chemaster/prototype/parent_item = null
 
-	New(var/obj/item/robot_chemaster/prototype2/parent_item = null)
+	New(var/obj/item/robot_chemaster/prototype/parent_item = null)
 		..()
 		if (!src.emagged && islist(global.chem_whitelist) && length(global.chem_whitelist))
 			src.whitelist = global.chem_whitelist

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -1436,10 +1436,12 @@ TYPEINFO(/obj/machinery/chemicompiler_stationary)
 			ST.name = "Small Storage Tank [count]"
 			count++
 		AddComponent(/datum/component/transfer_input/quickloading, allowed, "tryLoading")
-		AddComponent(/datum/component/transfer_output)
 
 	attack_ai(var/mob/user as mob)
-		return attack_hand(user)
+		return
+
+	attack_self(mob/user as mob)
+		ui_interact(user)
 
 	ui_interact(mob/user, datum/tgui/ui)
 		remove_distant_beaker()
@@ -1494,7 +1496,6 @@ TYPEINFO(/obj/machinery/chemicompiler_stationary)
 				if (!I)
 					return
 				if(src.inserted.loc == src)
-					TRANSFER_OR_DROP(src, I) // causes Exited proc to be called
 					usr.put_in_hand_or_eject(I)
 				if (I == src.extract_to) src.extract_to = null
 				src.inserted = null
@@ -1511,7 +1512,7 @@ TYPEINFO(/obj/machinery/chemicompiler_stationary)
 				var/obj/item/ingredient = src.ingredients[id]
 				if (istype(ingredient))
 					src.ingredients.Remove(id)
-					TRANSFER_OR_DROP(src, ingredient)
+					usr.put_in_hand_or_eject(ingredient)
 					. = TRUE
 			if("autoextract")
 				src.autoextract = !src.autoextract
@@ -1566,8 +1567,6 @@ TYPEINFO(/obj/machinery/chemicompiler_stationary)
 		if(istype(W, /obj/item/reagent_containers/glass/) || istype(W, /obj/item/reagent_containers/food/drinks/))
 			tryInsert(W, user)
 
-		..()
-
 	proc/remove_distant_beaker(force = FALSE)
 		// borgs and people with item arms don't insert the beaker into the machine itself
 		// but whenever something would happen to the dispenser and the beaker is far it should disappear
@@ -1609,12 +1608,6 @@ TYPEINFO(/obj/machinery/chemicompiler_stationary)
 		storage_tank_1 = src.storage_tank_1,
 		storage_tank_2 = src.storage_tank_2
 	)
-
-/obj/item/robot_chemaster/prototype/update_icon()
-	if (src.ingredients.len)
-		src.icon_state = "reex-on"
-	else
-		src.icon_state = "reex-off"
 
 /obj/item/robot_chemaster/prototype/proc/doExtract(atom/movable/AM)
 	// Welp -- we don't want anyone extracting these. They'll probably

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -528,7 +528,7 @@ TYPEINFO(/obj/machinery/chem_master)
 
 	var/obj/item/robot_chemaster/prototype/parent_item = null
 
-	New(var/obj/item/robot_chemaster/prototype/parent_item = null)
+	New(var/loc, var/obj/item/robot_chemaster/prototype/parent_item = null)
 		..()
 		if (!src.emagged && islist(global.chem_whitelist) && length(global.chem_whitelist))
 			src.whitelist = global.chem_whitelist
@@ -1432,8 +1432,9 @@ TYPEINFO(/obj/machinery/chemicompiler_stationary)
 
 	New()
 		..()
-		reagent_extractor = new(src)
-		che_master = new(src)
+		//Loc needs to be this item itself otherwise we get "nopower"
+		reagent_extractor = new(src, src)
+		che_master = new(src, src)
 		AddComponent(/datum/component/transfer_input/quickloading, allowed, "tryLoading")
 
 	//We don't want anything to do with /obj/item/robot_chemaster's attackby(...)

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -1436,6 +1436,7 @@ TYPEINFO(/obj/machinery/chemicompiler_stationary)
 		che_master = new(src)
 		AddComponent(/datum/component/transfer_input/quickloading, allowed, "tryLoading")
 
+	//We don't want anything to do with /obj/item/robot_chemaster's attackby(...)
 	attackby(var/obj/item/W, var/mob/user)
 		return
 

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -1437,6 +1437,18 @@ TYPEINFO(/obj/machinery/chemicompiler_stationary)
 			count++
 		AddComponent(/datum/component/transfer_input/quickloading, allowed, "tryLoading")
 
+	attackby(var/obj/item/W, var/mob/user)
+		if(istype(W, /obj/item/reagent_containers/glass/))
+			var/mode_type = tgui_alert(user, "Which mode do you want to use?", "Mini-CheMaster", list("Reagent Extractor", "CheMaster"))
+			if(mode_type == "CheMaster")
+				do_chemaster_stuff_oldschool(W, user)
+
+			else if(mode_type == "Reagent Extractor")
+				tryInsert(W, user)
+
+		else if (istype(W, /obj/item/reagent_containers/food/drinks/))
+			tryInsert(W, user)
+
 	proc/do_chemaster_stuff_oldschool(var/obj/item/reagent_containers/glass/B, var/mob/user)
 		if (working)
 			boutput(user, SPAN_ALERT("CheMaster is working, be patient"))
@@ -1665,18 +1677,6 @@ TYPEINFO(/obj/machinery/chemicompiler_stationary)
 		. = ..()
 		if(inserted?.loc != src)
 			remove_distant_beaker(force = TRUE)
-
-	attackby(var/obj/item/W, var/mob/user)
-		if(istype(W, /obj/item/reagent_containers/glass/))
-			var/mode_type = tgui_alert(user, "Which mode do you want to use?", "Mini-CheMaster", list("Reagent Extractor", "CheMaster"))
-			if(mode_type == "CheMaster")
-				do_chemaster_stuff_oldschool(W, user)
-
-			else if(mode_type == "Reagent Extractor")
-				tryInsert(W, user)
-
-		else if (istype(W, /obj/item/reagent_containers/food/drinks/))
-			tryInsert(W, user)
 
 	proc/remove_distant_beaker(force = FALSE)
 		// borgs and people with item arms don't insert the beaker into the machine itself

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -1418,14 +1418,14 @@ TYPEINFO(/obj/machinery/chemicompiler_stationary)
 	icon_state = "minichem_proto"
 	flags = NOSPLASH
 	var/mode = "overview"
-	var/autoextract = 0
+	var/autoextract = FALSE
+	var/nextingredientkey = 0
 	var/obj/item/reagent_containers/glass/extract_to = null
 	var/obj/item/reagent_containers/glass/inserted = null
 	var/obj/item/reagent_containers/glass/storage_tank_1 = null
 	var/obj/item/reagent_containers/glass/storage_tank_2 = null
 	var/list/ingredients = list()
 	var/list/allowed = list(/obj/item/reagent_containers/food/snacks/,/obj/item/plant/,/obj/item/seashell)
-	var/output_target = null
 
 	New()
 		..()
@@ -1435,395 +1435,207 @@ TYPEINFO(/obj/machinery/chemicompiler_stationary)
 		for (var/obj/item/reagent_containers/glass/beaker/large/ST in src.contents)
 			ST.name = "Small Storage Tank [count]"
 			count++
-		output_target = src.loc
-
-	attackby(obj/item/W, mob/user)
-		if (istype(W, /obj/item/reagent_containers/glass/))
-			var/obj/item/reagent_containers/glass/B = W
-
-			if (working)
-				boutput(user, SPAN_ALERT("CheMaster is working, be patient"))
-				return
-			var/mode_type = input("Which mode do you want to use?", "Mini-CheMaster",null,null) in list("CheMaster", "Reagent Extractor")
-			if(mode_type == "CheMaster")
-				if(!B.reagents.reagent_list.len || B.reagents.total_volume < 1)
-					boutput(user, SPAN_ALERT("That beaker is empty! There are no reagents for the [src.name] to process!"))
-					return
-				working = 1
-				var/holder = src.loc
-				var/the_reagent = input("Which reagent do you want to manipulate?","Mini-CheMaster",null,null) in B.reagents.reagent_list
-				if (src.loc != holder || !the_reagent)
-					return
-				var/action = input("What do you want to do with the [the_reagent]?","Mini-CheMaster",null,null) in list("Isolate","Purge","Remove One Unit","Remove Five Units","Create Pill","Create Pill Bottle","Create Bottle","Create Patch","Create Ampoule","Do Nothing")
-				if (src.loc != holder || !action || action == "Do Nothing")
-					working = 0
-					return
-
-				switch(action)
-					if("Isolate") B.reagents.isolate_reagent(the_reagent)
-					if("Purge") B.reagents.del_reagent(the_reagent)
-					if("Remove One Unit") B.reagents.remove_reagent(the_reagent, 1)
-					if("Remove Five Units") B.reagents.remove_reagent(the_reagent, 5)
-					if("Create Pill")
-						var/obj/item/reagent_containers/pill/P = new/obj/item/reagent_containers/pill(user.loc)
-						var/default = B.reagents.get_master_reagent_name()
-						var/name = copytext(html_encode(input(user,"Name:","Name your pill!",default)), 1, 32)
-						if(!name || name == " ") name = default
-						if(name && name != default)
-							phrase_log.log_phrase("pill", name, no_duplicates=TRUE)
-						P.name = "[name] pill"
-						B.reagents.trans_to(P,B.reagents.total_volume)
-					if("Create Pill Bottle")
-						// copied from chem_master because fuck fixing everything at once jeez
-						var/default = B.reagents.get_master_reagent_name()
-						var/pillname = copytext( html_encode( input( user, "Name:", "Name the pill!", default ) ), 1, 32)
-						if(!pillname || pillname == " ")
-							pillname = default
-						if(pillname && pillname != default)
-							phrase_log.log_phrase("pill", pillname, no_duplicates=TRUE)
-
-						var/pillvol = input( user, "Volume:", "Volume of chemical per pill!", "5" ) as num
-						if( !pillvol || !isnum_safe(pillvol) || pillvol < 5 )
-							pillvol = 5
-
-						var/pillcount = round( B.reagents.total_volume / pillvol ) // round with a single parameter is actually floor because byond
-						if(!pillcount)
-							boutput(user, "[src] makes a weird grinding noise. That can't be good.")
-						else
-							var/obj/item/chem_pill_bottle/pillbottle = new /obj/item/chem_pill_bottle(user.loc)
-							pillbottle.create_from_reagents(B.reagents, pillname, pillvol, pillcount)
-					if("Create Bottle")
-						var/obj/item/reagent_containers/glass/bottle/P = new/obj/item/reagent_containers/glass/bottle/plastic(user.loc)
-						var/default = B.reagents.get_master_reagent_name()
-						var/name = copytext(html_encode(input(user,"Name:","Name your bottle!",default)), 1, 32)
-						if(!name || name == " ") name = default
-						if(name && name != default)
-							phrase_log.log_phrase("bottle", name, no_duplicates=TRUE)
-						P.name = "[name] bottle"
-						B.reagents.trans_to(P,30)
-					if("Create Patch")
-						var/datum/reagents/R = B.reagents
-						var/input_name = input(user, "Name the patch:", "Name", R.get_master_reagent_name()) as null|text
-						var/patchname = copytext(html_encode(input_name), 1, 32)
-						if (isnull(patchname) || !length(patchname) || patchname == " ")
-							working = 0
-							return
-						var/all_safe = 1
-						for (var/reagent_id in R.reagent_list)
-							if (!global.chem_whitelist.Find(reagent_id))
-								all_safe = 0
-						var/obj/item/reagent_containers/patch/P
-						if (R.total_volume <= 15)
-							P = new /obj/item/reagent_containers/patch/mini(user.loc)
-							P.name = "[patchname] mini-patch"
-							R.trans_to(P, P.initial_volume)
-						else
-							P = new /obj/item/reagent_containers/patch(user.loc)
-							P.name = "[patchname] patch"
-							R.trans_to(P, P.initial_volume)
-						P.medical = all_safe
-						P.on_reagent_change()
-						logTheThing(LOG_CHEMISTRY, user, "used the [src.name] to create a [patchname] patch containing [log_reagents(P)] at [log_loc(src)].")
-					if("Create Ampoule")
-						var/datum/reagents/R = B.reagents
-						var/input_name = input(user, "Name the ampoule:", "Name", R.get_master_reagent_name()) as null|text
-						var/ampoulename = copytext(html_encode(input_name), 1, 32)
-						if(!ampoulename)
-							working = 0
-							return
-						if(ampoulename == " ")
-							ampoulename = R.get_master_reagent_name()
-						var/obj/item/reagent_containers/ampoule/A
-						A = new /obj/item/reagent_containers/ampoule(user.loc)
-						A.name = "ampoule ([ampoulename])"
-						R.trans_to(A, 5)
-						logTheThing(LOG_CHEMISTRY, user, "used the [src.name] to create a [ampoulename] ampoule containing [log_reagents(A)] at [log_loc(src)].")
-
-				working = 0
-			else if(mode_type == "Reagent Extractor")
-				if(src.inserted)
-					boutput(user, SPAN_ALERT("A container is already loaded into the machine."))
-					return
-				src.inserted =  W
-				user.drop_item()
-				W.set_loc(src)
-				boutput(user, SPAN_NOTICE("You add [W] to the machine!"))
-				src.updateUsrDialog()
-
-		else if (istype(W,/obj/item/satchel/hydro)) //Extractor
-			var/obj/item/satchel/S = W
-			var/loadcount = 0
-			for (var/obj/item/I in S.contents)
-				if (src.canExtract(I) && (src.tryLoading(I, user)))
-					loadcount++
-			if (!loadcount)
-				boutput(user, SPAN_ALERT("No items were loaded from the satchel!"))
-			else if (src.autoextract)
-				boutput(user, SPAN_NOTICE("[loadcount] items were automatically extracted from the satchel!"))
-			else
-				boutput(user, SPAN_NOTICE("[loadcount] items were loaded from the satchel!"))
-
-			S.UpdateIcon()
-			S.tooltip_rebuild = 1
-			src.updateUsrDialog()
-
-		else
-			if (!src.canExtract(W))
-				boutput(user, SPAN_ALERT("The extractor cannot accept that!"))
-				return
-
-			if (!src.tryLoading(W, user)) return
-			boutput(user, SPAN_NOTICE("You add [W] to the machine!"))
-
-			user.u_equip(W)
-			W.dropped(user)
-
-			src.updateUsrDialog()
-			return
+		AddComponent(/datum/component/transfer_input/quickloading, allowed, "tryLoading")
+		AddComponent(/datum/component/transfer_output)
 
 	attack_ai(var/mob/user as mob)
-		return
+		return attack_hand(user)
 
-	attack_hand(mob/user)
-		if(src in user.equipped_list())
-			src.add_dialog(user)
-			var/list/dat = list("<B>Reagent Extractor</B><BR><HR>")
-			if (src.mode == "overview")
-				dat += "<b><u>Extractor Overview</u></b><br><br>"
-				// Overview mode is just a general outline of what's in the machine at the time
-				// Internal Storage Tanks
-				if (src.storage_tank_1)
-					dat += "<b>Storage Tank 1:</b> ([src.storage_tank_1.reagents.total_volume]/[src.storage_tank_1.reagents.maximum_volume])<br>"
-					if(src.storage_tank_1.reagents.reagent_list.len)
-						for(var/current_id in storage_tank_1.reagents.reagent_list)
-							var/datum/reagent/current_reagent = storage_tank_1.reagents.reagent_list[current_id]
-							dat += "* <i>[current_reagent.volume] units of [current_reagent.name]</i><br>"
-					else dat += "Empty<BR>"
-					dat += "<br>"
-				else dat += "<b>Storage Tank 1 Missing!</b><br>"
-				if (src.storage_tank_2)
-					dat += "<b>Storage Tank 2:</b> ([src.storage_tank_2.reagents.total_volume]/[src.storage_tank_2.reagents.maximum_volume])<br>"
-					if(src.storage_tank_2.reagents.reagent_list.len)
-						for(var/current_id in storage_tank_2.reagents.reagent_list)
-							var/datum/reagent/current_reagent = storage_tank_2.reagents.reagent_list[current_id]
-							dat += "* <i>[current_reagent.volume] units of [current_reagent.name]</i><br>"
-					else dat += "Empty<BR>"
-					dat += "<br>"
-				else dat += "<b>Storage Tank 2 Missing!</b><br>"
-				// Inserted Beaker or whatever
-				if (src.inserted)
-					dat += "<B>Receptacle:</B> [src.inserted] ([src.inserted.reagents.total_volume]/[src.inserted.reagents.maximum_volume]) <A href='?src=\ref[src];ejectbeaker=1'>(Eject)</A><BR>"
-					dat += "<b>Contents:</b> "
-					if(src.inserted.reagents.reagent_list.len)
-						for(var/current_id in inserted.reagents.reagent_list)
-							var/datum/reagent/current_reagent = inserted.reagents.reagent_list[current_id]
-							dat += "<BR><i>[current_reagent.volume] units of [current_reagent.name]</i>"
-					else dat += "Empty<BR>"
-				else dat += "<B>No receptacle inserted!</B><BR>"
+	ui_interact(mob/user, datum/tgui/ui)
+		remove_distant_beaker()
+		if (src.inserted)
+			SEND_SIGNAL(src.inserted.reagents, COMSIG_REAGENTS_ANALYZED, user)
+		ui = tgui_process.try_update_ui(user, src, ui)
+		if(!ui)
+			ui = new(user, src, "ReagentExtractor", src.name)
+			ui.open()
 
-				if(src.ingredients.len)
-					dat += "<BR><B>[src.ingredients.len] Items Ready for Extraction</B>"
-				else
-					dat += "<BR><B>No Items inserted!</B>"
 
-			else if (src.mode == "extraction")
-				dat += "<b><u>Extraction Management</u></b><br><br>"
-				if (src.autoextract)
-					dat += "<b>Auto-Extraction:</b> <A href='?src=\ref[src];autoextract=1'>Enabled</A>"
-				else
-					dat += "<b>Auto-Extraction:</b> <A href='?src=\ref[src];autoextract=1'>Disabled</A>"
-				dat += "<br>"
-				if (src.extract_to)
-					dat += "<b>Extraction Target:</b> <A href='?src=\ref[src];extracttarget=1'>[src.extract_to]</A> ([src.extract_to.reagents.total_volume]/[src.extract_to.reagents.maximum_volume])"
-					if (src.extract_to == src.inserted) dat += "<A href='?src=\ref[src];ejectbeaker=1'>(Eject)</A>"
-				else dat += "<A href='?src=\ref[src];extracttarget=1'><b>No current extraction target set.</b></A>"
+	ui_data(mob/user)
+		. = list()
+		var/list/containers = src.getContainers()
 
-				if(src.ingredients.len)
-					dat += "<br><br><B>Extractable Items:</B><br><br>"
-					for (var/obj/item/I in src.ingredients)
-						dat += "* [I]<br>"
-						dat += "<A href='?src=\ref[src];extractingred=\ref[I]'>(Extract)</A> <A href='?src=\ref[src];ejectingred=\ref[I]'>(Eject)</A><br>"
-				else dat += "<br><br><B>No Items inserted!</B>"
+		var/list/containersData = list()
+		// Container data
+		for(var/container_id in containers)
+			var/obj/item/reagent_containers/thisContainer = containers[container_id]
+			if (!thisContainer)
+				continue
+			containersData[container_id] = ui_describe_reagents(thisContainer)
+			containersData[container_id]["selected"] = src.extract_to == thisContainer
+			containersData[container_id]["id"] = container_id
 
-			else if (src.mode == "transference")
-				dat += "<b><u>Transfer Management</u></b><br><br>"
+		.["containersData"] = containersData
 
-				if (src.inserted)
-					dat += "<A href='?src=\ref[src];chemtransfer=\ref[src.inserted]'><b>[src.inserted]:</b></A> ([src.inserted.reagents.total_volume]/[src.inserted.reagents.maximum_volume]) <A href='?src=\ref[src];flush=\ref[src.inserted]'>(Flush All)</A> <A href='?src=\ref[src];ejectbeaker=1'>(Eject)</A><br>"
-					if(src.inserted.reagents.reagent_list.len)
-						for(var/current_id in inserted.reagents.reagent_list)
-							var/datum/reagent/current_reagent = inserted.reagents.reagent_list[current_id]
-							dat += "* <i>[current_reagent.volume] units of [current_reagent.name]</i> <A href='?src=\ref[src];flush=\ref[src.inserted];flush_reagent=[current_id]'>(X)</A><br>"
-					else dat += "Empty<BR>"
-				else dat += "<b>No receptacle inserted!</b><br>"
+		var/list/ingredientsData = list()
+		// Ingredient/Extractable data
+		for(var/ingredient_id in src.ingredients)
+			var/obj/item/thisIngredient = src.ingredients[ingredient_id]
+			if(thisIngredient)
+				var/list/thisIngredientData = list(
+					name = thisIngredient.name,
+					id = ingredient_id
+				)
+				ingredientsData += list(thisIngredientData)
 
-				dat += "<br>"
+		.["ingredientsData"] = ingredientsData
 
-				dat += "<A href='?src=\ref[src];chemtransfer=\ref[src.storage_tank_1]'><b>Storage Tank 1:</b></A> ([src.storage_tank_1.reagents.total_volume]/[src.storage_tank_1.reagents.maximum_volume]) <A href='?src=\ref[src];flush=\ref[src.storage_tank_1]'>(Flush All)</A><br>"
-				if(src.storage_tank_1.reagents.reagent_list.len)
-					for(var/current_id in storage_tank_1.reagents.reagent_list)
-						var/datum/reagent/current_reagent = storage_tank_1.reagents.reagent_list[current_id]
-						dat += "* <i>[current_reagent.volume] units of [current_reagent.name]</i> <A href='?src=\ref[src];flush=\ref[src.storage_tank_1];flush_reagent=[current_id]'>(X)</A><br>"
-				else dat += "Empty<BR>"
+		.["autoextract"] = src.autoextract
 
-				dat += "<br>"
-				dat += "<A href='?src=\ref[src];chemtransfer=\ref[src.storage_tank_2]'><b>Storage Tank 2:</b></A> ([src.storage_tank_2.reagents.total_volume]/[src.storage_tank_2.reagents.maximum_volume]) <A href='?src=\ref[src];flush=\ref[src.storage_tank_2]'>(Flush All)</A><br>"
-				if(src.storage_tank_2.reagents.reagent_list.len)
-					for(var/current_id in storage_tank_2.reagents.reagent_list)
-						var/datum/reagent/current_reagent = storage_tank_2.reagents.reagent_list[current_id]
-						dat += "* <i>[current_reagent.volume] units of [current_reagent.name]</i> <A href='?src=\ref[src];flush=\ref[src.storage_tank_2];flush_reagent=[current_id]'>(X)</A><br>"
-				else dat += "Empty<BR>"
-
-			else
-				dat += {"<b>Software Error.</b><br>
-				<A href='?src=\ref[src];page=1'>Please click here to return to the Overview.</A>"}
-
-			dat += "<HR>"
-			dat += "<b><u>Mode:</u></b> <A href='?src=\ref[src];page=1'>(Overview)</A> <A href='?src=\ref[src];page=2'>(Extraction)</A> <A href='?src=\ref[src];page=3'>(Transference)</A>"
-
-			user.Browse(dat.Join(), "window=rextractor;size=370x500")
-			onclose(user, "rextractor")
-		else
-			return ..()
-
-	attack_self(mob/user)
-		src.Attackhand(user)
-
-	MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
-		return
-
-	handle_event(var/event, var/sender)
-		if (event == "reagent_holder_update")
-			src.updateUsrDialog()
-
-	Topic(href, href_list)
-		if(BOUNDS_DIST(usr, src) > 0 && !issilicon(usr) && !isAI(usr) )
-			boutput(usr, SPAN_ALERT("You need to be closer to the extractor to do that!"))
+	ui_act(action, params)
+		. = ..()
+		if(.)
 			return
-		if(href_list["page"])
-			var/ops = text2num_safe(href_list["page"])
-			switch(ops)
-				if(2) src.mode = "extraction"
-				if(3) src.mode = "transference"
-				else src.mode = "overview"
-			src.updateUsrDialog()
-
-		else if(href_list["ejectbeaker"])
-			if (!src.inserted) boutput(usr, SPAN_ALERT("No receptacle found to eject."))
-			else
-				if (src.inserted == src.extract_to) src.extract_to = null
-				src.inserted.set_loc(src.output_target)
-				usr.put_in_hand_or_eject(inserted)
-				src.inserted = null
-			src.updateUsrDialog()
-
-		else if(href_list["ejectingred"])
-			var/obj/item/I = locate(href_list["ejectingred"]) in src
-			if (istype(I))
-				src.ingredients.Remove(I)
-				I.set_loc(src.output_target)
-				boutput(usr, SPAN_NOTICE("You eject [I] from the machine!"))
-			src.updateUsrDialog()
-
-		else if (href_list["autoextract"])
-			src.autoextract = !src.autoextract
-			src.updateUsrDialog()
-
-		else if (href_list["flush_reagent"])
-			var/id = href_list["flush_reagent"]
-			var/obj/item/reagent_containers/T = locate(href_list["flush"]) in src
-			if (istype(T, /obj/item/reagent_containers/food/drinks) || istype(T, /obj/item/reagent_containers/glass) && T.reagents)
-				T.reagents.remove_reagent(id, 500)
-			src.updateUsrDialog()
-
-		else if (href_list["flush"])
-			var/obj/item/reagent_containers/T = locate(href_list["flush"]) in src
-			if (istype(T, /obj/item/reagent_containers/food/drinks) || istype(T, /obj/item/reagent_containers/glass) && T.reagents)
-				T.reagents.clear_reagents()
-			src.updateUsrDialog()
-
-		else if(href_list["extracttarget"])
-			var/list/ext_targets = list(src.storage_tank_1,src.storage_tank_2)
-			if (src.inserted) ext_targets.Add(src.inserted)
-			var/target = input(usr, "Extract to which target?", "Reagent Extractor", 0) in ext_targets
-			if(BOUNDS_DIST(usr, src) > 0) return
-			src.extract_to = target
-			src.updateUsrDialog()
-
-		else if(href_list["extractingred"])
-			if (!src.extract_to)
-				boutput(usr, SPAN_ALERT("You must first select an extraction target."))
-			else
-				if (src.extract_to.reagents.total_volume == src.extract_to.reagents.maximum_volume)
-					boutput(usr, SPAN_ALERT("The extraction target is already full."))
-				else
-					var/obj/item/I = locate(href_list["extractingred"]) in src
-					if (!istype(I) || !I.reagents)
-						return
-
-					src.doExtract(I)
-					src.ingredients -= I
-					qdel(I)
-			src.updateUsrDialog()
-
-		else if(href_list["chemtransfer"])
-			var/obj/item/reagent_containers/glass/G = locate(href_list["chemtransfer"]) in src
-			if (!G)
-				boutput(usr, SPAN_ALERT("Transfer target not found."))
-				src.updateUsrDialog()
-				return
-			else if (!G.reagents.total_volume)
-				boutput(usr, SPAN_ALERT("Nothing in container to transfer."))
-				src.updateUsrDialog()
-				return
-
-			var/list/ext_targets = list(src.storage_tank_1,src.storage_tank_2)
-			if (src.inserted) ext_targets.Add(src.inserted)
-			ext_targets.Remove(G)
-			var/target = input(usr, "Transfer to which target?", "Reagent Extractor", 0) in ext_targets
-			if(BOUNDS_DIST(usr, src) > 0) return
-			var/obj/item/reagent_containers/glass/T = target
-
-			if (!T) boutput(usr, SPAN_ALERT("Transfer target not found."))
-			else if (G == T) boutput(usr, SPAN_ALERT("Cannot transfer a container's contents to itself."))
-			else
-				var/amt = input(usr, "Transfer how many units?", "Chemical Transfer", 0) as null|num
-				if(!isnum_safe(amt))
+		remove_distant_beaker()
+		var/list/containers = src.getContainers()
+		switch(action)
+			if("ejectcontainer")
+				var/obj/item/I = src.inserted
+				if (!I)
 					return
-				if(BOUNDS_DIST(usr, src) > 0) return
-				if (amt < 1) boutput(usr, SPAN_ALERT("Invalid transfer quantity."))
-				else G.reagents.trans_to(T,amt)
+				if(src.inserted.loc == src)
+					TRANSFER_OR_DROP(src, I) // causes Exited proc to be called
+					usr.put_in_hand_or_eject(I)
+				if (I == src.extract_to) src.extract_to = null
+				src.inserted = null
+				. = TRUE
+			if("insertcontainer")
+				if (src.inserted)
+					return
+				var/obj/item/inserting = usr.equipped()
+				if(istype(inserting, /obj/item/reagent_containers/glass/) || istype(inserting, /obj/item/reagent_containers/food/drinks/))
+					tryInsert(inserting, usr)
+					. = TRUE
+			if("ejectingredient")
+				var/id = params["ingredient_id"]
+				var/obj/item/ingredient = src.ingredients[id]
+				if (istype(ingredient))
+					src.ingredients.Remove(id)
+					TRANSFER_OR_DROP(src, ingredient)
+					. = TRUE
+			if("autoextract")
+				src.autoextract = !src.autoextract
+				. = TRUE
+			if("flush_reagent")
+				var/obj/item/reagent_containers/glass/target = containers[params["container_id"]]
+				var/id = params["reagent_id"]
+				if (target?.reagents)
+					target.reagents.remove_reagent(id, 500)
+					. = TRUE
+			if("isolate")
+				var/obj/item/reagent_containers/glass/target = containers[params["container_id"]]
+				var/id = params["reagent_id"]
+				if (target?.reagents)
+					target.reagents.isolate_reagent(id)
+					. = TRUE
+			if("flush")
+				var/obj/item/reagent_containers/glass/target = containers[params["container_id"]]
+				if (target)
+					target.reagents.clear_reagents()
+					. = TRUE
+			if("extractto")
+				var/obj/item/reagent_containers/glass/target = containers[params["container_id"]]
+				if (target)
+					src.extract_to = target
+					. = TRUE
+			if("extractingredient")
+				if (!src.extract_to || src.extract_to.reagents.total_volume >= src.extract_to.reagents.maximum_volume)
+					return
+				var/id = params["ingredient_id"]
+				var/obj/item/ingredient = src.ingredients[id]
+				if (!istype(ingredient) || !ingredient.reagents)
+					return
+				src.doExtract(ingredient)
+				src.ingredients.Remove(id)
+				qdel(ingredient)
+				. = TRUE
+			if("chemtransfer")
+				var/obj/item/reagent_containers/glass/from = containers[params["container_id"]]
+				var/obj/item/reagent_containers/glass/target = src.extract_to
+				if (from?.reagents.total_volume && target && from != target)
+					from.reagents.trans_to(target, clamp(params["amount"], 1, 500))
+					. = TRUE
+		src.UpdateIcon()
 
-			src.updateUsrDialog()
+	ui_close(mob/user)
+		. = ..()
+		if(inserted?.loc != src)
+			remove_distant_beaker(force = TRUE)
 
-/obj/item/robot_chemaster/prototype/proc/doExtract(var/obj/item/I)
+	attackby(var/obj/item/W, var/mob/user)
+		if(istype(W, /obj/item/reagent_containers/glass/) || istype(W, /obj/item/reagent_containers/food/drinks/))
+			tryInsert(W, user)
+
+		..()
+
+	proc/remove_distant_beaker(force = FALSE)
+		// borgs and people with item arms don't insert the beaker into the machine itself
+		// but whenever something would happen to the dispenser and the beaker is far it should disappear
+		if(src.inserted && (BOUNDS_DIST(src.inserted, src) > 0 || force))
+			if (src.inserted == src.extract_to) src.extract_to = null
+			src.inserted = null
+			src.UpdateIcon()
+
+	proc/tryInsert(var/obj/item/W, var/mob/user)
+		remove_distant_beaker()
+
+		if(BOUNDS_DIST(user, src) > 0) // prevent message from appearing in case a borg inserts from afar
+			return
+
+		if(src.inserted)
+			boutput(user, SPAN_ALERT("A container is already loaded into the machine."))
+			return
+		src.inserted =  W
+
+		if(!W.cant_drop)
+			user.drop_item()
+			if(!QDELETED(W))
+				W.set_loc(src)
+		if(QDELETED(W))
+			W = null
+		else
+			if(!src.extract_to) src.extract_to = W
+			boutput(user, SPAN_NOTICE("You add [W] to the machine!"))
+		src.ui_interact(user)
+
+	Exited(Obj, newloc)
+		if(Obj == src.inserted)
+			src.inserted = null
+			tgui_process.update_uis(src)
+
+/obj/item/robot_chemaster/prototype/proc/getContainers()
+	. = list(
+		inserted = src.inserted,
+		storage_tank_1 = src.storage_tank_1,
+		storage_tank_2 = src.storage_tank_2
+	)
+
+/obj/item/robot_chemaster/prototype/update_icon()
+	if (src.ingredients.len)
+		src.icon_state = "reex-on"
+	else
+		src.icon_state = "reex-off"
+
+/obj/item/robot_chemaster/prototype/proc/doExtract(atom/movable/AM)
 	// Welp -- we don't want anyone extracting these. They'll probably
 	// feed them to monkeys and then exsanguinate them trying to get at the chemicals.
-	if (istype(I, /obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor))
+	if (istype(AM, /obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor))
 		src.extract_to.reagents.add_reagent("sugar", 50)
 		return
+	AM.reagents.trans_to(src.extract_to, AM.reagents.total_volume)
+	qdel(AM)
+	src.UpdateIcon()
 
-	I.reagents.trans_to(src.extract_to, I.reagents.total_volume)
+/obj/item/robot_chemaster/prototype/proc/tryLoading(atom/movable/incoming)
+	var/can_autoextract = src.autoextract && src.extract_to
+	if (can_autoextract && src.extract_to.reagents.total_volume >= src.extract_to.reagents.maximum_volume)
+		playsound(src, 'sound/machines/chime.ogg', 10, TRUE)
+		src.visible_message(SPAN_ALERT("[src]'s tank over-fill alarm burps!"))
+		can_autoextract = FALSE
 
-/obj/item/robot_chemaster/prototype/proc/canExtract(O)
-	. = FALSE
-	for(var/check_path in src.allowed)
-		if(istype(O, check_path))
-			return TRUE
-
-/obj/item/robot_chemaster/prototype/proc/tryLoading(var/obj/item/O, var/mob/user as mob)
-	// Pre: make sure that the item type can be extracted
-	if (src.autoextract)
-		if (!src.extract_to)
-			boutput(user, SPAN_ALERT("You must first select an extraction target if you want items to be automatically extracted."))
-			return FALSE
-		if (src.extract_to.reagents.total_volume >= src.extract_to.reagents.maximum_volume)
-			boutput(user, SPAN_ALERT("The auto-extraction target is full."))
-			return FALSE
-		src.doExtract(O)
-		qdel(O)
-		return TRUE
+	if (can_autoextract)
+		doExtract(incoming)
 	else
-		O.set_loc(src)
-		src.ingredients += O
-		return TRUE
+		src.ingredients["[nextingredientkey++]"] = incoming
+		tgui_process.update_uis(src)
+		src.UpdateIcon()

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -526,11 +526,14 @@ TYPEINFO(/obj/machinery/chem_master)
 		/obj/item/reagent_containers/patch // 30u
 	)
 
-	New()
+	var/obj/item/robot_chemaster/prototype2/parent_item = null
+
+	New(var/obj/item/robot_chemaster/prototype2/parent_item = null)
 		..()
 		if (!src.emagged && islist(global.chem_whitelist) && length(global.chem_whitelist))
 			src.whitelist = global.chem_whitelist
 		AddComponent(/datum/component/transfer_output)
+		src.parent_item = parent_item
 
 	// borrowed from the reagent heater/cooler code
 	proc/tryInsert(obj/item/reagent_containers/glass/B, var/mob/user)
@@ -1163,6 +1166,12 @@ TYPEINFO(/obj/machinery/chem_master)
 			src.UpdateIcon()
 			global.tgui_process.update_uis(src)
 
+	ui_status(mob/user, datum/ui_state/state)
+		if (src.parent_item)
+			return src.parent_item.ui_status(user, state)
+		else
+			return ..()
+
 #undef CHEMMASTER_NO_CONTAINER_MAX
 #undef CHEMMASTER_ITEMNAME_MAXSIZE
 #undef CHEMMASTER_MAX_PILL
@@ -1417,329 +1426,25 @@ TYPEINFO(/obj/machinery/chemicompiler_stationary)
 	desc = "A prototype of a compact CheMaster/Reagent Extractor device."
 	icon_state = "minichem_proto"
 	flags = NOSPLASH
-	var/mode = "overview"
-	var/autoextract = FALSE
-	var/nextingredientkey = 0
-	var/obj/item/reagent_containers/glass/extract_to = null
-	var/obj/item/reagent_containers/glass/inserted = null
-	var/obj/item/reagent_containers/glass/storage_tank_1 = null
-	var/obj/item/reagent_containers/glass/storage_tank_2 = null
-	var/list/ingredients = list()
+	var/obj/submachine/chem_extractor/reagent_extractor
+	var/obj/machinery/chem_master/che_master
 	var/list/allowed = list(/obj/item/reagent_containers/food/snacks/,/obj/item/plant/,/obj/item/seashell)
 
 	New()
 		..()
-		src.storage_tank_1 = new /obj/item/reagent_containers/glass/beaker/large(src)
-		src.storage_tank_2 = new /obj/item/reagent_containers/glass/beaker/large(src)
-		var/count = 1
-		for (var/obj/item/reagent_containers/glass/beaker/large/ST in src.contents)
-			ST.name = "Small Storage Tank [count]"
-			count++
+		reagent_extractor = new(src)
+		che_master = new(src)
 		AddComponent(/datum/component/transfer_input/quickloading, allowed, "tryLoading")
 
 	attackby(var/obj/item/W, var/mob/user)
-		if(istype(W, /obj/item/reagent_containers/glass/))
-			var/mode_type = tgui_alert(user, "Which mode do you want to use?", "Mini-CheMaster", list("Reagent Extractor", "CheMaster"))
-			if(mode_type == "CheMaster")
-				do_chemaster_stuff_oldschool(W, user)
+		return
 
-			else if(mode_type == "Reagent Extractor")
-				tryInsert(W, user)
-
-		else if (istype(W, /obj/item/reagent_containers/food/drinks/))
-			tryInsert(W, user)
-
-	proc/do_chemaster_stuff_oldschool(var/obj/item/reagent_containers/glass/B, var/mob/user)
-		if (working)
-			boutput(user, SPAN_ALERT("CheMaster is working, be patient"))
-			return
-		if(!B.reagents.reagent_list.len || B.reagents.total_volume < 1)
-			boutput(user, SPAN_ALERT("That beaker is empty! There are no reagents for the [src.name] to process!"))
-			return
-		working = 1
-		var/holder = src.loc
-
-		var/action = tgui_input_list(user, "What do you want to create?", "Mini-CheMaster", list("Create Pill","Create Pill Bottle","Create Bottle","Create Patch","Create Ampoule"))
-		if (src.loc != holder || !action || action == "Do Nothing")
-			working = 0
-			return
-
-		switch(action)
-			if("Create Pill")
-				var/obj/item/reagent_containers/pill/P = new/obj/item/reagent_containers/pill(user.loc)
-				var/default = B.reagents.get_master_reagent_name()
-				var/name = copytext(html_encode(tgui_input_text(user,"Name:","Name your pill!",default)), 1, 32)
-				if(!name || name == " ") name = default
-				if(name && name != default)
-					phrase_log.log_phrase("pill", name, no_duplicates=TRUE)
-				P.name = "[name] pill"
-				B.reagents.trans_to(P,B.reagents.total_volume)
-			if("Create Pill Bottle")
-				// copied from chem_master because fuck fixing everything at once jeez
-				var/default = B.reagents.get_master_reagent_name()
-				var/pillname = copytext( html_encode( tgui_input_text( user, "Name:", "Name the pill!", default ) ), 1, 32)
-				if(!pillname || pillname == " ")
-					pillname = default
-				if(pillname && pillname != default)
-					phrase_log.log_phrase("pill", pillname, no_duplicates=TRUE)
-
-				var/pillvol = tgui_input_number(user, "Volume:", "Volume of chemical per pill!", 5, B.reagents.total_volume, 5)
-				if( !pillvol || !isnum_safe(pillvol) || pillvol < 5 )
-					pillvol = 5
-
-				var/pillcount = round( B.reagents.total_volume / pillvol ) // round with a single parameter is actually floor because byond
-				if(!pillcount)
-					boutput(user, "[src] makes a weird grinding noise. That can't be good.")
-				else
-					var/obj/item/chem_pill_bottle/pillbottle = new /obj/item/chem_pill_bottle(user.loc)
-					pillbottle.create_from_reagents(B.reagents, pillname, pillvol, pillcount)
-			if("Create Bottle")
-				var/obj/item/reagent_containers/glass/bottle/P = new/obj/item/reagent_containers/glass/bottle/plastic(user.loc)
-				var/default = B.reagents.get_master_reagent_name()
-				var/name = copytext(html_encode(tgui_input_text(user,"Name:","Name your bottle!",default)), 1, 32)
-				if(!name || name == " ") name = default
-				if(name && name != default)
-					phrase_log.log_phrase("bottle", name, no_duplicates=TRUE)
-				P.name = "[name] bottle"
-				B.reagents.trans_to(P,30)
-			if("Create Patch")
-				var/datum/reagents/R = B.reagents
-				var/input_name = tgui_input_text(user, "Name the patch:", "Name", R.get_master_reagent_name())
-				var/patchname = copytext(html_encode(input_name), 1, 32)
-				if (isnull(patchname) || !length(patchname) || patchname == " ")
-					working = 0
-					return
-				var/all_safe = 1
-				for (var/reagent_id in R.reagent_list)
-					if (!global.chem_whitelist.Find(reagent_id))
-						all_safe = 0
-				var/obj/item/reagent_containers/patch/P
-				if (R.total_volume <= 15)
-					P = new /obj/item/reagent_containers/patch/mini(user.loc)
-					P.name = "[patchname] mini-patch"
-					R.trans_to(P, P.initial_volume)
-				else
-					P = new /obj/item/reagent_containers/patch(user.loc)
-					P.name = "[patchname] patch"
-					R.trans_to(P, P.initial_volume)
-				P.medical = all_safe
-				P.on_reagent_change()
-				logTheThing(LOG_CHEMISTRY, user, "used the [src.name] to create a [patchname] patch containing [log_reagents(P)] at [log_loc(src)].")
-			if("Create Ampoule")
-				var/datum/reagents/R = B.reagents
-				var/input_name = tgui_input_text(user, "Name the ampoule:", "Name", R.get_master_reagent_name())
-				var/ampoulename = copytext(html_encode(input_name), 1, 32)
-				if(!ampoulename)
-					working = 0
-					return
-				if(ampoulename == " ")
-					ampoulename = R.get_master_reagent_name()
-				var/obj/item/reagent_containers/ampoule/A
-				A = new /obj/item/reagent_containers/ampoule(user.loc)
-				A.name = "ampoule ([ampoulename])"
-				R.trans_to(A, 5)
-				logTheThing(LOG_CHEMISTRY, user, "used the [src.name] to create a [ampoulename] ampoule containing [log_reagents(A)] at [log_loc(src)].")
-
-		working = 0
+	attack_self(mob/user as mob)
+		reagent_extractor.ui_interact(user)
+		che_master.ui_interact(user)
 
 	attack_ai(var/mob/user as mob)
 		return
 
-	attack_self(mob/user as mob)
-		ui_interact(user)
-
-	ui_interact(mob/user, datum/tgui/ui)
-		remove_distant_beaker()
-		if (src.inserted)
-			SEND_SIGNAL(src.inserted.reagents, COMSIG_REAGENTS_ANALYZED, user)
-		ui = tgui_process.try_update_ui(user, src, ui)
-		if(!ui)
-			ui = new(user, src, "ReagentExtractor", src.name)
-			ui.open()
-
-
-	ui_data(mob/user)
-		. = list()
-		var/list/containers = src.getContainers()
-
-		var/list/containersData = list()
-		// Container data
-		for(var/container_id in containers)
-			var/obj/item/reagent_containers/thisContainer = containers[container_id]
-			if (!thisContainer)
-				continue
-			containersData[container_id] = ui_describe_reagents(thisContainer)
-			containersData[container_id]["selected"] = src.extract_to == thisContainer
-			containersData[container_id]["id"] = container_id
-
-		.["containersData"] = containersData
-
-		var/list/ingredientsData = list()
-		// Ingredient/Extractable data
-		for(var/ingredient_id in src.ingredients)
-			var/obj/item/thisIngredient = src.ingredients[ingredient_id]
-			if(thisIngredient)
-				var/list/thisIngredientData = list(
-					name = thisIngredient.name,
-					id = ingredient_id
-				)
-				ingredientsData += list(thisIngredientData)
-
-		.["ingredientsData"] = ingredientsData
-
-		.["autoextract"] = src.autoextract
-
-	ui_act(action, params)
-		. = ..()
-		if(.)
-			return
-		remove_distant_beaker()
-		var/list/containers = src.getContainers()
-		switch(action)
-			if("ejectcontainer")
-				var/obj/item/I = src.inserted
-				if (!I)
-					return
-				if(src.inserted.loc == src)
-					usr.put_in_hand_or_eject(I)
-				if (I == src.extract_to) src.extract_to = null
-				src.inserted = null
-				. = TRUE
-			if("insertcontainer")
-				if (src.inserted)
-					return
-				var/obj/item/inserting = usr.equipped()
-
-				if(istype(inserting, /obj/item/reagent_containers/glass/))
-					var/mode_type = tgui_alert(usr, "Which mode do you want to use?", "Mini-CheMaster", list("Reagent Extractor", "CheMaster"))
-					if(mode_type == "CheMaster")
-						do_chemaster_stuff_oldschool(inserting, usr)
-
-					else if(mode_type == "Reagent Extractor")
-						tryInsert(inserting, usr)
-						. = TRUE
-
-				else if(istype(inserting, /obj/item/reagent_containers/food/drinks/))
-					tryInsert(inserting, usr)
-					. = TRUE
-			if("ejectingredient")
-				var/id = params["ingredient_id"]
-				var/obj/item/ingredient = src.ingredients[id]
-				if (istype(ingredient))
-					src.ingredients.Remove(id)
-					usr.put_in_hand_or_eject(ingredient)
-					. = TRUE
-			if("autoextract")
-				src.autoextract = !src.autoextract
-				. = TRUE
-			if("flush_reagent")
-				var/obj/item/reagent_containers/glass/target = containers[params["container_id"]]
-				var/id = params["reagent_id"]
-				if (target?.reagents)
-					target.reagents.remove_reagent(id, 500)
-					. = TRUE
-			if("isolate")
-				var/obj/item/reagent_containers/glass/target = containers[params["container_id"]]
-				var/id = params["reagent_id"]
-				if (target?.reagents)
-					target.reagents.isolate_reagent(id)
-					. = TRUE
-			if("flush")
-				var/obj/item/reagent_containers/glass/target = containers[params["container_id"]]
-				if (target)
-					target.reagents.clear_reagents()
-					. = TRUE
-			if("extractto")
-				var/obj/item/reagent_containers/glass/target = containers[params["container_id"]]
-				if (target)
-					src.extract_to = target
-					. = TRUE
-			if("extractingredient")
-				if (!src.extract_to || src.extract_to.reagents.total_volume >= src.extract_to.reagents.maximum_volume)
-					return
-				var/id = params["ingredient_id"]
-				var/obj/item/ingredient = src.ingredients[id]
-				if (!istype(ingredient) || !ingredient.reagents)
-					return
-				src.doExtract(ingredient)
-				src.ingredients.Remove(id)
-				qdel(ingredient)
-				. = TRUE
-			if("chemtransfer")
-				var/obj/item/reagent_containers/glass/from = containers[params["container_id"]]
-				var/obj/item/reagent_containers/glass/target = src.extract_to
-				if (from?.reagents.total_volume && target && from != target)
-					from.reagents.trans_to(target, clamp(params["amount"], 1, 500))
-					. = TRUE
-		src.UpdateIcon()
-
-	ui_close(mob/user)
-		. = ..()
-		if(inserted?.loc != src)
-			remove_distant_beaker(force = TRUE)
-
-	proc/remove_distant_beaker(force = FALSE)
-		// borgs and people with item arms don't insert the beaker into the machine itself
-		// but whenever something would happen to the dispenser and the beaker is far it should disappear
-		if(src.inserted && (BOUNDS_DIST(src.inserted, src) > 0 || force))
-			if (src.inserted == src.extract_to) src.extract_to = null
-			src.inserted = null
-			src.UpdateIcon()
-
-	proc/tryInsert(var/obj/item/W, var/mob/user)
-		remove_distant_beaker()
-
-		if(BOUNDS_DIST(user, src) > 0) // prevent message from appearing in case a borg inserts from afar
-			return
-
-		if(src.inserted)
-			boutput(user, SPAN_ALERT("A container is already loaded into the machine."))
-			return
-		src.inserted =  W
-
-		if(!W.cant_drop)
-			user.drop_item()
-			if(!QDELETED(W))
-				W.set_loc(src)
-		if(QDELETED(W))
-			W = null
-		else
-			if(!src.extract_to) src.extract_to = W
-			boutput(user, SPAN_NOTICE("You add [W] to the machine!"))
-		src.ui_interact(user)
-
-	Exited(Obj, newloc)
-		if(Obj == src.inserted)
-			src.inserted = null
-			tgui_process.update_uis(src)
-
-/obj/item/robot_chemaster/prototype/proc/getContainers()
-	. = list(
-		inserted = src.inserted,
-		storage_tank_1 = src.storage_tank_1,
-		storage_tank_2 = src.storage_tank_2
-	)
-
-/obj/item/robot_chemaster/prototype/proc/doExtract(atom/movable/AM)
-	// Welp -- we don't want anyone extracting these. They'll probably
-	// feed them to monkeys and then exsanguinate them trying to get at the chemicals.
-	if (istype(AM, /obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor))
-		src.extract_to.reagents.add_reagent("sugar", 50)
-		return
-	AM.reagents.trans_to(src.extract_to, AM.reagents.total_volume)
-	qdel(AM)
-	src.UpdateIcon()
-
-/obj/item/robot_chemaster/prototype/proc/tryLoading(atom/movable/incoming)
-	var/can_autoextract = src.autoextract && src.extract_to
-	if (can_autoextract && src.extract_to.reagents.total_volume >= src.extract_to.reagents.maximum_volume)
-		playsound(src, 'sound/machines/chime.ogg', 10, TRUE)
-		src.visible_message(SPAN_ALERT("[src]'s tank over-fill alarm burps!"))
-		can_autoextract = FALSE
-
-	if (can_autoextract)
-		doExtract(incoming)
-	else
-		src.ingredients["[nextingredientkey++]"] = incoming
-		tgui_process.update_uis(src)
-		src.UpdateIcon()
+	proc/tryLoading(atom/movable/incoming)
+		reagent_extractor.tryLoading(incoming)

--- a/code/obj/submachine/chem_extractor.dm
+++ b/code/obj/submachine/chem_extractor.dm
@@ -22,8 +22,9 @@ TYPEINFO(/obj/submachine/chem_extractor)
 	var/obj/item/reagent_containers/glass/storage_tank_2 = null
 	var/list/ingredients = list()
 	var/list/allowed = list(/obj/item/reagent_containers/food/fish/, /obj/item/reagent_containers/food/snacks/,/obj/item/plant/,/obj/item/clothing/head/flower/,/obj/item/seashell)
+	var/obj/item/robot_chemaster/prototype2/parent_item = null
 
-	New()
+	New(var/obj/item/robot_chemaster/prototype2/parent_item = null)
 		..()
 		src.storage_tank_1 = new /obj/item/reagent_containers/glass/beaker/extractor_tank(src)
 		src.storage_tank_2 = new /obj/item/reagent_containers/glass/beaker/extractor_tank(src)
@@ -33,6 +34,7 @@ TYPEINFO(/obj/submachine/chem_extractor)
 			count++
 		AddComponent(/datum/component/transfer_input/quickloading, allowed, "tryLoading")
 		AddComponent(/datum/component/transfer_output)
+		src.parent_item = parent_item
 
 	attack_ai(var/mob/user as mob)
 		return attack_hand(user)
@@ -108,7 +110,10 @@ TYPEINFO(/obj/submachine/chem_extractor)
 				var/obj/item/ingredient = src.ingredients[id]
 				if (istype(ingredient))
 					src.ingredients.Remove(id)
-					TRANSFER_OR_DROP(src, ingredient)
+					if (!src.parent_item)
+						TRANSFER_OR_DROP(src, ingredient)
+					else
+						usr.put_in_hand_or_eject(ingredient)
 					. = TRUE
 			if("autoextract")
 				src.autoextract = !src.autoextract
@@ -199,6 +204,12 @@ TYPEINFO(/obj/submachine/chem_extractor)
 		if(Obj == src.inserted)
 			src.inserted = null
 			tgui_process.update_uis(src)
+
+	ui_status(mob/user, datum/ui_state/state)
+		if (src.parent_item)
+			return src.parent_item.ui_status(user, state)
+		else
+			return ..()
 
 /obj/submachine/chem_extractor/proc/getContainers()
 	. = list(

--- a/code/obj/submachine/chem_extractor.dm
+++ b/code/obj/submachine/chem_extractor.dm
@@ -205,9 +205,9 @@ TYPEINFO(/obj/submachine/chem_extractor)
 			src.inserted = null
 			tgui_process.update_uis(src)
 
-	ui_status(mob/user, datum/ui_state/state)
+	ui_status()
 		if (src.parent_item)
-			return src.parent_item.ui_status(user, state)
+			return src.parent_item.ui_status(arglist(args))
 		else
 			return ..()
 

--- a/code/obj/submachine/chem_extractor.dm
+++ b/code/obj/submachine/chem_extractor.dm
@@ -22,9 +22,9 @@ TYPEINFO(/obj/submachine/chem_extractor)
 	var/obj/item/reagent_containers/glass/storage_tank_2 = null
 	var/list/ingredients = list()
 	var/list/allowed = list(/obj/item/reagent_containers/food/fish/, /obj/item/reagent_containers/food/snacks/,/obj/item/plant/,/obj/item/clothing/head/flower/,/obj/item/seashell)
-	var/obj/item/robot_chemaster/prototype2/parent_item = null
+	var/obj/item/robot_chemaster/prototype/parent_item = null
 
-	New(var/obj/item/robot_chemaster/prototype2/parent_item = null)
+	New(var/obj/item/robot_chemaster/prototype/parent_item = null)
 		..()
 		src.storage_tank_1 = new /obj/item/reagent_containers/glass/beaker/extractor_tank(src)
 		src.storage_tank_2 = new /obj/item/reagent_containers/glass/beaker/extractor_tank(src)

--- a/code/obj/submachine/chem_extractor.dm
+++ b/code/obj/submachine/chem_extractor.dm
@@ -24,7 +24,7 @@ TYPEINFO(/obj/submachine/chem_extractor)
 	var/list/allowed = list(/obj/item/reagent_containers/food/fish/, /obj/item/reagent_containers/food/snacks/,/obj/item/plant/,/obj/item/clothing/head/flower/,/obj/item/seashell)
 	var/obj/item/robot_chemaster/prototype/parent_item = null
 
-	New(var/obj/item/robot_chemaster/prototype/parent_item = null)
+	New(var/loc, var/obj/item/robot_chemaster/prototype/parent_item = null)
 		..()
 		src.storage_tank_1 = new /obj/item/reagent_containers/glass/beaker/extractor_tank(src)
 		src.storage_tank_2 = new /obj/item/reagent_containers/glass/beaker/extractor_tank(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that the Portable Reagent Extractor (prototype ChemiTool) uses the Reagent Extractor's UI and the CheMaster UI instead of some old html extractor UI and a bunch of alerts
![image](https://github.com/user-attachments/assets/3ecb4c58-c7fa-4a0c-8274-b12fbef586a2)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
All reagent extractors/CheMasters should have the same UI
Old UI:
![261896918-32a052a3-3a20-4522-bd12-1c10f0373694](https://github.com/user-attachments/assets/7eba0778-d68a-4d81-abef-ac82c4687d22)


[ui][qol]