### PR TITLE
Fix audit logging

### DIFF
--- a/_std/defines/admin.dm
+++ b/_std/defines/admin.dm
@@ -41,7 +41,7 @@ var/global/list/toggleable_admin_verb_categories = list(
 //Auditing
 
 /// Whether or not a potentially suspicious action gets denied by the code.
-#define AUDIT_ACCESS_DENIED (0 << 1)
+#define AUDIT_ACCESS_DENIED (1 << 0)
 /// Logged whenever you try to View Variables a thing
 #define AUDIT_VIEW_VARIABLES (1 << 1)
 

--- a/code/client.dm
+++ b/code/client.dm
@@ -115,6 +115,8 @@
 /client/proc/audit(var/category, var/message, var/target)
 	if(src.holder && (src.holder.audit & category))
 		logTheThing(LOG_AUDIT, src, message)
+	else if (!src.holder)
+		logTheThing(LOG_AUDIT, src, message)
 
 /client/proc/updateXpRewards()
 	if(qualifiedXpRewards == null)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adjust the value of `AUDIT_ACCESS_DENIED` from `0` to `1` so that the `&` check passes in `proc/audit`
* Adds an else if to always log a non-admin managing to stumble into an audit call rather than dropping info


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Audit logging has been essentially half broken for years.