### PR TITLE
Fix Donut2 bar floors

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -9814,7 +9814,7 @@
 	icon_state = "line1"
 	},
 /obj/disposalpipe/segment,
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "aZb" = (
 /obj/cable{
@@ -16558,7 +16558,7 @@
 /area/station/medical/medbay)
 "bXk" = (
 /obj/disposalpipe/segment,
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "bXn" = (
 /obj/cable{
@@ -17655,7 +17655,7 @@
 /area/station/maintenance/disposal)
 "cGF" = (
 /obj/stool/bar,
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "cGR" = (
 /obj/decal/cleanable/rust{
@@ -20451,7 +20451,7 @@
 "esx" = (
 /obj/item/instrument/large/jukebox,
 /obj/machinery/light/incandescent,
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "ete" = (
 /obj/machinery/camera{
@@ -21167,7 +21167,7 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "ePd" = (
 /obj/machinery/camera{
@@ -22383,7 +22383,7 @@
 	},
 /obj/item/device/radio/intercom,
 /obj/machinery/firealarm/east,
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "fHr" = (
 /obj/disposalpipe/segment{
@@ -23335,7 +23335,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "glZ" = (
 /obj/decal/cleanable/rust/jen,
@@ -24157,7 +24157,7 @@
 /obj/machinery/alarm{
 	pixel_y = 25
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "gNq" = (
 /obj/cable{
@@ -27178,7 +27178,7 @@
 /obj/machinery/light/incandescent{
 	dir = 4
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "iFJ" = (
 /obj/machinery/light/incandescent,
@@ -29411,7 +29411,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "keB" = (
 /obj/table/wood/auto,
@@ -30808,7 +30808,7 @@
 /obj/cable{
 	icon_state = "4-9"
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "kTR" = (
 /obj/storage/crate/rcd/CE,
@@ -32155,7 +32155,7 @@
 /obj/disposalpipe/segment/food{
 	dir = 8
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "lHA" = (
 /obj/disposalpipe/segment/food,
@@ -35286,7 +35286,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "nzd" = (
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "nzf" = (
 /turf/simulated/wall/grass/leafy,
@@ -35619,7 +35619,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "nLy" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
@@ -35913,7 +35913,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/food,
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "nVj" = (
 /obj/cable{
@@ -36315,7 +36315,7 @@
 	dir = 4;
 	icon_state = "line1"
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "ofQ" = (
 /obj/item/feather,
@@ -39830,7 +39830,7 @@
 /area/station/turret_protected/Zeta)
 "qdy" = (
 /obj/disposalpipe/junction/left/east,
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "qdU" = (
 /obj/mapping_helper/wingrille_spawn/auto,
@@ -40570,7 +40570,7 @@
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "qzB" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -44441,7 +44441,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "sRx" = (
 /obj/landmark/gps_waypoint,
@@ -45845,7 +45845,7 @@
 	dir = 6;
 	icon_state = "line1"
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "tHq" = (
 /turf/simulated/wall/auto/supernorn,
@@ -47660,7 +47660,7 @@
 /obj/cable{
 	icon_state = "0-6"
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "uSf" = (
 /obj/decal/tile_edge/line/black{
@@ -48956,7 +48956,7 @@
 /obj/disposalpipe/segment/food{
 	dir = 8
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "vDc" = (
 /obj/cable{
@@ -49836,7 +49836,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "weo" = (
 /obj/stool/chair/green{
@@ -52043,7 +52043,7 @@
 /obj/decal/poster/wallsign/teaparty{
 	pixel_y = -32
 	},
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "xzS" = (
 /obj/submachine/chef_sink/chem_sink{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces turf/simulated/bar in donut2's bar with turf/simulated/floor/specialroom/bar


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #21173
Floor and wall designer only works on turf/simulated/floor

