### PR TITLE
Make laser mirrors do actual angle maths for projectiles

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -1392,3 +1392,12 @@ TYPEINFO(/atom/movable)
 	if (istype(target.loc, /atom/movable))
 		return src.is_that_in_this(target.loc)
 	return FALSE
+
+
+//these procs are a thought experiment and should be expunged before committing
+//TODO
+/atom/proc/normal_x(obj/projectile/P)
+	return P.incidence == WEST ? -1 : (P.incidence == EAST ?  1 : 0)
+
+/atom/proc/normal_y(obj/projectile/P)
+	return P.incidence == SOUTH ? -1 : (P.incidence == NORTH ?  1 : 0)

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -1393,11 +1393,12 @@ TYPEINFO(/atom/movable)
 		return src.is_that_in_this(target.loc)
 	return FALSE
 
+//Used for projectile bounces, override these for funny shaped objects like angled mirrors
 
-//these procs are a thought experiment and should be expunged before committing
-//TODO
-/atom/proc/normal_x(obj/projectile/P)
-	return P.incidence == WEST ? -1 : (P.incidence == EAST ?  1 : 0)
+///Returns the x component of the surface normal of the atom relative to an incident direction
+/atom/proc/normal_x(incident_dir)
+	return incident_dir == WEST ? -1 : (incident_dir == EAST ?  1 : 0)
 
-/atom/proc/normal_y(obj/projectile/P)
-	return P.incidence == SOUTH ? -1 : (P.incidence == NORTH ?  1 : 0)
+///Returns the y component of the surface normal of the atom relative to an incident direction
+/atom/proc/normal_y(incident_dir)
+	return incident_dir == SOUTH ? -1 : (incident_dir == NORTH ?  1 : 0)

--- a/code/modules/lasers/laser_mirror.dm
+++ b/code/modules/lasers/laser_mirror.dm
@@ -75,41 +75,44 @@ TYPEINFO(/obj/laser_sink/mirror)
 	src.out_laser = null
 	..()
 
-///One over root 2
+///One over root 2, the length of a 45 degree unit vector
 #define LENGTH 1/(2**(1/2))
 
-//this is all dumb and stupid and bad and should probably be a vector transform but aaaa
-/obj/laser_sink/mirror/normal_x(obj/projectile/P)
-	if (P.incidence == WEST)
-		return -LENGTH
-	if (P.incidence == EAST)
-		return LENGTH
-	if (P.incidence == SOUTH)
-		if (src.facing == NW_SE)
-			return LENGTH
-		else
+///Manually defined angled normals depending on mirror direction
+///I think this may be stupid and bad and should probably be a vector transform somehow but it works for now
+/obj/laser_sink/mirror/normal_x(incident_dir)
+	switch(incident_dir)
+		if (WEST)
 			return -LENGTH
-	if (P.incidence == NORTH)
-		if (src.facing == NW_SE)
-			return -LENGTH
-		else
+		if (EAST)
 			return LENGTH
+		if (SOUTH)
+			if (src.facing == NW_SE)
+				return LENGTH
+			else
+				return -LENGTH
+		if (NORTH)
+			if (src.facing == NW_SE)
+				return -LENGTH
+			else
+				return LENGTH
 
-/obj/laser_sink/mirror/normal_y(obj/projectile/P)
-	if (P.incidence == WEST)
-		if (src.facing == NW_SE)
-			return LENGTH
-		else
+/obj/laser_sink/mirror/normal_y(incident_dir)
+	switch(incident_dir)
+		if (WEST)
+			if (src.facing == NW_SE)
+				return LENGTH
+			else
+				return -LENGTH
+		if (EAST)
+			if (src.facing == NW_SE)
+				return -LENGTH
+			else
+				return LENGTH
+		if (SOUTH)
 			return -LENGTH
-	if (P.incidence == EAST)
-		if (src.facing == NW_SE)
-			return -LENGTH
-		else
+		if (NORTH)
 			return LENGTH
-	if (P.incidence == SOUTH)
-		return -LENGTH
-	if (P.incidence == NORTH)
-		return LENGTH
 
 #undef LENGTH
 

--- a/code/modules/lasers/laser_mirror.dm
+++ b/code/modules/lasers/laser_mirror.dm
@@ -1,3 +1,4 @@
+//These are the surface normal directions for the two states (so NW_SE has faces pointing north west and south east)
 #define NW_SE 0
 #define SW_NE 1
 
@@ -74,14 +75,52 @@ TYPEINFO(/obj/laser_sink/mirror)
 	src.out_laser = null
 	..()
 
+///One over root 2
+#define LENGTH 1/(2**(1/2))
+
+//this is all dumb and stupid and bad and should probably be a vector transform but aaaa
+/obj/laser_sink/mirror/normal_x(obj/projectile/P)
+	if (P.incidence == WEST)
+		return -LENGTH
+	if (P.incidence == EAST)
+		return LENGTH
+	if (P.incidence == SOUTH)
+		if (src.facing == NW_SE)
+			return LENGTH
+		else
+			return -LENGTH
+	if (P.incidence == NORTH)
+		if (src.facing == NW_SE)
+			return -LENGTH
+		else
+			return LENGTH
+
+/obj/laser_sink/mirror/normal_y(obj/projectile/P)
+	if (P.incidence == WEST)
+		if (src.facing == NW_SE)
+			return LENGTH
+		else
+			return -LENGTH
+	if (P.incidence == EAST)
+		if (src.facing == NW_SE)
+			return -LENGTH
+		else
+			return LENGTH
+	if (P.incidence == SOUTH)
+		return -LENGTH
+	if (P.incidence == NORTH)
+		return LENGTH
+
+#undef LENGTH
+
 /obj/laser_sink/mirror/bullet_act(obj/projectile/P)
 	//cooldown to prevent client lag caused by infinite projectile loops
-	if (istype(P.proj_data, /datum/projectile/laser/heavy) && !ON_COOLDOWN(src, "reflect_projectile", 1 DECI SECOND))
-		var/obj/projectile/new_proj = shoot_projectile_DIR(src, P.proj_data, src.get_reflected_dir(P.dir))
+	if (P.proj_data.damage_type == D_ENERGY && !ON_COOLDOWN(src, "reflect_projectile", 1 DECI SECOND))
+		var/obj/projectile/new_proj = shoot_reflected_bounce(P, src, INFINITY, play_shot_sound = FALSE, fire_from = get_turf(src))
 		new_proj.travelled = P.travelled
 		P.die()
 	else
-		..()
+		. = ..()
 
 /obj/laser_sink/mirror/traverse(proc_to_call)
 	src.out_laser.traverse(proc_to_call)

--- a/code/modules/lasers/laser_mirror.dm
+++ b/code/modules/lasers/laser_mirror.dm
@@ -75,7 +75,7 @@ TYPEINFO(/obj/laser_sink/mirror)
 	src.out_laser = null
 	..()
 
-///One over root 2, the length of a 45 degree unit vector
+///One over root 2, the component length of a 45 degree unit vector
 #define LENGTH 1/(2**(1/2))
 
 ///Manually defined angled normals depending on mirror direction

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -988,8 +988,8 @@ ABSTRACT_TYPE(/datum/projectile)
 	var/ry = 0
 
 	//x and y components of the surface normal vector
-	var/nx = reflector.normal_x(P)
-	var/ny = reflector.normal_y(P)
+	var/nx = reflector.normal_x(P.incidence)
+	var/ny = reflector.normal_y(P.incidence)
 
 	var/dn = 2 * (P.xo * nx + P.yo * ny) // incident direction DOT normal * 2
 	rx = P.xo - dn * nx // r = d - 2 * (d * n) * n

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -930,14 +930,12 @@ ABSTRACT_TYPE(/datum/projectile)
  * So I made my own proc, but left the old one in place just in case -- Sovexe
  * var/reflect_on_nondense_hits - flag for handling hitting objects that let bullets pass through like secbots, rather than duplicating projectiles
  */
-/proc/shoot_reflected_bounce(var/obj/projectile/P, var/atom/reflector, var/max_reflects = 3, var/mode = PROJ_RAPID_HEADON_BOUNCE, var/reflect_on_nondense_hits = FALSE)
+/proc/shoot_reflected_bounce(var/obj/projectile/P, var/atom/reflector, var/max_reflects = 3, var/mode = PROJ_RAPID_HEADON_BOUNCE, var/reflect_on_nondense_hits = FALSE, var/play_shot_sound = TRUE, var/turf/fire_from = null)
 	if (!P || !reflector)
 		return
 
 	if(P.reflectcount >= max_reflects)
 		return
-
-	var/play_shot_sound = TRUE
 
 	switch (mode)
 		if (PROJ_NO_HEADON_BOUNCE) //no head-on bounce
@@ -990,8 +988,8 @@ ABSTRACT_TYPE(/datum/projectile)
 	var/ry = 0
 
 	//x and y components of the surface normal vector
-	var/nx = P.incidence == WEST ? -1 : (P.incidence == EAST ?  1 : 0)
-	var/ny = P.incidence == SOUTH ? -1 : (P.incidence == NORTH ?  1 : 0)
+	var/nx = reflector.normal_x(P)
+	var/ny = reflector.normal_y(P)
 
 	var/dn = 2 * (P.xo * nx + P.yo * ny) // incident direction DOT normal * 2
 	rx = P.xo - dn * nx // r = d - 2 * (d * n) * n
@@ -1002,7 +1000,7 @@ ABSTRACT_TYPE(/datum/projectile)
 		return // unknown error
 
 	//spawns the new projectile in the same location as the existing one, not inside the hit thing
-	var/obj/projectile/Q = initialize_projectile(get_turf(P), P.proj_data, rx, ry, reflector, play_shot_sound = play_shot_sound)
+	var/obj/projectile/Q = initialize_projectile(fire_from || get_turf(P), P.proj_data, rx, ry, reflector, play_shot_sound = play_shot_sound)
 	if (!Q)
 		return
 	Q.reflectcount = P.reflectcount + 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MATHS] [FEATURE] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements a conditional normals system that lets atoms define how projectiles should reflect off them and uses it to give laser mirrors angled normals to reflect laser projectiles accurately.

I feel like there's a smarter way to define angled normals than a big switch table but this works for now.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I always meant to do this but didn't have the spoons to dive into projectile vector code so I just restricted it to emitters and used the right angle reflection code.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Laser mirrors now reflect any energy projectile at any angle.
```
