### PR TITLE
Add a (CE-locked) supply pack for Rockboxes

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1626,6 +1626,16 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 	containername = "Magnet Kit"
 #endif
 
+/datum/supply_packs/complex/mining_rockbox
+	name = "Rockbox™ Storage Container (Cardlocked \[Chief Engineer])"
+	desc = "1x Rockbox™ Ore Cloud Storage Container"
+	category = "Engineering Department"
+	frames = list(/obj/machinery/ore_cloud_storage_container)
+	cost = PAY_EMBEZZLED
+	containertype = /obj/storage/secure/crate/plasma
+	containername = "Rockbox™ Storage Container (Cardlocked \[Chief Engineer])"
+	access = access_engineering_chief
+
 /datum/supply_packs/complex/manufacturer_kit
 	name = "Manufacturer Kit"
 	desc = "Frames: 1x General Manufacturer, 1x Mining Manufacturer, 1x Science Manufacturer, 1x Gas Extractor, 1x Clothing Manufacturer, 1x Reclaimer"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add an orderable Rockbox supply pack for QM. It is card-locked to chief engineer and very expensive.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's not possible to replace Rockboxes at all in-round. While not a common occurence, permanently losing a rockbox early in the round to e.g. a pda bomb kills a lot of the enthusiasm for miners. I don't think they should be spammable so I didn't want to make them scannable via ruck-kit; a heavily access-restricted, expensive crate seemed like a solid option instead.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Quartermasters can order a replacement Rockbox. It requires Chief Engineer access to open, and must be assembled.
```
