### PR TITLE
Fix breaking out of handcuffs while only having one arm 

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2523,7 +2523,7 @@
 
 			src.handcuffs.material_trigger_when_attacked(src, src, 1)
 			src.handcuffs.destroy_handcuffs(src)
-		else if ( src.limbs && src.limbs.l_arm.breaks_cuffs && src.limbs.r_arm.breaks_cuffs)
+		else if ( src.limbs && src.limbs.l_arm?.breaks_cuffs && src.limbs.r_arm?.breaks_cuffs)
 			for (var/mob/O in AIviewers(src))
 				O.show_message(SPAN_ALERT("<B>[src] rips apart the handcuffs with [src.limbs.l_arm.kind_of_limb & LIMB_ROBOT ? "machine-like" : "unnatural"] strength!</B>"), 1)
 			boutput(src, SPAN_NOTICE("You rip apart your handcuffs."))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[player actions][bug][runtime]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ensure `l_arm` and `r_arm` exist before trying to read `breaks_cuffs` from them in the cuff breaking check code.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21302