### PR TITLE
Stop AIEye from hearing speechpro/sound synth

### DIFF
--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -1221,7 +1221,7 @@ proc/outermost_movable(atom/movable/target)
 				var/mob/living/carbon/human/H = A
 				if (H.organHolder.head?.head_type == HEAD_SKELETON) // do they have their head
 					. += A
-			else
+			else if(!isAIeye(A)) // AI camera eyes can't hear
 				. += A
 		if (isobj(A) || ismob(A))
 			if (istype(A, /obj/item/organ/head))	//Skeletons can hear from their heads!


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][silicons]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevent the intangible aieye mob from counting as a hearer in `all_hearers`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #13827
Fix #21293
