### PR TITLE
Allow filing cabinets to be deconstructable

### DIFF
--- a/code/obj/storage/filing_cabinet.dm
+++ b/code/obj/storage/filing_cabinet.dm
@@ -5,6 +5,7 @@
 	icon_state = "filecabinet" //i guess its a feature now               ok bye
 	anchored = ANCHORED
 	density = 1
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH
 
 	attackby(var/obj/item/W, var/mob/user)
 		if (istype(W, /obj/item/paper) || istype(W, /obj/item/folder))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add decon flags (screwdriver, wrench) for filing cabinets


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Let filing cabinets be re/movable for repair or otherwise.
Fix #21227