### PR TITLE
Let Trichochromatic Shift work with Hairy trait

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -540,11 +540,8 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 			boutput(H, SPAN_NOTICE("This only works on human hair!"))
 			return
 
-		if (istype(H.mutantrace, /datum/mutantrace/lizard))
+		if (!HAS_FLAG(H.mutantrace.mutant_appearance_flags, HAS_HUMAN_HAIR) && !H.bioHolder.HasEffect("hair_growth"))
 			boutput(H, SPAN_NOTICE("You don't have any hair!"))
-			return
-		else if (H.mutantrace?.override_hair && !istype(H.mutantrace, /datum/mutantrace/cow))
-			boutput(H, SPAN_NOTICE("Whatever hair you have isn't affected!"))
 			return
 
 		if (H.bioHolder?.mobAppearance)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mutantraces][feature][traits]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Change the no-hair checks for Trichochromatic Shift to the `HAS_HUMAN_HAIR` flag and add an exception for that for the `hair_growth` bio-effect, given by Hairy trait.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21236