### PR TITLE
Fix transception array unpowered/broken sprites

### DIFF
--- a/code/WorkInProgress/nadir_antenna.dm
+++ b/code/WorkInProgress/nadir_antenna.dm
@@ -517,7 +517,7 @@ TYPEINFO(/obj/machinery/communications_dish/transception)
 	desc = "Endpoint for status reporting and configuration for a nearby transception array."
 
 	icon = 'icons/obj/computer.dmi'
-	icon_state = "alert:0"
+	icon_state = "atmos"
 	flags = TGUI_INTERACTIVE
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WIRECUTTERS | DECON_MULTITOOL
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Use the `atmos` icon instead of `alert:0` for the transception array, which allows the base computer unpowered/broken icon state modifications work. The icons are the same.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21204