### PR TITLE
Ensure HUD includes hygiene meter when cloned with Stinky trait

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -376,6 +376,7 @@
 			if (!H.sims)
 				H.sims = new /datum/simsHolder(H)
 			H.sims.addMotive(/datum/simsMotive/hygiene)
+			H.sims.add_hud() // ensure hud has hygiene motive
 
 	onRemove(var/mob/owner)
 		if(ishuman(owner))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[traits][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Call `add_hud` for sims motives when adding the stinky trait to a mob.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21214
