### PR TITLE
PDA Announcement Request App

### DIFF
--- a/_std/defines/announcement_origins.dm
+++ b/_std/defines/announcement_origins.dm
@@ -7,3 +7,6 @@
 #endif
 #define ALERT_GENERAL "Frontier Authority Update"
 #define ALERT_STATION "Automated Mainframe Alert"
+
+
+#define JOBS_CAN_APPROVE_ANNOUNCEMENTS list("Captain","Head of Security","Head of Personnel", "AI")

--- a/_std/defines/announcement_origins.dm
+++ b/_std/defines/announcement_origins.dm
@@ -7,6 +7,3 @@
 #endif
 #define ALERT_GENERAL "Frontier Authority Update"
 #define ALERT_STATION "Automated Mainframe Alert"
-
-
-#define JOBS_CAN_APPROVE_ANNOUNCEMENTS list("Captain","Head of Security","Head of Personnel", "AI")

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -499,7 +499,6 @@
 
 	var/approved = FALSE
 	var/approver = null
-	var/approver_job = null
 	var/approver_byond_key = null
 
 	var/sound_to_play = 'sound/misc/bingbong.ogg'
@@ -509,12 +508,10 @@
 		..()
 		generate_ID()
 
-/datum/announcement_request/proc/approve(var/approved_by,var/their_job)
+/datum/announcement_request/proc/approve(var/approved_by)
 	src.approver = approved_by
-	src.approver_job = their_job
 	src.approver_byond_key = get_byond_key(approver)
 	src.approved = TRUE
-	logTheThing(LOG_ADMIN, usr, "approved an announcement from [src.requester]([src.requester_job]) using [src.approver]([src.approver_job])'s PDA. It reads [src.content].")
 	var/header = "PDA Requested Announcement by [src.requester] ([src.requester_job])"
 	command_announcement(src.content, header, src.sound_to_play, volume = src.sound_volume)
 	return TRUE

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -510,8 +510,6 @@
 		generate_ID()
 
 /datum/announcement_request/proc/approve(var/approved_by,var/their_job)
-	if (!(their_job in JOBS_CAN_APPROVE_ANNOUNCEMENTS)) return
-
 	src.approver = approved_by
 	src.approver_job = their_job
 	src.approver_byond_key = get_byond_key(approver)

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -6,6 +6,7 @@
 	var/datum/record_database/bank = new(list("name", "id"))
 	var/list/datum/fine/fines = list()
 	var/list/datum/ticket/tickets = list()
+	var/list/datum/announcement_request/announcement_requests = list()
 	var/obj/machinery/networked/mainframe/mainframe = null
 
 /datum/datacore/proc/addManifest(mob/living/carbon/human/H as mob, sec_note = "", med_note = "", pda_net_id = null, synd_int_note = "")
@@ -487,3 +488,38 @@
 
 /datum/fine/proc/generate_ID()
 	if(!ID) ID = (data_core.fines.len + 1)
+
+/datum/announcement_request
+	var/ID = null
+	var/name = "announcement"
+	var/content = null
+	var/requester = null
+	var/requester_job = null
+	var/requester_byond_key = null
+
+	var/approved = FALSE
+	var/approver = null
+	var/approver_job = null
+	var/approver_byond_key = null
+
+	var/sound_to_play = 'sound/misc/bingbong.ogg'
+	var/sound_volume = 70
+
+	New()
+		..()
+		generate_ID()
+
+/datum/announcement_request/proc/approve(var/approved_by,var/their_job)
+	if (!(their_job in JOBS_CAN_APPROVE_ANNOUNCEMENTS)) return
+
+	src.approver = approved_by
+	src.approver_job = their_job
+	src.approver_byond_key = get_byond_key(approver)
+	src.approved = TRUE
+	logTheThing(LOG_ADMIN, usr, "approved an announcement from [src.requester]([src.requester_job]) using [src.approver]([src.approver_job])'s PDA. It reads [src.content].")
+	var/header = "PDA Requested Announcement by [src.requester] ([src.requester_job])"
+	command_announcement(src.content, header, src.sound_to_play, volume = src.sound_volume)
+	return TRUE
+
+/datum/announcement_request/proc/generate_ID()
+	if(!ID) ID = (data_core.announcement_requests.len + 1)

--- a/code/modules/networks/computer3/announcement_request.dm
+++ b/code/modules/networks/computer3/announcement_request.dm
@@ -1,0 +1,161 @@
+
+#define MENU_MAIN 0
+#define MENU_REQUESTS 1
+#define MENU_IN_REQUEST 2
+
+#define ANNOUNCEMENT_PREVIEW_LENGTH 30
+
+/datum/computer/file/terminal_program/announcer
+	name = "AnnouncerPRO"
+	size = 8
+	req_access = list(access_heads)
+	var/tmp/menu = MENU_MAIN
+	var/obj/item/peripheral/network/radio/radiocard = null
+
+	var/list/valid_requests = list() //stored list of valid requests
+	var/datum/announcement_request/active_request = null //currently observed request
+
+	initialize()
+		if (..())
+			return TRUE
+		src.master.temp = null
+
+		src.radiocard = locate() in src.master.peripherals
+		if(!radiocard || !istype(src.radiocard))
+			src.radiocard = null
+			src.print_text("<b>Warning:</b> No radio module detected.")
+
+		src.print_intro_text()
+
+
+	proc/print_intro_text()
+		var/intro_text = {"Welcome to AnnouncerPRO!
+		<br>Announcing \"poo fart\" since 2047
+		<br><b>Commands:</b>
+		<br>(Requests) to view current requests.
+		<br>(Clear) to clear the screen.
+		<br>(Quit) to exit AnnouncerPRO."}
+		src.print_text(intro_text)
+
+	input_text(text)
+		if(..())
+			return
+
+		var/list/command_list = parse_string(text)
+		var/command = command_list[1]
+		command_list -= command_list[1]
+
+		if (isghostdrone(usr))
+			src.print_text("<b>Error:</b> Permission denied.")
+			return
+
+		switch(menu)
+			if(MENU_MAIN)
+				switch(lowertext(command))
+					if("requests")
+						src.menu = MENU_REQUESTS
+						src.print_requests()
+
+					if("clear")
+						src.master.temp = null
+						src.master.temp_add = "Workspace cleared.<br>"
+
+					if("quit")
+						src.master.temp = ""
+						print_text("Now quitting...")
+						src.master.unload_program(src)
+						return
+
+					else
+						print_text("Unknown command : \"[copytext(strip_html(command), 1, 16)]\"")
+
+			if(MENU_REQUESTS)
+				var/index_number = round( max( text2num_safe(command), 0) )
+				if (index_number == 0)
+					src.menu = MENU_MAIN
+					src.master.temp = null
+					src.print_intro_text()
+					return
+
+				if (index_number > valid_requests.len)
+					src.print_text("Invalid request.")
+					return
+
+				var/datum/announcement_request/check = src.valid_requests[index_number]
+				if(!check || !istype(check))
+					src.print_text("<b>Error:</b> Request Data Invalid.")
+					return
+
+				src.active_request = check
+				if (src.print_active_request())
+					src.menu = MENU_IN_REQUEST
+				return
+
+
+			if(MENU_IN_REQUEST)
+				var/datum/announcement_request/request = src.active_request
+				switch(lowertext(command))
+					if("approve")
+						if(request.approved)
+							src.print_text("<b>Error:</b> Request already approved.")
+						else
+							request.approve(src.authenticated)
+							logTheThing(LOG_SAY, usr, "uses [src.authenticated]'s credentials to approve announcement: \"[request.content]\" requested by [request.requester]'s PDA")
+							logTheThing(LOG_DIARY, usr, "uses [src.authenticated]'s credentials to approve announcement: \"[request.content]\" requested by [request.requester]'s PDA", "say")
+
+					if("return")
+						src.menu = MENU_REQUESTS
+						src.print_requests()
+
+					else
+						print_text("Unknown command : \"[copytext(strip_html(command), 1, 16)]\"")
+
+		src.master.add_fingerprint(usr)
+		src.master.updateUsrDialog()
+		return
+
+	proc/print_requests()
+		src.master.temp = null
+		var/dat = ""
+		src.valid_requests = list()
+		if(!data_core.announcement_requests || !length(data_core.announcement_requests))
+			src.print_text("<b>Error:</b> No requests found in database.")
+			src.print_text("<br> Enter (Return) to return to menu.")
+			return
+		for(var/datum/announcement_request/request in data_core.announcement_requests)
+			if(!request.approved)
+				valid_requests+=request
+		if(!valid_requests || !length(valid_requests))
+			src.print_text("<b>Error:</b> No unapproved requests found in database.")
+			src.print_text("<br> Enter (Return) to return to menu.")
+			return
+		else
+			dat = "Please select a request:"
+			for(var/index = 1, index <= src.valid_requests.len, index++)
+				var/datum/announcement_request/request = src.valid_requests[index]
+				dat += "<br><br>([index])\"[copytext(request.content, 1, ANNOUNCEMENT_PREVIEW_LENGTH)]...\" - [request.requester]"
+		dat += "<br><br>Enter record number, or 0 to return."
+
+		src.print_text(dat)
+
+	proc/print_active_request()
+		if (!src.active_request)
+			src.print_text("<b>Error:</b> Request data corrupt.")
+			src.print_text("<br> Enter (Return) to return to menu.")
+			return 0
+		src.master.temp = null
+
+		var/view_string = {"
+		Requested by [src.active_request.requester] ([src.active_request.requester_job])
+		<br>\"[src.active_request.content]\""}
+
+		view_string += "<br>(Approve) to approve this request"
+		view_string += "<br>(Return) to return to menu"
+
+		src.print_text("<b>Request Data:</b><br>[view_string]")
+		return 1
+
+#undef MENU_MAIN
+#undef MENU_REQUESTS
+#undef MENU_IN_REQUEST
+#undef ANNOUNCEMENT_PREVIEW_LENGTH

--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -106,7 +106,9 @@
 		communications
 			name = "Communications Console"
 			icon_state = "comm"
-			setup_starting_program = list(/datum/computer/file/terminal_program/communications, /datum/computer/file/terminal_program/job_controls)
+			setup_starting_program = list(/datum/computer/file/terminal_program/communications,
+										/datum/computer/file/terminal_program/job_controls,
+										/datum/computer/file/terminal_program/announcer)
 			setup_starting_peripheral1 = /obj/item/peripheral/network/powernet_card
 			setup_starting_peripheral2 = /obj/item/peripheral/network/radio/locked/status
 			setup_drive_size = 80

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -423,6 +423,7 @@
 		src.hd.root.add_file(new /datum/computer/file/pda_program/emergency_alert)
 		src.hd.root.add_file(new /datum/computer/file/pda_program/gps)
 		src.hd.root.add_file(new /datum/computer/file/pda_program/cargo_request(src))
+		src.hd.root.add_file(new /datum/computer/file/pda_program/announcement_request)
 		if(length(src.default_muted_mailgroups))
 			src.host_program.muted_mailgroups = src.default_muted_mailgroups
 		if(ismob(src.loc))

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1239,8 +1239,7 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 
 					for (var/datum/announcement_request/request in data_core.announcement_requests)
 						if(!request.approved)
-							dat += "'[request.content]'<br>Requested by: [request.requester] - [request.requester_job]"
-							if(access_change_ids in src.master.access) dat += "<br><a href='byond://?src=\ref[src];approve=\ref[request]'>Approve Announcement</a>"
+							dat += "\"[request.content]\"<br>Requested by: [request.requester] - [request.requester_job]"
 							dat += "<br><br>"
 
 				if(2) //approved announcements
@@ -1250,7 +1249,7 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 
 					for (var/datum/announcement_request/request in data_core.announcement_requests)
 						if(request.approved)
-							dat += "'[request.content]'<br>[request.requester != request.approver ? "Requested by: [request.requester] - [request.requester_job]<br>Approved by: [request.approver] - [request.approver_job]" : "Created by: [request.approver] - [request.approver_job]"]<br><br>"
+							dat += "\"[request.content]\"<br>Requested by: [request.requester] ([request.requester_job])<br>Approved by: [request.approver]<br><br>"
 		else
 			dat += "<br><br>[message]<br><br>"
 			dat += "<a href='byond://?src=\ref[src];ok=1'>Ok</a>"
@@ -1277,26 +1276,11 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 				request.requester_byond_key = usr.key
 				data_core.announcement_requests += request
 
-				logTheThing(LOG_ADMIN, usr, "requested an announcement using [IDowner]([IDownerjob])'s ID. It reads [announcement_content].")
-				if(access_change_ids in src.master.access)
-					request.approve(IDowner, IDownerjob)
-				else
-					src.message = "Announcement request created, awaiting approval."
+				logTheThing(LOG_SAY, usr, "requested an announcement using [IDowner]([IDownerjob])'s ID. It reads \"[announcement_content]\".")
+				logTheThing(LOG_DIARY, usr, "requested an announcement using [IDowner]([IDownerjob])'s ID. It reads \"[announcement_content]\".", "say")
+				src.message = "Announcement request created, awaiting approval."
 			else
 				src.message = "You have made a request too recently, please wait."
-
-		else if(href_list["approve"])
-			if (!src.master.ID_card)
-				src.message = "Please insert ID card to approve announcements."
-			else
-				var/IDowner = src.master.registered
-				var/IDownerjob = src.master.assignment
-
-				if (access_change_ids in src.master.access)
-					var/datum/announcement_request/request = locate(href_list["approve"])
-					request.approve(IDowner,IDownerjob)
-				else
-					message = "You do not have access to authorize announcements."
 
 		else if(href_list["back"])
 			mode = 0

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -16,6 +16,7 @@
 //Old-style detomatix program
 //Detomatix Detomanual
 //Ticket writer
+//Announcement request
 //Cargo request
 //Station Namer
 //Revhead tracker
@@ -1201,6 +1202,107 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 
 		else if(href_list["viewpaidfines"])
 			mode = 4
+
+		else if(href_list["ok"])
+			message = null
+
+		src.master.add_fingerprint(usr)
+		src.master.updateSelfDialog()
+		return
+
+/datum/computer/file/pda_program/announcement_request
+	name = "Announcer"
+	size = 4
+	var/mode = 0
+	var/message = null
+	var/announcement_delay = 1200
+
+	return_text()
+		if(..())
+			return
+
+		var/dat = src.return_text_header()
+
+		if(!src.message)
+			switch(src.mode)
+				if(0) //menu
+					dat += "<br><br>\[ <a href='byond://?src=\ref[src];announcement=1'>Request Announcement</a> \]<br>"
+					dat += "View Announcements: \[ <a href='byond://?src=\ref[src];viewannouncementrequests=1'>Requested</a> | <a href='byond://?src=\ref[src];viewapprovedannouncements=1'>Approved</a> \]<br>"
+
+				if(1) //requests
+					var/PDAowner = src.master.owner
+					var/PDAownerjob = data_core.general.find_record("name", PDAowner)?["rank"] || "Unknown Job"
+
+					dat += "<br><br><a href='byond://?src=\ref[src];back=1'>Back</a>"
+
+					dat += "<h4>Announcement Requests</h4>"
+
+					for (var/datum/announcement_request/request in data_core.announcement_requests)
+						if(!request.approved)
+							dat += "'[request.content]'<br>Requested by: [request.requester] - [request.requester_job]"
+							if(PDAownerjob in JOBS_CAN_APPROVE_ANNOUNCEMENTS) dat += "<br><a href='byond://?src=\ref[src];approve=\ref[request]'>Approve Announcement</a>"
+							dat += "<br><br>"
+
+				if(2) //approved announcements
+					dat += "<br><br><a href='byond://?src=\ref[src];back=1'>Back</a>"
+
+					dat += "<h4>Approved Announcements List</h4>"
+
+					for (var/datum/announcement_request/request in data_core.announcement_requests)
+						if(request.approved)
+							dat += "'[request.content]'<br>[request.requester != request.approver ? "Requested by: [request.requester] - [request.requester_job]<br>Approved by: [request.approver] - [request.approver_job]" : "Created by: [request.approver] - [request.approver_job]"]<br><br>"
+		else
+			dat += "<br><br>[message]<br><br>"
+			dat += "<a href='byond://?src=\ref[src];ok=1'>Ok</a>"
+
+		return dat
+
+	Topic(href, href_list)
+		if(..())
+			return
+
+		if(href_list["announcement"])
+			if (!ON_COOLDOWN(src.master,"announcement_request", announcement_delay))
+				var/PDAowner = src.master.owner
+				var/PDAownerjob = data_core.general.find_record("name", PDAowner)?["rank"] || "Unknown Job"
+				if (istype(src.master, /obj/item/device/pda2/ai))
+					PDAownerjob = "AI"
+
+				var/announcement_content = input(usr, "Announcement:",src.name) as text | null
+				if(!announcement_content) return
+				announcement_content = copytext(sanitize(html_encode(announcement_content)), 1, MAX_MESSAGE_LEN)
+
+				var/datum/announcement_request/request = new /datum/announcement_request()
+				request.content = announcement_content
+				request.requester = PDAowner
+				request.requester_job = PDAownerjob
+				request.requester_byond_key = usr.key
+				data_core.announcement_requests += request
+
+				logTheThing(LOG_ADMIN, usr, "requested an announcement using [PDAowner]([PDAownerjob])'s PDA. It reads [announcement_content].")
+				if(PDAownerjob in JOBS_CAN_APPROVE_ANNOUNCEMENTS)
+					request.approve(PDAowner, PDAownerjob)
+				else
+					src.message = "Announcement request created, awaiting approval from the [english_list(JOBS_CAN_APPROVE_ANNOUNCEMENTS, "nobody", " or ")]."
+			else
+				src.message = "You have made a request too recently, please wait."
+				return
+
+		else if(href_list["approve"])
+			var/PDAowner = src.master.owner
+			var/PDAownerjob = data_core.general.find_record("name", PDAowner)?["rank"] || "Unknown Job"
+
+			var/datum/announcement_request/request = locate(href_list["approve"])
+			request.approve(PDAowner,PDAownerjob)
+
+		else if(href_list["back"])
+			mode = 0
+
+		else if(href_list["viewannouncementrequests"])
+			mode = 1
+
+		else if(href_list["viewapprovedannouncements"])
+			mode = 2
 
 		else if(href_list["ok"])
 			message = null

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1286,7 +1286,6 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 					src.message = "Announcement request created, awaiting approval from the [english_list(JOBS_CAN_APPROVE_ANNOUNCEMENTS, "nobody", " or ")]."
 			else
 				src.message = "You have made a request too recently, please wait."
-				return
 
 		else if(href_list["approve"])
 			var/PDAowner = src.master.owner

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1544,6 +1544,7 @@
 #include "code\modules\mining\mining_encounters.dm"
 #include "code\modules\mining\ore.dm"
 #include "code\modules\mining\tile_events.dm"
+#include "code\modules\networks\computer3\announcement_request.dm"
 #include "code\modules\networks\computer3\base_os.dm"
 #include "code\modules\networks\computer3\base_program.dm"
 #include "code\modules\networks\computer3\buildandrepair.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an "Announcer" app to all PDAs, allowing anyone to request an announcement and anyone with ID computer access on their inserted ID can approve announcements. You must have your ID inserted to use the app.
![image](https://github.com/user-attachments/assets/5eaa2e08-835a-4f38-80f1-52533aa01e08)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Doing gimmicks is much easier when everyone knows what you are doing. Catering recently got an announcement computer and using that creates a noticeable difference in visitors to the cafeteria, making announcements more accessible to other gimmicks will encourage further interaction with said gimmicks. 

The current solution is to just ask "hey AI can you announce X for me" or asking the HoP/Cap for bridge access to make your announcement from there, or some other departmental announcer access and building your own announcement computer, this heavily reduces the time needed to announce your gimmicks to the crew.

If it gets overused then it could probably be moved to a unique PDA cartridge that no PDAs start with.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Added "Announcer" PDA app to all PDAs, requested announcements can be approved by either the Captain, HoP, HoS or AI!
```
