### PR TITLE
Ensure omnitool doesn't get lost with item arms

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1101,11 +1101,15 @@
 							if ((locate(/obj/item/tool/omnitool/syndicate) in C) != null)
 								var/obj/item/tool/omnitool/syndicate/O = (locate(/obj/item/tool/omnitool/syndicate) in C)
 								var/drophand = (src.hand == RIGHT_HAND ? SLOT_R_HAND : SLOT_L_HAND)
+								var/original_tool_loc = O.loc
 								drop_item()
 								O.set_loc(src)
-								equip_if_possible(O, drophand)
-								src.visible_message(SPAN_ALERT("<B>[src] pulls a set of tools out of \the [C]!</B>"))
-								playsound(src.loc, "rustle", 60, 1)
+								if(equip_if_possible(O, drophand))
+									src.visible_message(SPAN_ALERT("<B>[src] pulls a set of tools out of \the [C]!</B>"))
+									playsound(src.loc, "rustle", 60, 1)
+								else
+									O.set_loc(original_tool_loc)
+									boutput(src, SPAN_ALERT("You aren't able to equip the omnitool to that hand!"))
 								break
 				else
 					message = "<B>[src]</B> tries to stretch [his_or_her(src)] arms."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When using the flex emote to pull out the syndie omnitool, check the return of `equip_if_possible` and move the syndicate omnitool back to its original location if trying to equip fails.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21314