### PR TITLE
Omnitools in welding mode cauterize like welders

### DIFF
--- a/code/obj/item/tool/omnitool.dm
+++ b/code/obj/item/tool/omnitool.dm
@@ -33,6 +33,14 @@
 		if (src.mode == OMNI_MODE_PRYING)
 			if (!pry_surgery(target, user))
 				return ..()
+		else if (src.mode == OMNI_MODE_WELDING)
+			if (src.welding && ishuman(target) && (user.a_intent != INTENT_HARM))
+				var/mob/living/carbon/human/H = target
+				if (H.bleeding || (H.organHolder?.back_op_stage > BACK_SURGERY_OPENED && user.zone_sel.selecting == "chest"))
+					if (!src.cautery_surgery(H, user, 15, src.welding))
+						return ..()
+			else
+				..()
 		else
 			..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Dirty copy/paste of welding tool code to allow for cauterization. Unless we want to do something like creating `welding_attack` in `/obj/item` this is maybe the easiest way?


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #20230