### PR TITLE
Despawn foam dart projectiles after they drop as ammo

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -542,6 +542,7 @@ toxic - poisons
 		..()
 		var/turf/T = istype(hit, /mob) ? get_turf(hit) : get_turf(P) // drop on same tile if mob, drop 1 tile away otherwise
 		drop_as_ammo(get_turf(T))
+		qdel(P) // we dropped, don't keep going
 
 	on_max_range_die(obj/projectile/P)
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
After a foam dart drops as ammo, qdel the original projectile to prevent additional darts from being created


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21313