### PR TITLE
Pilot pods always spawn with a weak mining laser

### DIFF
--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -127,7 +127,7 @@
 
 ////////armed civ putt
 
-obj/machinery/vehicle/miniputt/pilot
+/obj/machinery/vehicle/miniputt/pilot
 	New()
 		. = ..()
 		src.com_system.deactivate()
@@ -135,9 +135,9 @@ obj/machinery/vehicle/miniputt/pilot
 		qdel(src.com_system)
 		src.components -= src.engine
 		src.components -= src.com_system
-		src.engine = new /obj/item/shipcomponent/engine/zero(src)
-		src.engine.ship = src
-		src.components += src.engine
+		src.engine = null
+		src.Install(new /obj/item/shipcomponent/engine/zero(src))
+		src.Install(new /obj/item/shipcomponent/mainweapon/bad_mining(src))
 		src.engine.activate()
 		src.com_system = null
 		myhud.update_systems()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[traits][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add the weak mining laser to pilot trait miniputts, matching the way they're installed for pilot trait minisubs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Though the pilot spawn does place you in open space, it does not guarantee that you won't be stuck in a space "lake" inside an asteroid.

Fix #21309