### PR TITLE
Admin Syndicate recolor command

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -379,6 +379,7 @@ var/list/admin_verbs = list(
 		/client/proc/implant_all,
 		/client/proc/cmd_crusher_walls,
 		/client/proc/cmd_disco_lights,
+		/client/proc/cmd_nukie_colour,
 		/client/proc/cmd_event_controller,
 		/client/proc/cmd_blindfold_monkeys,
 		/client/proc/cmd_terrainify_station,

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2848,7 +2848,7 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 			if("Yes")
 				var/list/inputted_color_matrix = nuke_op_color_matrix.Copy()
 				for (var/i in 1 to 3)
-					inputted_color_matrix[i] = input("Choose a color for syndicate","Syndicate Recolor", nuke_op_color_matrix[i]) as color as color
+					inputted_color_matrix[i] = input("Choose a color for syndicate","Syndicate Recolor", nuke_op_color_matrix[i]) as color
 				if (length(inputted_color_matrix) != 3)
 					boutput(src, "You must input 3 colors.")
 					return

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2844,7 +2844,7 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 	SHOW_VERB_DESC
 
 	if(holder && src.holder.level >= LEVEL_ADMIN)
-		switch(alert("Recolor syndicate gear?",,"Yes","No","Reset"))
+		switch(tgui_alert(src,"Recolor syndicate gear?","Syndicate Recolor",list("Yes", "No","Reset"), theme = "syndicate"))
 			if("Yes")
 				var/list/inputted_color_matrix = nuke_op_color_matrix.Copy()
 				for (var/i in 1 to 3)
@@ -2855,7 +2855,6 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 				nuke_op_camo_matrix = inputted_color_matrix
 				var/color_matrix = color_mapping_matrix(nuke_op_color_matrix, nuke_op_camo_matrix)
 				for (var/atom/A as anything in by_cat[TR_CAT_NUKE_OP_STYLE])
-					A.color = null
 					A.color = color_matrix
 					LAGCHECK(LAG_LOW)
 				logTheThing(LOG_ADMIN, src, "changed the syndicate colour scheme.")

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2836,6 +2836,43 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 	else
 		boutput(src, "You must be at least an Administrator to use this command.")
 
+/client/proc/cmd_nukie_colour()
+	SET_ADMIN_CAT(ADMIN_CAT_FUN)
+	set name = "Recolor Syndicate"
+	set desc = "Recolor (most) syndicate gear, mostly nukie gear."
+	ADMIN_ONLY
+	SHOW_VERB_DESC
+
+	if(holder && src.holder.level >= LEVEL_ADMIN)
+		switch(alert("Recolor syndicate gear?",,"Yes","No","Reset"))
+			if("Yes")
+				var/list/inputted_color_matrix = nuke_op_color_matrix.Copy()
+				for (var/i in 1 to 3)
+					inputted_color_matrix[i] = input("Choose a color for syndicate","Syndicate Recolor", nuke_op_color_matrix[i]) as color as color
+				if (length(inputted_color_matrix) != 3)
+					boutput(src, "You must input 3 colors.")
+					return
+				nuke_op_camo_matrix = inputted_color_matrix
+				var/color_matrix = color_mapping_matrix(nuke_op_color_matrix, nuke_op_camo_matrix)
+				for (var/atom/A as anything in by_cat[TR_CAT_NUKE_OP_STYLE])
+					A.color = null
+					A.color = color_matrix
+					LAGCHECK(LAG_LOW)
+				logTheThing(LOG_ADMIN, src, "changed the syndicate colour scheme.")
+				logTheThing(LOG_DIARY, src, "changed the syndicate colour scheme.", "admin")
+				message_admins("[key_name(src)] changed the syndicate colour scheme.")
+			if ("Reset")
+				for (var/atom/A as anything in by_cat[TR_CAT_NUKE_OP_STYLE])
+					A.color = null
+					LAGCHECK(LAG_LOW)
+				logTheThing(LOG_ADMIN, src, "reset the syndicate colour scheme.")
+				logTheThing(LOG_DIARY, src, "reset the syndicate colour scheme.", "admin")
+				message_admins("[key_name(src)] reset the syndicate colour scheme.")
+			if("No")
+				return
+	else
+		boutput(src, "You must be at least an Administrator to use this command.")
+
 /client/proc/cmd_blindfold_monkeys()
 	SET_ADMIN_CAT(ADMIN_CAT_FUN)
 	set name = "See No Evil"

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2856,6 +2856,10 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 				var/color_matrix = color_mapping_matrix(nuke_op_color_matrix, nuke_op_camo_matrix)
 				for (var/atom/A as anything in by_cat[TR_CAT_NUKE_OP_STYLE])
 					A.color = color_matrix
+					var/obj/item/Item = A
+					if(istype(Item) && Item.equipped_in_slot)
+						var/mob/living/carbon/human/wearer = Item.loc
+						wearer.update_clothing()
 					LAGCHECK(LAG_LOW)
 				logTheThing(LOG_ADMIN, src, "changed the syndicate colour scheme.")
 				logTheThing(LOG_DIARY, src, "changed the syndicate colour scheme.", "admin")
@@ -2863,6 +2867,10 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 			if ("Reset")
 				for (var/atom/A as anything in by_cat[TR_CAT_NUKE_OP_STYLE])
 					A.color = null
+					var/obj/item/Item = A
+					if(istype(Item) && Item.equipped_in_slot)
+						var/mob/living/carbon/human/wearer = Item.loc
+						wearer.update_clothing()
 					LAGCHECK(LAG_LOW)
 				logTheThing(LOG_ADMIN, src, "reset the syndicate colour scheme.")
 				logTheThing(LOG_DIARY, src, "reset the syndicate colour scheme.", "admin")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an admin command under the "fun" category to recolour the syndicate operative gear in the TR_CAT_NUKE_OP_STYLE tracking category

Known error: Does not update worn icons for any players currently wearing syndicate gear.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The ability to restyle nukeop gear is only presently used in terrainify, this lets admins have a little fun with nukie gear and gives the tracking category more usage.

## Changelog:
This is an admin thing so if you merge this please also add a changelog entry to the admin changelog with accurate date