### PR TITLE
TOOL_CHOPPING now also does quad damage to windows

### DIFF
--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -473,7 +473,10 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 		else
 			attack_particle(user,src)
 			playsound(src.loc, src.hitsound , 75, 1)
-			src.damage_blunt(W.force)
+			if (W.tool_flags & TOOL_CHOPPING)
+				src.damage_blunt(W.force*4, user)
+			else
+				src.damage_blunt(W.force)
 			..()
 		return
 

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -473,7 +473,7 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 		else
 			attack_particle(user,src)
 			playsound(src.loc, src.hitsound , 75, 1)
-			if (W.tool_flags & TOOL_CHOPPING)
+			if (ischoppingtool(W))
 				src.damage_blunt(W.force*4, user)
 			else
 				src.damage_blunt(W.force)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[wiki]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title- weapons with the chopping flag (breaching hammers, syndie saws, fireaxes) deal quad damage to windows.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes breaching equipment more useful- airlock hammers and the like have their niches somewhat usurped by the fact that breaking down a window and grille will always be quicker than going through a door, even with the quad damage that TOOL_CHOPPING provides. Hopefully giving more window damage will make them useful in cases outside of "man I really want to get into this room but alas there's no windows that I can break down with a fire extinguisher"

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
unsure if should be small change but I put down big
```changelog
(u)NightmarechaMillian
(*)Breaching weapons (sledgehammers, fireaxes, etc) will now also deal 4x damage to windows
```
