### PR TITLE
Heat Surge artifact fire color changes based on origin

### DIFF
--- a/code/obj/artifacts/artifact_objects/heatwave.dm
+++ b/code/obj/artifacts/artifact_objects/heatwave.dm
@@ -19,6 +19,7 @@
 	var/recharge_time = 20 SECONDS
 	var/fire_range = 4
 	var/temperature = 7000 KELVIN
+	var/fire_color
 
 	post_setup()
 		..()
@@ -30,6 +31,14 @@
 				fire_range = rand(2,6)
 				temperature = rand(4000, 8900) KELVIN
 
+		switch(artitype.name)
+			if ("ancient")
+				src.fire_color = pick(CHEM_FIRE_RED, CHEM_FIRE_BLACK, CHEM_FIRE_WHITE)
+			if ("eldritch")
+				src.fire_color = pick(CHEM_FIRE_RED, CHEM_FIRE_DARKRED, CHEM_FIRE_PURPLE)
+			if ("precursor")
+				src.fire_color = pick(CHEM_FIRE_RED, CHEM_FIRE_BLUE, CHEM_FIRE_GREEN)
+
 	effect_activate(var/obj/O)
 		if (..())
 			return
@@ -39,6 +48,6 @@
 		var/turf/T = get_turf(O)
 		playsound(O.loc, 'sound/effects/mag_fireballlaunch.ogg', 50, 0)
 		T.visible_message(SPAN_ALERT("<b>[O]</b> erupts into a huge column of flames! Holy shit!"))
-		fireflash_melting(T, fire_range, temperature, temperature / fire_range, chemfire = CHEM_FIRE_RED)
+		fireflash_melting(T, fire_range, temperature, temperature / fire_range, chemfire = src.fire_color)
 		SPAWN(3 SECONDS)
 			O.ArtifactDeactivated()


### PR DESCRIPTION
[SCIENCE][GAME OBJECTS][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so the Heat Surge artifact fire color can be different than red, depending on origin


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
-Different fire colors would be cool
-Further makes Heat Surge artifact unique


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)Heat Surge artifact can now produce fire with different colors than just red.
```
