### PR TITLE
Mob-ifys Bats & Dr. Acula

### DIFF
--- a/code/datums/abilities/critter/small_animal.dm
+++ b/code/datums/abilities/critter/small_animal.dm
@@ -411,14 +411,6 @@
 
 		logTheThing(LOG_COMBAT, src.mini_vampire, "steals blood from [constructTarget(src.target,"combat")] at [log_loc(src.mini_vampire)].")
 
-	onEnd()
-		if(GET_DIST(src.mini_vampire, src.target) > 7 || src.mini_vampire == null || src.target == null)
-			..()
-			interrupt(INTERRUPT_ALWAYS)
-			return
-
-		src.onRestart()
-
 	onInterrupt()
 		if (state == ACTIONSTATE_RUNNING)
 			if (ishuman(src.target))

--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -739,16 +739,16 @@ ABSTRACT_TYPE(/datum/objective/crew/medicaldirector)
 /datum/objective/crew/medicaldirector/dr_acula
 	explanation_text = "Ensure that Dr. Acula escapes on the shuttle."
 	check_completion()
-		for (var/obj/critter/bat/doctor/Dr in by_cat[TR_CAT_PETS])
-			if (in_centcom(Dr) && Dr.alive)
+		for (var/mob/living/critter/small_animal/bat/doctor/Dr in by_cat[TR_CAT_PETS])
+			if (in_centcom(Dr) && isalive(Dr))
 				return 1
 		return 0
 
 /datum/objective/crew/medicaldirector/dr_acula_feeds
 	explanation_text = "Ensure that Dr. Acula survives and drinks 200 units of blood by the end of the shift."
 	check_completion()
-		for (var/obj/critter/bat/doctor/Dr in by_cat[TR_CAT_PETS])
-			if (Dr.blood_volume >= 200 && Dr.alive)
+		for (var/mob/living/critter/small_animal/bat/doctor/Dr in by_cat[TR_CAT_PETS])
+			if (Dr.amount_of_blood >= 200 && isalive(Dr))
 				return 1
 		return 0
 

--- a/code/mob/living/critter/ai/bat.dm
+++ b/code/mob/living/critter/ai/bat.dm
@@ -1,0 +1,52 @@
+/datum/aiHolder/bat
+	New()
+		..()
+		default_task = get_instance(/datum/aiTask/prioritizer/critter/bat, list(src))
+
+/datum/aiTask/prioritizer/critter/bat/New()
+	..()
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/bat/drink_blood, list(holder, src))
+
+// Bluh
+/datum/aiTask/sequence/goalbased/critter/bat/drink_blood
+	name = "drinking blood"
+	weight = 10
+	max_dist = 7
+	ai_turbo = TRUE
+
+/datum/aiTask/sequence/goalbased/critter/bat/drink_blood/New(parentHolder, transTask)
+	..()
+	add_task(holder.get_instance(/datum/aiTask/succeedable/critter/bat/drink_blood, list(holder)))
+
+/datum/aiTask/sequence/goalbased/critter/bat/drink_blood/get_targets()
+	var/mob/living/critter/small_animal/bat/the_bat = holder.owner
+	return the_bat.seek_target()
+
+// Drink blood subtask, go to target
+/datum/aiTask/succeedable/critter/bat/drink_blood
+	name = "drink subtask"
+	var/is_complete = FALSE
+
+/datum/aiTask/succeedable/critter/bat/drink_blood/failed()
+	var/mob/living/critter/C = holder.owner
+
+	// the tasks fails and is re-evaluated if the target is not in range
+	if(!C || !holder.target || BOUNDS_DIST(holder.target, C) > 0 || !istype(holder.target.loc, /turf))
+		return TRUE
+
+/datum/aiTask/succeedable/critter/bat/drink_blood/succeeded()
+	return is_complete
+
+/datum/aiTask/succeedable/critter/bat/drink_blood/on_tick()
+	if(!is_complete)
+		var/mob/living/critter/C = holder.owner
+		if(C && holder.target && BOUNDS_DIST(C, holder.target) == 0 && istype(holder.target.loc, /turf))
+			var/datum/targetable/critter/drink_blood/B = C.abilityHolder.getAbility(/datum/targetable/critter/drink_blood)
+			if (B && !B.disabled && B.cooldowncheck())
+				B.handleCast(holder.target)
+				is_complete = TRUE
+
+/datum/aiTask/succeedable/critter/bat/drink_blood/on_reset()
+	is_complete = FALSE
+

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -3064,7 +3064,6 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	health_brute = 30
 	health_burn = 30
 	is_pet = 2
-	ai_type = /datum/aiHolder/bat/doctor
 	player_can_spawn_with_pet = FALSE
 
 /* ------------------ Tiny Bat Rina ------------------ */

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -275,7 +275,7 @@ var/datum/score_tracker/score_tracker
 						command_pets_escaped += P
 					else if(P.is_pet)
 						pets_escaped += P
-					if (istype(P, /obj/critter/bat/doctor))
+					if (istype(P, /mob/living/critter/small_animal/bat/doctor))
 						acula_blood = P:blood_volume //this only gets populated if Dr. Acula escapes
 			else if(ismobcritter(pet))
 				var/mob/living/critter/P = pet

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -525,6 +525,7 @@
 #include "code\mob\living\critter\spider.dm"
 #include "code\mob\living\critter\vending.dm"
 #include "code\mob\living\critter\ai\aquatic.dm"
+#include "code\mob\living\critter\ai\bat.dm"
 #include "code\mob\living\critter\ai\brullbar.dm"
 #include "code\mob\living\critter\ai\bunny.dm"
 #include "code\mob\living\critter\ai\capybara.dm"

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -13145,7 +13145,7 @@
 /area/space)
 "hbK" = (
 /obj/stool/chair/comfy/blue,
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/carpet/blue/fancy,
 /area/station/medical/head)
 "hcj" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -35484,7 +35484,7 @@
 /turf/simulated/floor/plating,
 /area/station/science/research_director)
 "syb" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fblue2"

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -31994,7 +31994,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
 "ckR" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -46807,7 +46807,7 @@
 	bcolor = "black";
 	icon_state = "bedsheet-black"
 	},
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/landmark/start/job/medical_director,
 /obj/decal/poster/wallsign/poster_nt{
 	pixel_y = 28

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -8038,7 +8038,7 @@
 "aPO" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/blue,
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 9

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -57095,7 +57095,7 @@
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
 "riE" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -36224,7 +36224,7 @@
 /turf/space,
 /area/station/mining/magnet)
 "gxS" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/shrub{
 	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -20367,7 +20367,7 @@
 	},
 /area/station/medical/medbay/pharmacy)
 "iyS" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/shrub{
 	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -2142,7 +2142,7 @@
 	icon_state = "4-8"
 	},
 /obj/blind_switch/area/north,
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/bluegreen,
 /area/station/medical/medbay/treatment2)
 "ahu" = (

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -1617,7 +1617,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
 "adi" = (

--- a/maps/unused/destiny.dmm
+++ b/maps/unused/destiny.dmm
@@ -1197,7 +1197,7 @@
 	},
 /area/station/crew_quarters/md)
 "aeX" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;

--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -8502,7 +8502,7 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/machinery/phone/wall{
 	pixel_x = 24;
 	pixel_y = 4

--- a/maps/unused/manta.dmm
+++ b/maps/unused/manta.dmm
@@ -23820,7 +23820,7 @@
 	},
 /area/station/medical/head/private)
 "boJ" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/wood/eight{
 	dir = 4
 	},

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -20369,7 +20369,7 @@
 /turf/simulated/floor/bluegreen,
 /area/station/crew_quarters)
 "ixW" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/carpet/blue/fancy,
 /area/station/crew_quarters/md)
 "iyq" = (

--- a/maps/unused/ozymandias.dmm
+++ b/maps/unused/ozymandias.dmm
@@ -12460,7 +12460,7 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "dsJ" = (
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /obj/shrub{
 	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -11425,7 +11425,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aOz" = (

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -33852,7 +33852,7 @@
 	dir = 9;
 	icon_state = "line2"
 	},
-/obj/critter/bat/doctor,
+/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/wood,
 /area/station/medical/head)
 "oTz" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Feature] [Critters]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ports all of the features from `/obj/critter/bat` to `/mob/living/critter/small_animal/bat`.

Adds a `bat.dm` alongside `/datum/aiHolder/bat` with all of the bat AI handling.

Adds a new ability `/datum/targetable/critter/drink_blood` which bats use to drink blood.

Replaces all `/obj/critter/bat/doctor` with `/mob/living/critter/small_animal/bat/doctor`, and changes the handling for the Dr. Acula crew objectives.

There may be a slight increase in bats trying to drink blood.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Object critter bad. Also Dr. Acula needs to fit inside a pet carrier.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(+)Dr. Acula now fits inside of pet carriers.
```
