### PR TITLE
Clicking on an airlock with an item and harm intent will always attack the airlock

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -736,7 +736,9 @@ var/global/list/cycling_airlocks = list()
 		..()
 		return
 
-	if ((isweldingtool(C) && !( src.operating ) && src.density))
+	if(user.a_intent == INTENT_HARM) //pass attacking the door up the tree-- skip tool checks
+		..()
+	else if ((isweldingtool(C) && !( src.operating ) && src.density))
 		if (src.hardened)
 			boutput(user, SPAN_ALERT("Your tool is unable to weld this airlock! Huh."))
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

See title- adds a check before all the tool checks

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

There's a lot of weird mutual exclusivity with airlock-item interactions. By adding an intent check, you can, if you really want to, damage airlocks with crowbars even though they're prying tools.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)NightmarechaMillian
(+)Clicking an airlock with harm intent will now always attack it
```
