### PR TITLE
Only remove one assignment on self cryoing

### DIFF
--- a/code/obj/cryotron.dm
+++ b/code/obj/cryotron.dm
@@ -221,7 +221,6 @@
 								antagonist.handle_perma_cryo()
 							user.mind?.get_player()?.dnr = TRUE
 							user.ghostize()
-							var/datum/job/job = find_job_in_controller_by_string(user.job, soft=TRUE)
 							qdel(user)
 							return 1
 

--- a/code/obj/cryotron.dm
+++ b/code/obj/cryotron.dm
@@ -222,8 +222,6 @@
 							user.mind?.get_player()?.dnr = TRUE
 							user.ghostize()
 							var/datum/job/job = find_job_in_controller_by_string(user.job, soft=TRUE)
-							if (job && !job.unique)
-								job.assigned = max(0, job.assigned - 1)
 							qdel(user)
 							return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[respawning][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove the adjustment to `job.assigned` from the "Observe" cryotron option. Reducing job assignment count is already handled in `add_person_to_storage`. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When people self-cryoed and hit observe, they reduced the currently assigned count by 2 instead of 1. This leads to extra job slots becoming available.
Fix #19199
Fix #20598
Fix #19023