### PR TITLE
Station minimap tweaks/polish

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -705,6 +705,8 @@ ABSTRACT_TYPE(/area/shuttle)
 /area/shuttle/arrival/station
 	icon_state = "shuttle"
 	flags = FLUID_DENSE
+	minimaps_to_render_on = MAP_ALL
+	station_map_colour = MAPC_NANOTRASEN
 
 /area/shuttle/escape
 	allowed_restricted_z = TRUE
@@ -1284,10 +1286,6 @@ ABSTRACT_TYPE(/area/adventure)
 	requires_power = FALSE
 #endif
 
-/area/spacehabitat/pool
-	name = "Pool Room"
-	icon_state = "yellow"
-	requires_power = FALSE
 
 /area/abandonedship
 	name = "Abandoned ship"
@@ -1302,6 +1300,17 @@ ABSTRACT_TYPE(/area/adventure)
 	name = "Habitat Dome Beach"
 	icon_state = "yellow"
 	force_fullbright = 1
+
+/area/spacehabitat/pool
+	name = "Pool Room"
+	icon_state = "yellow"
+	requires_power = FALSE
+
+/area/spacehabitat/owlery
+	name = "Owlery"
+	icon_state = "yellow"
+	sound_environment = 15
+	requires_power = FALSE
 
 /area/salyut
 	name = "Soviet derelict"
@@ -3299,6 +3308,7 @@ ABSTRACT_TYPE(/area/station/janitor)
 
 /area/station/science/testchamber/bombchamber
 	name = "Bomb Testing Chamber"
+	minimaps_to_render_on = null
 
 ABSTRACT_TYPE(/area/station/science)
 /area/station/science
@@ -3619,6 +3629,7 @@ ABSTRACT_TYPE(/area/station/catwalk)
 
 /area/research_outpost/indigo_rye
 	name = "Indigo"
+	minimaps_to_render_on = null
 
 /area/research_outpost/hangar
 		name = "Research Outpost Hangar"

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -9986,7 +9986,7 @@
 	name = "Magnet Area Boundary"
 	},
 /turf/simulated/floor/airless/plating/catwalk/auto,
-/area/space)
+/area/mining/magnet)
 "cga" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -10767,7 +10767,7 @@
 	name = "Magnet Area Boundary"
 	},
 /turf/simulated/floor/airless/plating/catwalk/auto,
-/area/space)
+/area/mining/magnet)
 "dqZ" = (
 /obj/machinery/light/small/floor/harsh,
 /obj/cable{
@@ -10915,7 +10915,7 @@
 	name = "Magnet Area Boundary"
 	},
 /turf/simulated/floor/airless/plating/catwalk/auto,
-/area/space)
+/area/mining/magnet)
 "dCV" = (
 /obj/decal/tile_edge/stripe/big{
 	dir = 9
@@ -13101,7 +13101,7 @@
 	name = "ACTIVE MAGNET AREA"
 	},
 /turf/simulated/floor/airless/plating/catwalk/auto,
-/area/space)
+/area/mining/magnet)
 "gRl" = (
 /obj/machinery/vending/floppy,
 /turf/simulated/floor/plating/random,
@@ -15948,7 +15948,7 @@
 	name = "ACTIVE MAGNET AREA"
 	},
 /turf/simulated/floor/airless/plating/catwalk/auto,
-/area/space)
+/area/mining/magnet)
 "kNc" = (
 /obj/lattice{
 	dir = 4;
@@ -16512,6 +16512,9 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
+"lLe" = (
+/turf/space,
+/area/mining/magnet)
 "lLE" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -18995,7 +18998,7 @@
 	width = 13
 	},
 /turf/space,
-/area/space)
+/area/mining/magnet)
 "psU" = (
 /obj/railing/orange/reinforced{
 	dir = 1
@@ -19217,7 +19220,7 @@
 	name = "Magnet Area Boundary"
 	},
 /turf/simulated/floor/airless/plating/catwalk/auto,
-/area/space)
+/area/mining/magnet)
 "pRr" = (
 /obj/decal/poster/wallsign/security,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -19779,7 +19782,7 @@
 	name = "Magnet Area Boundary"
 	},
 /turf/simulated/floor/airless/plating/catwalk/auto,
-/area/space)
+/area/mining/magnet)
 "qTZ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -22236,7 +22239,7 @@
 	name = "ACTIVE MAGNET AREA"
 	},
 /turf/simulated/floor/airless/plating/catwalk/auto,
-/area/space)
+/area/mining/magnet)
 "uCW" = (
 /obj/storage/secure/closet/fridge,
 /obj/random_item_spawner/snacks/six,
@@ -23259,7 +23262,7 @@
 	name = "ACTIVE MAGNET AREA"
 	},
 /turf/simulated/floor/airless/plating/catwalk/auto,
-/area/space)
+/area/mining/magnet)
 "wbj" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -52017,19 +52020,19 @@ aaa
 aaa
 xML
 dCT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 pRb
 xML
 aaa
@@ -52319,19 +52322,19 @@ aaa
 aaa
 xML
 dCT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 pRb
 xML
 aaa
@@ -52621,19 +52624,19 @@ aaa
 aaa
 xML
 dCT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 pRb
 xML
 aaa
@@ -52923,19 +52926,19 @@ aaa
 aaa
 xML
 dCT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 pRb
 xML
 aaa
@@ -53225,19 +53228,19 @@ aaa
 aaa
 xML
 dCT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 pRb
 xML
 aaa
@@ -53527,19 +53530,19 @@ aaa
 aaa
 xML
 dCT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 pRb
 xML
 aaa
@@ -53829,19 +53832,19 @@ aaa
 aaa
 xML
 dCT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 psJ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 pRb
 xML
 aaa
@@ -54131,19 +54134,19 @@ aaa
 aaa
 xML
 dCT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 pRb
 xML
 aaa
@@ -54433,19 +54436,19 @@ aaa
 aaa
 xML
 dCT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 pRb
 xML
 aaa
@@ -54735,19 +54738,19 @@ aaa
 aaa
 xML
 dCT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 pRb
 xML
 aaa
@@ -55037,19 +55040,19 @@ aaa
 aaa
 xML
 dCT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 pRb
 xML
 aaa
@@ -55339,19 +55342,19 @@ aaa
 aaa
 xML
 dCT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 pRb
 xML
 aaa
@@ -55641,19 +55644,19 @@ aaa
 aaa
 xML
 dCT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
+lLe
 pRb
 xML
 aaa

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -21941,24 +21941,24 @@
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bzR" = (
 /obj/storage/crate,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bzS" = (
 /obj/machinery/ore_cloud_storage_container,
 /turf/simulated/floor/grime,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bzU" = (
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/grime,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bzX" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -22142,7 +22142,7 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bAL" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -22160,7 +22160,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bAQ" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -22174,7 +22174,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bAS" = (
 /turf/simulated/wall/auto/reinforced/supernorn{
 	explosion_resistance = 15;
@@ -22515,7 +22515,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bCD" = (
 /obj/grille/catwalk{
 	dir = 6
@@ -22523,7 +22523,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bCF" = (
 /obj/decal/cleanable/rust,
 /turf/simulated/wall/auto/reinforced/supernorn{
@@ -22689,13 +22689,13 @@
 /obj/landmark/gps_waypoint,
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bDF" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bDH" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk,
@@ -22887,19 +22887,19 @@
 	name = "Mineral Magnet Pad"
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bEs" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bEw" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bEB" = (
 /obj/item/slag_shovel{
 	pixel_x = 7;
@@ -27589,11 +27589,11 @@
 /area/station/mining/staff_room)
 "bWm" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bWn" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bWo" = (
 /obj/machinery/atmospherics/pipe/simple/junction{
 	dir = 1
@@ -27912,7 +27912,7 @@
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "bXs" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/storage)
@@ -28691,13 +28691,13 @@
 	name = "Danger: High Voltage"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "cab" = (
 /obj/machinery/neosmelter,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "cac" = (
 /obj/grille/catwalk,
 /obj/landmark/magnet_shield,
@@ -29115,13 +29115,13 @@
 	dir = 1
 	},
 /turf/simulated/floor/grime,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "cbB" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
 /turf/simulated/floor/grime,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "cbD" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -29494,17 +29494,17 @@
 "ccF" = (
 /obj/machinery/manufacturer/mining,
 /turf/simulated/floor/grime,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "ccJ" = (
 /obj/stool,
 /turf/simulated/floor/grime,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "ccK" = (
 /obj/machinery/computer/magnet{
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "ccL" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
@@ -29884,17 +29884,17 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/grime,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "cdW" = (
 /obj/machinery/light_switch{
 	name = "S light switch";
 	pixel_y = -24
 	},
 /turf/simulated/floor/grime,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "cdX" = (
 /turf/simulated/floor/grime,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "cdY" = (
 /obj/table/auto,
 /obj/machinery/recharger{
@@ -29905,14 +29905,14 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "cdZ" = (
 /obj/machinery/computer/barcode,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "cea" = (
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "ceb" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
@@ -30629,7 +30629,7 @@
 	dir = 8;
 	icon_state = "catwalk_cross"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "cgA" = (
 /obj/grille/catwalk{
 	dir = 5
@@ -31006,7 +31006,7 @@
 	dir = 8;
 	icon_state = "catwalk_cross"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "chK" = (
 /obj/landmark/magnet_center{
 	height = 13;
@@ -31348,7 +31348,7 @@
 	layer = 4
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "ciW" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -31756,7 +31756,7 @@
 	pixel_y = -2
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "ckn" = (
 /obj/machinery/door/poddoor/blast/pyro{
 	autoclose = 1;
@@ -32219,15 +32219,15 @@
 "clH" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "clI" = (
 /obj/machinery/oreaccumulator,
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "clJ" = (
 /obj/storage/crate,
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "clK" = (
 /obj/table/auto,
 /obj/item/paper/book/from_file/matsci_guide{
@@ -32247,7 +32247,7 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/plating/jen,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "clL" = (
 /obj/machinery/door/poddoor/blast/pyro{
 	autoclose = 1;
@@ -37313,7 +37313,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/grime,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "cKR" = (
 /obj/landmark/start/job/engineer,
 /obj/decal/tile_edge/stripe/extra_big,
@@ -37649,7 +37649,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "cVP" = (
 /obj/grille/catwalk{
 	dir = 10
@@ -38237,7 +38237,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "dtA" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -38921,7 +38921,7 @@
 	pixel_x = 12
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "dQM" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4;
@@ -40467,7 +40467,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "eQN" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -42198,7 +42198,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "geR" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/sortingRoom)
@@ -42685,7 +42685,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "gDS" = (
 /obj/machinery/vehicle/pod_smooth/heavy/security,
 /turf/simulated/floor/shuttlebay,
@@ -43717,7 +43717,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "hra" = (
 /obj/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple{
@@ -46288,7 +46288,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "jvf" = (
 /mob/living/critter/small_animal/cockroach,
 /turf/simulated/floor/plating,
@@ -46995,7 +46995,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "jVY" = (
 /obj/landmark/start/job/botanist,
 /turf/simulated/floor/green/side{
@@ -47417,7 +47417,7 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "koa" = (
 /obj/storage/closet/fire,
 /obj/machinery/alarm{
@@ -48197,7 +48197,7 @@
 	pixel_x = -15
 	},
 /turf/simulated/floor/grime,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "kTD" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -48269,7 +48269,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "kXt" = (
 /turf/simulated/floor/yellow/side{
 	dir = 10
@@ -49265,7 +49265,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "lUF" = (
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	name = "Core Access"
@@ -49678,7 +49678,7 @@
 	dir = 5;
 	icon_state = "catwalk_cross"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "mlR" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -51404,7 +51404,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "nyV" = (
 /obj/machinery/firealarm/north,
 /obj/machinery/disposal,
@@ -53865,7 +53865,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "pnt" = (
 /obj/stool/bed/moveable,
 /obj/item/clothing/suit/bedsheet,
@@ -54549,7 +54549,7 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "pTS" = (
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -54744,7 +54744,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "qcF" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -55315,7 +55315,7 @@
 	dir = 5;
 	icon_state = "catwalk_cross"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "qxz" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
 	dir = 8;
@@ -58512,7 +58512,7 @@
 	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "sRY" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -60748,7 +60748,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "uzt" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -60852,7 +60852,7 @@
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "uCf" = (
 /obj/storage/secure/closet/brig_automatic/minibrig,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -63284,7 +63284,7 @@
 	pixel_x = 12
 	},
 /turf/simulated/floor/grime,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "wzI" = (
 /obj/machinery/light{
 	dir = 8;
@@ -63705,7 +63705,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "wQB" = (
 /obj/machinery/light{
 	dir = 8;
@@ -64964,7 +64964,7 @@
 	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
-/area/station/quartermaster/refinery)
+/area/station/mining/magnet)
 "xUX" = (
 /obj/machinery/firealarm/east,
 /obj/storage/secure/closet/command/medical_director,

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -11624,7 +11624,7 @@
 	powerlevel = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "biO" = (
 /obj/stool/chair{
 	dir = 4
@@ -15571,11 +15571,11 @@
 /area/station/maintenance/south)
 "bGU" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "bGV" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "bGX" = (
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
@@ -15625,28 +15625,28 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "bHr" = (
 /obj/stool,
 /turf/simulated/floor/grime,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "bHs" = (
 /turf/simulated/floor/grime,
 /area/station/quartermaster/refinery)
 "bHt" = (
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "bHw" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "bHz" = (
 /obj/machinery/manufacturer/mining,
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "bHA" = (
 /obj/grille/catwalk{
 	dir = 9
@@ -15799,7 +15799,7 @@
 /obj/storage/closet/welding_supply,
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "bHX" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -15807,7 +15807,7 @@
 "bIa" = (
 /obj/storage/crate,
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "bIb" = (
 /obj/table/auto,
 /obj/item/device/appraisal{
@@ -15826,7 +15826,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "bId" = (
 /obj/grille/catwalk,
 /obj/cable/yellow{
@@ -16076,7 +16076,7 @@
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "bIQ" = (
 /obj/grille/catwalk{
 	dir = 5
@@ -16086,7 +16086,7 @@
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "bIR" = (
 /obj/landmark/magnet_shield,
 /obj/securearea{
@@ -16342,7 +16342,7 @@
 	pixel_x = -3
 	},
 /turf/simulated/floor/grime,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "bPa" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
@@ -17124,7 +17124,7 @@
 	rand_pos = 0
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/wreckage)
+/area/abandonedship)
 "cpz" = (
 /obj/machinery/camera/television{
 	c_tag = "test chamber 2";
@@ -17239,7 +17239,7 @@
 	name = "Ranch Ship"
 	},
 /turf/simulated/floor/green,
-/area/station/wreckage)
+/area/abandonedship)
 "cul" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -17628,7 +17628,7 @@
 	powerlevel = 1
 	},
 /turf/simulated/floor/plating,
-/area/station/wreckage)
+/area/abandonedship)
 "cFX" = (
 /obj/stool/chair{
 	dir = 8
@@ -17841,7 +17841,7 @@
 "cML" = (
 /obj/decal/poster/wallsign/stencil/left/h,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/wreckage)
+/area/abandonedship)
 "cNm" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -18290,7 +18290,7 @@
 /turf/simulated/floor/grasstodirt{
 	dir = 9
 	},
-/area/station/wreckage)
+/area/abandonedship)
 "cZN" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/shuttlebay,
@@ -18609,7 +18609,7 @@
 	},
 /obj/item/storage/toolbox/emergency,
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "dkq" = (
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/yellow/side{
@@ -19105,7 +19105,7 @@
 /obj/decal/poster/wallsign/stencil/left/r,
 /obj/decal/poster/wallsign/stencil/right/a,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/wreckage)
+/area/abandonedship)
 "dCn" = (
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
@@ -19902,7 +19902,7 @@
 "ead" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/shuttlebay,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "ear" = (
 /obj/cable/orange{
 	icon_state = "4-8"
@@ -20178,7 +20178,7 @@
 	dir = 6;
 	layer = 2
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "ejJ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -20496,7 +20496,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "etX" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blueblack,
@@ -20642,7 +20642,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/wreckage)
+/area/abandonedship)
 "exr" = (
 /obj/item/plate,
 /obj/item/reagent_containers/food/snacks/snack_cake/golden,
@@ -21284,7 +21284,7 @@
 	dir = 9;
 	layer = 2
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "eSH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -21316,7 +21316,7 @@
 "eUx" = (
 /obj/machinery/sheet_extruder,
 /turf/simulated/floor/grime,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "eVj" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -21490,7 +21490,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/grime,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "faR" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -21518,7 +21518,7 @@
 /obj/decal/poster/wallsign/stencil/left/n,
 /obj/decal/poster/wallsign/stencil/right/c,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/wreckage)
+/area/abandonedship)
 "fbx" = (
 /obj/table/auto,
 /obj/random_item_spawner/snacks/maybe_few,
@@ -21670,7 +21670,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "feA" = (
 /obj/cable/yellow{
 	icon_state = "2-4"
@@ -22005,7 +22005,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/dirt,
-/area/station/wreckage)
+/area/abandonedship)
 "fpl" = (
 /obj/decal/tile_edge/floorguide/arrow_s{
 	dir = 4
@@ -22265,7 +22265,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "fBl" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/scidisposal)
@@ -22449,7 +22449,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless/plating/catwalk,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "fIq" = (
 /obj/stool/bed/moveable,
 /obj/decal/cleanable/dirt/dirt2,
@@ -22498,7 +22498,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/grime,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "fJk" = (
 /obj/machinery/traymachine/locking/crematorium{
 	id = "crematorium"
@@ -22693,7 +22693,7 @@
 /area/station/hallway/secondary/exit)
 "fQm" = (
 /turf/simulated/floor/grime,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "fQt" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -22717,7 +22717,7 @@
 	dir = 10;
 	icon_state = "catwalk_cross"
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "fSn" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -23985,7 +23985,7 @@
 /area/station/maintenance/west)
 "gIe" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/wreckage)
+/area/abandonedship)
 "gIh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -24487,7 +24487,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "gUr" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -24539,7 +24539,7 @@
 "gVX" = (
 /obj/chicken_nesting_box,
 /turf/simulated/floor/grass/leafy,
-/area/station/wreckage)
+/area/abandonedship)
 "gYc" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -25063,7 +25063,7 @@
 "hqn" = (
 /obj/machinery/manufacturer/qm,
 /turf/simulated/floor/plating,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "hqG" = (
 /obj/railing/orange/reinforced{
 	dir = 1
@@ -25071,7 +25071,7 @@
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
-/area/station/wreckage)
+/area/abandonedship)
 "hqQ" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -25235,7 +25235,7 @@
 /obj/shrub,
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/grass/leafy,
-/area/station/wreckage)
+/area/abandonedship)
 "hwm" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	req_access = null
@@ -25494,7 +25494,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "hFr" = (
 /obj/table/endtable_classic,
 /obj/item/storage/box/nerd_kit{
@@ -25549,7 +25549,7 @@
 	},
 /obj/railing/orange/reinforced,
 /turf/simulated/floor/grasstodirt,
-/area/station/wreckage)
+/area/abandonedship)
 "hGM" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -25578,7 +25578,7 @@
 /turf/simulated/floor/grasstodirt{
 	dir = 10
 	},
-/area/station/wreckage)
+/area/abandonedship)
 "hIn" = (
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
@@ -25837,7 +25837,7 @@
 "hQp" = (
 /obj/railing/orange/reinforced,
 /turf/simulated/floor/grasstodirt,
-/area/station/wreckage)
+/area/abandonedship)
 "hQw" = (
 /obj/disposalpipe/segment,
 /obj/random_item_spawner/junk/one_or_zero,
@@ -27084,7 +27084,7 @@
 	powerlevel = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "iBz" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -27104,7 +27104,7 @@
 	dir = 5;
 	icon_state = "catwalk_cross"
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "iCW" = (
 /obj/storage/closet{
 	name = "shower storage"
@@ -28018,7 +28018,7 @@
 "jhA" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "jhM" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/baroffice)
@@ -28648,7 +28648,7 @@
 /turf/simulated/floor/grasstodirt{
 	dir = 8
 	},
-/area/station/wreckage)
+/area/abandonedship)
 "jCE" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/cargo,
@@ -30004,7 +30004,7 @@
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/plating,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "kxW" = (
 /obj/item/rods/steel,
 /turf/simulated/floor/plating/airless/asteroid/lighted,
@@ -30396,7 +30396,7 @@
 "kKI" = (
 /obj/machinery/vending/air_vendor/plasma,
 /turf/simulated/floor/shuttlebay,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "kKR" = (
 /obj/table/reinforced/auto,
 /obj/item/clipboard,
@@ -30658,7 +30658,7 @@
 "kPQ" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/grime,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "kPX" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -31558,7 +31558,7 @@
 /area/station/security/processing)
 "luE" = (
 /turf/simulated/floor/dirt,
-/area/station/wreckage)
+/area/abandonedship)
 "luU" = (
 /obj/machinery/door/airlock/pyro/glass/sci,
 /obj/mapping_helper/access/tox_storage,
@@ -32084,7 +32084,7 @@
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "lGz" = (
 /obj/decal/cleanable/blood/tracks,
 /obj/machinery/drainage,
@@ -32626,7 +32626,7 @@
 /area/station/security/checkpoint/research)
 "lTq" = (
 /turf/simulated/floor/grass/leafy,
-/area/station/wreckage)
+/area/abandonedship)
 "lUk" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -32736,7 +32736,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "lZI" = (
 /turf/simulated/wall/false_wall,
 /area/station/crew_quarters/baroffice)
@@ -32859,7 +32859,7 @@
 "mdZ" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/shuttlebay,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "mei" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -33332,7 +33332,7 @@
 "mro" = (
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "mrv" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable/blue{
@@ -35075,7 +35075,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "nso" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -35274,7 +35274,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/dirt,
-/area/station/wreckage)
+/area/abandonedship)
 "nyO" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -36071,7 +36071,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "nZu" = (
 /obj/machinery/neosmelter,
 /turf/simulated/floor/shuttlebay{
@@ -36723,7 +36723,7 @@
 	doants = 0
 	},
 /turf/simulated/floor/dirt,
-/area/station/wreckage)
+/area/abandonedship)
 "ory" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -37117,7 +37117,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/wreckage)
+/area/abandonedship)
 "ozB" = (
 /obj/item/toy/plush/small/stress_ball,
 /obj/disposalpipe/segment{
@@ -37994,7 +37994,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/shuttlebay,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "oWv" = (
 /obj/grille/catwalk,
 /obj/cable/yellow{
@@ -38025,7 +38025,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "oYS" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/stool/chair{
@@ -38464,7 +38464,7 @@
 /area/station/maintenance/east)
 "pou" = (
 /turf/simulated/floor/plating,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "pox" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -38593,7 +38593,7 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "psM" = (
 /obj/machinery/light/incandescent,
 /obj/shrub{
@@ -39309,7 +39309,7 @@
 	dir = 5;
 	layer = 2
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "pKa" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -39592,7 +39592,7 @@
 /obj/submachine/seed_vendor,
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/dirt,
-/area/station/wreckage)
+/area/abandonedship)
 "pWa" = (
 /obj/machinery/door/airlock/pyro/security/alt{
 	dir = 4
@@ -39836,7 +39836,7 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/structure/woodwall,
 /turf/simulated/floor/plating,
-/area/station/wreckage)
+/area/abandonedship)
 "qeb" = (
 /obj/shrub{
 	dir = 10
@@ -40481,7 +40481,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/dirt,
-/area/station/wreckage)
+/area/abandonedship)
 "qwN" = (
 /obj/overlay{
 	icon = 'icons/misc/beach2.dmi';
@@ -40819,7 +40819,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/dirt,
-/area/station/wreckage)
+/area/abandonedship)
 "qFw" = (
 /obj/machinery/light/emergency{
 	dir = 8
@@ -41846,7 +41846,7 @@
 "rqk" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/plating,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "rqV" = (
 /obj/table/auto,
 /obj/item/paper_bin{
@@ -42798,7 +42798,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/station/wreckage)
+/area/abandonedship)
 "rWe" = (
 /obj/decal/tile_edge/floorguide/command{
 	dir = 4
@@ -43160,7 +43160,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/wreckage)
+/area/abandonedship)
 "sgA" = (
 /turf/simulated/floor/plating,
 /area/station/security/beepsky)
@@ -43347,7 +43347,7 @@
 "snf" = (
 /obj/storage/crate,
 /turf/simulated/floor/plating,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "sng" = (
 /obj/landmark/start/job/medical_doctor,
 /obj/disposalpipe/segment{
@@ -43641,7 +43641,7 @@
 "stQ" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/wreckage)
+/area/abandonedship)
 "suc" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -44541,7 +44541,7 @@
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
-/area/station/wreckage)
+/area/abandonedship)
 "sTZ" = (
 /obj/cable/orange{
 	icon_state = "1-2"
@@ -44745,7 +44745,7 @@
 	name = "Rancher Shuttle Controls"
 	},
 /turf/simulated/floor/dirt,
-/area/station/wreckage)
+/area/abandonedship)
 "sZq" = (
 /obj/decal/poster/wallsign/danger_highvolt,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -44753,7 +44753,7 @@
 "sZG" = (
 /obj/machinery/manufacturer/hangar,
 /turf/simulated/floor/shuttlebay,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "taE" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/circuit/green,
@@ -44891,7 +44891,7 @@
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/airless/plating/catwalk,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "tgz" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -44908,7 +44908,7 @@
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "tgX" = (
 /obj/machinery/camera{
 	c_tag = "West Maintenance External Access";
@@ -44947,7 +44947,7 @@
 /area/station/hallway/primary/east)
 "tia" = (
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "tiL" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -46511,7 +46511,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "ufA" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -46545,7 +46545,7 @@
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/grass/leafy,
-/area/station/wreckage)
+/area/abandonedship)
 "ugn" = (
 /obj/submachine/ATM{
 	pixel_x = 30
@@ -46602,7 +46602,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "ugH" = (
 /obj/machinery/turret,
 /obj/lattice,
@@ -46622,7 +46622,7 @@
 "uiu" = (
 /obj/machinery/ore_cloud_storage_container,
 /turf/simulated/floor/grime,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "uiK" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -46701,7 +46701,7 @@
 	name = "Mineral Magnet Pad"
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "ukA" = (
 /turf/simulated/wall/false_wall,
 /area/station/security/brig)
@@ -46826,7 +46826,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/wreckage)
+/area/abandonedship)
 "umD" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -46865,7 +46865,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless/plating/catwalk,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "uoo" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -47521,7 +47521,7 @@
 /turf/simulated/floor/grasstodirt{
 	dir = 8
 	},
-/area/station/wreckage)
+/area/abandonedship)
 "uPc" = (
 /obj/decal/cleanable/writing{
 	words = "honk :("
@@ -47610,7 +47610,7 @@
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/dirt,
-/area/station/wreckage)
+/area/abandonedship)
 "uRu" = (
 /obj/machinery/light/incandescent,
 /obj/decal/tile_edge/stripe/extra_big,
@@ -47807,7 +47807,7 @@
 	name = "Ranch Ship"
 	},
 /turf/simulated/floor/plating,
-/area/station/wreckage)
+/area/abandonedship)
 "uWC" = (
 /obj/cable,
 /obj/machinery/power/apc{
@@ -48188,7 +48188,7 @@
 "vjI" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/grime,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "vjO" = (
 /obj/rack,
 /obj/item/device/radio/intercom/science{
@@ -48517,7 +48517,7 @@
 "vqG" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/grime,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "vqV" = (
 /obj/stool/chair/dining/wood{
 	dir = 1
@@ -48715,7 +48715,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "vvV" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -49034,7 +49034,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "vEU" = (
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/plating,
@@ -49097,7 +49097,7 @@
 	icon_state = "alt_propulsion"
 	},
 /turf/space,
-/area/station/wreckage)
+/area/abandonedship)
 "vGW" = (
 /obj/disposalpipe/switch_junction{
 	dir = 1;
@@ -50430,7 +50430,7 @@
 	dir = 9;
 	layer = 2
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "wwb" = (
 /obj/cable/yellow{
 	icon_state = "4-8"
@@ -51111,7 +51111,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 10
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "wUF" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -51835,7 +51835,7 @@
 /area/station/turret_protected/armory_outside)
 "xtE" = (
 /turf/simulated/floor/shuttlebay,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "xtW" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -52007,7 +52007,7 @@
 	dir = 8;
 	tag = "icon-catwalk (WEST)"
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "xza" = (
 /obj/stool/chair/comfy/blue{
 	dir = 8
@@ -52027,7 +52027,7 @@
 	dir = 9;
 	layer = 2
 	},
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "xzr" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/mail{
@@ -52050,7 +52050,7 @@
 	pixel_y = 15
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/wreckage)
+/area/abandonedship)
 "xAN" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -52302,7 +52302,7 @@
 /obj/table/auto,
 /obj/machinery/recharger,
 /turf/simulated/floor/grime,
-/area/station/quartermaster/magnet)
+/area/station/mining/magnet)
 "xMe" = (
 /obj/storage/crate,
 /obj/item/device/light/glowstick{
@@ -52563,7 +52563,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/dirt,
-/area/station/wreckage)
+/area/abandonedship)
 "xVY" = (
 /obj/lattice{
 	dir = 1;
@@ -52981,7 +52981,7 @@
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/grass/leafy,
-/area/station/wreckage)
+/area/abandonedship)
 "yhW" = (
 /obj/machinery/camera,
 /turf/simulated/floor/plating,

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -1267,7 +1267,7 @@
 	dir = 5;
 	icon_state = "fgreen2"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "apw" = (
 /obj/mapping_helper/access/kitchen,
 /obj/mapping_helper/firedoor_spawn,
@@ -1505,7 +1505,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/white,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "atd" = (
 /turf/simulated/floor/yellowblack{
 	dir = 6
@@ -2434,7 +2434,7 @@
 /area/station/hangar/science)
 "aGS" = (
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "aGZ" = (
 /obj/displaycase/captain,
 /obj/machinery/light/incandescent/greenish{
@@ -4826,7 +4826,7 @@
 /area/station/engine/singcore)
 "bsa" = (
 /turf/simulated/wall/auto/asteroid,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "bsi" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -7296,7 +7296,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "ccM" = (
 /obj/grille/catwalk/jen,
 /obj/cable{
@@ -8697,7 +8697,7 @@
 	name = "Hootarium Good Ending"
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "cvV" = (
 /obj/railing/green{
 	dir = 8;
@@ -8994,7 +8994,7 @@
 "cAc" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/white,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "cAG" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -10299,7 +10299,7 @@
 	name = "Hootsey McHootus III"
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "cWT" = (
 /obj/table/auto,
 /obj/item/screwdriver{
@@ -13163,7 +13163,7 @@
 /area/station/security/brig/north_side)
 "dRi" = (
 /turf/simulated/floor/white,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "dRn" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -14199,7 +14199,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "efW" = (
 /obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor/engine{
@@ -17671,7 +17671,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/white,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "flO" = (
 /obj/table/auto,
 /obj/item/sheet/glass/reinforced/fullstack,
@@ -17693,7 +17693,7 @@
 	},
 /obj/decal/stripe_delivery,
 /turf/simulated/floor/shuttlebay,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "flX" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -24789,7 +24789,7 @@
 	dir = 5;
 	icon_state = "fgreen3"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "htr" = (
 /obj/machinery/light/incandescent/warm,
 /obj/cable{
@@ -29159,7 +29159,7 @@
 "iPq" = (
 /obj/machinery/macrofab/emergency_pod,
 /turf/simulated/floor/shuttlebay,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "iPr" = (
 /obj/grille/steel,
 /turf/simulated/floor/black,
@@ -29967,7 +29967,7 @@
 	},
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "jba" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -30934,7 +30934,7 @@
 /area/station/crew_quarters/stockex)
 "jqe" = (
 /turf/simulated/floor/plating/airless/asteroid,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "jqj" = (
 /obj/table/wood/auto,
 /obj/machinery/computer3/generic/personal/personel_alt,
@@ -32046,7 +32046,7 @@
 "jGD" = (
 /mob/living/critter/rockworm,
 /turf/simulated/floor/plating/airless/asteroid,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "jGG" = (
 /obj/item/storage/wall/emergency{
 	dir = 8;
@@ -33648,7 +33648,7 @@
 	dir = 5;
 	icon_state = "fgreen2"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "kfG" = (
 /obj/decal/stripe_delivery,
 /obj/mapping_helper/firedoor_spawn,
@@ -34101,7 +34101,7 @@
 "kns" = (
 /obj/stone,
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "knx" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -35966,7 +35966,7 @@
 	dir = 10;
 	icon_state = "fgreen2"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "kQB" = (
 /obj/stool/chair{
 	dir = 8
@@ -36223,7 +36223,7 @@
 	name = "AWOL"
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "kVk" = (
 /obj/item/skull/odd,
 /turf/simulated/floor/plating/airless/asteroid,
@@ -37631,7 +37631,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "lsS" = (
 /obj/machinery/light/small/greenish,
 /obj/machinery/power/apc/autoname_west,
@@ -37927,7 +37927,7 @@
 	},
 /obj/decal/stripe_delivery,
 /turf/simulated/floor/shuttlebay,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "lxO" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -43321,7 +43321,7 @@
 	desc = "It's a tree. You see the phrase 'Haine <3 SpyGuy' carved into it."
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "nco" = (
 /obj/decal/tile_edge/line/green{
 	dir = 4;
@@ -45043,7 +45043,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "nCi" = (
 /obj/decal/tile_edge/line/red{
 	icon_state = "line4"
@@ -50015,7 +50015,7 @@
 	id = "habitat_bay"
 	},
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "pdw" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -50339,7 +50339,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen1"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "piq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -52618,7 +52618,7 @@
 	dir = 10;
 	icon_state = "fgreen3"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "pQv" = (
 /obj/cable/blue{
 	icon_state = "1-4"
@@ -53479,7 +53479,7 @@
 "qea" = (
 /obj/item/skull/odd,
 /turf/simulated/floor/plating/airless/asteroid,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "qed" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -53818,7 +53818,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "qiP" = (
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/bluewhite,
@@ -56347,7 +56347,7 @@
 "qWg" = (
 /obj/landmark/spawner/artifact,
 /turf/simulated/floor/plating/airless/asteroid,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "qWj" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -57479,7 +57479,7 @@
 	dir = 10;
 	icon_state = "fgreen2"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "rpc" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
@@ -58760,7 +58760,7 @@
 	dir = 9;
 	icon_state = "fgreen2"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "rKq" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
 	pixel_y = 24
@@ -59126,7 +59126,7 @@
 	dir = 9;
 	icon_state = "fgreen3"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "rQc" = (
 /obj/machinery/drainage,
 /obj/cable{
@@ -60987,7 +60987,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen1"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "str" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/window_blinds/cog2/middle,
@@ -61807,7 +61807,7 @@
 "sGq" = (
 /mob/living/critter/small_animal/mouse,
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "sGu" = (
 /turf/simulated/wall/auto/jen,
 /area/station/library)
@@ -63132,7 +63132,7 @@
 "tcV" = (
 /obj/landmark/spawner/loot,
 /turf/simulated/floor/plating/airless/asteroid,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "tdb" = (
 /turf/simulated/floor/white/checker2{
 	dir = 1
@@ -64363,7 +64363,7 @@
 	},
 /obj/decal/stripe_delivery,
 /turf/simulated/floor/shuttlebay,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "twN" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -64911,7 +64911,7 @@
 	dir = 9;
 	icon_state = "fgreen2"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "tEW" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/firedoor_spawn,
@@ -65868,7 +65868,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "tSd" = (
 /turf/simulated/wall/auto/jen,
 /area/station/hangar/main)
@@ -66658,7 +66658,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "udC" = (
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -67416,7 +67416,7 @@
 /area/station/science/chemistry)
 "utr" = (
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "uty" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
@@ -73087,7 +73087,7 @@
 	name = "Jowls"
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "wab" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable{
@@ -73953,7 +73953,7 @@
 	dir = 6;
 	icon_state = "fgreen2"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "wnm" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -76946,7 +76946,7 @@
 	dir = 6;
 	icon_state = "fgreen3"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "xdJ" = (
 /obj/cable{
 	icon_state = "6-8"
@@ -79070,7 +79070,7 @@
 /area/station/hallway/primary/south)
 "xJc" = (
 /turf/simulated/floor/shuttlebay,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "xJg" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -79099,7 +79099,7 @@
 	dir = 6;
 	icon_state = "fgreen2"
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "xJq" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor,

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -299,7 +299,7 @@
 /area/space)
 "abi" = (
 /turf/simulated/wall/auto/asteroid/dark,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abk" = (
 /obj/grille/catwalk{
 	dir = 9;
@@ -344,17 +344,17 @@
 /area/space)
 "abm" = (
 /turf/simulated/floor/plating/airless/asteroid/dark,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abq" = (
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
 	},
 /turf/simulated/floor/plating/airless/asteroid/dark,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abr" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abs" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
@@ -365,23 +365,23 @@
 	name = "Owlrey"
 	},
 /turf/simulated/floor/grey,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abt" = (
 /turf/simulated/floor/grey,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abu" = (
 /obj/machinery/r_door_control/podbay{
 	id = "habitat_bay"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abv" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
 	id = "habitat_bay";
 	name = "pod bay (habitat)"
 	},
 /turf/simulated/floor/shuttlebay,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abw" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Owl Zone Access"
@@ -391,97 +391,97 @@
 	name = "Owlrey"
 	},
 /turf/simulated/floor/caution/north,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abx" = (
 /turf/simulated/wall/auto/jen/green,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "aby" = (
 /turf/simulated/floor/shuttlebay,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abz" = (
 /turf/simulated/floor/caution/west,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abA" = (
 /turf/simulated/floor,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abB" = (
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abC" = (
 /obj/shrub{
 	dir = 8
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abD" = (
 /obj/machinery/macrofab/emergency_pod{
 	dir = 1;
 	override_dir = 4
 	},
 /turf/simulated/floor/shuttlebay,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abE" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Owl Zone"
 	},
 /turf/simulated/floor,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abF" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
 	name = "Owl Zone"
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abH" = (
 /obj/shrub{
 	dir = 4
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abI" = (
 /obj/machinery/portableowl/attached{
 	name = "Hans Owlo"
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abJ" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/caution/north,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abK" = (
 /turf/simulated/floor/caution/north,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abL" = (
 /obj/item/space_thing,
 /turf/simulated/floor/caution/corner/misc{
 	dir = 9
 	},
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abM" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
 /obj/machinery/light/small,
 /turf/simulated/floor,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abN" = (
 /obj/machinery/portableowl/attached{
 	name = "A Pretty Owl"
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abO" = (
 /obj/shrub{
 	dir = 1
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abP" = (
 /obj/shrub{
 	dir = 6
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abQ" = (
 /obj/table/auto,
 /obj/item/clothing/under/gimmick/owl,
@@ -491,36 +491,36 @@
 /obj/item/clothing/mask/owl_mask,
 /obj/item/clothing/mask/owl_mask,
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abR" = (
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abS" = (
 /obj/shrub,
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abT" = (
 /obj/machinery/portableowl/attached{
 	name = "Owl-iver"
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abU" = (
 /obj/machinery/portableowl/attached{
 	name = "Richelieu"
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abV" = (
 /obj/machinery/portableowl/attached{
 	name = "L. Ron Hootabembe"
 	},
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "abW" = (
 /obj/lattice{
 	icon_state = "lattice-dir-b"
@@ -31178,7 +31178,7 @@
 "cZV" = (
 /obj/landmark/spawner/loot,
 /turf/simulated/floor/plating/airless/asteroid/dark,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "dae" = (
 /obj/decal/cleanable/dirt,
 /obj/item/raw_material/shard/glass,
@@ -36047,7 +36047,7 @@
 "gsj" = (
 /obj/tree,
 /turf/simulated/floor/grass/leafy,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "gsq" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/binary/valve{

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -32236,7 +32236,7 @@
 /obj/item/currency/spacecash/thousand,
 /obj/item/tank/oxygen,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "dlG" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Medical Booth";
@@ -33507,7 +33507,7 @@
 "eIE" = (
 /obj/item/seed/grass,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "eJl" = (
 /obj/table/flock/auto,
 /obj/machinery/light/flock,
@@ -34625,7 +34625,7 @@
 "gbR" = (
 /obj/item/reagent_containers/food/snacks/donkpocket,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "gcE" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -35166,7 +35166,7 @@
 "gJW" = (
 /mob/living/critter/small_animal/walrus,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "gKt" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
@@ -35697,7 +35697,7 @@
 "hvM" = (
 /obj/item/seed/alien,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "hwl" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "QM"
@@ -35966,7 +35966,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "hPo" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -36082,7 +36082,7 @@
 /obj/shrub,
 /obj/landmark/spawner/loot,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "ieC" = (
 /obj/forcefield/energyshield/perma,
 /obj/strip_door,
@@ -36314,7 +36314,7 @@
 "isW" = (
 /obj/item/spraybottle,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "itd" = (
 /obj/table/reinforced/chemistry/auto,
 /turf/simulated/floor,
@@ -36514,7 +36514,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "iLk" = (
 /obj/mapping_helper/mob_spawn/corpse/critter/random/martian,
 /turf/simulated/floor/martian,
@@ -37513,7 +37513,7 @@
 	},
 /obj/landmark/spawner/loot,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "keq" = (
 /obj/disposalpipe/segment/morgue,
 /obj/cable{
@@ -38945,7 +38945,7 @@
 "maS" = (
 /mob/living/critter/small_animal/seal,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "mbP" = (
 /obj/item/raw_material/bohrum,
 /obj/item/raw_material/bohrum,
@@ -40225,7 +40225,7 @@
 /area/station/hallway/primary/south)
 "nxK" = (
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "nyt" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -41659,7 +41659,7 @@
 "ptx" = (
 /obj/item/reagent_containers/food/snacks/plant/coconut,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "ptF" = (
 /obj/machinery/door/airlock/pyro/engineering/alt{
 	dir = 8
@@ -41857,7 +41857,7 @@
 "pGL" = (
 /obj/item/currency/spacecash/thousand,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "pHw" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency{
@@ -42947,7 +42947,7 @@
 /area/station/crew_quarters/info)
 "rgy" = (
 /turf/simulated/wall/auto/asteroid,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "rhl" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable{
@@ -43268,7 +43268,7 @@
 "rDX" = (
 /obj/item/reagent_containers/food/snacks/granola_bar,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "rEn" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -44189,7 +44189,7 @@
 "tas" = (
 /obj/item/rubberduck,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "taN" = (
 /obj/submachine/weapon_vendor/fishing/portable,
 /turf/simulated/floor/green,
@@ -44197,7 +44197,7 @@
 "tbf" = (
 /obj/item/reagent_containers/food/snacks/snack_cake/golden,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "tbN" = (
 /obj/stool/chair/dining/wood{
 	dir = 8
@@ -44930,7 +44930,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "uew" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle{
@@ -45174,7 +45174,7 @@
 /obj/item/seed/grass,
 /obj/item/seed/grass,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "uAB" = (
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/baroffice)
@@ -45368,7 +45368,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "uRN" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -45628,7 +45628,7 @@
 "vwG" = (
 /obj/item/reagent_containers/food/snacks/burrito,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "vxJ" = (
 /obj/disposaloutlet{
 	mailgroup = "medresearch";
@@ -46994,7 +46994,7 @@
 "xdY" = (
 /obj/item/reagent_containers/food/snacks/snack_cake,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "xem" = (
 /obj/machinery/door/airlock/pyro/alt{
 	dir = 4
@@ -47380,7 +47380,7 @@
 "xIT" = (
 /obj/submachine/GTM,
 /turf/simulated/wall/auto/asteroid,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "xJL" = (
 /obj/machinery/door/airlock/pyro/alt{
 	id = "med_bathroom"
@@ -47527,7 +47527,7 @@
 /obj/item/skull,
 /obj/item/currency/spacecash/thousand,
 /turf/simulated/floor/grass,
-/area/station/garden/owlery)
+/area/spacehabitat/owlery)
 "xYi" = (
 /obj/mapping_helper/mob_spawn/corpse/critter/random/martian,
 /turf/simulated/floor/martian,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Add new area `/area/spacehabitat/owlery` and apply to the off-station owleries on Oshan, Dount3, and Kondaru.
  * This area no longer appears on minimaps. 
  * Like the existing `/area/station/garden/owlery` area, this area requires no power.
* Ensure arrivals shuttle `/area/shuttle/arrival/station` (Cogmap, Cogmap2, Donut2, Donut3, Nadir) renders on minimaps 
  * Uses the "nanotrasen" map colour
* Prevent the bomb test chambers (Atlas, Donut2, Donut3) from rendering on minimaps.
* Prevent Kondaru's indigo research outpost from rendering on minimaps.
* Change the area of Donut2's crashed rancher shuttle from `/area/station/wreckage/` to `/area/abandonedship` so it no longer appears on minimaps.
* In places where there is a separate area for mining magnet controls, ensure it uses the mining magnet control room area:
  * Cogmap: previously `/area/station/quartermater/refinery`
  * Donut2: previously `/area/station/quartermaster/magnet`
  * Atlas: Add `/area/mining/magnet/` to Atlas's mining magnet summon zone for map consistency

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Focus minimaps to on-station locations.
* Ensure everything that looks contiguous to the station appears in minimaps.
* Clarity for some spy/thief targets (e.g. "Refinery" on cogmap1)
* Fixes #19721 - Oshan owlery rezoned to not be on-station.

## Screenshots
Donut3 Before
![Screenshot 2024-11-19 113759](https://github.com/user-attachments/assets/6724c111-f89a-418e-bc15-d4ca5e78816c)
Donut3 After
![Screenshot 2024-11-19 115312](https://github.com/user-attachments/assets/6643ded6-943f-43e5-8b93-34b692c28891)
