### PR TITLE
Cigarette packet quality of life improvements

### DIFF
--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -550,6 +550,47 @@
 		for(var/i in 1 to src.max_cigs)
 			new src.cigtype(src)
 
+	MouseDrop_T(atom/movable/O as obj, mob/user as mob)
+		if (!istype(O, /obj/item/clothing/mask/cigarette) || src.loc != user) return
+		if (length(src.contents) < src.max_cigs)
+			user.visible_message(SPAN_NOTICE("[user] begins quickly filling \the [src]."))
+			var/staystill = user.loc
+			for(var/obj/item/I in view(1,user))
+				if (!istype(I, O) || QDELETED(I)) continue
+				if (I in user)
+					continue
+				I.add_fingerprint(user)
+				if ((length(src.contents) < src.max_cigs))
+					I.set_loc(src)
+				src.UpdateIcon()
+				sleep(0.2 SECONDS)
+				if (user.loc != staystill || src.loc != user) break
+				if (length(src.contents) >= src.max_cigs)
+					boutput(user, SPAN_NOTICE("\The [src] is now full!"))
+					break
+			boutput(user, SPAN_NOTICE("You finish filling \the [src]."))
+		else boutput(user, SPAN_ALERT("\The [src] is already full!"))
+
+	mouse_drop(atom/over_object, src_location, over_location, src_control, over_control, params)
+		if (istype(over_object, /obj/table) && src.contents.len > 0)
+			usr.visible_message(SPAN_NOTICE("[usr] dumps out [src]'s contents onto [over_object]!"))
+			for (var/obj/item/thing in src.contents)
+				thing.set_loc(over_location)
+			src.UpdateIcon()
+			if (!islist(params)) params = params2list(params)
+			if (params) params["dumped"] = 1
+		else ..()
+
+	should_place_on(obj/target, params)
+		if (istype(target, /obj/table) && params && params["dumped"])
+			return FALSE
+		return ..()
+
+	get_help_message(dist, mob/user)
+		. = ..()
+		. += "Hold this and drag a nearby cigarette onto it to auto-fill.\nDrag this onto a table while holding it to dump its contents."
+
+
 
 /obj/item/cigpacket/nicofree
 	name = "nicotine-free cigarette packet"

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -572,7 +572,10 @@
 		else boutput(user, SPAN_ALERT("\The [src] is already full!"))
 
 	mouse_drop(atom/over_object, src_location, over_location, src_control, over_control, params)
-		if (istype(over_object, /obj/table) && src.contents.len > 0)
+		if ((istype(over_object, /obj/table) || \
+					(isturf(over_object) && total_density(over_location) < 1)) && \
+					in_interact_range(over_object,src) && \
+					src.contents.len > 0)
 			usr.visible_message(SPAN_NOTICE("[usr] dumps out [src]'s contents onto [over_object]!"))
 			for (var/obj/item/thing in src.contents)
 				thing.set_loc(over_location)
@@ -588,7 +591,8 @@
 
 	get_help_message(dist, mob/user)
 		. = ..()
-		. += "Hold this and drag a nearby cigarette onto it to auto-fill.\nDrag this onto a table while holding it to dump its contents."
+		. += "Hold this and drag a nearby cigarette onto it to auto-fill.\n \
+			Drag this onto a nearby table or floor while holding it to dump its contents."
 
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label [qol][gameobjects]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Cigarette packets can be quick-filled via dragging cigs onto them, and dumped out by dragging them onto floors or tables.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This mostly just helps distribute custom cigarettes, it's currently quite cumbersome to deal with them if you make a bunch at once.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Egregorious
(+)Enabled quick-filling and dumping of cigarette packets. Inspect them for more detailed information. 
```
