### PR TITLE
Stop the derliect AI sat from issuing a poweralert at roundstart

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -14090,7 +14090,8 @@
 	pixel_x = 24;
 	req_access_txt = "";
 	start_charge = 0;
-	tag = "icon-apc-b (EAST)"
+	tag = "icon-apc-b (EAST)";
+	noalerts = 1
 	},
 /turf/simulated/floor/plating,
 /area/derelict_ai_sat/core)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mark the AI core in the derelict AI Satellite as noalert.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
AIs get roundstart power alerts for "AI Satellite Core", which is confusing as it's not e.g their satellite power core. It's not on station and there's no real reason to alert the station to it.