### PR TITLE
Fix wrong number of uses left shown for manudrives

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1614,7 +1614,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 				return -1 // Represents unlimited with manudrives, we roll with it
 			for (var/datum/computer/file/manudrive/MD in src.manudrive.root.contents)
 				if(!isnull(MD.num_working))
-					return src.manudrive.fablimit - MD.num_working
+					return MD.fablimit - MD.num_working
 		return 0 // none loaded
 
 	proc/begin_work(new_production = TRUE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Manudrives are weird and so the fablimit on the actual drive is different than that of the file. Fixes an issue with the code for getting the remaining uses to accurately show the remaining uses of the drive left.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #21279 (visual issue? was unable to repro otherwise)
Fixes #20546
Fixes #19277