### PR TITLE
Allow AI eyes to click-deploy into docked shells

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -260,7 +260,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 		mainframe = user
 
 	if(user.client.check_key(KEY_OPEN))
-		if (src.occupant && !ishuman(src.occupant))
+		if (src.occupant)
 			mainframe.deploy_to_shell(src.occupant)
 
 /obj/machinery/recharge_station/proc/build_icon()

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -246,6 +246,23 @@ TYPEINFO(/obj/machinery/recharge_station)
 	if (ishuman(AM))
 		src.move_human_inside(user, AM)
 
+/obj/machinery/recharge_station/receive_silicon_hotkey(mob/user)
+	. = ..()
+
+	if (!isAI(user))
+		return
+
+	var/mob/living/silicon/ai/mainframe = null
+	if (isAIeye(user))
+		var/mob/living/intangible/aieye/eye = user
+		mainframe = eye.mainframe
+	else
+		mainframe = user
+
+	if(user.client.check_key(KEY_OPEN))
+		if (src.occupant && !ishuman(src.occupant))
+			mainframe.deploy_to_shell(src.occupant)
+
 /obj/machinery/recharge_station/proc/build_icon()
 	if (src.occupant)
 		src.UpdateOverlays(image('icons/obj/robot_parts.dmi', "station-occu"), "occupant")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows AIs to use their open hotkey (ctrl click) to deploy into a docked shell


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The new click to deploy to shell is nice QoL over the clunky deploy menu which has no way to differentiate between shells, however it doesnt work if you left your shell charging.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)AI shell Ctrl-Click to deploy function expanded to cyborg docks for shells that are recharging.
```
