### PR TITLE
Add new manufacturer category: Organ

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1152,7 +1152,7 @@
 	item_outputs = list(/obj/item/organ/heart/cyber)
 	create = 1
 	time = 25 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cyberbutt
 	name = "Cyberbutt"
@@ -1162,7 +1162,7 @@
 	item_outputs = list(/obj/item/clothing/head/butt/cyberbutt)
 	create = 1
 	time = 15 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cardboard_ai
 	name = "Cardboard 'AI'"
@@ -1180,7 +1180,7 @@
 	item_outputs = list(/obj/item/organ/appendix/cyber)
 	create = 1
 	time = 15 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cyberpancreas
 	name = "Cyberpancreas"
@@ -1190,7 +1190,7 @@
 	item_outputs = list(/obj/item/organ/pancreas/cyber)
 	create = 1
 	time = 15 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cyberspleen
 	name = "Cyberspleen"
@@ -1200,7 +1200,7 @@
 	item_outputs = list(/obj/item/organ/spleen/cyber)
 	create = 1
 	time = 15 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cyberintestines
 	name = "Cyberintestines"
@@ -1210,7 +1210,7 @@
 	item_outputs = list(/obj/item/organ/intestines/cyber)
 	create = 1
 	time = 15 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cyberstomach
 	name = "Cyberstomach"
@@ -1220,7 +1220,7 @@
 	item_outputs = list(/obj/item/organ/stomach/cyber)
 	create = 1
 	time = 15 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cyberkidney
 	name = "Cyberkidney"
@@ -1230,7 +1230,7 @@
 	item_outputs = list(/obj/item/organ/kidney/cyber)
 	create = 1
 	time = 15 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cyberliver
 	name = "Cyberliver"
@@ -1240,7 +1240,7 @@
 	item_outputs = list(/obj/item/organ/liver/cyber)
 	create = 1
 	time = 15 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cyberlung_left
 	name = "Left Cyberlung"
@@ -1250,7 +1250,7 @@
 	item_outputs = list(/obj/item/organ/lung/cyber/left)
 	create = 1
 	time = 15 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cyberlung_right
 	name = "Right Cyberlung"
@@ -1260,7 +1260,7 @@
 	item_outputs = list(/obj/item/organ/lung/cyber/right)
 	create = 1
 	time = 15 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cybereye
 	name = "Cybereye"
@@ -1271,7 +1271,7 @@
 	item_outputs = list(/obj/item/organ/eye/cyber/configurable)
 	create = 1
 	time = 20 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cybereye_sunglass
 	name = "Polarized Cybereye"
@@ -1282,7 +1282,7 @@
 	item_outputs = list(/obj/item/organ/eye/cyber/sunglass)
 	create = 1
 	time = 25 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cybereye_sechud
 	name = "Security HUD Cybereye"
@@ -1293,7 +1293,7 @@
 	item_outputs = list(/obj/item/organ/eye/cyber/sechud)
 	create = 1
 	time = 25 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cybereye_thermal
 	name = "Thermal Imager Cybereye"
@@ -1304,7 +1304,7 @@
 	item_outputs = list(/obj/item/organ/eye/cyber/thermal)
 	create = 1
 	time = 25 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cybereye_meson
 	name = "Mesonic Imager Cybereye"
@@ -1315,7 +1315,7 @@
 	item_outputs = list(/obj/item/organ/eye/cyber/meson)
 	create = 1
 	time = 25 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cybereye_spectro
 	name = "Spectroscopic Imager Cybereye"
@@ -1326,7 +1326,7 @@
 	item_outputs = list(/obj/item/organ/eye/cyber/spectro)
 	create = 1
 	time = 25 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cybereye_prodoc
 	name = "ProDoc Healthview Cybereye"
@@ -1337,7 +1337,7 @@
 	item_outputs = list(/obj/item/organ/eye/cyber/prodoc)
 	create = 1
 	time = 25 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cybereye_camera
 	name = "Camera Cybereye"
@@ -1348,7 +1348,7 @@
 	item_outputs = list(/obj/item/organ/eye/cyber/camera)
 	create = 1
 	time = 25 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/cybereye_laser
 	name = "Laser Cybereye"
@@ -1360,7 +1360,7 @@
 	item_outputs = list(/obj/item/organ/eye/cyber/laser)
 	create = 1
 	time = 40 SECONDS
-	category = "Component"
+	category = "Organ"
 
 /datum/manufacture/implant_health
 	name = "Health Monitor Implant"

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -97,7 +97,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 
 	/* Production options */
 	/// A list of valid categories the manufacturer will use. Any invalid provided categories are assigned "Miscellaneous".
-	var/list/categories = list("Tool", "Clothing", "Resource", "Component", "Machinery", "Medicine", "Miscellaneous", "Downloaded")
+	var/list/categories = list("Tool", "Clothing", "Resource", "Component", "Organ", "Machinery", "Medicine", "Miscellaneous", "Downloaded")
 	var/accept_blueprints = TRUE //! Whether or not we accept blueprints from the ruk kit into this manufacturer.
 
 	var/list/available = list() //! A list of every manufacture datum typepath available in this unit subtype by default


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Add a new manufacturer category: Organ
* Apply Organ manufacturer category to related manufacture datums

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The robotics fabricator on live has 58 "Component" entries. It's a lot to sift through, and having the human organs separated out from cyborg components will make it a little easier to find what you're looking for.

The medical fabricator "Component" section is now completely shifted over to "Organ", as the only components they had were organs.

## Screenshots
### Before
![Screenshot 2024-11-21 114425](https://github.com/user-attachments/assets/f87c462b-a865-4c34-be75-ead50ce00ba7)
### After
![Screenshot 2024-11-21 114755](https://github.com/user-attachments/assets/2da5119e-e2c8-4020-82e7-30055119af0e)
