### PR TITLE
Allow mining loot crates to show welded/barcode overlays

### DIFF
--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -124,11 +124,7 @@ var/global/datum/loot_crate_manager/loot_crate_manager = new /datum/loot_crate_m
 				icon_closed = "lootcrime"
 
 	update_icon()
-		if (open)
-			icon_state = icon_opened
-		else
-			icon_state = icon_closed
-
+		..()
 		if (src.locked)
 			light.color = "#FF0000"
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game-objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Make loot crates `update_icon` call its parents


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The barcode and welded overlays are set in the parents, so let it be set. Opening and closing is likewise already handled in the parent proc.
Fix #16325