### PR TITLE
Early return for non-human can sprayers

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1055,6 +1055,7 @@ proc/broadcast_to_all_gangs(var/message)
 			return
 		if(!ishuman(user))
 			boutput(user, SPAN_ALERT("You don't have the dexterity to spray paint a gang tag!"))
+			return
 
 		return validLocation
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If the sprayer is not a human, return early/without a TRUE. This matches the pattern for the various other checks in this proc.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21224
