### PR TITLE
Fix Law Racks not being blown up by breaching charges

### DIFF
--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1462,6 +1462,9 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 				if (istype(O, /obj/machinery/door))
 					O.ex_act(1)
 					continue
+				if (istype(O, /obj/machinery/lawrack))
+					O.ex_act(1)
+					continue
 				if (istype(O, /obj/storage))
 					O.ex_act(2)
 					continue


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a special law rack check to breaching charges to always call ex_act with severity 1


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
With commit ae4530c law racks only get damaged by the actual explosion, causing them to require 6-12 breaching charges to blow up, before this commit it always took 2.

Fixes #21402