### PR TITLE
Replaces the cogmap1 upload door with a see trough one

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -55125,12 +55125,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/command{
-	name = "AI Upload"
-	},
 /obj/mapping_helper/access/ai_upload,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
+/obj/machinery/door/airlock/pyro/glass/command,
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload)
 "qqS" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -21956,6 +21956,12 @@
 	pixel_y = 32
 	},
 /obj/decal/stripe_caution,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload_foyer)
 "bzz" = (
@@ -59310,14 +59316,6 @@
 "tzH" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	pixel_y = -20;
-	tag = ""
 	},
 /obj/machinery/light{
 	dir = 1;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SILICONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
You can't see inside without bridge access. Camera also moved so it can't see laws
![image](https://github.com/user-attachments/assets/dba60682-a2e2-40e0-87ee-5f4725afa86f)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've had a lot of fun interactions in the old thindow observational area and i miss it


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Valtsu0
(+)Cogmap1 AI upload door has been replaced with a see-through one
```
