### PR TITLE
Add hotkeys to store to/unstore from belt and backpack

### DIFF
--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -317,26 +317,22 @@
 						master.autoequip_slot(I, SLOT_GLASSES) || \
 						master.autoequip_slot(I, SLOT_EARS) || \
 						master.autoequip_slot(I, SLOT_WEAR_MASK) || \
-						master.autoequip_slot(I, SLOT_HEAD))
-						return
-
-					if (master.autoequip_slot(I, SLOT_BACK))
-						master.last_stored_backpack = I
+						master.autoequip_slot(I, SLOT_HEAD) || \
+						master.autoequip_slot(I, SLOT_BACK))
 						return
 
 					if (!master.belt?.storage || I.storage) // belt BEFORE trying storages, and only swap if its not a storage swap
 						master.autoequip_slot(I, SLOT_BELT)
 						if (master.equipped() != I)
-							master.last_stored_belt = I
+
 							return
 
 					for (var/datum/hud/storage/S in user.huds) //ez storage stowing
+						if ((S.master == src.master.belt?.storage || S.master == src.master.back?.storage) && GET_COOLDOWN(src.master, "auto_store_hotkey"))
+							return
 						S.master.add_contents_safe(I, user)
 						if (master.equipped() != I)
-							if (S.master == src.master.belt?.storage)
-								src.master.last_stored_belt = I
-							else if (S.master == src.master.back?.storage)
-								src.master.last_stored_backpack = I
+							ON_COOLDOWN(src.master, "auto_unstore_hotkey", COMBAT_CLICK_DELAY)
 							return
 
 					//ONLY do these if theyre actually empty, we dont want to pocket swap.
@@ -384,26 +380,22 @@
 						master.autoequip_slot(I, SLOT_GLASSES) || \
 						master.autoequip_slot(I, SLOT_EARS) || \
 						master.autoequip_slot(I, SLOT_WEAR_MASK) || \
-						master.autoequip_slot(I, SLOT_HEAD))
-						return
-
-					if (master.autoequip_slot(I, SLOT_BACK))
-						master.last_stored_backpack = I
+						master.autoequip_slot(I, SLOT_HEAD) || \
+						master.autoequip_slot(I, SLOT_BACK))
 						return
 
 					if (!master.belt?.storage || I.storage) // belt BEFORE trying storages, and only swap if its not a storage swap
 						master.autoequip_slot(I, SLOT_BELT)
 						if (master.equipped() != I)
-							master.last_stored_belt = I
+
 							return
 
 					for (var/datum/hud/storage/S in user.huds) //ez storage stowing
+						if ((S.master == src.master.belt?.storage || S.master == src.master.back?.storage) && GET_COOLDOWN(src.master, "auto_store_hotkey"))
+							return
 						S.master.add_contents_safe(I, user)
 						if (master.equipped() != I)
-							if (S.master == src.master.belt?.storage)
-								src.master.last_stored_belt = I
-							else if (S.master == src.master.back?.storage)
-								src.master.last_stored_backpack = I
+							ON_COOLDOWN(src.master, "auto_unstore_hotkey", COMBAT_CLICK_DELAY)
 							return
 
 					//ONLY do these if theyre actually empty, we dont want to pocket swap.

--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -317,18 +317,26 @@
 						master.autoequip_slot(I, SLOT_GLASSES) || \
 						master.autoequip_slot(I, SLOT_EARS) || \
 						master.autoequip_slot(I, SLOT_WEAR_MASK) || \
-						master.autoequip_slot(I, SLOT_HEAD) || \
-						master.autoequip_slot(I, SLOT_BACK))
+						master.autoequip_slot(I, SLOT_HEAD))
+						return
+
+					if (master.autoequip_slot(I, SLOT_BACK))
+						master.last_stored_backpack = I
 						return
 
 					if (!master.belt?.storage || I.storage) // belt BEFORE trying storages, and only swap if its not a storage swap
 						master.autoequip_slot(I, SLOT_BELT)
 						if (master.equipped() != I)
+							master.last_stored_belt = I
 							return
 
 					for (var/datum/hud/storage/S in user.huds) //ez storage stowing
 						S.master.add_contents_safe(I, user)
 						if (master.equipped() != I)
+							if (S.master == src.master.belt?.storage)
+								src.master.last_stored_belt = I
+							else if (S.master == src.master.back?.storage)
+								src.master.last_stored_backpack = I
 							return
 
 					//ONLY do these if theyre actually empty, we dont want to pocket swap.
@@ -376,18 +384,26 @@
 						master.autoequip_slot(I, SLOT_GLASSES) || \
 						master.autoequip_slot(I, SLOT_EARS) || \
 						master.autoequip_slot(I, SLOT_WEAR_MASK) || \
-						master.autoequip_slot(I, SLOT_HEAD) || \
-						master.autoequip_slot(I, SLOT_BACK))
+						master.autoequip_slot(I, SLOT_HEAD))
+						return
+
+					if (master.autoequip_slot(I, SLOT_BACK))
+						master.last_stored_backpack = I
 						return
 
 					if (!master.belt?.storage || I.storage) // belt BEFORE trying storages, and only swap if its not a storage swap
 						master.autoequip_slot(I, SLOT_BELT)
 						if (master.equipped() != I)
+							master.last_stored_belt = I
 							return
 
 					for (var/datum/hud/storage/S in user.huds) //ez storage stowing
 						S.master.add_contents_safe(I, user)
 						if (master.equipped() != I)
+							if (S.master == src.master.belt?.storage)
+								src.master.last_stored_belt = I
+							else if (S.master == src.master.back?.storage)
+								src.master.last_stored_backpack = I
 							return
 
 					//ONLY do these if theyre actually empty, we dont want to pocket swap.
@@ -547,13 +563,19 @@
 
 			#define clicked_slot(slot) var/obj/item/W = master.get_slot(slot); if (W) { master.click(W, params); } else { var/obj/item/I = master.equipped(); if (!I || !master.can_equip(I, slot) || istype(I.loc, /obj/item/parts/)) { return; } master.u_equip(I); master.force_equip(I, slot); }
 			if("belt")
+				var/obj/item/item = src.master.equipped()
 				clicked_slot(SLOT_BELT)
+				if (item && !src.master.equipped())
+					src.master.last_stored_belt = item
 			if("storage1")
 				clicked_slot(SLOT_L_STORE)
 			if("storage2")
 				clicked_slot(SLOT_R_STORE)
 			if("back")
+				var/obj/item/item = src.master.equipped()
 				clicked_slot(SLOT_BACK)
+				if (item && !src.master.equipped())
+					src.master.last_stored_backpack = item
 			if("shoes")
 				clicked_slot(SLOT_SHOES)
 			if("gloves")

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3674,32 +3674,38 @@ mob/living/carbon/human/has_genetics()
 
 	. = ..()
 
-/// handles hotkey actino for storing/unstoring item to/from belt storage
+/// handles hotkey action for storing/unstoring item to/from belt storage
 /mob/living/carbon/human/proc/auto_store_unstore_belt()
 	if (!src.belt || !src.belt.storage)
 		return
 	var/obj/item/I = src.equipped()
 	var/list/belt_contents = src.belt.storage.get_contents()
 	if (I)
+		if (GET_COOLDOWN(src, "auto_store_hotkey"))
+			return
 		src.belt.Attackby(I, src)
 		if (I in belt_contents)
 			src.last_stored_belt = I
-			ON_COOLDOWN(src, "belt_auto_unstore", COMBAT_CLICK_DELAY)
-	else if (src.last_stored_belt && !GET_COOLDOWN(src, "belt_auto_unstore"))
+			ON_COOLDOWN(src, "auto_unstore_hotkey", COMBAT_CLICK_DELAY)
+	else if (src.last_stored_belt && !GET_COOLDOWN(src, "auto_unstore_hotkey"))
 		if (!QDELETED(src.last_stored_belt) && (src.last_stored_belt in belt_contents))
 			src.last_stored_belt.Attackhand(src)
+			ON_COOLDOWN(src, "auto_store_hotkey", COMBAT_CLICK_DELAY)
 
-/// handles hotkey actino for storing/unstoring item to/from backpack storage
+/// handles hotkey action for storing/unstoring item to/from backpack storage
 /mob/living/carbon/human/proc/auto_store_unstore_backpack()
 	if (!src.back || !src.back.storage)
 		return
 	var/obj/item/I = src.equipped()
 	var/list/backpack_contents = src.back.storage.get_contents()
 	if (I)
+		if (GET_COOLDOWN(src, "auto_store_hotkey"))
+			return
 		src.back.Attackby(I, src)
 		if (I in backpack_contents)
 			src.last_stored_backpack = I
-			ON_COOLDOWN(src, "backpack_auto_unstore", COMBAT_CLICK_DELAY)
-	else if (src.last_stored_backpack && !GET_COOLDOWN(src, "backpack_auto_unstore"))
+			ON_COOLDOWN(src, "auto_unstore_hotkey", COMBAT_CLICK_DELAY)
+	else if (src.last_stored_backpack && !GET_COOLDOWN(src, "auto_unstore_hotkey"))
 		if (!QDELETED(src.last_stored_backpack) && (src.last_stored_backpack in backpack_contents))
 			src.last_stored_backpack.Attackhand(src)
+			ON_COOLDOWN(src, "auto_store_hotkey", COMBAT_CLICK_DELAY)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3684,7 +3684,8 @@ mob/living/carbon/human/has_genetics()
 		src.belt.Attackby(I, src)
 		if (I in belt_contents)
 			src.last_stored_belt = I
-	else if (src.last_stored_belt)
+			ON_COOLDOWN(src, "belt_auto_unstore", COMBAT_CLICK_DELAY)
+	else if (src.last_stored_belt && !GET_COOLDOWN(src, "belt_auto_unstore"))
 		if (!QDELETED(src.last_stored_belt) && (src.last_stored_belt in belt_contents))
 			src.last_stored_belt.Attackhand(src)
 
@@ -3698,6 +3699,7 @@ mob/living/carbon/human/has_genetics()
 		src.back.Attackby(I, src)
 		if (I in backpack_contents)
 			src.last_stored_backpack = I
-	else if (src.last_stored_backpack)
+			ON_COOLDOWN(src, "backpack_auto_unstore", COMBAT_CLICK_DELAY)
+	else if (src.last_stored_backpack && !GET_COOLDOWN(src, "backpack_auto_unstore"))
 		if (!QDELETED(src.last_stored_backpack) && (src.last_stored_backpack in backpack_contents))
 			src.last_stored_backpack.Attackhand(src)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -167,6 +167,11 @@
 
 	var/datum/humanInventory/inventory = null
 
+	/// last item that the human stored in their belt storage
+	var/obj/item/last_stored_belt = null
+	/// last item that the human stored in their backpack storage
+	var/obj/item/last_stored_backpack = null
+
 	var/default_mutantrace = /datum/mutantrace/human
 
 /mob/living/carbon/human/New(loc, datum/appearanceHolder/AH_passthru, datum/preferences/init_preferences, ignore_randomizer=FALSE, role_for_traits)
@@ -958,6 +963,10 @@
 			src.set_a_intent(INTENT_HARM)
 		if ("drop")
 			src.drop_item(null, TRUE)
+		if ("autostore_belt")
+			src.auto_store_unstore_belt()
+		if ("autostore_backpack")
+			src.auto_store_unstore_backpack()
 		if ("swaphand")
 			src.swap_hand()
 		if ("attackself")
@@ -3664,3 +3673,31 @@ mob/living/carbon/human/has_genetics()
 			return hand_color
 
 	. = ..()
+
+/// handles hotkey actino for storing/unstoring item to/from belt storage
+/mob/living/carbon/human/proc/auto_store_unstore_belt()
+	if (!src.belt || !src.belt.storage)
+		return
+	var/obj/item/I = src.equipped()
+	var/list/belt_contents = src.belt.storage.get_contents()
+	if (I)
+		src.belt.Attackby(I, src)
+		if (I in belt_contents)
+			src.last_stored_belt = I
+	else if (src.last_stored_belt)
+		if (!QDELETED(src.last_stored_belt) && (src.last_stored_belt in belt_contents))
+			src.last_stored_belt.Attackhand(src)
+
+/// handles hotkey actino for storing/unstoring item to/from backpack storage
+/mob/living/carbon/human/proc/auto_store_unstore_backpack()
+	if (!src.back || !src.back.storage)
+		return
+	var/obj/item/I = src.equipped()
+	var/list/backpack_contents = src.back.storage.get_contents()
+	if (I)
+		src.back.Attackby(I, src)
+		if (I in backpack_contents)
+			src.last_stored_backpack = I
+	else if (src.last_stored_backpack)
+		if (!QDELETED(src.last_stored_backpack) && (src.last_stored_backpack in backpack_contents))
+			src.last_stored_backpack.Attackhand(src)

--- a/code/modules/interface/action_associations.dm
+++ b/code/modules/interface/action_associations.dm
@@ -66,6 +66,8 @@ var/list/action_names = list(
 
 	"unequip" = "Unequip (Silicon)",
 	"pickup" = "Pick Up",
+	"autostore_belt" = "Store to/Unstore from Belt",
+	"autostore_backpack" = "Store to/Unstore from Backpack",
 	"drop" = "Drop",
 	"stop_pull" = "Stop Pulling",
 

--- a/code/modules/interface/keybind_style.dm
+++ b/code/modules/interface/keybind_style.dm
@@ -166,6 +166,8 @@ var/global/list/datum/keybind_style/keybind_styles = null
 		"=" = "rest",
 		"V" = "equip",
 		"Q" = "drop",
+		"H" = "autostore_belt",
+		"N" = "autostore_backpack",
 		"E" = "swaphand",
 		"C" = "attackself",
 		"DELETE" = "togglethrow"

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -926,6 +926,13 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 			..()
 	else
 		..()
+	// only items can be worn on belt or back right now
+	if (src.storage && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if (src == H.belt && (W in src.storage.get_contents()))
+			H.last_stored_belt = W
+		else if (src == H.back && (W in src.storage.get_contents()))
+			H.last_stored_backpack = W
 
 /obj/item/proc/process()
 	SHOULD_NOT_SLEEP(TRUE)

--- a/code/world/topic.dm
+++ b/code/world/topic.dm
@@ -194,6 +194,14 @@
 							twitch_mob.hotkey("drop")
 							return 1
 
+						if ("autostore_belt")
+							twitch_mob.hotkey("autostore_belt")
+							return TRUE
+
+						if ("autostore_backpack")
+							twitch_mob.hotkey("autostore_backpack")
+							return TRUE
+
 						if("use")
 							twitch_mob.hotkey("attackself")
 							return 1


### PR DESCRIPTION
[PLAYER ACTIONS][FEATURE][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds hotkeys that let you automatically store items specifically to the storage in your belt or backpack slot. Default key is "H" for belt and "N" for backpack
-Pressing the hotkey will automatically store anything that you are holding to the storage item in that slot
-You don't need the storage UI open for it to work
-It keeps track of the last item you stored, so pressing the hotkey again will automatically take what you last stored out of the storage, without you needing to open the UI


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
-QoL/faster player inventory interaction


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(*)Added two new hotkeys for auto-storing/unstoring items to/from your belt storage (default "H") and backpack storage (default "N")
(+)Hotkeys do not need the storage UI to be open, and have a 1 second cooldown on alternating store/unstore actions
```
