### PR TITLE
Fix material swapping in manufacturers, I optimized too hard

### DIFF
--- a/tgui/packages/tgui/interfaces/Manufacturer/index.tsx
+++ b/tgui/packages/tgui/interfaces/Manufacturer/index.tsx
@@ -114,18 +114,17 @@ export const Manufacturer = () => {
   // Local states for pleasant UX while selecting one button (highlight green) and then second button (perform action)
   const handleSwapPriority = useCallback(
     (materialRef: string) => {
-      if (materialRef === swappingMaterialRef) {
+      if (swappingMaterialRef === null) {
+        setSwappingMaterialRef(materialRef);
+      } else if (swappingMaterialRef === materialRef) {
+        setSwappingMaterialRef(null);
+      } else {
         act('material_swap', {
           resource_1: swappingMaterialRef,
           resource_2: materialRef,
         });
+        setSwappingMaterialRef(null);
       }
-      setSwappingMaterialRef((prev) => {
-        if (prev === null) {
-          return materialRef;
-        }
-        return null;
-      });
     },
     [act, swappingMaterialRef],
   );


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[UI][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Lets people reorder materials in manufacturers again, reverts to previous implementation.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes a bug introduced in #21418