### PR TITLE
Add AI Upload Foyer to list of AI only camera areas

### DIFF
--- a/code/modules/camera/camera.dm
+++ b/code/modules/camera/camera.dm
@@ -69,7 +69,8 @@
 	var/list/aiareas = list(/area/station/turret_protected/ai,
 							/area/station/turret_protected/ai_upload,
 							/area/station/turret_protected/AIsat,
-							/area/station/turret_protected/AIbasecore1)
+							/area/station/turret_protected/AIbasecore1,
+							/area/station/turret_protected/ai_upload_foyer)
 	if (locate(area) in aiareas)
 		src.ai_only = TRUE
 		src.prefix = "AI"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the /area/station/turret_protected/ai_upload_foyer to the list of aiareas cameras use to apply ai_only to a camera
(I agree with the year old TODO of "man what if these AI areas had a common parent" but this is a simpler fix than repathing ALL ai areas to turret_protected/ai/upload or whatever)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
With most foyers getting windows into upload it can be difficult to place a camera down in the foyer that doesn't see upload, and if you can see foyer you can usually tell if an AI is being rogue anyway by seeing turret controls on lethal/door bolted.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)AI Upload Foyer cameras can now only be viewed by AIs
```
