### PR TITLE
Adds a round start hint about the gps verb

### DIFF
--- a/strings/roundstart_hints.txt
+++ b/strings/roundstart_hints.txt
@@ -163,3 +163,4 @@ Different items do different types of damage in different amounts, both to your 
 The cloning console displays a red flashing icon when someone can be cloned.
 Shuttle votes aren't in the rules, if you have access and the station's in bad shape you can call the shuttle!
 Want to express yourself, but can't put things into words? Press M to make your own, custom emote! You can also press CTRL + M to emote audibly - chortle and snort at your own, bad jokes!
+You can find the GPS verb under the commands tab after the game has started. It is quite helpful in finding your way around the station!


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

`You can find the GPS verb under the commands tab after the game has started. It is quite helpful in finding your way around the station!`
Might be able to be worded better

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The people who know about the gps verb are the ones who don't benefit from it.
