### PR TITLE
Fix atlas toxins dwaine terminal

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -11948,10 +11948,10 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/computer3/terminal,
 /obj/machinery/light/incandescent/harsh{
 	dir = 1
 	},
+/obj/machinery/computer3/terminal/zeta,
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[station systems][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Change the atlas toxins terminal to the `/zeta` subtype.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21444
