### PR TITLE
Makes a few pain-killing chems have some stun resist

### DIFF
--- a/code/modules/chemistry/Reagents-Drugs.dm
+++ b/code/modules/chemistry/Reagents-Drugs.dm
@@ -975,8 +975,10 @@ datum
 			addiction_prob = 10
 			addiction_min = 10
 			overdose = 20
+			stun_resist = 50
 			hunger_value = -0.1
 			thirst_value = -0.09
+			threshold = THRESHOLD_INIT
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -76,6 +76,7 @@ datum
 			overdose = 15
 			var/counter = 1 //Data is conserved...so some jerkbag could inject a monkey with this, wait for data to build up, then extract some instant KO juice.  Dumb.
 			depletion_rate = 0.4
+			stun_resist = 25
 			value = 5
 			threshold = THRESHOLD_INIT
 
@@ -135,6 +136,7 @@ datum
 			minimum_reaction_temperature = T0C + 80 //This stuff is extremely flammable
 			var/temp_reacted = 0
 			value = 5
+			stun_resist = 30
 			threshold = THRESHOLD_INIT
 
 			cross_threshold_over()
@@ -1286,6 +1288,7 @@ datum
 			transparency = 220
 			addiction_prob = 1
 			addiction_min = 10
+			stun_resist = 15
 			value = 10 // 4 3 1 1 1
 			threshold = THRESHOLD_INIT
 			var/list/flushed_reagents = list("histamine","itching")


### PR DESCRIPTION
[LABEL][chemicals][feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pull request makes it so a few pain numbing chemicals have some degree of stun resistance to them.
- Morphine - 25% resistance.
- Ether - 30% resistance.
- Diphenhidramine - 15% resistance.
- Krokodil - 50% resistance.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Something that makes sense for pain numbing medication to have, trying to be balanced around availability and the severity of the side effects, while not being as top notch at this as stimulants. Makes sense flavor wise and adds a bit of diversity to their possible usecases.


## Changelog
```changelog
(u)Colossus
(+)Some pain numbing chemicals received some stun resistance. These are Morphine(25%), Ether(30%), Diphenhydramine(15%), and Krokodil(50%).
```
