### PR TITLE
Prevent headbands from being transmuted into berets

### DIFF
--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -341,7 +341,7 @@
 	rewardActivate(var/mob/activator)
 		if (ishuman(activator))
 			var/mob/living/carbon/human/H = activator
-			if (!istype(H.head, /obj/item/clothing/head/helmet) && istype(H.head, /obj/item/clothing/head)) // ha...
+			if (!istype(H.head, /obj/item/clothing/head/helmet) && !istype(H.head, /obj/item/clothing/head/headband && istype(H.head, /obj/item/clothing/head))) // ha...
 				var/obj/item/clothing/head/M = H.head
 				M.icon = 'icons/obj/clothing/item_hats.dmi'
 				M.icon_state = "beret_base"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a check to the colored beret reward to prevent headbands from turning into berets


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Headsets can be stuck into headbands and worn on the ear slot.
Fix #20402
