### PR TITLE
Unempowered Anaerobic Metabolism recovers baseline losebreath

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1494,7 +1494,7 @@
 	var/special = 0
 	if (src.stamina < STAMINA_WINDED_SPEAK_MIN)
 		special = "gasp_whisper"
-	if (src.oxyloss > 10)
+	if (src.oxyloss > 10 && !HAS_ATOM_PROPERTY(src, PROP_MOB_REBREATHING))
 		special = "gasp_whisper"
 
 	return ..(text, special, sayverb)

--- a/code/mob/living/life/breath.dm
+++ b/code/mob/living/life/breath.dm
@@ -112,8 +112,6 @@
 			src.update_breath_hud(status_updates)
 			if(owner.losebreath)
 				owner.losebreath -= (1.3 * mult) // base losebreath recovery
-			if(owner.get_oxygen_deprivation())
-				owner.take_oxygen_deprivation(-3 * mult) // base oxydep recovery
 			return
 
 		// Changelings generally can't take OXY/LOSEBREATH damage...except when they do.

--- a/code/mob/living/life/breath.dm
+++ b/code/mob/living/life/breath.dm
@@ -110,6 +110,10 @@
 
 		if (HAS_ATOM_PROPERTY(owner, PROP_MOB_REBREATHING))
 			src.update_breath_hud(status_updates)
+			if(owner.losebreath)
+				owner.losebreath -= (1.3 * mult) // base losebreath recovery
+			if(owner.get_oxygen_deprivation())
+				owner.take_oxygen_deprivation(-3 * mult) // base oxydep recovery
 			return
 
 		// Changelings generally can't take OXY/LOSEBREATH damage...except when they do.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[medical][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add baseline losebreathrecovery if the mob has `PROP_MOB_REBREATHING`, commonly given by the Anaerobic Metabolism gene.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There's no natural recovery of losebreath/oxy damage while having `PROP_MOB_REBREATHING`, but that does not prevent this type of damage from happening. This leads to a state where people can be stuck gasping for air from their lungs that otherwise don't need air to work. Providing the recovery that would ordinarily happen when breathing normally shouldn't encroach on the empowered version of the gene while preventing this 'stuck' state.
Fix #21169
Fix #15693
Fix #20801
Fix #18462