### PR TITLE
Prevent ant growth on conveyor belts

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -57,6 +57,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 			return TRUE
 		if (locate(/obj/storage/secure/closet/fridge) in src.loc) // includes fridges
 			return TRUE
+		if (locate(/obj/machinery/conveyor) in src.loc) // Sushi Belts
+			return TRUE
 		return FALSE
 
 	get_average_color()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Catering][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds Conveyor belts to the list of ant safe conditions.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This allows players to setup sushi belts without the food being coated in copious amounts of ants
![image](https://github.com/user-attachments/assets/6abb8555-bc9d-4dcc-add9-8396a20808c8)

