### PR TITLE
Allow cutting tools to get meat from meat spikes

### DIFF
--- a/code/obj/kitchenspike.dm
+++ b/code/obj/kitchenspike.dm
@@ -54,16 +54,17 @@ TYPEINFO(/obj/kitchenspike)
 	src.get_meat(user)
 
 /obj/kitchenspike/proc/get_meat(mob/user)
-	if(src.occupied)
-		if(src.meat >= 1)
-			src.meat--
-			new /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat(src.loc)
-			if (src.meat >= 1)
-				boutput(user, "You remove some meat from the monkey.")
-			else
-				boutput(user, "You remove the last piece of meat from the monkey!")
-				src.occupied = FALSE
-				src.UpdateIcon()
+	if(!src.occupied)
+		return
+	if(src.meat >= 1)
+		src.meat--
+		new /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat(src.loc)
+		if (src.meat >= 1)
+			boutput(user, "You remove some meat from the monkey.")
+		else
+			boutput(user, "You remove the last piece of meat from the monkey!")
+			src.occupied = FALSE
+			src.UpdateIcon()
 
 /obj/kitchenspike/update_icon()
 	. = ..()

--- a/code/obj/kitchenspike.dm
+++ b/code/obj/kitchenspike.dm
@@ -12,10 +12,15 @@ TYPEINFO(/obj/kitchenspike)
 	var/occupied = FALSE
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR
 
-/obj/kitchenspike/attackby(obj/item/grab/G, mob/user)
-	if(!istype(G))
+/obj/kitchenspike/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/grab))
+		var/obj/item/grab/G = W
+		if(!src.spike(user, G.affecting))
+			return ..()
+	if(iscuttingtool(W))
+		src.get_meat(user)
 		return
-	spike(user, G.affecting)
+	. = ..()
 
 /obj/kitchenspike/hitby(atom/movable/A, datum/thrown_thing/thr)
 	if (!src.spike(null, A))
@@ -46,17 +51,19 @@ TYPEINFO(/obj/kitchenspike)
 
 /obj/kitchenspike/attack_hand(mob/user)
 	. = ..()
+	src.get_meat(user)
+
+/obj/kitchenspike/proc/get_meat(mob/user)
 	if(src.occupied)
-		if(src.meat > 1)
-			src.meat--
-			new /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat( src.loc )
-			boutput(user, "You remove some meat from the monkey.")
-		else if(src.meat == 1)
+		if(src.meat >= 1)
 			src.meat--
 			new /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat(src.loc)
-			boutput(user, "You remove the last piece of meat from the monkey!")
-			src.occupied = FALSE
-			src.UpdateIcon()
+			if (src.meat >= 1)
+				boutput(user, "You remove some meat from the monkey.")
+			else
+				boutput(user, "You remove the last piece of meat from the monkey!")
+				src.occupied = FALSE
+				src.UpdateIcon()
 
 /obj/kitchenspike/update_icon()
 	. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Generalize a `get_meat` proc for kitchen spikes, and add a new condition for attackby that allows cutting tools to call it. Do a little bit of style cleanup on that logic while we're here.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A way to stop accidently grabbing meat when spam-clicking on a meat-spike. Feels like cutting tools should be able to cut meat.
Fix #10937

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Knives (and other cutting tools) get steaks from meat spikes.
```
