### PR TITLE
Refactors HoS Medal to be a badge and lets you show it off

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -1980,14 +1980,18 @@
 	var/hand_icon = ""
 	var/pixel_x_offset = null
 	var/pixel_y_offset = null
+	var/pixel_x_hand_offset = null
+	var/pixel_y_hand_offset = null
 
-	New(mob/user, obj/item/item, hand_icon, x_offset = 6, y_offset = 2)
+	New(mob/user, obj/item/item, hand_icon, x_offset = 6, y_offset = 2, x_hand_offset = 6, y_hand_offset = 2)
 		. = ..()
 		src.user = user
 		src.item = item
 		src.hand_icon = hand_icon
 		src.pixel_x_offset = x_offset
 		src.pixel_y_offset = y_offset
+		src.pixel_x_hand_offset = x_hand_offset
+		src.pixel_y_hand_offset = y_hand_offset
 
 	onStart()
 		. = ..()
@@ -1999,7 +2003,7 @@
 			src.pixel_x_offset = -src.pixel_x_offset
 
 		var/image/overlay = src.item.SafeGetOverlayImage("showoff_overlay", src.item.icon, src.item.icon_state, MOB_LAYER + 0.1, src.pixel_x_offset, src.pixel_y_offset)
-		var/image/hand_overlay = src.item.SafeGetOverlayImage("showoff_hand_overlay", 'icons/effects/effects.dmi', hand_icon_state, MOB_LAYER + 0.11, src.pixel_x_offset, src.pixel_y_offset, color=user.get_fingertip_color())
+		var/image/hand_overlay = src.item.SafeGetOverlayImage("showoff_hand_overlay", 'icons/effects/effects.dmi', hand_icon_state, MOB_LAYER + 0.11, src.pixel_x_hand_offset, src.pixel_y_hand_offset, color=user.get_fingertip_color())
 
 		src.user.UpdateOverlays(overlay, "showoff_overlay")
 		src.user.UpdateOverlays(hand_overlay, "showoff_hand_overlay")

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -332,7 +332,7 @@
 	station_bounties[/obj/item/reagent_containers/food/drinks/bottle/champagne] = 2
 	station_bounties[/obj/item/pen/crayon/golden] = 2
 	station_bounties[/obj/item/remote/porter/port_a_sci] = 2
-	station_bounties[/obj/item/clothing/suit/hosmedal] = 3
+	station_bounties[/obj/item/clothing/suit/security_badge/hosmedal] = 3
 	station_bounties[/obj/item/rddiploma] = 2
 	station_bounties[/obj/item/mdlicense] = 2
 	station_bounties[/obj/item/firstbill] = 2

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -194,7 +194,7 @@ proc/create_fluff(datum/mind/target)
 			if("aurora MKII utility belt")
 				steal_target = /obj/item/storage/belt/utility/prepared/ceshielded
 			if("Head of Security\'s war medal")
-				steal_target = /obj/item/clothing/suit/hosmedal
+				steal_target = /obj/item/clothing/suit/security_badge/hosmedal
 			if("Research Director\'s Diploma")
 				steal_target = /obj/item/rddiploma
 			if("Medical Director\'s Medical License")

--- a/code/obj/decal/poster.dm
+++ b/code/obj/decal/poster.dm
@@ -954,14 +954,14 @@
 			var/icon_award = "rddiploma"
 			var/icon_empty = "frame"
 			var/glass_type = /obj/item/sheet/glass
+			var/obj/item/award_item
 			icon_state = "rddiploma"
 			pixel_y = -6
 
 			New()
 				..()
-				var/obj/item/M = new award_type(src.loc)
-				M.desc = src.desc
-				src.contents.Add(M)
+				src.award_item = new award_type(src)
+				src.award_item.desc = src.desc
 
 			get_desc()
 				if(award_text)
@@ -993,10 +993,9 @@
 
 					if (1)
 						playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-						var/obj/item/award_item = locate(award_type) in src
-						if(award_item)
-							award_item.desc = src.desc
-							user.put_in_hand_or_drop(award_item)
+						if(istype(src.award_item) && src.award_item.loc == src)
+							src.award_item.desc = src.desc
+							user.put_in_hand_or_drop(src.award_item)
 							user.visible_message("[user] takes the [award_name] from the frame.", "You take the [award_name] out of the frame.")
 							src.icon_state = icon_empty
 							src.add_fingerprint(user)
@@ -1007,7 +1006,7 @@
 					return
 
 				if (src.usage_state == 2)
-					if (istype(W, award_type))
+					if (istype(W, src.award_type))
 						playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 						user.u_equip(W)
 						W.set_loc(src)
@@ -1033,13 +1032,19 @@
 		framed_award/hos_medal
 			name = "framed medal"
 			desc = "A dusty old war medal."
-			award_type = /obj/item/clothing/suit/hosmedal
+			award_type = /obj/item/clothing/suit/security_badge/hosmedal
 			award_name = "medal"
 			owner_job = "Head of Security"
 			icon_glass = "medal1"
 			icon_award = "medal"
 			icon_empty = "frame"
 			icon_state = "medal"
+
+			New()
+				..()
+				if (istype(src.award_item, src.award_type))
+					var/obj/item/clothing/suit/security_badge/hosmedal/medal = src.award_item
+					medal.award_text = src.get_award_text()
 
 			attackby(obj/item/W, mob/user)
 				if (user.stat)

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -2113,17 +2113,20 @@ ABSTRACT_TYPE(/obj/item/clothing/suit/sweater_vest)
 	get_desc()
 		. += "This one belongs to [badge_owner_name], the [badge_owner_job]."
 
-	attack_self(mob/user as mob)
+	proc/show_off_badge(var/mob/user, var/mob/target = null)
 		if(ON_COOLDOWN(user, "showoff_item", SHOWOFF_COOLDOWN))
 			return
-		user.visible_message("[user] flashes the badge: <br>[SPAN_BOLD("[bicon(src)] Nanotrasen's Finest [badge_owner_job]: [badge_owner_name].")]", "You show off the badge: <br>[SPAN_BOLD("[bicon(src)] Nanotrasen's Finest [badge_owner_job] [badge_owner_name].")]")
+		if (istype(target))
+			user.visible_message("[user] flashes the badge at [target.name]: <br>[SPAN_BOLD("[bicon(src)] Nanotrasen's Finest [badge_owner_job]: [badge_owner_name].")]", "You show off the badge to [target.name]: <br>[SPAN_BOLD("[bicon(src)] Nanotrasen's Finest [badge_owner_job] [badge_owner_name].")]")
+		else
+			user.visible_message("[user] flashes the badge: <br>[SPAN_BOLD("[bicon(src)] Nanotrasen's Finest [badge_owner_job]: [badge_owner_name].")]", "You show off the badge: <br>[SPAN_BOLD("[bicon(src)] Nanotrasen's Finest [badge_owner_job] [badge_owner_name].")]")
 		actions.start(new /datum/action/show_item(user, src, "badge"), user)
 
+	attack_self(mob/user as mob)
+		src.show_off_badge(user)
+
 	attack(mob/target, mob/user, def_zone, is_special = FALSE, params = null)
-		if(ON_COOLDOWN(user, "showoff_item", SHOWOFF_COOLDOWN))
-			return
-		user.visible_message("[user] flashes the badge at [target.name]: <br>[SPAN_BOLD("[bicon(src)] Nanotrasen's Finest [badge_owner_job]: [badge_owner_name].")]", "You show off the badge to [target.name]: <br>[SPAN_BOLD("[bicon(src)] Nanotrasen's Finest [badge_owner_job] [badge_owner_name].")]")
-		actions.start(new /datum/action/show_item(user, src, "badge"), user)
+		src.show_off_badge(user, target)
 
 /obj/item/clothing/suit/security_badge/shielded
 	name = "NTSO Tactical Badge"
@@ -2146,7 +2149,7 @@ ABSTRACT_TYPE(/obj/item/clothing/suit/sweater_vest)
 	desc = "A piece of soggy notebook paper with a red S doodled on it, presumably to represent security."
 	icon_state = "security_badge_paper"
 
-/obj/item/clothing/suit/hosmedal
+/obj/item/clothing/suit/security_badge/hosmedal
 	name = "war medal"
 	desc = ""
 	icon = 'icons/obj/clothing/overcoats/item_suit_gimmick.dmi'
@@ -2154,6 +2157,16 @@ ABSTRACT_TYPE(/obj/item/clothing/suit/sweater_vest)
 	wear_image_icon = 'icons/mob/clothing/overcoats/worn_suit_gimmick.dmi'
 	icon_state = "hosmedal"
 	icon_state = "hosmedal"
+	var/award_text = "This is a medal. There are many like it, but this one's mine."
+
+	show_off_badge(var/mob/user, var/mob/target = null)
+		if(ON_COOLDOWN(user, "showoff_item", SHOWOFF_COOLDOWN))
+			return
+		if (istype(target))
+			user.visible_message("[user] flashes the medal at [target.name]. It reads: <br>[SPAN_BOLD("[bicon(src)]\"[src.award_text]\".")]", "You show off the medal to [target.name]. It reads: <br>[SPAN_BOLD("[bicon(src)]\"[src.award_text]\".")]")
+		else
+			user.visible_message("[user] flashes the medal. It reads: <br>[SPAN_BOLD("[bicon(src)]\"[src.award_text]\".")]", "You show off the medal. It reads: <br>[SPAN_BOLD("[bicon(src)]\"[src.award_text]\".")]")
+		actions.start(new /datum/action/show_item(user, src, "badge", x_hand_offset = -5, y_hand_offset = -3), user)
 
 	get_desc(var/dist, var/mob/user)
 		if (user.mind?.assigned_role == "Head of Security")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes `/obj/item/clothing/suit/hosmedal` to `/obj/item/clothing/suit/security_badge/hosmedal`.

Adds `/obj/item/clothing/suit/security_badge/show_off_medal()` to reduce duplicate code.

Reworks `/obj/decal/framed_award` to contain its award instead of doing a `locate` inside its contents.

Adds an `award_text` var to HoS medals which are displayed when showing off the medal.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Medals are cool and underused, this gives them a cool new gimmick usage.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(+)You can now show off the HoS medal like other badges.
```
