### PR TITLE
Spy thief redeemed items summary fix

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -127,7 +127,7 @@
 				hostpda.uplink.purchase_log[reward.type] = 0
 			hostpda.uplink.purchase_log[reward.type]++
 			if (istype(antag_role))
-				antag_role.redeemed_item_paths.Add(reward.type)
+				antag_role.redeemed_items.Add(reward)
 
 		for(var/obj/item/uplink/integrated/pda/spy/spy_uplink in game_mode.uplinks)
 			LAGCHECK(LAG_LOW)

--- a/code/modules/antagonists/spy_thief/spy_thief.dm
+++ b/code/modules/antagonists/spy_thief/spy_thief.dm
@@ -9,7 +9,7 @@
 	/// A list of buylist datums that this traitor has redeemed using their uplink.
 	///
 	///This tracks items redeemed with any uplink, so if a spy thief steals another spy thief's uplink, redeemed items will show up here too!
-	var/list/redeemed_item_paths = list()
+	var/list/datum/syndicate_buylist/redeemed_items = list()
 
 
 	New()
@@ -128,13 +128,13 @@
 			)
 
 		var/list/redeemed_items = list()
-		for (var/datum/syndicate_buylist/redeemed_entry as anything in src.redeemed_item_paths)
+		for (var/datum/syndicate_buylist/redeemed_entry as anything in src.redeemed_items)
 			if(length(redeemed_entry.items) > 0)
 				var/obj/item_type = initial(redeemed_entry.items[1])
 				redeemed_items += list(
 					list(
 						"iconBase64" = "[icon2base64(icon(initial(item_type.icon), initial(item_type.icon_state), frame = 1, dir = initial(item_type.dir)))]",
-						"name" = "[initial(redeemed_entry[1].name)]",
+						"name" = "[initial(redeemed_entry.name)]",
 					)
 				)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactors spy thief redeemed_item_paths to redeemed_items, like every other purchase-tracking antagonist does


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #21475
