### PR TITLE
Fix catwalk auto-connection

### DIFF
--- a/code/obj/grille.dm
+++ b/code/obj/grille.dm
@@ -101,8 +101,8 @@
 				var/connectdir = 0
 				for (var/dir in cardinal)
 					var/turf/T = get_step(src, dir)
-					for (var/i in 1 to length(connects_to_obj))
-						var/atom/movable/AM = locate(connects_to_obj[i]) in T
+					for (var/i in 1 to length(connects_to))
+						var/atom/movable/AM = locate(connects_to[i]) in T
 						if (AM?.anchored)
 							connectdir |= dir
 							break


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Use the `connects_to` var set for the `catwalk` grille subtype. Previously it was using `connects_to_obj`, completely skipping the specially defined list.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Catwalks auto-connect to windows with grilles under them which looks kinda ugly and isn't intended by code. 