### PR TITLE
makes it so that atmos devices can filter their connections

### DIFF
--- a/code/modules/atmospherics/machinery.dm
+++ b/code/modules/atmospherics/machinery.dm
@@ -49,3 +49,7 @@ ABSTRACT_TYPE(/obj/machinery/atmospherics)
 
 /// Disconnect reference from our nodes.
 /obj/machinery/atmospherics/proc/disconnect(obj/machinery/atmospherics/reference)
+
+/// Is the device we want to connect to not compatible with us? Direction is from them to us.
+/obj/machinery/atmospherics/proc/cant_connect(obj/machinery/atmospherics/device, direction)
+	return FALSE

--- a/code/modules/atmospherics/machinery/binary/binary_base.dm
+++ b/code/modules/atmospherics/machinery/binary/binary_base.dm
@@ -81,11 +81,15 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			node1 = target
 			break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			node2 = target
 			break
 	if(player_caused_init)

--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -429,11 +429,15 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			src.node1 = target
 			break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			src.node2 = target
 			break
 	if(player_caused_init)
@@ -522,24 +526,13 @@
 	fatigue_pressure = INFINITY
 
 /obj/machinery/atmospherics/pipe/simple/junction/update_icon()
-	if(istype(node1, /obj/machinery/atmospherics/pipe/simple/heat_exchanging))
-		dir = get_dir(src, node1)
+	icon_state = (src.node1 && src.node2) ? "intact" : "exposed"
 
-		if(node2)
-			icon_state = "intact"
-		else
-			icon_state = "exposed"
-
-	else if(istype(node2, /obj/machinery/atmospherics/pipe/simple/heat_exchanging))
-		dir = get_dir(src, node2)
-
-		if(node1)
-			icon_state = "intact"
-		else
-			icon_state = "exposed"
-
-	else
-		icon_state = "exposed"
+/obj/machinery/atmospherics/pipe/simple/junction/cant_connect(obj/machinery/atmospherics/device, direction)
+	if(!istype(device, /obj/machinery/atmospherics/pipe/simple/heat_exchanging) && direction != src.dir)
+		return TRUE
+	if(istype(device, /obj/machinery/atmospherics/pipe/simple/heat_exchanging) && direction == src.dir)
+		return TRUE
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging
 	icon = 'icons/obj/atmospherics/pipes/heat_pipe.dmi'
@@ -554,6 +547,9 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/update_icon()
 	icon_state = (node1 && node2) ? "intact" : "exposed"
 
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/cant_connect(obj/machinery/atmospherics/device, direction)
+	if(!(istype(device, /obj/machinery/atmospherics/pipe/simple/heat_exchanging) || istype(device, /obj/machinery/atmospherics/pipe/simple/junction)))
+		return TRUE
 
 /obj/machinery/atmospherics/pipe/vertical_pipe
 	icon = 'icons/obj/atmospherics/pipes/manifold_pipe.dmi'
@@ -584,6 +580,8 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,connect_direction))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			node1 = target
 			break
 	if(player_caused_init)
@@ -693,16 +691,22 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			src.node1 = target
 			break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			src.node2 = target
 			break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node3_connect))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			src.node3 = target
 			break
 	if(player_caused_init)
@@ -798,21 +802,29 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src, SOUTH))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			src.node1 = target
 			break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src, WEST))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			src.node2 = target
 			break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src, NORTH))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			src.node3 = target
 			break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src, EAST))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			src.node4 = target
 			break
 	if(player_caused_init)

--- a/code/modules/atmospherics/machinery/trinary/trinary_base.dm
+++ b/code/modules/atmospherics/machinery/trinary/trinary_base.dm
@@ -53,16 +53,22 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			src.node1 = target
 			break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			src.node2 = target
 			break
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node3_connect))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			src.node3 = target
 			break
 	if(player_caused_init)

--- a/code/modules/atmospherics/machinery/unary/unary_base.dm
+++ b/code/modules/atmospherics/machinery/unary/unary_base.dm
@@ -42,6 +42,8 @@
 
 	for(var/obj/machinery/atmospherics/target in get_step(src,node_connect))
 		if(target.initialize_directions & get_dir(target,src))
+			if(src.cant_connect(target, get_dir(target,src)) || target.cant_connect(src, get_dir(src,target)))
+				continue
 			node = target
 			break
 	if(player_caused_init)


### PR DESCRIPTION
[BUG][ATMOSPHERICS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds a system that lets pipes filter out what they can connect to. this means he pipes can no longer connect to pipes without a junction and stuff. theres probably a better cleaner way to implement this but im lazyyyyyyyyyyyyy and it would take too long and this is good enough for now.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad
