### PR TITLE
Recharge station mob clickdrag fix

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -187,12 +187,8 @@ TYPEINFO(/obj/machinery/recharge_station)
 		. = ..()
 
 /obj/machinery/recharge_station/MouseDrop_T(atom/movable/AM as mob|obj, mob/user as mob)
-	if (ismob(AM))
-		if (BOUNDS_DIST(AM, src) > 0 || BOUNDS_DIST(src, user) > 0)
-			return
-	else
-		if (BOUNDS_DIST(AM, user) > 0 || BOUNDS_DIST(src, user) > 0)
-			return
+	if (BOUNDS_DIST(AM, user) > 0 || BOUNDS_DIST(src, user) > 0 || (ismob(AM) && BOUNDS_DIST(AM, src)))
+		return
 	if (!isturf(AM.loc) && !(AM in user))
 		return
 	if (!isliving(user) || isAI(user))

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -187,7 +187,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 		. = ..()
 
 /obj/machinery/recharge_station/MouseDrop_T(atom/movable/AM as mob|obj, mob/user as mob)
-	if (BOUNDS_DIST(AM, user) > 0 || BOUNDS_DIST(src, user) > 0 || (ismob(AM) && BOUNDS_DIST(AM, src)))
+	if (BOUNDS_DIST(AM, user) > 0 || BOUNDS_DIST(src, user) > 0 || (ismob(AM) && BOUNDS_DIST(AM, src) > 0))
 		return
 	if (!isturf(AM.loc) && !(AM in user))
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes recharge station mousedrop logic to always check if the user is next to the target


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes being able to put a mob in the dock if both you and they are next to the dock (e.g. here the 3 borgs next to the dock could put each other in)
![image](https://github.com/user-attachments/assets/c996f6c7-2d97-4d12-aca7-aefe452722c1)

Its also much cleaner