### PR TITLE
Makes address fields consistent on atmos devices.

### DIFF
--- a/code/modules/atmospherics/machinery/binary/pump.dm
+++ b/code/modules/atmospherics/machinery/binary/pump.dm
@@ -89,7 +89,7 @@ Thus, the two variables affect pump operation are set in New():
 	signal.source = src
 
 	signal.data["tag"] = src.id
-	signal.data["netid"] = src.net_id
+	signal.data["sender"] = src.net_id
 	signal.data["device"] = "AGP"
 	signal.data["power"] = src.on ? "on" : "off"
 	signal.data["min_output"] = MIN_PRESSURE
@@ -103,7 +103,7 @@ Thus, the two variables affect pump operation are set in New():
 
 
 /obj/machinery/atmospherics/binary/pump/receive_signal(datum/signal/signal)
-	if(!((signal.data["tag"] && (signal.data["tag"] == src.id)) || (signal.data["netid"] && (signal.data["netid"] == src.net_id))))
+	if(!((signal.data["tag"] && (signal.data["tag"] == src.id)) || (signal.data["address_1"] == src.net_id)))
 		if(signal.data["command"] != "broadcast_status")
 			return FALSE
 

--- a/code/modules/atmospherics/machinery/binary/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/binary/volume_pump.dm
@@ -58,7 +58,7 @@
 	signal.source = src
 
 	signal.data["tag"] = src.id
-	signal.data["netid"] = src.net_id
+	signal.data["sender"] = src.net_id
 	signal.data["device"] = "APV"
 	signal.data["power"] = src.on
 	signal.data["transfer_rate"] = src.transfer_rate
@@ -72,7 +72,7 @@
 	src.ui = new/datum/pump_ui/volume_pump_ui(src)
 
 /obj/machinery/atmospherics/binary/volume_pump/receive_signal(datum/signal/signal)
-	if(!((signal.data["tag"] && (signal.data["tag"] == src.id)) || (signal.data["netid"] && (signal.data["netid"] == src.net_id))))
+	if(!((signal.data["tag"] && (signal.data["tag"] == src.id)) || (signal.data["address_1"] == src.net_id)))
 		if(signal.data["command"] != "broadcast_status")
 			return FALSE
 

--- a/code/modules/atmospherics/machinery/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/unary/outlet_injector.dm
@@ -73,7 +73,7 @@
 	signal.source = src
 
 	signal.data["tag"] = src.id
-	signal.data["netid"] = src.net_id
+	signal.data["sender"] = src.net_id
 	signal.data["device"] = "AO"
 	signal.data["power"] = src.on
 	signal.data["volume_rate"] = src.volume_rate
@@ -83,7 +83,7 @@
 	return TRUE
 
 /obj/machinery/atmospherics/unary/outlet_injector/receive_signal(datum/signal/signal)
-	if(!((signal.data["tag"] && (signal.data["tag"] == src.id)) || (signal.data["netid"] && (signal.data["netid"] == src.net_id))))
+	if(!((signal.data["tag"] && (signal.data["tag"] == src.id)) || (signal.data["address_1"] == src.net_id)))
 		if(signal.data["command"] != "broadcast_status")
 			return FALSE
 

--- a/code/modules/atmospherics/machinery/unary/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/unary/vent_pump.dm
@@ -88,15 +88,12 @@
 	return TRUE
 
 /obj/machinery/atmospherics/unary/vent_pump/proc/broadcast_status()
-	if(!src.id)
-		return FALSE
-
 	var/datum/signal/signal = get_free_signal()
 	signal.transmission_method = TRANSMISSION_RADIO
 	signal.source = src
 
 	signal.data["tag"] = src.id
-	signal.data["netid"] = src.net_id
+	signal.data["sender"] = src.net_id
 	signal.data["device"] = "AVP"
 	signal.data["power"] = src.on ? "on": "off"
 	signal.data["direction"] = src.pump_direction ? "release" : "siphon"
@@ -113,7 +110,7 @@
 	UpdateIcon()
 
 /obj/machinery/atmospherics/unary/vent_pump/receive_signal(datum/signal/signal)
-	if(!((signal.data["tag"] && (signal.data["tag"] == src.id)) || (signal.data["netid"] && (signal.data["netid"] == src.net_id))))
+	if(!((signal.data["tag"] && (signal.data["tag"] == src.id)) || (signal.data["address_1"] == src.net_id)))
 		if(signal.data["command"] != "broadcast_status")
 			return FALSE
 

--- a/code/modules/atmospherics/machinery/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/unary/vent_scrubber.dm
@@ -99,8 +99,25 @@
 
 	SET_PIPE_UNDERLAY(src.node, src.dir, "long", issimplepipe(src.node) ?  src.node.color : null, hide_pipe)
 
+/obj/machinery/atmospherics/unary/vent_scrubber/proc/broadcast_status()
+	var/datum/signal/signal = get_free_signal()
+	signal.transmission_method = TRANSMISSION_RADIO
+	signal.source = src
+
+	signal.data["tag"] = src.id
+	signal.data["sender"] = src.net_id
+	signal.data["power"] = src.on ? "on": "off"
+	signal.data["mode"] = src.scrubbing ? "scrubbing" : "siphoning"
+	#define COMPILE_GAS_MOLES(GAS, ...) if(scrub_##GAS) {signal.data[#GAS] = "1"}
+	APPLY_TO_GASES(COMPILE_GAS_MOLES)
+	#undef COMPILE_GAS_MOLES
+
+	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, signal)
+
+	return TRUE
+
 /obj/machinery/atmospherics/unary/vent_scrubber/receive_signal(datum/signal/signal)
-	if(!((signal.data["tag"] && (signal.data["tag"] == src.id)) || (signal.data["netid"] && (signal.data["netid"] == src.net_id))))
+	if(!((signal.data["tag"] && (signal.data["tag"] == src.id)) || (signal.data["address_1"] == src.net_id)))
 		if(signal.data["command"] != "broadcast_status")
 			return FALSE
 
@@ -125,6 +142,19 @@
 			src.scrubbing = SCRUBBING
 			. = TRUE
 
+		if("toggle_scrub_gas")
+			switch(signal.data["parameter"])
+				#define _FILTER_OUT_GAS(GAS, ...) \
+				if(#GAS) { \
+					scrub_##GAS = !scrub_##GAS; \
+				}
+				APPLY_TO_GASES(_FILTER_OUT_GAS)
+				#undef _FILTER_OUT_GAS
+			. = TRUE
+
+		if("broadcast_status")
+			SPAWN(0.5 SECONDS) broadcast_status()
+
 		if("help")
 			var/datum/signal/help = get_free_signal()
 			help.transmission_method = TRANSMISSION_RADIO
@@ -136,7 +166,7 @@
 									power_toggle - Toggles scrubber. \
 									set_siphon - Begins siphoning all gas. \
 									set_scrubbing - Begins scrubbing select gases. \
-									set_volume_rate (parameter: Number) - Sets rate in liters to parameter. Max at [src.air_contents.volume] L."
+									toggle_scrub_gas (parameter: String) - Toggles filtering for a specific gas. Uses the shortform name for a gas."
 
 			SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, help)
 


### PR DESCRIPTION
[ATMOSPHERICS][WIKI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the netid field to address_1 and sender like other packet devices.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
consistency good. Also adds some missing features to vent scrubbers.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)cringe
(+)The netid field on packets was changed to address_1 and sender for atmospheric devices.
```
