### PR TITLE
Removes imposter bat

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -6067,7 +6067,6 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/mob/living/critter/small_animal/bat/doctor,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aHz" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the second Dr. Acula accidentally left on Atlas. PRing because the diff looked funny and I want to check with MDB.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The second one is sus.