### PR TITLE
Increase quantity of counterrev boxes on Donut 3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2692,8 +2692,8 @@
 /obj/table/reinforced/bar/auto{
 	name = "table"
 	},
-/obj/item/implantcase/counterrev{
-	pixel_y = 6
+/obj/item/storage/box/revimp_kit{
+	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/red/fancy,
 /area/station/security/hos)
@@ -60268,6 +60268,10 @@
 	dir = 8;
 	pixel_x = -23
 	},
+/obj/item/storage/box/revimp_kit{
+	pixel_x = -6;
+	pixel_y = 17
+	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "shD" = (
@@ -71153,6 +71157,9 @@
 	},
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/item/storage/box/revimp_kit{
+	pixel_x = 8
 	},
 /turf/simulated/floor/carpet{
 	dir = 6;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases quantity of boxes of counterrev implants on Donut 3 from 1 to 4, to match cogmap 2
One in the armory, one in the HoS office, one on the main sec table (and the original one by the sleeper to the south)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
For a highpop map with cargo insanely far from security and bridge one counterrev box is nowhere near enough to lead a decent counterrev operation compared to maps such as cog1 which has 2 boxes.
