### PR TITLE
Fix Syndicate Weapons Vendor using the Kestrel revolver's old name

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -440,7 +440,7 @@
 	description = "A gun-belt containing a semi-automatic, 9mm caliber service pistol and four magazines."
 
 /datum/materiel/sidearm/revolver
-	name = "Predator Revolver"
+	name = "Kestrel Revolver"
 	path = /obj/item/storage/belt/gun/revolver
 	description = "A gun-belt containing a hefty combat revolver and three .357 caliber speedloaders."
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Commit 43ecbb5 renamed the Predator revolver to the Kestrel, but the Syndicate Weapons Vendor still calls it the "Predator Revolver". This PR fixes that. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* LORE
* But seriously, consistency, because using two different names for the same thing is kinda confusing. 
