### PR TITLE
Ensure the magnet area irradiates during radstorms

### DIFF
--- a/code/datums/controllers/mining_controls.dm
+++ b/code/datums/controllers/mining_controls.dm
@@ -166,6 +166,7 @@ var/list/asteroid_blocked_turfs = list()
 	requires_power = 0
 	luminosity = 1
 	expandable = 0
+	do_not_irradiate = FALSE
 
 /obj/forcefield/mining
 	name = "magnetic forcefield"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][events]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Set `do_not_irradiate` on the mining magnet area to `FALSE` (default from root `/area` is TRUE)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Since pure space is irradiated, the space inside the mining magnet should be irradiated too.
(Should) Fix #13756
Fix #14761