### PR TITLE
Fix magnetizer eating stacks of plasmastone

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -317,7 +317,7 @@
 		if (istype(W, /obj/item/raw_material/plasmastone) && !loaded)
 			loaded = 1
 			boutput(user, SPAN_NOTICE("You charge the magnetizer with the plasmastone."))
-			qdel(W)
+			W.change_stack_amount(-1)
 
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 		var/turf/target_turf = target


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Use `change_stack_amount` instead of directly qdeling the ore item, as it may be a stack of ore. `change_stack_amount` will qdel a one-stack of ore, so we don't need to worry about it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Deleting a whole stack of ore instead of one is bad.
Fix #21490