### PR TITLE
Add Santa space suit to syndicate apparel

### DIFF
--- a/code/modules/vending/jobclothing.dm
+++ b/code/modules/vending/jobclothing.dm
@@ -467,6 +467,10 @@ ABSTRACT_TYPE(/obj/machinery/vending/jobclothing)
 	create_products(restocked)
 		..()
 		product_list += new/datum/data/vending_product(/obj/item/clothing/under/misc/syndicate, 4)
+#ifdef XMAS
+		product_list += new/datum/data/vending_product(/obj/item/clothing/head/helmet/space/santahat/noslow, 2)
+		product_list += new/datum/data/vending_product(/obj/item/clothing/suit/space/santa/noslow, 2)
+#endif
 		product_list += new/datum/data/vending_product(/obj/item/clothing/head/helmet/space/syndicate, 2)
 		product_list += new/datum/data/vending_product(/obj/item/clothing/suit/space/syndicate, 2)
 		product_list += new/datum/data/vending_product(/obj/item/tank/jetpack/syndicate, 2)
@@ -478,4 +482,3 @@ ABSTRACT_TYPE(/obj/machinery/vending/jobclothing)
 		product_list += new/datum/data/vending_product(/obj/item/storage/backpack/syndie, 1)
 		product_list += new/datum/data/vending_product(/obj/item/storage/backpack/satchel/syndie, 1)
 		product_list += new/datum/data/vending_product(/obj/item/storage/fanny/syndie, 1)
-


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If its christmas, have a santa version of the space suit available


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The old gear prep locker that got replaced with this vendor had these.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)The syndicate have gotten into the christmas spirit! You can now buy santa space suits from the apparel vendor.
```
