### PR TITLE
Drone Recycler type

### DIFF
--- a/code/mob/living/critter/ai/artifact_robot.dm
+++ b/code/mob/living/critter/ai/artifact_robot.dm
@@ -249,11 +249,12 @@
 
 /datum/aiTask/succeedable/actionbar/recycle_random_object/failed()
 	.=..() //did actionbar fail
-	if(. || !holder.owner || !holder.target || BOUNDS_DIST(holder.owner, holder.target) > 0) //the tasks fails and is re-evaluated if the target is not in range. "in range" counts for the item being inside the mob
+	if(.)
 		//drop the item if the task failed
 		var/obj/item/pickup = holder.target
 		if(istype(pickup))
 			pickup.set_loc(get_turf(holder.owner))
+			holder.owner.visible_message(SPAN_NOTICE("[holder.owner] drops \the [pickup] on the floor"))
 		return TRUE
 
 /datum/aiTask/succeedable/actionbar/recycle_random_object/before_action_start()
@@ -269,5 +270,6 @@
 	if(istype(owner) && istype(target))
 		var/datum/artifact/robot/art_datum = owner.parent_artifact?.artifact
 		if(istype(art_datum))
-			new art_datum.item_type(get_turf(owner)) //spawn item on turf
+			var/obj/item/thing = new art_datum.item_type(get_turf(owner)) //spawn item on turf
+			holder.owner.visible_message(SPAN_NOTICE("[holder.owner] drops \a [thing] on the floor"))
 			qdel(target) //delete the recycled one

--- a/code/mob/living/critter/ai/artifact_robot.dm
+++ b/code/mob/living/critter/ai/artifact_robot.dm
@@ -212,7 +212,7 @@
 
 /datum/aiTask/prioritizer/artifact_recycler/New()
 	..()
-	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander, list(src.holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/short, list(src.holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/recycle_random_object, list(src.holder, src))
 
 /datum/aiTask/sequence/goalbased/recycle_random_object
@@ -242,8 +242,8 @@
 	name = "recycle object subtask"
 	duration = 3 SECONDS
 	callback_proc = PROC_REF(produce_object)
-	action_icon = 'icons/obj/scrap.dmi'
-	action_icon_state = "Crusher_1"
+	action_icon = 'icons/effects/effects.dmi'
+	action_icon_state = "gears"
 	end_message = null
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ACTION
 

--- a/code/mob/living/critter/ai/artifact_robot.dm
+++ b/code/mob/living/critter/ai/artifact_robot.dm
@@ -219,7 +219,7 @@
 	name = "recycling objects"
 	weight = 1
 	distance_from_target = 0
-	max_dist = 5
+	max_dist = 7
 
 /datum/aiTask/sequence/goalbased/recycle_random_object/New(parentHolder, transTask) //goalbased aitasks have an inherent movement component
 	..(parentHolder, transTask)
@@ -233,7 +233,7 @@
 	if(!istype(art_datum))
 		return
 	for(var/obj/item/O in view(src.max_dist, src.holder.owner))
-		if(!istype(O, art_datum.item_type) && istype(O.loc, /turf))
+		if(!istype(O, art_datum.item_type) && istype(O.loc, /turf) && !O.anchored)
 			results += O
 	return results
 
@@ -266,10 +266,13 @@
 		holder.owner.visible_message(SPAN_NOTICE("[holder.owner] pulls \the [pickup] into itself"))
 	playsound(holder.owner, 'sound/items/mining_drill.ogg', 40, TRUE, 0, 0.8)
 
-/datum/aiTask/succeedable/actionbar/recycle_random_object/proc/produce_object(var/mob/living/critter/robotic/artifact/owner, var/obj/target)
+/datum/aiTask/succeedable/actionbar/recycle_random_object/proc/produce_object(var/mob/living/critter/robotic/artifact/owner, var/obj/item/target)
 	if(istype(owner) && istype(target))
 		var/datum/artifact/robot/art_datum = owner.parent_artifact?.artifact
 		if(istype(art_datum))
-			var/obj/item/thing = new art_datum.item_type(get_turf(owner)) //spawn item on turf
-			holder.owner.visible_message(SPAN_NOTICE("[holder.owner] drops \a [thing] on the floor"))
+			art_datum.absorbed_item_health += target.health*target.amount
+			if(art_datum.absorbed_item_health >= art_datum.item_cost)
+				var/obj/item/thing = new art_datum.item_type(get_turf(owner)) //spawn item on turf
+				holder.owner.visible_message(SPAN_NOTICE("[holder.owner] drops \a [thing] on the floor"))
+				art_datum.absorbed_item_health = 0
 			qdel(target) //delete the recycled one

--- a/code/mob/living/critter/ai/artifact_robot.dm
+++ b/code/mob/living/critter/ai/artifact_robot.dm
@@ -228,8 +228,12 @@
 /datum/aiTask/sequence/goalbased/recycle_random_object/get_targets()
 	. = ..()
 	var/list/obj/item/results = list()
+	var/mob/living/critter/robotic/artifact/robit = holder.owner
+	var/datum/artifact/robot/art_datum = robit.parent_artifact.artifact
+	if(!istype(art_datum))
+		return
 	for(var/obj/item/O in view(src.max_dist, src.holder.owner))
-		if(istype(O.loc, /turf))
+		if(!istype(O, art_datum.item_type) && istype(O.loc, /turf))
 			results += O
 	return results
 
@@ -256,7 +260,9 @@
 	//pick up the item
 	var/obj/item/pickup = holder.target
 	if(istype(pickup))
+		holder.owner.put_in_hand(pickup)
 		pickup.set_loc(holder.owner)
+		holder.owner.visible_message(SPAN_NOTICE("[holder.owner] pulls \the [pickup] into itself"))
 	playsound(holder.owner, 'sound/items/mining_drill.ogg', 40, TRUE, 0, 0.8)
 
 /datum/aiTask/succeedable/actionbar/recycle_random_object/proc/produce_object(var/mob/living/critter/robotic/artifact/owner, var/obj/target)

--- a/code/mob/living/critter/ai/shared.dm
+++ b/code/mob/living/critter/ai/shared.dm
@@ -273,20 +273,24 @@
 	var/end_message = null
 	// flags which indicate what actions should interupt the actionbar
 	var/interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ACTION
+	// internal flag for having started
+	var/_has_started = FALSE
 
 /datum/aiTask/succeedable/actionbar/on_reset()
 	QDEL_NULL(src.actionbar)
+	_has_started = FALSE
 
 /datum/aiTask/succeedable/actionbar/on_tick()
 	if(!istype(actionbar))
 		src.before_action_start()
 		actionbar = SETUP_GENERIC_ACTIONBAR(src.holder.owner, src.holder.target, src.duration, src.callback_proc, list(src.holder.owner, src.holder.target), src.action_icon, src.action_icon_state, src.end_message, src.interrupt_flags)
 		actionbar.call_proc_on = src
+		_has_started = TRUE
 
 /datum/aiTask/succeedable/actionbar/proc/before_action_start()
 
 /datum/aiTask/succeedable/actionbar/succeeded()
-	return (istype(actionbar) && actionbar.state == ACTIONSTATE_DELETE && actionbar.interrupt_time == 0)
+	return (_has_started && QDELETED(actionbar)) || (istype(actionbar) && actionbar.state == ACTIONSTATE_DELETE && actionbar.interrupt_start == 0)
 
 /datum/aiTask/succeedable/actionbar/failed()
 	return (istype(actionbar) && actionbar.state == ACTIONSTATE_DELETE && actionbar.interrupt_start > -1)

--- a/code/mob/living/critter/ai/shared.dm
+++ b/code/mob/living/critter/ai/shared.dm
@@ -81,6 +81,10 @@
 	holder?.stop_move() // Just in case they yeet themselves out of existance
 	holder?.owner.move_dir = null // clear out direction so it doesn't get latched when client is attached
 
+/datum/aiTask/timed/wander/short
+	minimum_task_ticks = 1
+	maximum_task_ticks = 3
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TARGETED TASK
 // a timed task that also relates to a target and the acquisition of said target

--- a/code/mob/living/critter/ai/shared.dm
+++ b/code/mob/living/critter/ai/shared.dm
@@ -290,7 +290,7 @@
 /datum/aiTask/succeedable/actionbar/proc/before_action_start()
 
 /datum/aiTask/succeedable/actionbar/succeeded()
-	return (_has_started && QDELETED(actionbar)) || (istype(actionbar) && actionbar.state == ACTIONSTATE_DELETE && actionbar.interrupt_start == 0)
+	return (_has_started && QDELETED(actionbar)) || (istype(actionbar) && actionbar.state == ACTIONSTATE_DELETE && actionbar.interrupt_start == -1)
 
 /datum/aiTask/succeedable/actionbar/failed()
 	return (istype(actionbar) && actionbar.state == ACTIONSTATE_DELETE && actionbar.interrupt_start > -1)

--- a/code/obj/artifacts/artifact_machines/robot.dm
+++ b/code/obj/artifacts/artifact_machines/robot.dm
@@ -19,13 +19,32 @@
 	var/static/list/turf/floor_types = list(/turf/simulated/floor/industrial, /turf/simulated/floor/auto/glassblock/cyan, /turf/simulated/floor/circuit/vintage, /turf/simulated/floor/glassblock/transparent, /turf/simulated/floor/engine, /turf/simulated/floor/techfloor/yellow, /turf/simulated/floor/mauxite)
 	// possible wall types for the wall placing robots
 	var/static/list/turf/wall_types = list(/turf/simulated/wall/auto/supernorn/material/mauxite, /turf/simulated/wall/auto/reinforced/supernorn, /turf/simulated/wall/auto/supernorn)
-	// possible item types for the recycler to create
-	var/static/list/obj/item/item_types = list(/obj/item/bananapeel)
+	// possible item types for the recycler to create - /obj/item/path = cost. Cost is total item health of absorbed items
+	var/static/list/item_types = list(
+		/obj/item/bananapeel=1,
+	 	/obj/item/fuel_pellet/cerenkite=25,
+		/obj/item/balloon_animal/random=5,
+		/obj/item/brick=10,
+		/obj/item/chilly_orb=100, //weird, mysterious, useless
+		/obj/item/mine/radiation/armed=100, //haha mean
+		/obj/item/mine/stun/armed=80,
+		/obj/item/nuclear_waste=50,
+		/obj/item/old_grenade/light_gimmick=1000,
+		/obj/item/rubberduck=15, //quack
+		/obj/item/seed/alien=100,
+		/mob/living/critter/robotic/repairbot=1000,
+		/mob/living/critter/robotic/repairbot/security=1200,
+		/obj/item/artifact=2000, //maybe too OP, so expensive
+		/obj/machinery/bot/duckbot=100 //implies duckbots are ancient eldritch tech
+		)
 
 	var/aiHolder_type
 	var/floor_type
 	var/wall_type
 	var/item_type
+	var/item_cost
+	//total health of absorbed items, for tracking recylcing
+	var/absorbed_item_health = 0
 	//artifact limb var storage
 	var/limb_damtype = "brute"
 	var/limb_dmg_amount = 0
@@ -39,6 +58,8 @@
 		floor_type = pick(floor_types)
 		wall_type = pick(wall_types)
 		item_type = pick(item_types)
+		SPAWN(0) //the reason for this cursed spawn is that the artifact controller tries to init before the static lists are init'd
+			item_cost = item_types[item_type]
 
 		//this is copy pasted from the melee artifact New()
 		limb_damtype = pick("brute", "fire", "toxin")

--- a/code/obj/artifacts/artifact_machines/robot.dm
+++ b/code/obj/artifacts/artifact_machines/robot.dm
@@ -19,10 +19,13 @@
 	var/static/list/turf/floor_types = list(/turf/simulated/floor/industrial, /turf/simulated/floor/auto/glassblock/cyan, /turf/simulated/floor/circuit/vintage, /turf/simulated/floor/glassblock/transparent, /turf/simulated/floor/engine, /turf/simulated/floor/techfloor/yellow, /turf/simulated/floor/mauxite)
 	// possible wall types for the wall placing robots
 	var/static/list/turf/wall_types = list(/turf/simulated/wall/auto/supernorn/material/mauxite, /turf/simulated/wall/auto/reinforced/supernorn, /turf/simulated/wall/auto/supernorn)
+	// possible item types for the recycler to create
+	var/static/list/obj/item/item_types = list(/obj/item/bananapeel)
 
 	var/aiHolder_type
 	var/floor_type
 	var/wall_type
+	var/item_type
 	//artifact limb var storage
 	var/limb_damtype = "brute"
 	var/limb_dmg_amount = 0

--- a/code/obj/artifacts/artifact_machines/robot.dm
+++ b/code/obj/artifacts/artifact_machines/robot.dm
@@ -38,6 +38,7 @@
 		aiHolder_type = pick(possible_ais)
 		floor_type = pick(floor_types)
 		wall_type = pick(wall_types)
+		item_type = pick(item_types)
 
 		//this is copy pasted from the melee artifact New()
 		limb_damtype = pick("brute", "fire", "toxin")

--- a/code/obj/artifacts/artifact_machines/robot.dm
+++ b/code/obj/artifacts/artifact_machines/robot.dm
@@ -25,16 +25,16 @@
 	 	/obj/item/fuel_pellet/cerenkite=25,
 		/obj/item/balloon_animal/random=5,
 		/obj/item/brick=10,
-		/obj/item/chilly_orb=100, //weird, mysterious, useless
+		/obj/item/chilly_orb=50, //weird, mysterious, useless
 		/obj/item/mine/radiation/armed=100, //haha mean
 		/obj/item/mine/stun/armed=80,
 		/obj/item/nuclear_waste=50,
-		/obj/item/old_grenade/light_gimmick=1000,
+		/obj/item/old_grenade/light_gimmick=200,
 		/obj/item/rubberduck=15, //quack
 		/obj/item/seed/alien=100,
-		/mob/living/critter/robotic/repairbot=1000,
-		/mob/living/critter/robotic/repairbot/security=1200,
-		/obj/item/artifact=2000, //maybe too OP, so expensive
+		/mob/living/critter/robotic/repairbot=100,
+		/mob/living/critter/robotic/repairbot/security=120,
+		/obj/item/artifact=200, //maybe too OP, so expensive
 		/obj/machinery/bot/duckbot=100 //implies duckbots are ancient eldritch tech
 		)
 

--- a/code/obj/artifacts/artifact_machines/robot.dm
+++ b/code/obj/artifacts/artifact_machines/robot.dm
@@ -14,7 +14,7 @@
 	deact_text = "becomes eerily still."
 	react_xray = list(50,20,90,8,"MECHANICAL")
 	// possible AI types that the robot can have
-	var/static/list/datum/aiHolder/possible_ais = list(/datum/aiHolder/artifact_wallplacer, /datum/aiHolder/artifact_wallsmasher, /datum/aiHolder/artifact_floorplacer, /datum/aiHolder/wanderer, /datum/aiHolder/aggressive)
+	var/static/list/datum/aiHolder/possible_ais = list(/datum/aiHolder/artifact_wallplacer, /datum/aiHolder/artifact_wallsmasher, /datum/aiHolder/artifact_floorplacer, /datum/aiHolder/wanderer, /datum/aiHolder/aggressive, /datum/aiHolder/artifact_recycler)
 	// possible floor types for the floor placing robots
 	var/static/list/turf/floor_types = list(/turf/simulated/floor/industrial, /turf/simulated/floor/auto/glassblock/cyan, /turf/simulated/floor/circuit/vintage, /turf/simulated/floor/glassblock/transparent, /turf/simulated/floor/engine, /turf/simulated/floor/techfloor/yellow, /turf/simulated/floor/mauxite)
 	// possible wall types for the wall placing robots


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new ai type for the drone artifacts: Recycler
It bumbles around picking up items off the floor (only the floor, won't grab things off tables), converts them to internal resources (like flockdrones), and then when it has enough, spits out an object of the selected type

Also fixes a couple bugs with the actionbar ai task.


