### PR TITLE
Do not give vandalism points for spraying an already graffiti'd turf

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1409,10 +1409,13 @@ proc/broadcast_to_all_gangs(var/message)
 		spraycan.charges -= targets
 		spraycan.UpdateIcon()
 		if (targets == 1)
+			var/vandalism_points = 0
+			if(!(locate(/obj/decal/cleanable/gang_graffiti) in spraycan.graffititargets[1]))
+				vandalism_points += GANG_VANDALISM_PER_GRAFFITI_TILE
 			var/obj/decal/cleanable/gang_graffiti/tag = new/obj/decal/cleanable/gang_graffiti(spraycan.graffititargets[1])
 			tag.icon_state = iconstate
 			tag.dir = spraycan.tagging_direction
-			gang?.do_vandalism(GANG_VANDALISM_PER_GRAFFITI_TILE, spraycan.graffititargets[1])
+			gang?.do_vandalism(vandalism_points, spraycan.graffititargets[1])
 		else
 			var/list/turf/turfs_ordered = new/list(length(spraycan.graffititargets))
 			var/spraydirection = dir_to_angle(spraycan.tagging_direction)
@@ -1430,11 +1433,12 @@ proc/broadcast_to_all_gangs(var/message)
 			var/vandal_score = 0
 			var/turf/chosenTurf
 			for (var/i = 1 to targets)
+				if(!(locate(/obj/decal/cleanable/gang_graffiti) in turfs_ordered[i]))
+					vandal_score += GANG_VANDALISM_PER_GRAFFITI_TILE
 				var/obj/decal/cleanable/gang_graffiti/tag = new/obj/decal/cleanable/gang_graffiti(turfs_ordered[i])
 				var/area = get_area(turfs_ordered[i])
 				tag.icon_state = "[iconstate][i]"
 				tag.dir = spraycan.tagging_direction
-				vandal_score += GANG_VANDALISM_PER_GRAFFITI_TILE
 
 				if (gang && !chosenTurf)
 					for (var/area/targetArea as anything in gang.vandalism_tracker)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][gamemodes]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When laying down graffiti for a vandalism objective, check if there is already graffiti on the tile before adding vandalism points.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A strat I've seen on live is to stand in one place and spray the same three tiles over and over until the bag pops out. This will make people actually have to move around the target area to vandalize it.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)In gang war, when vandalizing areas, you do not gain points for spraying over existing graffiti.
```
