### PR TITLE
Fixes All Randrooms With Airless/Unsimulated Tiles

### DIFF
--- a/assets/maps/random_rooms/3x5/enginetest.dmm
+++ b/assets/maps/random_rooms/3x5/enginetest.dmm
@@ -1,27 +1,27 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/simulated/floor/airless/caution/east,
+/turf/simulated/floor/caution/east,
 /area/dmm_suite/clear_area)
 "e" = (
 /obj/table/auto,
 /obj/machinery/computer3/generic/personal,
-/turf/simulated/floor/airless/caution/corner/ne,
+/turf/simulated/floor/caution/corner/ne,
 /area/dmm_suite/clear_area)
 "f" = (
-/turf/simulated/floor/airless/caution/west,
+/turf/simulated/floor/caution/west,
 /area/dmm_suite/clear_area)
 "m" = (
 /obj/decal/cleanable/dirt/dirt5,
-/turf/simulated/floor/airless/caution/west,
+/turf/simulated/floor/caution/west,
 /area/dmm_suite/clear_area)
 "p" = (
 /obj/stool/chair/office,
 /obj/decal/cleanable/dirt/dirt2,
-/turf/simulated/floor/airless/caution/east,
+/turf/simulated/floor/caution/east,
 /area/dmm_suite/clear_area)
 "s" = (
 /obj/fakeobject/shuttleweapon/base,
-/turf/simulated/floor/airless/caution/corner,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "v" = (
 /obj/item/paper/safehouse/delivery_note{
@@ -31,37 +31,37 @@
 	},
 /obj/decal/cleanable/dirt/dirt3,
 /obj/fakeobject/lightbulb_broken,
-/turf/simulated/floor/airless/caution/corner/sw,
+/turf/simulated/floor/caution/corner/sw,
 /area/dmm_suite/clear_area)
 "y" = (
 /obj/storage/closet/radiation,
-/turf/simulated/floor/airless/caution/corner/nw,
+/turf/simulated/floor/caution/corner/nw,
 /area/dmm_suite/clear_area)
 "z" = (
 /obj/decal/cleanable/blood/gibs,
 /obj/machinery/light/emergency,
 /obj/fakeobject/lightbulb_broken,
-/turf/simulated/floor/airless/caution/corner/se,
+/turf/simulated/floor/caution/corner/se,
 /area/dmm_suite/clear_area)
 "C" = (
 /obj/fakeobject/skeleton/decomposed_corpse,
 /obj/decal/cleanable/dirt/jen,
-/turf/simulated/floor/airless/caution/south,
+/turf/simulated/floor/caution/south,
 /area/dmm_suite/clear_area)
 "F" = (
 /obj/fakeobject/shuttlethruster,
-/turf/simulated/floor/airless/caution/corner,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "G" = (
-/turf/simulated/floor/airless/caution/north,
+/turf/simulated/floor/caution/north,
 /area/dmm_suite/clear_area)
 "P" = (
 /obj/machinery/light/emergency,
-/turf/simulated/floor/airless/caution/corner,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "V" = (
 /obj/decal/cleanable/dirt/jen,
-/turf/simulated/floor/airless/caution/west,
+/turf/simulated/floor/caution/west,
 /area/dmm_suite/clear_area)
 
 (1,1,1) = {"

--- a/assets/maps/random_rooms/3x5/fishingtrip.dmm
+++ b/assets/maps/random_rooms/3x5/fishingtrip.dmm
@@ -13,20 +13,20 @@
 	pixel_y = -11;
 	pixel_x = 8
 	},
-/turf/unsimulated/floor/setpieces/swampgrass,
+/turf/simulated/swampgrass,
 /area/space)
 "h" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/blue,
 /area/space)
 "i" = (
-/turf/simulated/floor/airless/stairs/wood2,
+/turf/simulated/floor/stairs/wood2,
 /area/space)
 "o" = (
 /obj/machinery/light/incandescent{
 	dir = 1
 	},
-/turf/unsimulated/floor/setpieces/swampgrass,
+/turf/simulated/swampgrass,
 /area/space)
 "t" = (
 /obj/item/fishing_rod/basic{
@@ -41,7 +41,7 @@
 	pixel_y = -5;
 	pixel_x = 12
 	},
-/turf/unsimulated/floor/wood,
+/turf/simulated/floor/wood,
 /area/space)
 "w" = (
 /obj/decal/cleanable/paper,
@@ -56,20 +56,20 @@
 	pixel_y = 3;
 	pixel_x = 8
 	},
-/turf/unsimulated/floor/setpieces/swampgrass,
+/turf/simulated/swampgrass,
 /area/space)
 "E" = (
-/turf/unsimulated/floor/setpieces/swampgrass,
+/turf/simulated/swampgrass,
 /area/space)
 "I" = (
-/turf/unsimulated/floor/setpieces/swampgrass_edging,
+/turf/simulated/swampgrass_edging,
 /area/space)
 "Q" = (
 /obj/storage/crate/freezer{
 	desc = "A cooler to keep your fresh catches in.";
 	name = "cooler"
 	},
-/turf/unsimulated/floor/setpieces/swampgrass,
+/turf/simulated/swampgrass,
 /area/space)
 "R" = (
 /turf/simulated/floor/twotone/blue,
@@ -85,7 +85,7 @@
 	pixel_y = -6;
 	pixel_x = -12
 	},
-/turf/unsimulated/floor/wood,
+/turf/simulated/floor/wood,
 /area/space)
 
 (1,1,1) = {"

--- a/assets/maps/random_rooms/3x5/fishingtrip.dmm
+++ b/assets/maps/random_rooms/3x5/fishingtrip.dmm
@@ -13,7 +13,7 @@
 	pixel_y = -11;
 	pixel_x = 8
 	},
-/turf/simulated/swampgrass,
+/turf/simulated/floor/swampgrass,
 /area/space)
 "h" = (
 /obj/machinery/light/incandescent,
@@ -26,7 +26,7 @@
 /obj/machinery/light/incandescent{
 	dir = 1
 	},
-/turf/simulated/swampgrass,
+/turf/simulated/floor/swampgrass,
 /area/space)
 "t" = (
 /obj/item/fishing_rod/basic{
@@ -56,20 +56,20 @@
 	pixel_y = 3;
 	pixel_x = 8
 	},
-/turf/simulated/swampgrass,
+/turf/simulated/floor/swampgrass,
 /area/space)
 "E" = (
-/turf/simulated/swampgrass,
+/turf/simulated/floor/swampgrass,
 /area/space)
 "I" = (
-/turf/simulated/swampgrass_edging,
+/turf/simulated/floor/swampgrass_edging,
 /area/space)
 "Q" = (
 /obj/storage/crate/freezer{
 	desc = "A cooler to keep your fresh catches in.";
 	name = "cooler"
 	},
-/turf/simulated/swampgrass,
+/turf/simulated/floor/swampgrass,
 /area/space)
 "R" = (
 /turf/simulated/floor/twotone/blue,

--- a/assets/maps/random_rooms/3x5/openmic.dmm
+++ b/assets/maps/random_rooms/3x5/openmic.dmm
@@ -8,7 +8,7 @@
 /obj/item/reagent_containers/food/snacks/plant/tomato,
 /obj/item/reagent_containers/food/snacks/plant/tomato,
 /obj/item/kitchen/food_box/egg_box,
-/turf/simulated/floor/airless/damaged2,
+/turf/simulated/floor/damaged2,
 /area/dmm_suite/clear_area)
 "c" = (
 /obj/decal/cleanable/dirt/jen,

--- a/assets/maps/random_rooms/5x3/borglounge.dmm
+++ b/assets/maps/random_rooms/5x3/borglounge.dmm
@@ -1,12 +1,12 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/simulated/floor/airless/grime,
+/turf/simulated/floor/grime,
 /area/dmm_suite/clear_area)
 "f" = (
 /obj/stool/chair/couch{
 	dir = 8
 	},
-/turf/simulated/floor/airless/grime,
+/turf/simulated/floor/grime,
 /area/dmm_suite/clear_area)
 "h" = (
 /obj/machinery/vending/standard,
@@ -14,16 +14,16 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/airless/grime,
+/turf/simulated/floor/grime,
 /area/dmm_suite/clear_area)
 "j" = (
 /obj/machinery/recharge_station,
-/turf/simulated/floor/airless/grime,
+/turf/simulated/floor/grime,
 /area/dmm_suite/clear_area)
 "m" = (
 /obj/storage/crate/loot,
 /obj/random_item_spawner/tools/some,
-/turf/simulated/floor/airless/grime,
+/turf/simulated/floor/grime,
 /area/dmm_suite/clear_area)
 "p" = (
 /obj/stool/chair/couch{
@@ -37,19 +37,19 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/airless/grime,
+/turf/simulated/floor/grime,
 /area/dmm_suite/clear_area)
 "r" = (
 /obj/storage/crate/loot,
 /obj/item/weldingtool,
 /obj/random_item_spawner/tools/maybe_few,
-/turf/simulated/floor/airless/grime,
+/turf/simulated/floor/grime,
 /area/dmm_suite/clear_area)
 "C" = (
 /obj/item/storage/secure/ssafe/loot{
 	pixel_y = 32
 	},
-/turf/simulated/floor/airless/grime,
+/turf/simulated/floor/grime,
 /area/dmm_suite/clear_area)
 
 (1,1,1) = {"

--- a/assets/maps/random_rooms/5x3/crimepodbay_70.dmm
+++ b/assets/maps/random_rooms/5x3/crimepodbay_70.dmm
@@ -6,7 +6,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/tank/air,
 /obj/item/device/light/flashlight,
-/turf/simulated/floor/airless/caution/south,
+/turf/simulated/floor/caution/south,
 /area/dmm_suite/clear_area)
 "d" = (
 /obj/cable/black{

--- a/assets/maps/random_rooms/5x3/laundromat.dmm
+++ b/assets/maps/random_rooms/5x3/laundromat.dmm
@@ -6,7 +6,7 @@
 /area/dmm_suite/clear_area)
 "b" = (
 /obj/decal/cleanable/dirt/dirt3,
-/turf/simulated/floor/airless/plating,
+/turf/simulated/floor/plating,
 /area/dmm_suite/clear_area)
 "g" = (
 /obj/decal/cleanable/dirt/dirt2,
@@ -24,7 +24,7 @@
 /area/dmm_suite/clear_area)
 "L" = (
 /obj/decal/cleanable/dirt/dirt5,
-/turf/simulated/floor/airless/plating,
+/turf/simulated/floor/plating,
 /area/dmm_suite/clear_area)
 "M" = (
 /obj/fakeobject/lighttube_broken{
@@ -37,12 +37,12 @@
 	pixel_y = 3
 	},
 /obj/item/raw_material/scrap_metal,
-/turf/simulated/floor/airless/plating,
+/turf/simulated/floor/plating,
 /area/dmm_suite/clear_area)
 "R" = (
 /obj/submachine/laundry_machine,
 /obj/item/clothing/under/misc/bandshirt,
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/dmm_suite/clear_area)
 "V" = (
 /obj/submachine/laundry_machine,
@@ -55,12 +55,12 @@
 /obj/machinery/light_switch/north{
 	pixel_x = 13
 	},
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/dmm_suite/clear_area)
 "W" = (
 /obj/submachine/laundry_machine,
 /obj/decal/cleanable/cobweb,
-/turf/simulated/floor/airless/black,
+/turf/simulated/floor/black,
 /area/dmm_suite/clear_area)
 "X" = (
 /obj/item/cloth/towel/white{

--- a/assets/maps/random_rooms/5x3/plushbridge.dmm
+++ b/assets/maps/random_rooms/5x3/plushbridge.dmm
@@ -8,7 +8,7 @@
 	pixel_y = -1;
 	pixel_x = -3
 	},
-/turf/simulated/floor/airless/blue/corner{
+/turf/simulated/floor/blue/corner{
 	dir = 4
 	},
 /area/dmm_suite/clear_area)
@@ -83,7 +83,7 @@
 	pixel_y = 34;
 	pixel_x = -7
 	},
-/turf/simulated/floor/airless/blue/side,
+/turf/simulated/floor/blue/side,
 /area/dmm_suite/clear_area)
 "J" = (
 /obj/table/wood,
@@ -99,7 +99,7 @@
 /obj/decal/cleanable/cobweb{
 	layer = 14
 	},
-/turf/simulated/floor/airless/blue/corner,
+/turf/simulated/floor/blue/corner,
 /area/dmm_suite/clear_area)
 "N" = (
 /obj/table/wood,
@@ -157,7 +157,7 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/dmm_suite/clear_area)
 "X" = (
-/turf/simulated/floor/airless/blue/side{
+/turf/simulated/floor/blue/side{
 	dir = 4
 	},
 /area/dmm_suite/clear_area)
@@ -166,7 +166,7 @@
 /obj/machinery/light/small{
 	pixel_y = -5
 	},
-/turf/simulated/floor/airless/blue/side{
+/turf/simulated/floor/blue/side{
 	dir = 1
 	},
 /area/dmm_suite/clear_area)

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -2702,6 +2702,23 @@ TYPEINFO(/turf/simulated/floor/auto/water/ice)
 		if(prob(10))
 			src.icon_state = "snow_rough[rand(1,3)]"
 
+/turf/simulated/floor/swampgrass
+	name = "reedy grass"
+	desc = ""
+	icon = 'icons/misc/worlds.dmi'
+	icon_state = "swampgrass"
+
+	New()
+		..()
+		set_dir(pick(1,2,4,8))
+		return
+
+/turf/simulated/floor/swampgrass_edging
+	name = "reedy grass"
+	desc = ""
+	icon = 'icons/misc/worlds.dmi'
+	icon_state = "swampgrass_edge"
+
 TYPEINFO(/turf/simulated/floor/auto/glassblock)
 	mat_appearances_to_ignore = list("steel","synthrubber","glass")
 	connect_diagonal = 1

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -1465,3 +1465,20 @@ TYPEINFO(/turf/simulated)
 				qdel(mover) // so the mob inside can GC in case references got freed up since qdel
 			else
 				mover.set_loc(null)
+
+/turf/simulated/swampgrass
+	name = "reedy grass"
+	desc = ""
+	icon = 'icons/misc/worlds.dmi'
+	icon_state = "swampgrass"
+
+	New()
+		..()
+		set_dir(pick(1,2,4,8))
+		return
+
+/turf/simulated/swampgrass_edging
+	name = "reedy grass"
+	desc = ""
+	icon = 'icons/misc/worlds.dmi'
+	icon_state = "swampgrass_edge"

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -1465,20 +1465,3 @@ TYPEINFO(/turf/simulated)
 				qdel(mover) // so the mob inside can GC in case references got freed up since qdel
 			else
 				mover.set_loc(null)
-
-/turf/simulated/swampgrass
-	name = "reedy grass"
-	desc = ""
-	icon = 'icons/misc/worlds.dmi'
-	icon_state = "swampgrass"
-
-	New()
-		..()
-		set_dir(pick(1,2,4,8))
-		return
-
-/turf/simulated/swampgrass_edging
-	name = "reedy grass"
-	desc = ""
-	icon = 'icons/misc/worlds.dmi'
-	icon_state = "swampgrass_edge"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

seven of the random maintenance rooms had airless tiles along with one of them having airless and unsimulated tiles, which results in sections of maints occasionally having no air. this pr fixes that!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

breathing is cool!

