### PR TITLE
Stocks now fluctuate 10 times as fast and have quicker events

### DIFF
--- a/code/modules/economy/stocks/stock_events.dm
+++ b/code/modules/economy/stocks/stock_events.dm
@@ -35,7 +35,7 @@ ABSTRACT_TYPE(/datum/stock/event)
 	New(datum/stock/ticker/S)
 		..()
 		company = S
-		var/mins = rand(5,20)
+		var/mins = rand(2,5)
 		next_phase = mins * 600 + (ticker?.round_elapsed_ticks ? ticker.round_elapsed_ticks : 0)
 		current_title = "Product demo"
 		current_desc = S.industry.detokenize("[S.name] will unveil a new product on an upcoming %industrial% conference held at spacetime [spacetime(next_phase)]")
@@ -72,7 +72,7 @@ ABSTRACT_TYPE(/datum/stock/event)
 		..()
 		hidden = TRUE
 		company = S
-		var/mins = rand(9,60)
+		var/mins = rand(3,7)
 		bailout_millions = rand(70, 190)
 		next_phase = mins * 600 + (ticker?.round_elapsed_ticks ? ticker.round_elapsed_ticks : 0)
 		current_title = ""
@@ -152,7 +152,7 @@ ABSTRACT_TYPE(/datum/stock/event)
 		..()
 		hidden = TRUE
 		company = S
-		var/mins = rand(10, 35)
+		var/mins = rand(1, 10)
 		next_phase = mins * 600 + (ticker?.round_elapsed_ticks ? ticker.round_elapsed_ticks : 0)
 		current_title = ""
 		current_desc = ""

--- a/code/modules/economy/stocks/stock_tickers.dm
+++ b/code/modules/economy/stocks/stock_tickers.dm
@@ -13,7 +13,7 @@
 	/// The current performance of the company. Tends itself to 0 when no events happen.
 	var/performance = 0
 	/// How much the price fluctuates on an average daily basis
-	var/fluctuational_coefficient = 1
+	var/fluctuational_coefficient = 10
 	/// The history of shareholder optimism of this stock
 	var/average_optimism = 0
 	var/current_trend = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As the title implies, makes stocks fluctuate more dramatically. Makes events much shorter, as well.

Goonstation's stock market is a surprisingly in-depth simulation, and a lot of people don't ever use it (or use it and have no fun whatsoever), because of how painstakingly long things take to change. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Was requested in https://forum.ss13.co/showthread.php?tid=23356. Was further requested by someone talking to me in-game about it.

Stocks move _LETHARGICALLY_ slow. While it's realistic, it just isn't fun. Nobody likes to see thousandth decimal places gradually count up or down. Similarly, events take ridiculously long-- a full, real life hour or half an hour is just mind-numbing.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)NightmarechaMillian
(+)Stocks now fluctuate 10 times harder, events are shorter.
```
