### PR TITLE
Armory Authorization causes red alert.

### DIFF
--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -22,8 +22,8 @@ TYPEINFO(/obj/machinery/shipalert)
 
 	var/usageState = 0 // 0 = glass cover, hammer. 1 = glass cover, no hammer. 2 = cover smashed
 	var/working = FALSE //processing loops
-	var/cooldownPeriod = 3 SECONDS //5 minutes, change according to player abuse
-	var/deactivateCooldown = 3 SECONDS // 30 seconds, no instantly taking it back
+	var/cooldownPeriod = 5 MINUTES //5 minutes, change according to player abuse
+	var/deactivateCooldown = 30 SECONDS // 30 seconds, no instantly taking it back
 	var/max_msg_length = 200 //half of a command alert
 
 	New()

--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -22,14 +22,16 @@ TYPEINFO(/obj/machinery/shipalert)
 
 	var/usageState = 0 // 0 = glass cover, hammer. 1 = glass cover, no hammer. 2 = cover smashed
 	var/working = FALSE //processing loops
-	var/cooldownPeriod = 5 MINUTES //5 minutes, change according to player abuse
-	var/deactivateCooldown = 30 SECONDS //no instantly taking it back
+	var/cooldownPeriod = 3 SECONDS //5 minutes, change according to player abuse
+	var/deactivateCooldown = 3 SECONDS // 30 seconds, no instantly taking it back
 	var/max_msg_length = 200 //half of a command alert
 
 	New()
 		..()
 		src.name = "[capitalize(station_or_ship())] Alert Button"
 		UnsubscribeProcess()
+		RegisterSignal(GLOBAL_SIGNAL, COMSIG_GLOBAL_ARMORY_AUTH, PROC_REF(activate))
+		RegisterSignal(GLOBAL_SIGNAL, COMSIG_GLOBAL_ARMORY_UNAUTH, PROC_REF(deactivate))
 
 /obj/machinery/shipalert/attack_hand(mob/user)
 	if (user.stat || isghostdrone(user) || !isliving(user) || isintangible(user))
@@ -98,35 +100,12 @@ TYPEINFO(/obj/machinery/shipalert)
 			boutput(user, SPAN_ALERT("The alert coils are still in high-power mode, please wait to lift alert."))
 			src.working = FALSE
 			return FALSE
-		else
-			//centcom alert
-			command_alert("The emergency is over. Return to your regular duties.", "Alert - All Clear", alert_origin = ALERT_STATION)
-
-			//toggle off
-			shipAlertState = SHIP_ALERT_GOOD
-
-			// set status displays to default
-			var/datum/signal/status_signal = get_free_signal()
-			status_signal.data["sender"] = "00000000"
-			status_signal.data["command"] = STATUS_DISPLAY_PACKET_MODE_DISPLAY_DEFAULT
-			status_signal.data["address_tag"] = "STATDISPLAY"
-			radio_controller.get_frequency(FREQ_STATUS_DISPLAY).post_packet_without_source(status_signal)
-
-			src.update_lights()
-
-			ON_COOLDOWN(src, "alert_cooldown", src.cooldownPeriod)
-			. = TRUE
-
+		. = src.deactivate(user, TRUE)
 	else
 		if (GET_COOLDOWN(src, "alert_cooldown"))
 			boutput(user, SPAN_ALERT("The alert coils are still priming themselves."))
 			src.working = FALSE
 			return FALSE
-
-		//alert and siren
-#ifdef MAP_OVERRIDE_MANTA
-		command_alert("This is not a drill. This is not a drill. General Quarters, General Quarters. All hands man your battle stations. Crew without military training shelter in place. Set material condition '[rand(1, 100)]-[pick_string("station_name.txt", "militaryLetters")]' throughout the ship. The route of travel is forward and up to starboard, down and aft to port. Prepare for hostile contact.", "NSS Manta - General Quarters")
-#else //frick manta, no reason for you
 		var/reason
 		// no flockdrones, critters, etc
 		if(!ishuman(user))
@@ -137,25 +116,7 @@ TYPEINFO(/obj/machinery/shipalert)
 			src.working = FALSE
 			return FALSE
 		reason = sanitize(adminscrub(reason, src.max_msg_length))
-		command_alert("All personnel, this is not a test. There is a confirmed, hostile threat on-board and/or near the station: [reason]. Report to your stations. Prepare for the worst.", "Alert - Condition Red", alert_origin = ALERT_STATION)
-#endif
-		playsound_global(world, soundGeneralQuarters, 100, pitch = 0.9) //lower pitch = more serious or something idk
-		//toggle on
-		shipAlertState = SHIP_ALERT_BAD
-
-		// status display red alert
-		var/datum/signal/status_signal = get_free_signal()
-		status_signal.data["sender"] = "00000000"
-		status_signal.data["command"] = STATUS_DISPLAY_PACKET_MODE_DISPLAY_ALERT
-		status_signal.data["address_tag"] = "STATDISPLAY"
-		status_signal.data["picture_state"] = STATUS_DISPLAY_PACKET_ALERT_REDALERT
-		radio_controller.get_frequency(FREQ_STATUS_DISPLAY).post_packet_without_source(status_signal)
-
-		ON_COOLDOWN(src, "deactivate_cooldown", src.deactivateCooldown)
-		src.update_lights()
-		src.do_lockdown(user)
-		. = TRUE
-
+		. = src.activate(user, reason, TRUE)
 	//alertWord stuff would go in a dedicated proc for extension
 	var/alertWord = "green"
 	if (shipAlertState == SHIP_ALERT_BAD)
@@ -164,6 +125,55 @@ TYPEINFO(/obj/machinery/shipalert)
 	logTheThing(LOG_STATION, user, "toggled the ship alert to \"[alertWord]\"")
 	message_admins("[user] toggled the ship alert to \"[alertWord]\"")
 	src.working = FALSE
+
+/obj/machinery/shipalert/proc/activate(mob/user, var/reason, var/announce = FALSE)
+	if (shipAlertState == SHIP_ALERT_BAD)
+		return FALSE
+	//alert and siren
+	if (announce)
+#ifdef MAP_OVERRIDE_MANTA
+		command_alert("This is not a drill. This is not a drill. General Quarters, General Quarters. All hands man your battle stations. Crew without military training shelter in place. Set material condition '[rand(1, 100)]-[pick_string("station_name.txt", "militaryLetters")]' throughout the ship. The route of travel is forward and up to starboard, down and aft to port. Prepare for hostile contact.", "NSS Manta - General Quarters")
+#else
+		command_alert("All personnel, this is not a test. There is a confirmed, hostile threat on-board and/or near the station: [reason]. Report to your stations. Prepare for the worst.", "Alert - Condition Red", alert_origin = ALERT_STATION)
+#endif
+		playsound_global(world, soundGeneralQuarters, 100, pitch = 0.9) //lower pitch = more serious or something idk
+	//toggle on
+	shipAlertState = SHIP_ALERT_BAD
+
+	// status display red alert
+	var/datum/signal/status_signal = get_free_signal()
+	status_signal.data["sender"] = "00000000"
+	status_signal.data["command"] = STATUS_DISPLAY_PACKET_MODE_DISPLAY_ALERT
+	status_signal.data["address_tag"] = "STATDISPLAY"
+	status_signal.data["picture_state"] = STATUS_DISPLAY_PACKET_ALERT_REDALERT
+	radio_controller.get_frequency(FREQ_STATUS_DISPLAY).post_packet_without_source(status_signal)
+
+	ON_COOLDOWN(src, "deactivate_cooldown", src.deactivateCooldown)
+	src.update_lights()
+	src.do_lockdown(user)
+	. = TRUE
+
+/obj/machinery/shipalert/proc/deactivate(mob/user,var/announce = FALSE)
+	if (shipAlertState == SHIP_ALERT_GOOD)
+		return FALSE
+	//centcom alert
+	if (announce)
+		command_alert("The emergency is over. Return to your regular duties.", "Alert - All Clear", alert_origin = ALERT_STATION)
+
+	//toggle off
+	shipAlertState = SHIP_ALERT_GOOD
+
+	// set status displays to default
+	var/datum/signal/status_signal = get_free_signal()
+	status_signal.data["sender"] = "00000000"
+	status_signal.data["command"] = STATUS_DISPLAY_PACKET_MODE_DISPLAY_DEFAULT
+	status_signal.data["address_tag"] = "STATDISPLAY"
+	radio_controller.get_frequency(FREQ_STATUS_DISPLAY).post_packet_without_source(status_signal)
+
+	src.update_lights()
+
+	ON_COOLDOWN(src, "alert_cooldown", src.cooldownPeriod)
+	. = TRUE
 
 /obj/machinery/shipalert/proc/update_lights()
 	for(var/obj/machinery/light/emergency/light in by_cat[TR_CAT_STATION_EMERGENCY_LIGHTS])


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the red alert activation and deactivition in obj/machinery/shipalert to their own procs rather than inside toggleActivation
Authorizing armory activates red alert, deauthing cancels it (without announcement, armory already has a unique announcement)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Armory auth is a far more trustworthy form of red alert and if its being authed it should declare red alert.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Authorizing armory now activates red alert.
```
