### PR TITLE
Adds a framework for luck based prob calculation

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -181,6 +181,7 @@
 #include "machinery.dm"
 #include "map.dm"
 #include "math.dm"
+#include "macros\luck.dm"
 #include "matrix.dm"
 #include "parallax.dm"
 #include "pathfinding.dm"

--- a/_std/defines/atom.dm
+++ b/_std/defines/atom.dm
@@ -116,3 +116,10 @@
 #define UNDERFLOOR 1
 /// The atom is above the floor tiles.
 #define OVERFLOOR 2
+
+var/global/global_luck = 1
+
+#define local_luck ((GET_ATOM_PROPERTY(src, PROP_ATOM_LUCK) + GET_ATOM_PROPERTY(usr, PROP_ATOM_LUCK) + global.global_luck) / 3)
+#define luckprob(x) (prob(x) || prob(local_luck * 10) && prob(x))
+#define luckprob_bad(x) (prob(x) && !(prob(local_luck * 10)))
+#undef local_luck

--- a/_std/defines/atom.dm
+++ b/_std/defines/atom.dm
@@ -116,10 +116,3 @@
 #define UNDERFLOOR 1
 /// The atom is above the floor tiles.
 #define OVERFLOOR 2
-
-var/global/global_luck = 1
-
-#define local_luck ((GET_ATOM_PROPERTY(src, PROP_ATOM_LUCK) + GET_ATOM_PROPERTY(usr, PROP_ATOM_LUCK) + global.global_luck) / 3)
-#define luckprob(x) (prob(x) || prob(local_luck * 10) && prob(x))
-#define luckprob_bad(x) (prob(x) && !(prob(local_luck * 10)))
-#undef local_luck

--- a/_std/macros/atom_properties.dm
+++ b/_std/macros/atom_properties.dm
@@ -317,6 +317,7 @@ To remove:
 ///for tracking if a borg/cyborg frame was a roundstart one, for stats purposes
 #define PROP_ATOM_ROUNDSTART_BORG(x) x("rounstart_borg", APPLY_ATOM_PROPERTY_SIMPLE, REMOVE_ATOM_PROPERTY_SIMPLE)
 
+#define PROP_ATOM_LUCK(x) x("luck", APPLY_ATOM_PROPERTY_SUM, REMOVE_ATOM_PROPERTY_SUM)
 
 // In lieu of comments, these are the indexes used for list access in the macros below.
 #define ATOM_PROPERTY_ACTIVE_VALUE 1

--- a/_std/macros/luck.dm
+++ b/_std/macros/luck.dm
@@ -1,0 +1,38 @@
+var/global/global_luck = 0
+
+#define LOCAL_LUCK(thing) (GET_ATOM_PROPERTY(thing, PROP_ATOM_LUCK) + GET_ATOM_PROPERTY(usr, PROP_ATOM_LUCK) + global.global_luck)
+
+#define LUCK_CALC(x, probfunc) (probfunc(x) || probfunc(LOCAL_LUCK(local_object) * 10) && probfunc(x))
+#define BAD_LUCK_CALC(x, probfunc) (probfunc(x) && !(probfunc(LOCAL_LUCK(local_object) * 10) && probfunc(100 - x)))
+
+//couldn't figure out a way to build this entirely out of macros so we'll deal with the proc overhead for now
+// #define luckprob(prob_value, local_object, mult...) !isnull(mult) ? LUCK_CALC(prob_value, probmult) : LUCK_CALC(prob_value, prob)
+
+///Used when luck should make the chance MORE likely (ie you get candy if it succeeds)
+/proc/luckprob(prob_value, atom/local_object = src, mult = null)
+	if (!isnull(mult))
+		return LUCK_CALC(prob_value, probmult)
+	else
+		return LUCK_CALC(prob_value, prob)
+
+///Used when luck should make the chance LESS likely (ie you DIE INSTANTLY if it succeeds)
+/proc/badluckprob(prob_value, atom/local_object = src, mult = null)
+	if (!isnull(mult))
+		return BAD_LUCK_CALC(prob_value, probmult)
+	else
+		return BAD_LUCK_CALC(prob_value, prob)
+
+#undef LOCAL_LUCK
+#undef LUCK_CALC
+#undef BAD_LUCK_CALC
+
+
+/datum/targetable/make_lucky
+	name = "Make lucky"
+	targeted = TRUE
+	target_anything = TRUE
+
+	cast(atom/target)
+		. = ..()
+		APPLY_ATOM_PROPERTY(target, PROP_ATOM_LUCK, usr, 10)
+		target.color = "green"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INTERNAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new atom property `PROP_ATOM_LUCK` along with `prob` replacement procs that take it into account.
Each point of luck adds 10% to the chance of re-rolling the original roll.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Neat idea, might be useful for Things. Will need adding to a LOT of places before it is.
