### PR TITLE
standardize drains under surgical tables

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -15859,6 +15859,7 @@
 	name = "Autopsy Table"
 	},
 /obj/landmark/start/job/medical_doctor,
+/obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "dHN" = (
@@ -24115,11 +24116,6 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/medical/staff)
-"jZa" = (
-/obj/machinery/drainage,
-/obj/landmark/start/job/medical_doctor,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
 "jZr" = (
 /obj/table/auto,
 /obj/item/rods/steel{
@@ -24216,7 +24212,6 @@
 /obj/submachine/chef_sink/chem_sink{
 	pixel_y = 8
 	},
-/obj/machinery/drainage,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -36092,6 +36087,7 @@
 /obj/machinery/optable{
 	id = "OR1"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/redwhite{
 	dir = 8
 	},
@@ -37787,6 +37783,7 @@
 /obj/machinery/ai_status_display{
 	pixel_y = 28
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/redwhite{
 	dir = 9
 	},
@@ -68094,7 +68091,7 @@ bsL
 lfY
 brX
 obg
-jZa
+pmh
 kVT
 fAz
 lLh

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -10805,7 +10805,6 @@
 /obj/cable{
 	icon_state = "5-10"
 	},
-/obj/machinery/drainage,
 /turf/simulated/floor/white,
 /area/station/medical/medbooth)
 "aNk" = (
@@ -31212,6 +31211,7 @@
 /obj/machinery/optable{
 	id = "robotics"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "cil" = (
@@ -34767,6 +34767,7 @@
 /area/station/science/testchamber)
 "ctP" = (
 /obj/machinery/optable,
+/obj/machinery/drainage,
 /turf/simulated/floor/shuttlebay{
 	name = "test chamber plating"
 	},
@@ -34941,6 +34942,7 @@
 /obj/machinery/optable{
 	id = "OR1"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cuo" = (
@@ -35467,6 +35469,7 @@
 /obj/machinery/optable{
 	id = "OR2"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "cwe" = (
@@ -37184,10 +37187,6 @@
 	dir = 8
 	},
 /area/station/medical/medbay/surgery)
-"cCT" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/black,
-/area/station/medical/robotics)
 "cCV" = (
 /obj/window/reinforced{
 	dir = 2
@@ -46449,6 +46448,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/light_switch/east,
+/obj/machinery/drainage,
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -46638,7 +46638,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple,
 /obj/disposalpipe/segment/morgue,
-/obj/machinery/drainage,
 /obj/machinery/computer/operating/small{
 	id = "OR1"
 	},
@@ -48500,7 +48499,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple,
 /obj/disposalpipe/segment/morgue,
-/obj/machinery/drainage,
 /obj/machinery/computer/operating/small{
 	id = "OR2"
 	},
@@ -105593,7 +105591,7 @@ cca
 cdl
 ceB
 dfG
-cCT
+ceB
 cik
 ceB
 dHk

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -54308,6 +54308,7 @@
 	desc = "A precision instrument for biological research.";
 	name = "dissection knife"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/engine{
 	dir = 6;
 	icon_state = "engine_caution_misc"
@@ -69015,6 +69016,7 @@
 /obj/machinery/optable{
 	name = "Autopsy Table"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/sanitary/blue,
 /area/station/medical/morgue)
 "qVa" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -6845,6 +6845,7 @@
 /obj/machinery/optable{
 	name = "Autopsy Table"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "bWY" = (
@@ -32111,10 +32112,6 @@
 /obj/disposalpipe/junction/left/east,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/east)
-"jHF" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/white,
-/area/station/medical/medbooth)
 "jHO" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
@@ -37221,7 +37218,6 @@
 	icon_state = "pipe-c";
 	name = "crematorium pipe"
 	},
-/obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "lmX" = (
@@ -47471,6 +47467,7 @@
 "ops" = (
 /obj/decal/stripe_caution,
 /obj/machinery/optable,
+/obj/machinery/drainage,
 /turf/simulated/floor/shuttlebay{
 	name = "test chamber plating"
 	},
@@ -58477,6 +58474,7 @@
 /obj/blind_switch/area/south{
 	pixel_x = 4
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbooth)
 "rGo" = (
@@ -134993,7 +134991,7 @@ oyi
 gcu
 lNp
 lNp
-jHF
+lNp
 rGf
 wst
 rdj

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -24828,6 +24828,7 @@
 /obj/machinery/optable{
 	name = "Autopsy Table"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "bVT" = (
@@ -27597,6 +27598,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "chX" = (
@@ -30134,10 +30136,6 @@
 	dir = 1
 	},
 /area/station/crew_quarters/quarters_south)
-"crq" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/engine,
-/area/station/science/testchamber)
 "csd" = (
 /obj/machinery/disposal/morgue{
 	desc = "A pneumatic delivery chute for sending a prisoner's items to their release zone.";
@@ -30393,6 +30391,7 @@
 /obj/machinery/optable{
 	id = "robotics"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "czm" = (
@@ -30416,10 +30415,6 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"czV" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/robotics)
 "czW" = (
 /obj/disposalpipe/segment/transport,
 /turf/space,
@@ -48809,10 +48804,6 @@
 /obj/item/device/radio/intercom/engineering,
 /turf/simulated/floor/engine/caution/north,
 /area/station/engine/core)
-"pKT" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
 "pLb" = (
 /obj/machinery/atmospherics/binary/pump/active{
 	dir = 8;
@@ -53044,6 +53035,7 @@
 	pixel_y = -1;
 	rand_pos = 0
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbooth)
 "sMK" = (
@@ -87116,7 +87108,7 @@ abZ
 chw
 chB
 dnP
-crq
+chS
 qrw
 kQR
 chw
@@ -95541,7 +95533,7 @@ oGg
 axG
 baC
 bbC
-pKT
+bGb
 bGb
 qIt
 bfZ
@@ -95857,7 +95849,7 @@ bfZ
 rUu
 chN
 coo
-czV
+con
 czk
 boV
 bxK

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -23011,6 +23011,7 @@
 /area/station/crew_quarters/pool)
 "jFB" = (
 /obj/machinery/optable,
+/obj/machinery/drainage,
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
 "jFU" = (
@@ -26809,6 +26810,7 @@
 /obj/machinery/optable{
 	id = "robotics"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "lix" = (
@@ -30867,7 +30869,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "mNV" = (
-/obj/machinery/drainage,
 /obj/machinery/computer/operating/small{
 	id = "robotics"
 	},

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -2037,13 +2037,13 @@
 /obj/item/device/analyzer/healthanalyzer,
 /obj/item/scissors/surgical_scissors,
 /obj/item/scissors/surgical_scissors,
-/obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "agT" = (
 /obj/machinery/optable{
 	id = "robotics"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "agU" = (

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -10895,7 +10895,6 @@
 /obj/cable{
 	icon_state = "6-9"
 	},
-/obj/machinery/drainage,
 /turf/simulated/floor/white,
 /area/station/medical/medbooth)
 "aya" = (
@@ -15597,6 +15596,7 @@
 /obj/machinery/optable{
 	id = "OR2"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "aKE" = (
@@ -23480,6 +23480,7 @@
 /obj/machinery/optable{
 	id = "OR1"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "beu" = (
@@ -31785,10 +31786,6 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
-"bDe" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/black,
-/area/station/medical/robotics)
 "bDf" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -31812,10 +31809,6 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
-"bDl" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
 "bDm" = (
 /obj/machinery/atmospherics/pipe/simple{
 	level = 2
@@ -33940,6 +33933,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -36644,6 +36638,7 @@
 /area/station/medical/medbay/surgery)
 "bNJ" = (
 /obj/machinery/optable,
+/obj/machinery/drainage,
 /turf/simulated/floor/shuttlebay{
 	name = "test chamber plating"
 	},
@@ -36652,6 +36647,7 @@
 /obj/machinery/optable{
 	id = "robotics"
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "bNL" = (
@@ -36659,6 +36655,7 @@
 	name = "Autopsy Table"
 	},
 /obj/item/storage/box/body_bag,
+/obj/machinery/drainage,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "bNM" = (
@@ -52583,7 +52580,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple,
 /obj/disposalpipe/segment/morgue,
-/obj/machinery/drainage,
 /obj/machinery/computer/operating/small{
 	id = "OR2"
 	},
@@ -61784,7 +61780,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple,
 /obj/disposalpipe/segment/morgue,
-/obj/machinery/drainage,
 /obj/machinery/computer/operating/small{
 	id = "OR1"
 	},
@@ -113810,7 +113805,7 @@ aKv
 cCn
 chA
 cwU
-bDl
+cwU
 cwU
 aLi
 bbA
@@ -116825,7 +116820,7 @@ cCp
 cpX
 crp
 beo
-bDe
+crp
 bNK
 crp
 beB

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -4251,6 +4251,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/optable,
+/obj/machinery/drainage,
 /turf/simulated/floor/white,
 /area/station/medical/medbooth)
 "bRL" = (
@@ -6233,6 +6234,7 @@
 	},
 /obj/machinery/optable,
 /obj/item/paper/book/from_file/medical_surgery_guide,
+/obj/machinery/drainage,
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/medical/medbay/surgery)
 "cND" = (
@@ -42889,6 +42891,7 @@
 	pixel_y = 21
 	},
 /obj/machinery/optable,
+/obj/machinery/drainage,
 /turf/simulated/floor/blue,
 /area/station/medical/robotics)
 "sUb" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

makes all drains that appear near surgical tables spawn underneath them instead

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

around half of drains already show up under the surgical tables but the other half have them on the tile over or within the area. drains that aren't directly under the table leave an annoying blood puddle that coats patients in blood when you lay them down on it, angering the patient. makes more sense for them to always show up beneath them instead of only some times


