### PR TITLE
Fix underwater lighting for some special areas

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -777,6 +777,9 @@ ABSTRACT_TYPE(/area/shuttle)
 /area/shuttle/john/diner
 	name = "John's Bus Diner Dock"
 	icon_state = "shuttle"
+	#ifdef UNDERWATER_MAP
+	ambient_light = OCEAN_LIGHT
+	#endif
 
 /area/shuttle/john/diner/nadir
 	name = "John's Bus Station Dock"

--- a/code/modules/economy/supply_misc.dm
+++ b/code/modules/economy/supply_misc.dm
@@ -9,6 +9,7 @@ ABSTRACT_TYPE(/area/supply)
 
 	#ifdef UNDERWATER_MAP
 	color = OCEAN_COLOR
+	ambient_light = OCEAN_LIGHT
 	#endif
 
 /area/supply/delivery_point //the area supplies are fired at
@@ -18,6 +19,7 @@ ABSTRACT_TYPE(/area/supply)
 
 	#ifdef UNDERWATER_MAP
 	color = OCEAN_COLOR
+	ambient_light = OCEAN_LIGHT
 	#endif
 
 /area/supply/sell_point //the area where supplies move from the station z level
@@ -27,6 +29,7 @@ ABSTRACT_TYPE(/area/supply)
 
 	#ifdef UNDERWATER_MAP
 	color = OCEAN_COLOR
+	ambient_light = OCEAN_LIGHT
 	#endif
 
 	Entered(var/atom/movable/AM)

--- a/code/obj/machinery/shield_generators/shield_generator.dm
+++ b/code/obj/machinery/shield_generators/shield_generator.dm
@@ -10,6 +10,9 @@ TYPEINFO(/area/station/shield_zone)
 	requires_power = FALSE
 	minimaps_to_render_on = null
 	occlude_foreground_parallax_layers = FALSE
+	#ifdef UNDERWATER_MAP
+	ambient_light = OCEAN_LIGHT
+	#endif
 
 /* ==================== Generator ==================== */
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
For some areas that are in the ocean on underwater maps, set the ambient light to `OCEAN_LIGHT` while on an underwater map:
* Supply buy/sell/target points
* John's Bus diner dock (on station z-level for underwater maps)
* Station shield (Manta)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #13225