### PR TITLE
Fix wrong category on drone artifacts

### DIFF
--- a/code/obj/artifacts/artifact_machines/robot.dm
+++ b/code/obj/artifacts/artifact_machines/robot.dm
@@ -5,7 +5,7 @@
 /datum/artifact/robot
 	associated_object = /obj/machinery/artifact/robot
 	type_name = "Drone"
-	type_size = ARTIFACT_SIZE_MEDIUM
+	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 200
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,/datum/artifact_trigger/radiation,/datum/artifact_trigger/carbon_touch, /datum/artifact_trigger/language)
 	validtypes = list("ancient")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
They're showing up in the hand-held section because I forgot to set the size properly.
