### PR TITLE
Prevents changelings from releasing a headspider in nullspace after being loafed

### DIFF
--- a/code/modules/disposals/disposal.dm
+++ b/code/modules/disposals/disposal.dm
@@ -1234,9 +1234,9 @@ TYPEINFO(/obj/disposalpipe/loafer)
 						newLoaf.loaf_factor += (newLoaf.loaf_factor / 10) + 50
 					if(!isdead(M))
 						M:emote("scream")
-					M.death()
-					if (M.mind || M.client)
+					if (M.mind || M.client) // Swapped ghostize and death to keep changelings from headspider-ing from a qdel'd body
 						M.ghostize()
+					M.death()
 				else if (isitem(newIngredient))
 					var/obj/item/I = newIngredient
 					newLoaf.loaf_factor += I.w_class * 5

--- a/code/modules/disposals/disposal.dm
+++ b/code/modules/disposals/disposal.dm
@@ -1234,7 +1234,7 @@ TYPEINFO(/obj/disposalpipe/loafer)
 						newLoaf.loaf_factor += (newLoaf.loaf_factor / 10) + 50
 					if(!isdead(M))
 						M:emote("scream")
-					if (M.mind || M.client) // Swapped ghostize and death to keep changelings from headspider-ing from a qdel'd body
+					if (M.mind || M.client)
 						M.ghostize()
 					M.death()
 				else if (isitem(newIngredient))


### PR DESCRIPTION
[Station Systems][Bug][Minor]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Swaps ghostize() and death() in the loafer code, preventing changelings from being able to release a headspider after being qdel'd

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being trapped in nullspace SUCKS