### PR TITLE
Add staff bonuses to bank computer

### DIFF
--- a/code/obj/machinery/computer/bank_records.dm
+++ b/code/obj/machinery/computer/bank_records.dm
@@ -271,36 +271,36 @@
 						boutput(usr, SPAN_ALERT("NT Regulations forbid issuing multiple staff incentives within five minutes."))
 						return
 
-					var/amount = input(usr, "How many credits should we issue to each staff member?", "Issue Bonus", 100) as null|num
-					if(isnull(amount)) return
+					var/bonus = input(usr, "How many credits should we issue to each staff member?", "Issue Bonus", 100) as null|num
+					if(isnull(bonus)) return
 
-					amount = ceil(clamp(amount, 1, 999999))
-					var/bonus_amt = (length(data_core.bank.records) * amount)
-					if ( bonus_amt > wagesystem.station_budget)
+					bonus = ceil(clamp(bonus, 1, 999999))
+					var/bonus_total = (length(data_core.bank.records) * bonus)
+					if ( bonus_total > wagesystem.station_budget)
 						//Let the user know the budget is too small before they set the reason if we can
-						boutput(usr, SPAN_ALERT("Total bonus cost would be [bonus_amt][CREDIT_SIGN], payroll budget is only [wagesystem.station_budget][CREDIT_SIGN]!"))
+						boutput(usr, SPAN_ALERT("Total bonus cost would be [bonus_total][CREDIT_SIGN], payroll budget is only [wagesystem.station_budget][CREDIT_SIGN]!"))
 						return
 					var/message = input(usr, "What is the reason for this staff bonus?", "Bonus Reason") as text
 					if(isnull(message) || message == "")
 						boutput(usr, SPAN_ALERT("NT Regulations require that the reason for issuing a staff bonus be recorded."))
 						return
 
-					if(isnull(amount) || bonus_amt > wagesystem.station_budget)
+					if(isnull(bonus)|| isnull(bonus_total) || bonus_total > wagesystem.station_budget)
 						//Something ain't right but it could be a coincidence
 						//Maybe someone stole the budget under our feet, or payroll was issued
-						boutput(usr, SPAN_ALERT("Total bonus cost would be [bonus_amt][CREDIT_SIGN], payroll budget is only [wagesystem.station_budget][CREDIT_SIGN]!"))
+						boutput(usr, SPAN_ALERT("Total bonus cost would be [bonus_total][CREDIT_SIGN], payroll budget is only [wagesystem.station_budget][CREDIT_SIGN]!"))
 						return
 
-					logTheThing(LOG_STATION, usr, "issued a bonus of [amount][CREDIT_SIGN] ([bonus_amt][CREDIT_SIGN] total) to the staff.")
+					logTheThing(LOG_STATION, usr, "issued a bonus of [bonus][CREDIT_SIGN] ([bonus_total][CREDIT_SIGN] total) to the staff.")
 					src.bonus_rate_limit_time = world.time + (5 MINUTES)
-					command_announcement("[message]<br>Bonus of [amount][CREDIT_SIGN] issued to all staff.", "Payroll Annoucment by [scan.registered] ([scan.assignment])")
-					wagesystem.station_budget = wagesystem.station_budget - bonus_amt
+					command_announcement("[message]<br>Bonus of [bonus][CREDIT_SIGN] issued to all staff.", "Payroll Annoucment by [scan.registered] ([scan.assignment])")
+					wagesystem.station_budget = wagesystem.station_budget - bonus_total
 					for(var/datum/db_record/R as anything in data_core.bank.records)
 						if(R["job"] == "Clown")
 							//Tax the clown
-							R["current_money"] = (R["current_money"] + ceil((amount / 2)))
+							R["current_money"] = (R["current_money"] + ceil((bonus / 2)))
 							return
-						R["current_money"] = (R["current_money"] + amount)
+						R["current_money"] = (R["current_money"] + bonus)
 
 
 		src.add_fingerprint(usr)

--- a/code/obj/machinery/computer/bank_records.dm
+++ b/code/obj/machinery/computer/bank_records.dm
@@ -280,14 +280,17 @@
 						//Let the user know the budget is too small before they set the reason if we can
 						boutput(usr, SPAN_ALERT("Total bonus cost would be [bonus_total][CREDIT_SIGN], payroll budget is only [wagesystem.station_budget][CREDIT_SIGN]!"))
 						return
+
 					var/message = input(usr, "What is the reason for this staff bonus?", "Bonus Reason") as text
 					if(isnull(message) || message == "")
 						boutput(usr, SPAN_ALERT("NT Regulations require that the reason for issuing a staff bonus be recorded."))
 						return
 
-					if(isnull(bonus)|| isnull(bonus_total) || bonus_total > wagesystem.station_budget)
-						//Something ain't right but it could be a coincidence
-						//Maybe someone stole the budget under our feet, or payroll was issued
+					//Something ain't right  if we enter either of these but it could be a coincidence
+					//Maybe someone stole the budget under our feet, or payroll was issued
+					if(isnull(bonus)|| isnull(bonus_total))
+						return
+					if(bonus_total > wagesystem.station_budget)
 						boutput(usr, SPAN_ALERT("Total bonus cost would be [bonus_total][CREDIT_SIGN], payroll budget is only [wagesystem.station_budget][CREDIT_SIGN]!"))
 						return
 

--- a/code/obj/machinery/computer/bank_records.dm
+++ b/code/obj/machinery/computer/bank_records.dm
@@ -26,7 +26,11 @@
 		"Catering" = list(/datum/job/civilian/chef, /datum/job/civilian/bartender, /datum/job/special/souschef, /datum/job/daily/waiter),
 		"Hydroponics" = list(/datum/job/civilian/botanist, /datum/job/civilian/rancher),
 		"Security" = list(/datum/job/security, /datum/job/command/head_of_security),
-		"Medical" = list(/datum/job/research/medical_doctor, /datum/job/research/medical_assistant, /datum/job/command/medical_director)
+		"Medical" = list(/datum/job/research/medical_doctor, /datum/job/research/medical_assistant, /datum/job/command/medical_director),
+		"Civilian" = list(/datum/job/civilian/janitor, /datum/job/civilian/chaplain, /datum/job/civilian/staff_assistant, /datum/job/civilian/clown,\
+		/datum/job/special) //Who really makes the world go round? At least one of these guys
+							//I can live with the sous chef getting paid in two categories
+							//If you have a special role and you're on the manifest everything is probably normal
 	)
 
 	attack_ai(mob/user as mob)

--- a/code/obj/machinery/computer/bank_records.dm
+++ b/code/obj/machinery/computer/bank_records.dm
@@ -289,6 +289,8 @@
 					//Something ain't right  if we enter either of these but it could be a coincidence
 					//Maybe someone stole the budget under our feet, or payroll was issued
 					if(isnull(bonus)|| isnull(bonus_total))
+						//No you really shouldn't be here
+						logTheThing(LOG_ADMIN, usr, "may have attempted href hacking. Do not take this as a guarantee.")
 						return
 					if(bonus_total > wagesystem.station_budget)
 						boutput(usr, SPAN_ALERT("Total bonus cost would be [bonus_total][CREDIT_SIGN], payroll budget is only [wagesystem.station_budget][CREDIT_SIGN]!"))

--- a/code/obj/machinery/computer/bank_records.dm
+++ b/code/obj/machinery/computer/bank_records.dm
@@ -290,7 +290,6 @@
 					//Maybe someone stole the budget under our feet, or payroll was issued
 					if(isnull(bonus)|| isnull(bonus_total))
 						//No you really shouldn't be here
-						logTheThing(LOG_ADMIN, usr, "may have attempted href hacking Bank Computer. Do not take this as a guarantee.")
 						return
 					if(bonus_total > wagesystem.station_budget)
 						boutput(usr, SPAN_ALERT("Total bonus cost would be [bonus_total][CREDIT_SIGN], payroll budget is only [wagesystem.station_budget][CREDIT_SIGN]!"))

--- a/code/obj/machinery/computer/bank_records.dm
+++ b/code/obj/machinery/computer/bank_records.dm
@@ -290,7 +290,7 @@
 					//Maybe someone stole the budget under our feet, or payroll was issued
 					if(isnull(bonus)|| isnull(bonus_total))
 						//No you really shouldn't be here
-						logTheThing(LOG_ADMIN, usr, "may have attempted href hacking. Do not take this as a guarantee.")
+						logTheThing(LOG_ADMIN, usr, "may have attempted href hacking Bank Computer. Do not take this as a guarantee.")
 						return
 					if(bonus_total > wagesystem.station_budget)
 						boutput(usr, SPAN_ALERT("Total bonus cost would be [bonus_total][CREDIT_SIGN], payroll budget is only [wagesystem.station_budget][CREDIT_SIGN]!"))

--- a/code/obj/machinery/computer/bank_records.dm
+++ b/code/obj/machinery/computer/bank_records.dm
@@ -298,7 +298,7 @@
 
 					logTheThing(LOG_STATION, usr, "issued a bonus of [bonus][CREDIT_SIGN] ([bonus_total][CREDIT_SIGN] total) to the staff.")
 					src.bonus_rate_limit_time = world.time + (5 MINUTES)
-					command_announcement("[message]<br>Bonus of [bonus][CREDIT_SIGN] issued to all staff.", "Payroll Annoucment by [scan.registered] ([scan.assignment])")
+					command_announcement("[message]<br>Bonus of [bonus][CREDIT_SIGN] issued to all staff.", "Payroll Announcement by [scan.registered] ([scan.assignment])")
 					wagesystem.station_budget = wagesystem.station_budget - bonus_total
 					for(var/datum/db_record/R as anything in data_core.bank.records)
 						if(R["job"] == "Clown")

--- a/code/obj/machinery/computer/bank_records.dm
+++ b/code/obj/machinery/computer/bank_records.dm
@@ -304,8 +304,8 @@
 						if(R["job"] == "Clown")
 							//Tax the clown
 							R["current_money"] = (R["current_money"] + ceil((bonus / 2)))
-							return
-						R["current_money"] = (R["current_money"] + bonus)
+						else
+							R["current_money"] = (R["current_money"] + bonus)
 
 
 		src.add_fingerprint(usr)

--- a/code/obj/machinery/computer/bank_records.dm
+++ b/code/obj/machinery/computer/bank_records.dm
@@ -16,7 +16,7 @@
 	var/static/bonus_rate_limit_time = 0 //prevent bonus spam because these have an annoucement
 	///I know we already have department job lists but they suck and are brittle and way too general so I made my own here
 	var/static/list/departments = list(
-		"Stationwide" = list(/datum/job/), //hacky, yet generic
+		"Stationwide" = list(),
 		"Genetics" = list(/datum/job/research/geneticist),
 		"Robotics" = list(/datum/job/research/roboticist),
 		"Cargo" = list(/datum/job/engineering/quartermaster, /datum/job/civilian/mail_courier),
@@ -294,6 +294,9 @@
 
 					var/list/datum/db_record/lucky_crew = list()
 					for (var/datum/db_record/record in data_core.bank.records)
+						if(department == "Stationwide")
+							lucky_crew += record
+							continue
 						for (var/job_type in src.departments[department])
 							for (var/datum/job/child_type as anything in concrete_typesof(job_type))
 								if (record["job"] == child_type::name)

--- a/code/obj/machinery/computer/bank_records.dm
+++ b/code/obj/machinery/computer/bank_records.dm
@@ -277,11 +277,18 @@
 					amount = ceil(clamp(amount, 1, 999999))
 					var/bonus_amt = (length(data_core.bank.records) * amount)
 					if ( bonus_amt > wagesystem.station_budget)
+						//Let the user know the budget is too small before they set the reason if we can
 						boutput(usr, SPAN_ALERT("Total bonus cost would be [bonus_amt][CREDIT_SIGN], payroll budget is only [wagesystem.station_budget][CREDIT_SIGN]!"))
 						return
 					var/message = input(usr, "What is the reason for this staff bonus?", "Bonus Reason") as text
 					if(isnull(message) || message == "")
 						boutput(usr, SPAN_ALERT("NT Regulations require that the reason for issuing a staff bonus be recorded."))
+						return
+
+					if(isnull(amount) || bonus_amt > wagesystem.station_budget)
+						//Something ain't right but it could be a coincidence
+						//Maybe someone stole the budget under our feet, or payroll was issued
+						boutput(usr, SPAN_ALERT("Total bonus cost would be [bonus_amt][CREDIT_SIGN], payroll budget is only [wagesystem.station_budget][CREDIT_SIGN]!"))
 						return
 
 					logTheThing(LOG_STATION, usr, "issued a bonus of [amount][CREDIT_SIGN] ([bonus_amt][CREDIT_SIGN] total) to the staff.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a button to the bank computer to pay a bonus to the entire staff from the payroll budget. It creates an announcement when used, and is restricted to only being available every five minutes.

![image](https://github.com/user-attachments/assets/a14646d9-66d2-44f9-a7f3-24ccd8f2800b)

![image](https://github.com/user-attachments/assets/3c19c5df-a375-4b86-9352-33a476eb96a5)

The clown is taxed at 50% for their pleasure.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The station can end up with a lot of money and generally it would be nice to be able to issue a bonus to the crew for good performance or comedy

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)patricia
(*)The HoP bank computer can now issue bonuses to department staff, or stationwide!

```
