### PR TITLE
Trying to help a paralyzed person reacts like they're dead.

### DIFF
--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -20,6 +20,9 @@
 		src.help_put_out_fire(M)
 	else if (src == M && src.getStatusDuration("burning"))
 		M.resist()
+	else if (src != M && M.hasStatus("paralysis")) // we "dead"
+		src.visible_message(SPAN_ALERT("<B>[src] tries to perform CPR, but it's too late for [M]!</B>"))
+		return
 	//If we use an empty hand on a cut up person, we might wanna rip out their organs by hand
 	else if (surgeryCheck(M, src) && M.organHolder?.chest?.op_stage >= 2 && ishuman(src))
 		if (M.organHolder.build_region_buttons())


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][chemistry]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When attempting to help someone paralyzed, you act as though they are dead. i.e. "...tries to perform CPR, but it's too late for X!"


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Capulettium makes you death-gasp, but anyone green-handing you will immediately know you're not dead as they attempt to shake you awake. While reagent and health scans will still reveal the ruse, to random crew in the halls it will look even more like you're dead.

This gives RP lings (and other poisoners) some pluasibility while carrying their victims "to medbay".