### PR TITLE
Blind skeleton head can still see if it has a VISOR on

### DIFF
--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -235,6 +235,11 @@
 		if (G.allow_blind_sight)
 			return 1
 
+	if (isskeleton(src))
+		var/datum/mutantrace/skeleton/skele = src.mutantrace
+		if (skele.head_tracker?.glasses?.allow_blind_sight)
+			return 1
+
 	if ((src.bioHolder && src.bioHolder.HasEffect("blind")) || src.blinded || src.get_eye_damage(1) || (src.organHolder && !src.organHolder.left_eye && !src.organHolder.right_eye && !isskeleton(src)))
 		return 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mutantrace][trait]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
In the case where you are blind and a skeleton and you have removed your head, if your detached head has glasses that allow you to see while blinded (i.e. VISOR) then you get to see.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #13159