### PR TITLE
Fixes changelings being trapped in nullspace after getting loafed

### DIFF
--- a/code/modules/disposals/disposal.dm
+++ b/code/modules/disposals/disposal.dm
@@ -1234,9 +1234,9 @@ TYPEINFO(/obj/disposalpipe/loafer)
 						newLoaf.loaf_factor += (newLoaf.loaf_factor / 10) + 50
 					if(!isdead(M))
 						M:emote("scream")
-					M.death()
 					if (M.mind || M.client)
 						M.ghostize()
+					M.death()
 				else if (isitem(newIngredient))
 					var/obj/item/I = newIngredient
 					newLoaf.loaf_factor += I.w_class * 5


### PR DESCRIPTION
[Station Systems][Respawning][Bug][Minor]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR moves death() to be after ghostize() when a mob is loafed, preventing changelings from being trapped in nullspace when trying to release a headspider from a qdel'd body. Video of the bug attached:

https://github.com/user-attachments/assets/3a152ed7-3f91-49b3-92c9-c1d6bf65d6ad

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Getting trapped in nullspace isn't so good...