### PR TITLE
Full-size Nuclear bombs declare red alert.

### DIFF
--- a/_std/defines/component_defines/component_defines_global.dm
+++ b/_std/defines/component_defines/component_defines_global.dm
@@ -21,6 +21,11 @@
 	/// Armory computer unauthorized
 	#define COMSIG_GLOBAL_ARMORY_UNAUTH "armory_auth_removed"
 
+// ---- nukes ----
+
+	/// "Nuke" sized nuke planted on station Z
+	#define COMSIG_GLOBAL_NUKE_PLANTED "nuclear_bomb_planted"
+
 // ---- ඞ ----
 
 /// ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⣤⣤⣤⣤⣤⣶⣦⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠀

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -201,6 +201,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 		src.anchored = ANCHORED
 		if (src.z == Z_LEVEL_STATION && src.boom_size == "nuke")
 			src.change_status_display()
+			SEND_GLOBAL_SIGNAL(COMSIG_GLOBAL_NUKE_PLANTED)
 		if (!src.image_light)
 			src.image_light = image(src.icon, "nblightc")
 			for(var/obj/bomb_or_decoy as anything in get_self_and_decoys())

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -200,8 +200,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 		src.armed = TRUE
 		src.anchored = ANCHORED
 		if (src.z == Z_LEVEL_STATION && src.boom_size == "nuke")
-			src.change_status_display()
 			SEND_GLOBAL_SIGNAL(COMSIG_GLOBAL_NUKE_PLANTED)
+			src.change_status_display()
 		if (!src.image_light)
 			src.image_light = image(src.icon, "nblightc")
 			for(var/obj/bomb_or_decoy as anything in get_self_and_decoys())

--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -30,6 +30,9 @@ TYPEINFO(/obj/machinery/shipalert)
 		..()
 		src.name = "[capitalize(station_or_ship())] Alert Button"
 		UnsubscribeProcess()
+
+		// Global signals that declare red alert automatically
+		RegisterSignal(GLOBAL_SIGNAL, COMSIG_GLOBAL_NUKE_PLANTED, PROC_REF(activate))
 		RegisterSignal(GLOBAL_SIGNAL, COMSIG_GLOBAL_ARMORY_AUTH, PROC_REF(activate))
 		RegisterSignal(GLOBAL_SIGNAL, COMSIG_GLOBAL_ARMORY_UNAUTH, PROC_REF(deactivate))
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds COMSIG_GLOBAL_NUKE_PLANTED which is broadcasted when a "nuke" size nuke is planted (e.g. the one in Nuclear Emergency, but not the micronuke found in surplus crates)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The nuke already has a custom status display, it makes sense it would declare a red alert and cause big red emergency lights


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Full-size Nuclear Bombs being planted cause red alert.
```
