### PR TITLE
Virutal / test dummy mob deaths don't count against spacemas cheer

### DIFF
--- a/_std/macros/ismob.dm
+++ b/_std/macros/ismob.dm
@@ -45,6 +45,7 @@
 #define ishelpermouse(x) (istype(x, /mob/living/critter/small_animal/mouse/weak/mentor))//mentor and admin mice
 #define islivingobject(x) (istype(x, /mob/living/object)) //! Is a possessed object
 #define is_dead_or_ghost_role(M) (isdead(M) || (isVRghost(M) || isghostcritter(M) || inafterlife(M) || isghostdrone(M)))
+#define istestdummy(x) (istype(x, /mob/living/carbon/human/tdummy))
 
 /// Returns true if x is a new player mob (what u r if ur in the lobby screen, usually)
 #define isnewplayer(x) (istype(x, /mob/new_player))

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -732,7 +732,7 @@
 	if (!HAS_ATOM_PROPERTY(src, PROP_MOB_SUPPRESS_DEATH_SOUND))
 		emote("deathgasp") //let the world KNOW WE ARE DEAD
 
-	if (!inafterlife(src) && current_state >= GAME_STATE_PLAYING) // prevent corpse spawners from reducing cheer; TODO: better fix
+	if (!inafterlife(src) && !istestdummy(src) && !isvirtual(src) && current_state >= GAME_STATE_PLAYING) // prevent corpse spawners from reducing cheer; TODO: better fix
 		modify_christmas_cheer(-7)
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][holiday]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Add a new ismob check for test dummies `istestdummy`
* In `/death` Add a check for `istestdummy` and `isvirtual` before reducing christmas cheer


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The VR Murder Box includes a test dummy spawn button, so this should cover everything in VR.
Fix #21555
Fix #12260
