### PR TITLE
Weightlifter barbell sprite should appear above mob

### DIFF
--- a/code/obj/item/fitness.dm
+++ b/code/obj/item/fitness.dm
@@ -124,12 +124,8 @@
 			APPLY_ATOM_PROPERTY(user, PROP_MOB_CANTMOVE, "fitness_machine")
 			user.set_dir(SOUTH)
 			user.set_loc(src.loc)
-			var/obj/decal/W = new /obj/decal
-			W.icon = 'icons/obj/stationobjs.dmi'
-			W.icon_state = "fitnessweight-w"
-			W.set_loc(loc)
-			W.anchored = ANCHORED
-			W.layer = MOB_LAYER_BASE+1
+			var/image/new_overlay = src.SafeGetOverlayImage("barbell", 'icons/obj/stationobjs.dmi', "fitnessweight-w", MOB_LAYER + 1)
+			src.UpdateOverlays(new_overlay, "barbell")
 			var/bragmessage = pick("pushing it to the limit","going into overdrive","burning with determination","rising up to the challenge", "getting strong now","getting ripped")
 			user.visible_message(SPAN_ALERT("<B>[user] is [bragmessage]!</B>"))
 			var/reps = 0
@@ -158,6 +154,6 @@
 					H.sims.affectMotive("fun", 4)
 			var/finishmessage = pick("You feel stronger!","You feel like you can take on the world!","You feel robust!","You feel indestructible!")
 			icon_state = "fitnessweight"
-			qdel(W)
+			src.UpdateOverlays(null, "barbell")
 			boutput(user, SPAN_NOTICE("[finishmessage]"))
 			user.changeStatus("fitness_stam_max", 100 SECONDS)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game-objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace the barbell decal object with an overlay

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #11041