### PR TITLE
Null global camo matrix on syndie colour reset

### DIFF
--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2865,6 +2865,7 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 				logTheThing(LOG_DIARY, src, "changed the syndicate colour scheme.", "admin")
 				message_admins("[key_name(src)] changed the syndicate colour scheme.")
 			if ("Reset")
+				nuke_op_camo_matrix = null
 				for (var/atom/A as anything in by_cat[TR_CAT_NUKE_OP_STYLE])
 					A.color = null
 					var/obj/item/Item = A


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
sets the global nuke_op_camo_matrix back to null upon resetting syndicate colour with the "recolor syndicate" admin command


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
New objects in the tracking category will recolour themselves according to the global nuke_op_camo_matrix so it needs to be reset.
