### PR TITLE
Fix Hooty McJudgementowl Frowning at Ghosts

### DIFF
--- a/code/obj/machinery/owlhoot.dm
+++ b/code/obj/machinery/owlhoot.dm
@@ -66,7 +66,7 @@
 		if (prob(5)) // I stole this from the automaton because I am a dirty code frankenstein
 			var/list/mob/mobs_nearby = list()
 			for (var/mob/M as anything in viewers(7, src))
-				if (iswraith(M) || isintangible(M))
+				if (!isliving(M) || isintangible(M))
 					continue
 				mobs_nearby += M
 			if(length(mobs_nearby))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[bug][game objects]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

adds an !isliving check to hooty's process to prevent frowning at ghosts, this replaces the iswraith check because wraiths are intangible and are covered by the isintangible check

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

fixes #21598