### PR TITLE
Fix "Scannner" typo in Security Weapons Vendor

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -408,7 +408,7 @@
 	description = "One case of 40mm Paint Marker Rounds, totalling 5 rounds, for the Riot Launcher."
 
 /datum/materiel/utility/prisonerscanner
-	name = "RecordTrak Scannner"
+	name = "RecordTrak Scanner"
 	path = /obj/item/device/prisoner_scanner
 	description = "A device used to scan in prisoners and update their security records."
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[bug][game objects]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes "RecordTrak Scannner" to "RecordTrak Scanner" in the Security Weapons Vendor

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Typos are bad!


