### PR TITLE
Prevent ghostcritters from triggering language arts

### DIFF
--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -531,6 +531,8 @@
 	var/datum/artifact_trigger/language/trigger = locate(/datum/artifact_trigger/language) in src.artifact.triggers
 	if (!trigger || GET_DIST(M, src) > 2)
 		return
+	if (isghostcritter(M))
+		return
 	if (ON_COOLDOWN(src, "speech_act_cd", 2 SECONDS))
 		return
 	var/result = trigger.speech_act(text)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a check to langauge-trigger artifacts to prevent ghostcritters from activating them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21502