### PR TITLE
Fix sun tea renaming itself to tea

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -4191,6 +4191,10 @@ datum
 			reagent_state = LIQUID
 			thirst_value = 0.8
 
+			reaction_temperature(exposed_temperature, exposed_volume)
+				return // avoid renaming in parent
+
+
 		fooddrink/kombucha
 			name = "kombucha"
 			id = "kombucha"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][chemistry]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Have sun tea override its parent tea reaction_temperature to avoid its renaming behavior. Sun tea is always sun tea, even if it's cold or hot.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21461
