### PR TITLE
Fix blue barrette clothing booth swatch

### DIFF
--- a/code/modules/clothingbooth/items/head.dm
+++ b/code/modules/clothingbooth/items/head.dm
@@ -14,7 +14,7 @@ ABSTRACT_TYPE(/datum/clothingbooth_item/head/barrettes)
 
 	blue
 		name = "Blue"
-		swatch_background_color = "#10a789"
+		swatch_background_color = "#3d92f4"
 		item_path = /obj/item/clothing/head/barrette/blue
 
 	gold


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][ui]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace duplicated green swatch with blue color-picked from barrette sprite.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21463
