### PR TITLE
Fix thermal vision showing dead critters as alive

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -882,6 +882,7 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 			src.visible_message(SPAN_ALERT("<b>[src]</b> dies!"))
 		setdead(src)
 		icon_state = icon_state_dead ? icon_state_dead : "[icon_state]-dead"
+		src.update_body()
 	empty_hands()
 	if (do_drop_equipment)
 		drop_equipment()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][critters]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Call update_body on mobcritter death, which will regenerate mob silhouettes and static image group used for thermalmk2 vision

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #16589
Fix #21408
