### PR TITLE
Nuclear Turbine flicker reduction

### DIFF
--- a/code/obj/nuclearreactor/turbine.dm
+++ b/code/obj/nuclearreactor/turbine.dm
@@ -151,6 +151,7 @@
 		else
 			if(abs(src._last_rpm_icon_update - src.RPM) > 10)
 				src._last_rpm_icon_update = src.RPM
+				// reduce image flicker while clients download the generated icon
 				var/image/old_icon
 				if(src.icon_state == "turbine_spin_speed")
 					old_icon = src.SafeGetOverlayImage("old_icon", src.icon, "turbine_spin_speed", src.layer-0.1)

--- a/code/obj/nuclearreactor/turbine.dm
+++ b/code/obj/nuclearreactor/turbine.dm
@@ -151,11 +151,14 @@
 		else
 			if(abs(src._last_rpm_icon_update - src.RPM) > 10)
 				src._last_rpm_icon_update = src.RPM
-				var/image/old_icon = src.SafeGetOverlayImage("old_icon", src.icon, "turbine_spin_speed", src.layer-0.1)
-				if(old_icon)
-					src.AddOverlays(old_icon, "old_icon")
-					SPAWN(0.5 SECONDS)
-						src.ClearSpecificOverlays("old_icon")
+				var/image/old_icon
+				if(src.icon_state == "turbine_spin_speed")
+					old_icon = src.SafeGetOverlayImage("old_icon", src.icon, "turbine_spin_speed", src.layer-0.1)
+				else
+					old_icon = src.SafeGetOverlayImage("old_icon", src.icon, "turbine_main", src.layer-0.1)
+				src.AddOverlays(old_icon, "old_icon")
+				SPAWN(0.5 SECONDS)
+					src.ClearSpecificOverlays("old_icon")
 				src.icon = src.generate_icon()
 				src.icon_state = "turbine_spin_speed"
 				UpdateIcon()

--- a/code/obj/nuclearreactor/turbine.dm
+++ b/code/obj/nuclearreactor/turbine.dm
@@ -151,6 +151,11 @@
 		else
 			if(abs(src._last_rpm_icon_update - src.RPM) > 10)
 				src._last_rpm_icon_update = src.RPM
+				var/image/old_icon = src.SafeGetOverlayImage("old_icon", src.icon, "turbine_spin_speed", src.layer-0.1)
+				if(old_icon)
+					src.AddOverlays(old_icon, "old_icon")
+					SPAWN(0.5 SECONDS)
+						src.ClearSpecificOverlays("old_icon")
 				src.icon = src.generate_icon()
 				src.icon_state = "turbine_spin_speed"
 				UpdateIcon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Borrows a trick used in `nuclearreactor.dm` to reduce grid overlay flicker; yeet the current icon into an underlay and show it for half a second while the new icon generates/downloads.

Testmerge recommended; hard to verify it'll do the job locally since the issue is affected by server download latency.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #18469