### PR TITLE
Gang objective & graffiti speed overhaul

### DIFF
--- a/_std/defines/gang.dm
+++ b/_std/defines/gang.dm
@@ -34,12 +34,15 @@
 #define GANG_STARTING_POINTS 1500
 
 /// number of spray bottles gangs start with in their locker, excluding the 2 in the recruitment briefcase
-#define GANG_STARTING_SPRAYPAINT 0
+#define GANG_STARTING_SPRAYPAINT 10
 /// time in seconds between gangs gaining spray bottles
-#define GANG_SPRAYPAINT_REGEN 7.5 MINUTES
+#define GANG_SPRAYPAINT_REGEN 30 MINUTES
 /// number of spray paints that are granted in this interval
-#define GANG_SPRAYPAINT_REGEN_QUANTITY 3
-
+#define GANG_SPRAYPAINT_REGEN_QUANTITY 5
+/// time to tag on an unclaimed tile
+#define GANG_SPRAYPAINT_TAG_TIME 3 SECONDS
+/// time to spray over an existing gang member's tag
+#define GANG_SPRAYPAINT_TAG_REPLACE_TIME 15 SECONDS
 
 /// Drug points:
 
@@ -84,11 +87,11 @@
 
 
 #ifdef RP_MODE
-#define GANG_LOOT_INITIAL_DROP 10 MINUTES //! when the first gang duffel bag spawns on RP
-#define GANG_LOOT_DROP_FREQUENCY 15 MINUTES //! how often gang duffel bags are dropped on RP
+#define GANG_LOOT_INITIAL_DROP 15 MINUTES //! when the first vandalism objectives are assigned on RP
+#define GANG_LOOT_DROP_FREQUENCY 30 MINUTES //! how often vandalism objectives are assigned on RP
 #else
-#define GANG_LOOT_INITIAL_DROP 5 MINUTES //! when the first gang duffel bag spawns on classic
-#define GANG_LOOT_DROP_FREQUENCY 15 MINUTES //! how often gang duffel bags are dropped on classic
+#define GANG_LOOT_INITIAL_DROP 8 MINUTES //! when the first vandalism objectives are assigned on classic
+#define GANG_LOOT_DROP_FREQUENCY 20 MINUTES //! how often vandalism objectives are assigned on classic
 #endif
 #define GANG_LOOT_DROP_VOLUME_PER_GANG 2 //! how many duffel bags spawn, per gang
 
@@ -186,6 +189,11 @@
 	#define GANG_TAG_SIGHT_RANGE 6
 #endif
 
+
+// code-related stuff
+#define GANG_CLAIM_INVALID 0
+#define GANG_CLAIM_VALID 1 /// spraying in a valid zone
+#define GANG_CLAIM_TAKEOVER 2 /// spraying over another tag
 // shorthands for range calcs
 #define GANG_TAG_INFLUENCE_SQUARED GANG_TAG_INFLUENCE*GANG_TAG_INFLUENCE
 #define GANG_TAG_SIGHT_RANGE_SQUARED GANG_TAG_SIGHT_RANGE*GANG_TAG_SIGHT_RANGE

--- a/code/datums/controllers/process/gang.dm
+++ b/code/datums/controllers/process/gang.dm
@@ -36,8 +36,12 @@
 		if (istype(ticker.mode, /datum/game_mode/gang))
 			var/datum/game_mode/gang/gamemode = ticker.mode
 			broadcast_to_all_gangs("Each gang has [GANG_SPRAYPAINT_REGEN_QUANTITY > 1 ? "extra spray cans" : "an extra spray can" ] available from their locker.")
+			var/nextTime = round((TIME + GANG_SPRAYPAINT_REGEN)/10 ,1)
+			var/timestring = "[(nextTime / 60) % 60]:[add_zero(num2text(nextTime % 60), 2)]"
+
 			for(var/datum/gang/gang as anything in gamemode.gangs)
 				gang.spray_paint_remaining += GANG_SPRAYPAINT_REGEN_QUANTITY
+				gang.next_spray_paint_restock = timestring
 
 
 /datum/controller/process/gang_launder_money

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -240,6 +240,8 @@ proc/broadcast_to_all_gangs(var/message)
 	var/datum/generic_radio_source/announcer_source
 	/// The radio headset that the gang's announcer will use.
 	var/obj/item/device/radio/headset/gang/announcer_radio
+	/// String displayed to show the next spray paint restock
+	var/next_spray_paint_restock ="--:--"
 
 	/// The chosen name of this gang.
 	var/gang_name = "Gang Name"
@@ -989,6 +991,7 @@ proc/broadcast_to_all_gangs(var/message)
 				boutput(user, SPAN_ALERT("This is too close to your locker!"))
 				return
 
+		var/tagging_over = FALSE
 		var/obj/decal/gangtag/existingTag
 		for (var/obj/decal/gangtag/turfTag in target.contents)
 			if (turfTag.active)
@@ -1004,12 +1007,14 @@ proc/broadcast_to_all_gangs(var/message)
 					if (locker.gang == user.get_gang())
 						validLocation = TRUE
 				for_by_tcl(otherTag, /obj/decal/gangtag)
+					//if we can see one of our own tags in 2x the influence, then these tags are touching
 					if(!IN_EUCLIDEAN_RANGE(otherTag, target, GANG_TAG_INFLUENCE*2)) continue
 					if (otherTag.owners && otherTag.owners == user.get_gang() && otherTag.active)
 						validLocation = TRUE
+						tagging_over = TRUE
 			else
 				boutput(user, SPAN_ALERT("You can't spray over your own tags!"))
-				return
+				return GANG_CLAIM_INVALID
 		else
 			//we're tagging, check it's in our territory and not someone else's territory
 			for_by_tcl(tag, /obj/decal/gangtag)
@@ -1019,45 +1024,51 @@ proc/broadcast_to_all_gangs(var/message)
 				else if (tag.owners && tag.active)
 					boutput(user, SPAN_ALERT("You can't spray in another gang's territory! Spray over their tag, instead!"))
 					if (user.GetComponent(/datum/component/tracker_hud))
-						return
+						return GANG_CLAIM_INVALID
 					var/datum/game_mode/gang/mode = ticker.mode
 					if (!istype(mode))
-						return
+						return GANG_CLAIM_INVALID
 					user.AddComponent(/datum/component/tracker_hud/gang, get_turf(tag))
 					SPAWN(3 SECONDS)
 						var/datum/component/tracker_hud/gang/component = user.GetComponent(/datum/component/tracker_hud/gang)
 						component.RemoveComponent()
-					return
+					return GANG_CLAIM_INVALID
 			for_by_tcl(locker, /obj/ganglocker)
 				if(!IN_EUCLIDEAN_RANGE(locker, target, GANG_TAG_INFLUENCE_LOCKER)) continue
 				if (locker.gang == user.get_gang())
 					validLocation = TRUE
 				else
 					boutput(user, SPAN_ALERT("There's better places to tag than near someone else's locker! "))
-					return
+					return GANG_CLAIM_INVALID
 
 		if(!validLocation)
 			boutput(user, SPAN_ALERT("This is outside your gang's influence!"))
-			return
+			return GANG_CLAIM_INVALID
 
 		var/area/getarea = get_area(target)
 		if(!getarea)
 			boutput(user, SPAN_ALERT("You can't claim this place!"))
-			return
+			return GANG_CLAIM_INVALID
 		if(getarea.name == "Space")
 			boutput(user, SPAN_ALERT("You can't claim space!"))
-			return
+			return GANG_CLAIM_INVALID
 		if(getarea.name == "Ocean")
 			boutput(user, SPAN_ALERT("You can't claim the entire ocean!"))
-			return
+			return GANG_CLAIM_INVALID
 		if((getarea.teleport_blocked) || istype(getarea, /area/supply) || istype(getarea, /area/shuttle/))
 			boutput(user, SPAN_ALERT("You can't claim this place!"))
-			return
+			return GANG_CLAIM_INVALID
 		if(!ishuman(user))
 			boutput(user, SPAN_ALERT("You don't have the dexterity to spray paint a gang tag!"))
-			return
+			return GANG_CLAIM_INVALID
 
-		return validLocation
+		if (validLocation)
+			if (tagging_over)
+				return GANG_CLAIM_TAKEOVER
+			else
+				return GANG_CLAIM_VALID
+
+		return GANG_CLAIM_INVALID
 
 	proc/do_gang_tag(target, mob/user)
 		if(!istype(target,/turf) && !istype(target,/obj/decal/gangtag)) return
@@ -1080,10 +1091,13 @@ proc/broadcast_to_all_gangs(var/message)
 		if(!gang)
 			boutput(user, SPAN_ALERT("You aren't in a gang, why would you do that?"))
 			return
-
-		if (check_tile_unclaimed(turftarget, user))
+		var/gang_claim = check_tile_unclaimed(turftarget, user)
+		if (gang_claim == GANG_CLAIM_TAKEOVER)
+			user.visible_message(SPAN_ALERT("[user] begins to spray over a gang tag on the [turftarget.name]!"))
+			actions.start(new/datum/action/bar/icon/spray_gang_tag(turftarget, src, TRUE), user)
+		else if (gang_claim == GANG_CLAIM_VALID)
 			user.visible_message(SPAN_ALERT("[user] begins to paint a gang tag on the [turftarget.name]!"))
-			actions.start(new/datum/action/bar/icon/spray_gang_tag(turftarget, src), user)
+			actions.start(new/datum/action/bar/icon/spray_gang_tag(turftarget, src, FALSE), user)
 /obj/item/spray_paint_graffiti
 	name = "'ProPaint' spray paint can"
 	desc = "A can of gloss spray paint. Great for doing wicked sick art. Not so great when the janitor shows up."
@@ -1218,7 +1232,7 @@ proc/broadcast_to_all_gangs(var/message)
 			add_target(user, turftarget)
 
 /datum/action/bar/icon/spray_gang_tag
-	duration = 15 SECONDS
+	duration = GANG_SPRAYPAINT_TAG_TIME
 	interrupt_flags = INTERRUPT_STUNNED
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "spraycan"
@@ -1232,10 +1246,12 @@ proc/broadcast_to_all_gangs(var/message)
 	/// when our next spray sound can beplayed
 	var/next_spray = 0 DECI SECONDS
 
-	New(var/turf/target_turf as turf, var/obj/item/spray_paint_gang/can)
+	New(var/turf/target_turf as turf, var/obj/item/spray_paint_gang/can, var/tag_over)
 		src.target_turf = target_turf
 		src.target_area = get_area(target_turf)
 		src.spraycan = can
+		if (tag_over)
+			src.duration = GANG_SPRAYPAINT_TAG_REPLACE_TIME
 		..()
 
 	onStart()
@@ -1564,7 +1580,10 @@ proc/broadcast_to_all_gangs(var/message)
 		<div style="width: 100%; overflow: hidden;">
 			<div style="height: 150px;width: 290px;padding-left: 5px;; float: left;border-style: solid; text-align: center;">
 				<center style="padding-top: 25px;"><font size="5"><a href='byond://?src=\ref[src];get_gear=1'>Get gear</a></font></center><br>
-				<font size="3">The gang has [gang.spray_paint_remaining] spray paints remaining.</font>
+				<font size="3">The gang has [gang.spray_paint_remaining] spray paints remaining.
+				<br>
+				<font size="3">Spray paint will restock at [gang.next_spray_paint_restock].
+				</font>
 				<center><font size="5"><a href='byond://?src=\ref[src];get_spray=1'>Grab spraypaint</a></font></center><br>
 			</div>
 			<div>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Makes restocks slower for tags
- Gangs start with more tags.
- Tagging now takes 3 seconds on unclaimed tiles (down from 15 seconds)
- Loot drops happen less often


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Tagging gets a lot of newbies in trouble, and probably shouldn't. Tagging over other players' tags is also an issue.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(*)Gangs tag way faster over unclaimed areas.
(*)Gangs start with more tags, and restock more tags less frequently.
(+)Gang loot events have more spacing between them.
(+)Gangs can now see the next restock time for graffiti.
```
