### PR TITLE
No UI Solar Controller

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -305,12 +305,6 @@
 				src.output = clamp(text2num_safe(target), 0 , SMESMAXOUTPUT)
 				. = TRUE
 
-/proc/rate_control(var/S, var/V, var/C, var/Min=1, var/Max=5, var/Limit=null)
-	var/href = "<A href='?src=\ref[S];rate control=1;[V]"
-	var/rate = "[href]=-[Max]'>-</A>[href]=-[Min]'>-</A> [(C?C : 0)] [href]=[Min]'>+</A>[href]=[Max]'>+</A>"
-	if (Limit) return "[href]=-[Limit]'>-</A>"+rate+"[href]=[Limit]'>+</A>"
-	return rate
-
 /obj/machinery/power/smes/smart
 	name = "Dianmu smart power storage unit"
 	icon_state = "smes_smart"

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -340,7 +340,7 @@ TYPEINFO(/obj/machinery/power/solar)
 	if (src.is_active_and_powered())
 		src.tracker_update(tracker.sun_angle)
 
-	src.update_solar_icon()
+	src.UpdateIcon()
 
 /obj/machinery/computer/solar_control/get_desc()
 	. = "<br />It is currently <em>[src.is_active_and_powered() ? "tracking the sun" : "disabled"]</em>"
@@ -351,17 +351,17 @@ TYPEINFO(/obj/machinery/power/solar)
 /obj/machinery/computer/solar_control/proc/is_active_and_powered()
 	. = active && !(status & (NOPOWER | BROKEN))
 
-/obj/machinery/computer/solar_control/proc/update_solar_icon()
+/obj/machinery/computer/solar_control/update_icon()
+	. = ..()
 	if (src.is_active_and_powered())
 		src.icon_state = initial(src.icon_state)
 	else
 		src.icon_state = "solar0"
-	src.UpdateIcon()
 
 /obj/machinery/computer/solar_control/power_change()
 	..()
 	if (!(src.status & (NOPOWER | BROKEN)))
-		src.update_solar_icon()
+		src.UpdateIcon()
 
 /obj/machinery/computer/solar_control/emag_act(var/mob/user)
 	. = ..()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -257,11 +257,9 @@ TYPEINFO(/obj/machinery/power/solar)
 	var/cdir = 0
 	var/gen = 0
 	var/lastgen = 0
-	var/track = 2			// 0= off  1=timed  2=auto (tracker)
-	var/trackrate = 600		// 300-900 seconds
-	var/trackdir = 1		// 0 =CCW, 1=CW
-	var/nexttime = 0
+	var/active = TRUE
 	var/obj/machinery/power/tracker/tracker
+	var/emagged = FALSE
 
 	north
 		solar_id = "north"
@@ -318,26 +316,13 @@ TYPEINFO(/obj/machinery/power/solar)
 	gen = 0
 	SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "power=[num2text(round(lastgen), 50)]&powerfmt=[engineering_notation(lastgen)]W&angle=[cdir]")
 
-	if(status & (NOPOWER | BROKEN))
-		return
-
-	if(track==1 && nexttime < world.timeofday && trackrate)
-		nexttime = world.timeofday + 3600/abs(trackrate)
-		cdir = (cdir+trackrate/abs(trackrate)+360)%360
-
-		set_panels(cdir)
-
-	src.updateDialog()
-
 
 // called by solar tracker when sun position changes
 /obj/machinery/computer/solar_control/proc/tracker_update(var/angle)
-	if(track != 2 || status & (NOPOWER | BROKEN))
+	if(!active || status & (NOPOWER | BROKEN))
 		return
-	cdir = angle
+	cdir = emagged ? (angle + 180) % 360 : angle
 	set_panels(cdir)
-
-	src.updateDialog()
 
 /obj/machinery/computer/solar_control/attack_hand(mob/user)
 	if(..())
@@ -345,68 +330,33 @@ TYPEINFO(/obj/machinery/power/solar)
 
 	if ( (BOUNDS_DIST(src, user) > 0 ))
 		if (!isAI(user))
-			src.remove_dialog(user)
-			user.Browse(null, "window=solcon")
 			return
 
-	add_fingerprint(user)
-	src.add_dialog(user)
-
-	var/t = "<TT><B>XIANG|GIESEL Photo-Electric Generator Control</B><HR><PRE>"
-	t += "Generated power : [round(lastgen)] W<BR><BR>"
-	t += "<B>Orientation</B>: [rate_control(src,"cdir","[cdir]&deg",1,15)] ([angle2text(cdir)])<BR><BR><BR>"
-
-	t += "<BR><HR><BR><BR>"
-
-	t += "Tracking: "
-	switch(track)
-		if(0)
-			t += "<B>Off</B> <A href='?src=\ref[src];track=1'>Timed</A> <A href='?src=\ref[src];track=2'>Auto</A><BR>"
-		if(1)
-			t += "<A href='?src=\ref[src];track=0'>Off</A> <B>Timed</B> <A href='?src=\ref[src];track=2'>Auto</A><BR>"
-		if(2)
-			t += "<A href='?src=\ref[src];track=0'>Off</A> <A href='?src=\ref[src];track=1'>Timed</A> <B>Auto</B><BR>"
-
-
-	t += "Tracking Rate: [rate_control(src,"tdir","[trackrate] deg/h ([trackrate<0 ? "CCW" : "CW"])",5,30,180)]<BR><BR>"
-	t += "<A href='?src=\ref[src];close=1'>Close</A></TT>"
-	user.Browse(t, "window=solcon")
-	onclose(user, "solcon")
-	return
-
-/obj/machinery/computer/solar_control/Topic(href, href_list)
-	if(..())
-		usr.Browse(null, "window=solcon")
-		src.remove_dialog(usr)
-		return
-	if(href_list["close"] )
-		usr.Browse(null, "window=solcon")
-		src.remove_dialog(usr)
+	if (istype(user.equipped(), /obj/item/card/emag))
 		return
 
-	if(href_list["dir"])
-		cdir = text2num_safe(href_list["dir"])
-		SPAWN(1 DECI SECOND)
-			set_panels(cdir)
+	active = !active
+	if (active)
+		src.tracker_update(tracker.sun_angle)
+		src.icon_state = initial(src.icon_state)
+	else
+		src.icon_state = "solar0"
 
-	if(href_list["rate control"])
-		if(href_list["cdir"])
-			src.cdir = clamp((360+src.cdir+text2num_safe(href_list["cdir"]))%360, 0, 359)
-			SPAWN(1 DECI SECOND)
-				set_panels(cdir)
-		if(href_list["tdir"])
-			src.trackrate = clamp(src.trackrate+text2num_safe(href_list["tdir"]), -7200,7200)
-			if(src.trackrate) nexttime = world.timeofday + 3600/abs(trackrate)
+/obj/machinery/computer/solar_control/get_desc()
+	. = "<br />It is currently: [active ? "tracking the sun" : "disabled"]"
+	. += "<br />Generated power: [round(lastgen)] W"
+	. += "<br />Current Orientation: [cdir]&deg; ([angle2text(cdir)])"
+	. += "<br />Sun Orientation: [tracker.sun_angle]&deg; ([angle2text(tracker.sun_angle)])"
 
-	if(href_list["track"])
-		if(src.trackrate) nexttime = world.timeofday + 3600/abs(trackrate)
-		track = text2num_safe(href_list["track"])
-		if(track == 2)
-			if(tracker) // we keep track of the tracker now
-				cdir = tracker.sun_angle
+/obj/machinery/computer/solar_control/emag_act(var/mob/user)
+	. = ..()
+	if (src.emagged)
+		return
 
-	src.updateUsrDialog()
-	return
+	src.emagged = TRUE
+	user.show_text("You short out the control circuit on [src]!", "blue")
+	if (active)
+		src.tracker_update(tracker.sun_angle)
 
 /obj/machinery/computer/solar_control/proc/set_panels(var/cdir=null)
 	var/datum/powernet/powernet = src.get_direct_powernet()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -360,7 +360,8 @@ TYPEINFO(/obj/machinery/power/solar)
 
 /obj/machinery/computer/solar_control/power_change()
 	..()
-	src.update_solar_icon()
+	if (!(src.status & (NOPOWER | BROKEN)))
+		src.update_solar_icon()
 
 /obj/machinery/computer/solar_control/emag_act(var/mob/user)
 	. = ..()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -336,17 +336,31 @@ TYPEINFO(/obj/machinery/power/solar)
 		return
 
 	active = !active
-	if (active)
+	user.show_text("You [active ? "activate" : "deactivate"] [src]'s solar tracking.", "blue")
+	if (src.is_active_and_powered())
 		src.tracker_update(tracker.sun_angle)
-		src.icon_state = initial(src.icon_state)
-	else
-		src.icon_state = "solar0"
+
+	src.update_solar_icon()
 
 /obj/machinery/computer/solar_control/get_desc()
-	. = "<br />It is currently: [active ? "tracking the sun" : "disabled"]"
+	. = "<br />It is currently <em>[src.is_active_and_powered() ? "tracking the sun" : "disabled"]</em>"
 	. += "<br />Generated power: [round(lastgen)] W"
 	. += "<br />Current Orientation: [cdir]&deg; ([angle2text(cdir)])"
 	. += "<br />Sun Orientation: [tracker.sun_angle]&deg; ([angle2text(tracker.sun_angle)])"
+
+/obj/machinery/computer/solar_control/proc/is_active_and_powered()
+	. = active && !(status & (NOPOWER | BROKEN))
+
+/obj/machinery/computer/solar_control/proc/update_solar_icon()
+	if (src.is_active_and_powered())
+		src.icon_state = initial(src.icon_state)
+	else
+		src.icon_state = "solar0"
+	src.UpdateIcon()
+
+/obj/machinery/computer/solar_control/power_change()
+	..()
+	src.update_solar_icon()
 
 /obj/machinery/computer/solar_control/emag_act(var/mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that the Solar Controller toggles Off or Auto after being clicked.
Prunes timed tracking mode, and manual angle setting code.
Makes them emaggable, during which they'll track the opposite direction of the sun instead!
State, generated power, current orientation and sun orientation can now be read in the description.

Enabled:
![image](https://github.com/user-attachments/assets/a3cc5ab5-e714-46d3-9f2f-faf3e0e9f9b0)
![image](https://github.com/user-attachments/assets/196c78d5-a863-4925-a8b0-4ae051570011)

Disabled:
![image](https://github.com/user-attachments/assets/21ff7f89-ac32-45d8-aaf1-902fb21e71b2)
![image](https://github.com/user-attachments/assets/0acb9334-d1fb-49c7-9a34-62e81f59272d)

Emagged:
![image](https://github.com/user-attachments/assets/87dfb63e-063e-47ab-8305-0fb1c7219698)
![image](https://github.com/user-attachments/assets/9840c198-8f1b-41aa-844c-1351b598e15b)




## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ease of use
From what I've read, timed mode was a legacy thing before auto got implemented?
Besides grief, I don't see much use for manually setting their angle or fiddling with the tracking rate.
Turning them off or emagging them offers plenty grief opportunities.

Pruned UI:
![261899265-34e7c4c2-c648-4e3a-bb5b-0bbadd2de3b3](https://github.com/user-attachments/assets/98ab6e4c-37d0-4623-8bd3-f869abd3167b)



## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Garash2k
(+)The solar panel controller is now easier to mess with, it can now only be turned on or off... Or emagged! Examine text has all the info it's old UI used to have.
```
[UI][Feature][QoL]