### PR TITLE
Balance: Hall Monitors get a pocket radio for eavesdropping on security.

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1199,9 +1199,10 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_belt = list(/obj/item/device/pda2)
 	slot_jump = list(/obj/item/clothing/under/color/red)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
-	slot_ears = list(/obj/item/device/radio/headset/hall_monitor)
+	slot_ears = list(/obj/item/device/radio/headset/civilian)
 	slot_head = list(/obj/item/clothing/head/basecap/red)
 	slot_poc1 = list(/obj/item/pen/pencil)
+	slot_poc2 = list(/obj/item/device/radio/hall_monitor)
 	items_in_backpack = list(/obj/item/instrument/whistle,/obj/item/device/ticket_writer/crust)
 
 

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -721,6 +721,8 @@ TYPEINFO(/obj/item/radiojammer)
 	desc = "So you can listen to(eavesdrop on) station security(drama)."
 	icon_state = "radio"
 	has_microphone = FALSE
+	frequency = R_FREQ_SECURITY
+	locked_frequency = TRUE
 	secure_frequencies = list("g" = R_FREQ_SECURITY)
 	secure_classes = list("g" = RADIOCL_SECURITY)
 

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -717,7 +717,7 @@ TYPEINFO(/obj/item/radiojammer)
 		..()
 
 /obj/item/device/radio/hall_monitor
-	name = "Hall monitor's bootleg radio"
+	name = "Hall monitor's radio"
 	desc = "So you can listen to(eavesdrop on) station security(drama)."
 	icon_state = "radio"
 	has_microphone = FALSE

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -716,6 +716,14 @@ TYPEINFO(/obj/item/radiojammer)
 			STOP_TRACKING_CAT(TR_CAT_RADIO_JAMMERS)
 		..()
 
+/obj/item/device/radio/hall_monitor
+	name = "Hall monitor's bootleg radio"
+	desc = "So you can listen to(eavesdrop on) station security(drama)."
+	icon_state = "radio"
+	has_microphone = FALSE
+	secure_frequencies = list("g" = R_FREQ_SECURITY)
+	secure_classes = list("g" = RADIOCL_SECURITY)
+
 /obj/item/device/radio/beacon
 	name = "tracking beacon"
 	icon_state = "beacon"

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -429,18 +429,6 @@
 	icon_override = "ghost_buster"
 	icon_tooltip = "Ghost Buster"
 
-/obj/item/device/radio/headset/hall_monitor
-	name = "Hall monitor's headset"
-	desc = "So you can listen to(evesdrop on) station security(drama)."
-	icon_state = "sec headset"
-	secure_frequencies = list("g" = R_FREQ_SECURITY, "c" = R_FREQ_CIVILIAN)
-	secure_classes = list(
-		"g" = RADIOCL_SECURITY,
-		"c" = RADIOCL_CIVILIAN,
-		)
-	icon_override = "civ"
-	icon_tooltip = "Hall Monitor"
-
 /obj/item/device/radio/headset/command/nt/commander
 	name = "\improper NT Commander's headset"
 	desc = "Issued to NanoTrasen Commanders, this radio headset can access several secure radio channels."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game-objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace the hall monitor's security-headset with a microphone-less pocket radio that can hear security's frequency.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some hall monitors are acting like a bonus SecAss. This change allows them to continue eavesdropping on sec lines, but removes their ability to actively coordinate via radio comms.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Hall monitors recieve a pocket radio that can only listen to security's frequency.
```
