### PR TITLE
Prevent packets from opening/closing bolted doors, and responding at all if power cut

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -908,9 +908,6 @@ TYPEINFO(/obj/machinery/door/airlock)
 			return
 
 		if((src.secondsMainPowerLost && src.secondsBackupPowerLost) || !src.powered())
-			SPAWN(0)
-				sleep(src.operation_time)
-				send_status(,senderid)
 			return
 
 		if(lowertext(signal.data["sender"]) == src.net_id)

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -907,6 +907,12 @@ TYPEINFO(/obj/machinery/door/airlock)
 		if(!signal || signal.encryption)
 			return
 
+		if((src.secondsMainPowerLost && src.secondsBackupPowerLost) || !src.powered())
+			SPAWN(0)
+				sleep(src.operation_time)
+				send_status(,senderid)
+			return
+
 		if(lowertext(signal.data["sender"]) == src.net_id)
 			return
 
@@ -983,11 +989,19 @@ TYPEINFO(/obj/machinery/door/airlock)
 		switch( lowertext(signal.data["command"]) )
 			if("open")
 				SPAWN(0)
+					if(src.locked)
+						sleep(src.operation_time)
+						send_status(,senderid)
+						return
 					src.open(1)
 					src.send_status(,senderid)
 
 			if("close")
 				SPAWN(0)
+					if(src.locked)
+						sleep(src.operation_time)
+						send_status(,senderid)
+						return
 					src.close(1)
 					src.send_status(,senderid)
 

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -907,7 +907,7 @@ TYPEINFO(/obj/machinery/door/airlock)
 		if(!signal || signal.encryption)
 			return
 
-		if((src.secondsMainPowerLost && src.secondsBackupPowerLost) || !src.powered())
+		if((!src.arePowerSystemsOn()) || (src.status & NOPOWER))
 			return
 
 		if(lowertext(signal.data["sender"]) == src.net_id)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Add check for door and area power to the top of recieve_signal.
* Add checks for bolted status for regular open/close packet commands


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21628
