### PR TITLE
Fix riot launcher chem/riot grenade wall hits not spreading smoke

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1688,6 +1688,8 @@ datum/projectile/bullet/autocannon
 
 	on_hit(atom/hit, angle, obj/projectile/O)
 		var/turf/T = get_turf(hit)
+		if (T.density) // hit previous (non-dense) turf to spread chems/effects better
+			T = get_turf(get_step(T, turn(angle, 180)))
 		if (T)
 			src.det(T)
 		else if (O)

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1688,9 +1688,9 @@ datum/projectile/bullet/autocannon
 
 	on_hit(atom/hit, angle, obj/projectile/O)
 		var/turf/T = get_turf(hit)
-		if (T.density) // hit previous (non-dense) turf to spread chems/effects better
-			T = get_turf(get_step(T, turn(angle, 180)))
 		if (T)
+			if (T.density) // hit previous (non-dense) turf to spread chems/effects better
+				T = get_turf(get_step(T, turn(angle, 180)))
 			src.det(T)
 		else if (O)
 			var/turf/pT = get_turf(O)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When launching an old/chem grenade from the riot launcher, if it hits a dense turf (i.e. a wall) start the grenade's effect from the previous turf.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Chems spreading from chem grenades (including riot pepper grenades) were trying to spread on a dense wall, causing no smoke to be emitted.
Fix #11018
Fix #12881
