### PR TITLE
Set real_name on generated mail

### DIFF
--- a/code/WorkInProgress/zamu_mail.dm
+++ b/code/WorkInProgress/zamu_mail.dm
@@ -288,6 +288,7 @@
 			package_color = pick("#FFFFAA", "#FFBB88", "#FF8800", "#CCCCFF", "#FEFEFE")
 
 		package.name = "mail for [recipient["name"]] ([recipient["job"]])"
+		package.real_name = package.name
 		var/list/color_list = rgb2num(package_color)
 		for(var/j in 1 to 3)
 			color_list[j] = 127 + (color_list[j] / 2) + rand(-10, 10)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Sets the real_name of mail to the full name + job of the crew member

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes mail stack by person in the Build-A-Vend
![image](https://github.com/user-attachments/assets/93d883e1-d236-459a-9e50-dc0994375ff0)

Fixes #21639

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)patricia
(+)Mail now stacks by person in player built vending machines
```
