### PR TITLE
Adminverb jump now uses tgui_input_list

### DIFF
--- a/code/modules/admin/adminjump.dm
+++ b/code/modules/admin/adminjump.dm
@@ -1,4 +1,4 @@
-/client/proc/Jump(var/area/A in by_type[/area])
+/client/proc/Jump(var/area/A as null|area in by_type[/area])
 	set desc = "Area to jump to"
 	SET_ADMIN_CAT(ADMIN_CAT_SELF)
 	set name = "Jump"
@@ -8,6 +8,8 @@
 	SHOW_VERB_DESC
 
 	if(config.allow_admin_jump)
+		if (!A)
+			A = tgui_input_list(usr, "Where do you want to jump?", "Jump", by_type[/area])
 		if(flourish)
 			shrink_teleport(src.mob)
 		var/turf/origin_turf = get_turf(usr)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[admin]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This only works if you type jump into the bottom. if you click it on the top right the native input list will be used. I don't think it is possible to have both the autocomplete on the bottom and tgui while clicking it
![image](https://github.com/user-attachments/assets/f3719469-5d32-43de-a5f4-195485983c66)
![image](https://github.com/user-attachments/assets/9f3010fc-dda8-4e8b-bf83-5c7de65c5743)

