### PR TITLE
Create a "Ticketing" access level and give it to the Hall Monitor

### DIFF
--- a/_std/defines/access.dm
+++ b/_std/defines/access.dm
@@ -20,7 +20,7 @@
 #define access_medical_lockers 10
 #define access_research_director 11
 #define access_maint_tunnels 12
-#define access_external_airlocks 13 // Unused
+#define access_ticket 13 // issuing tickets
 #define access_emergency_storage 14 // Unused
 #define access_change_ids 15
 #define access_ai_upload 16

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1190,10 +1190,9 @@ ABSTRACT_TYPE(/datum/job/civilian)
 
 /datum/job/special/hall_monitor
 	name = "Hall Monitor"
-	linkcolor = "#FF0000"
 	limit = 2
 	wages = PAY_UNTRAINED
-	access_string = "Security Assistant"
+	access_string = "Staff Assistant"
 	cant_spawn_as_rev = TRUE
 	receives_badge = /obj/item/clothing/suit/security_badge/paper
 	slot_belt = list(/obj/item/device/pda2)

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1192,7 +1192,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	name = "Hall Monitor"
 	limit = 2
 	wages = PAY_UNTRAINED
-	access_string = "Staff Assistant"
+	access_string = "Hall Monitor"
 	cant_spawn_as_rev = TRUE
 	receives_badge = /obj/item/clothing/suit/security_badge/paper
 	slot_belt = list(/obj/item/device/pda2)

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -998,6 +998,8 @@ TYPEINFO(/obj/item/device/prisoner_scanner)
 
 	flags = TABLEPASS | CONDUCT
 	c_flags = ONBELT
+	var/list/required_access = access_security
+	var/paper_icon_state = "paper_caution"
 
 	attack_self(mob/user)
 		var/menuchoice = tgui_alert(user, "What would you like to do?", "Ticket writer", list("Ticket", "Nothing"))
@@ -1016,7 +1018,7 @@ TYPEINFO(/obj/item/device/prisoner_scanner)
 		else if (issilicon(user))
 			var/mob/living/silicon/S = user
 			I = S.botcard
-		if (!I || !(access_security in I.access))
+		if (!I || !(src.required_access in I.access))
 			boutput(user, SPAN_ALERT("Insufficient access."))
 			return
 		playsound(src, 'sound/machines/keyboard3.ogg', 30, TRUE)
@@ -1050,13 +1052,15 @@ TYPEINFO(/obj/item/device/prisoner_scanner)
 			user.put_in_hand_or_drop(p)
 			p.name = "Official Caution - [ticket_target]"
 			p.info = ticket_text
-			p.icon_state = "paper_caution"
+			p.icon_state = src.paper_icon_state
 
 		return T.target_byond_key
 
 /obj/item/device/ticket_writer/crust
 	name = "crusty old security TicketWriter 1000"
 	desc = "An old TicketWriter model held together by hopes and dreams alone."
+	required_access = access_maint_tunnels
+	paper_icon_state = "paper_burned"
 
 TYPEINFO(/obj/item/device/appraisal)
 	mats = 5

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -1059,7 +1059,7 @@ TYPEINFO(/obj/item/device/prisoner_scanner)
 /obj/item/device/ticket_writer/crust
 	name = "crusty old security TicketWriter 1000"
 	desc = "An old TicketWriter model held together by hopes and dreams alone."
-	required_access = access_maint_tunnels
+	required_access = access_fuck_all
 	paper_icon_state = "paper_burned"
 
 TYPEINFO(/obj/item/device/appraisal)

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -998,7 +998,6 @@ TYPEINFO(/obj/item/device/prisoner_scanner)
 
 	flags = TABLEPASS | CONDUCT
 	c_flags = ONBELT
-	var/list/required_access = access_security
 	var/paper_icon_state = "paper_caution"
 
 	attack_self(mob/user)
@@ -1018,7 +1017,7 @@ TYPEINFO(/obj/item/device/prisoner_scanner)
 		else if (issilicon(user))
 			var/mob/living/silicon/S = user
 			I = S.botcard
-		if (!I || !(src.required_access in I.access))
+		if (!I || !(access_ticket in I.access))
 			boutput(user, SPAN_ALERT("Insufficient access."))
 			return
 		playsound(src, 'sound/machines/keyboard3.ogg', 30, TRUE)
@@ -1059,7 +1058,6 @@ TYPEINFO(/obj/item/device/prisoner_scanner)
 /obj/item/device/ticket_writer/crust
 	name = "crusty old security TicketWriter 1000"
 	desc = "An old TicketWriter model held together by hopes and dreams alone."
-	required_access = access_fuck_all
 	paper_icon_state = "paper_burned"
 
 TYPEINFO(/obj/item/device/appraisal)

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -15,7 +15,7 @@
 	var/list/engineering_access_list = list(access_engineering, access_engineering_storage, access_engineering_power, access_engineering_engine, access_engineering_mechanic, access_engineering_atmos, access_engineering_control)
 	var/list/supply_access_list = list(access_cargo, access_supply_console, access_mining, access_mining_outpost)
 	var/list/research_access_list = list(access_medical, access_tox, access_tox_storage, access_medlab, access_medical_lockers, access_research, access_robotics, access_chemistry, access_pathology, access_researchfoyer, access_artlab, access_telesci, access_robotdepot)
-	var/list/security_access_list = list(access_security, access_brig, access_forensics_lockers, access_maxsec, access_armory, access_securitylockers, access_carrypermit, access_contrabandpermit)
+	var/list/security_access_list = list(access_security, access_brig, access_forensics_lockers, access_maxsec, access_armory, access_securitylockers, access_carrypermit, access_contrabandpermit, access_ticket)
 	var/list/command_access_list = list(access_research_director, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_heads, access_captain, access_engineering_chief, access_medical_director, access_head_of_personnel, access_dwaine_superuser, access_money)
 	var/list/allowed_access_list
 	var/departmentcomp = FALSE

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -339,6 +339,8 @@
 						access_eva, access_heads, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
 						access_kitchen, access_robotics, access_cargo, access_research, access_hydro, access_ranch, access_pathology,
 						access_researchfoyer, access_artlab, access_telesci, access_robotdepot)
+		if("Hall Monitor")
+			return list(access_fuck_all)
 		if("Admin")
 			return access_all_actually
 		else

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -202,7 +202,7 @@
 		if("Captain")
 			return get_all_accesses()
 		if("Head of Personnel")
-			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_forensics_lockers,
+			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_forensics_lockers, access_ticket,
 						access_tox, access_tox_storage, access_chemistry, access_medical, access_medlab,
 						access_change_ids, access_eva, access_heads, access_head_of_personnel, access_medical_lockers,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
@@ -211,8 +211,8 @@
 						access_telesci, access_teleporter, access_money)
 		if("Head of Security")
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_maxsec, access_brig, access_securitylockers,
-						access_forensics_lockers, access_armory, access_tox, access_tox_storage, access_chemistry, access_medical, access_morgue,
-						access_change_ids, access_eva, access_heads, access_medical_lockers, access_medlab,
+						access_forensics_lockers, access_armory, access_ticket, access_tox, access_tox_storage, access_chemistry, access_medical,
+						access_morgue, access_change_ids, access_eva, access_heads, access_medical_lockers, access_medlab,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
 						access_crematorium, access_kitchen, access_robotics, access_cargo, access_money,
 						access_research, access_dwaine_superuser, access_hydro, access_ranch, access_mail, access_ai_upload,
@@ -245,16 +245,18 @@
 		if("Nanotrasen Security Consultant")
 			return get_access("Security Officer") + list(access_heads, access_eva)
 		if("Security Officer")
-			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig, access_maint_tunnels,
-			access_medical, access_morgue, access_research, access_cargo, access_engineering, access_engineering_control,
+			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig,  access_ticket,
+			access_maint_tunnels, access_medical, access_morgue, access_research, access_cargo, access_engineering, access_engineering_control,
 			access_chemistry, access_bar, access_kitchen, access_hydro, access_pathology, access_researchfoyer, access_mining
 			)
 		if("Vice Officer")
-			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_maint_tunnels,access_hydro, access_bar, access_kitchen, access_ranch)
+			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_ticket, access_maint_tunnels,
+			access_hydro, access_bar, access_kitchen, access_ranch)
 		if("Security Assistant")
-			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_maint_tunnels)
+			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_ticket, access_maint_tunnels)
 		if("Detective", "Forensic Technician")
-			return list(access_brig, access_carrypermit, access_contrabandpermit, access_security, access_forensics_lockers, access_morgue, access_maint_tunnels, access_crematorium, access_medical, access_research)
+			return list(access_brig, access_carrypermit, access_contrabandpermit, access_security, access_forensics_lockers, access_ticket,
+			access_morgue, access_maint_tunnels, access_crematorium, access_medical, access_research)
 		if("Lawyer")
 			return list(access_morgue, access_maint_tunnels)
 
@@ -335,12 +337,12 @@
 		if("Club member")
 			return list(access_special_club)
 		if("Inspector", "Communications Officer")
-			return list(access_security, access_tox, access_tox_storage, access_chemistry, access_medical, access_medlab,
+			return list(access_security, access_ticket, access_tox, access_tox_storage, access_chemistry, access_medical, access_medlab,
 						access_eva, access_heads, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
 						access_kitchen, access_robotics, access_cargo, access_research, access_hydro, access_ranch, access_pathology,
 						access_researchfoyer, access_artlab, access_telesci, access_robotdepot)
 		if("Hall Monitor")
-			return list(access_fuck_all)
+			return list(access_ticket)
 		if("Admin")
 			return access_all_actually
 		else
@@ -350,7 +352,7 @@
 #if defined(I_MEAN_ALL_ACCESS)
 	return access_all_actually
 #else
-	return list(access_security, access_brig, access_forensics_lockers,
+	return list(access_security, access_brig, access_forensics_lockers, access_ticket,
 				access_medical, access_medlab, access_morgue, access_securitylockers,
 				access_tox, access_tox_storage, access_chemistry, access_carrypermit, access_contrabandpermit,
 				access_change_ids, access_ai_upload,
@@ -521,6 +523,8 @@ var/list/access_all_actually = null
 			return "Robot Depot"
 		if (access_money)
 			return "Budget Control"
+		if (access_ticket)
+			return "Ticketing"
 
 
 proc/colorAirlock(access)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Make "Ticketing" its own access level
* Create new "Hall Monitor" access string and give it the ticketing permission
* Add ticketing access to all existing jobs with access_security
* Add Ticketing access to the ID Computer
* Ticket Writers now check for the ticketing access level
* Remove red border from hall monitor latejoin color
* Modify the Hall Monitor's ticket writer to print out crusty-looking tickets

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Further separate Hall Monitor from SecAss-lite; forums feedback.