### PR TITLE
Remove Auth Disk pointer from Nukie style tracking category

### DIFF
--- a/code/obj/item/pinpointer.dm
+++ b/code/obj/item/pinpointer.dm
@@ -223,14 +223,6 @@ TYPEINFO(/obj/item/pinpointer)
 	hudarrow_color = "#14ad00"
 	target_criteria = /obj/item/disk/data/floppy/read_only/authentication
 
-	New()
-		START_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
-		..()
-
-	disposing()
-		STOP_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
-		..()
-
 /obj/item/pinpointer/identificationcomputer
 	name = "pinpointer (identification computer)"
 	desc = "Points in the direction of the portable identification computer."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the Authentication disk pinpointer from the nukie style tracking category


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The captain gets a pinpointer so it isn't just nukie stuff, nothing on station should change colour if an admin decides to make the nukie pink or something.