### PR TITLE
Change the description for briefcases when plating in Real Genuine leather

### DIFF
--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -247,6 +247,11 @@
 		..()
 		BLOCK_SETUP(BLOCK_BOOK)
 
+	onMaterialChanged()
+		. = ..()
+		if(istype_exact(src, /obj/item/storage/briefcase) && src.material.getID() == "leather")
+			src.desc = "A fancy natural leather-bound briefcase, capable of holding a number of small objects, with exquisite style."
+
 /obj/item/storage/briefcase/toxins
 	name = "toxins research briefcase"
 	icon_state = "briefcase_rd"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When updating the material of the base briefcase, detect if it's been plated in leather.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The baseline description for briefcases shows them as made of synthleather, so we need to modify the description in this particular case.

Fix #21666
