### PR TITLE
floor flushers work on magbooted individuals

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2100,7 +2100,7 @@
 		logTheThing(LOG_COMBAT, src, "is taken by the floor cluwne at [log_loc(src)].")
 		src.transforming = 1
 		src.canmove = 0
-		src.anchored = ANCHORED
+		src.anchored = ANCHORED_ALWAYS
 		src.mouse_opacity = 0
 
 		var/mob/living/carbon/human/cluwne/floor/floorcluwne = null
@@ -3048,7 +3048,7 @@
 	SPAWN(0.7 SECONDS) //Length of animation.
 		newbody.set_loc(animation.loc)
 		qdel(animation)
-		newbody.anchored = ANCHORED // Stop running into the lava every half second jeez!
+		newbody.anchored = ANCHORED_ALWAYS // Stop running into the lava every half second jeez!
 		sleep(4 SECONDS)
 		reset_anchored(newbody)
 
@@ -3063,7 +3063,7 @@
 		logTheThing(LOG_COMBAT, src, "is damned to hell from [log_loc(src)].")
 		src.transforming = 1
 		src.canmove = 0
-		src.anchored = ANCHORED
+		src.anchored = ANCHORED_ALWAYS
 		src.mouse_opacity = 0
 
 		var/mob/living/carbon/human/satan/satan = new /mob/living/carbon/human/satan

--- a/code/obj/machinery/floorflusher.dm
+++ b/code/obj/machinery/floorflusher.dm
@@ -138,7 +138,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/floorflusher, proc/flush)
 				update()
 
 			if (isliving(AM))
-				if (AM:anchored) return
+				if (AM:anchored >= ANCHORED_ALWAYS) return
 				if (isintangible(AM)) // STOP EATING BLOB OVERMINDS ALSO
 					return
 				var/mob/living/M = AM


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Change floor flusher anchored check on living objects to check against ANCHORED_ALWAYS
* Make some mob gibs use ANCHORED_ALWAYS (no getting floor flushed away from anvils)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sure you're attached to the floor, but if the floor opens up, what are you standing on?
Fix #21652