### PR TITLE
Let rainbow/progressive/mlm capes swap like flags

### DIFF
--- a/code/obj/item/wall_flags.dm
+++ b/code/obj/item/wall_flags.dm
@@ -140,6 +140,15 @@ ABSTRACT_TYPE(/obj/item/clothing/suit/flag)
 	desc = "A makeshift cape made out of a pride flag. Still creased, of course."
 	icon = 'icons/obj/items/flag.dmi'
 	burn_possible = FALSE
+	var/altside_cape
+
+	attack_self(mob/user as mob)
+		if(src.altside_cape)
+			user.show_text("You flip the [src] around.")
+			if(src.loc == user)
+				user.u_equip(src)
+			qdel(src)
+			user.put_in_hand_or_drop(new src.altside_cape())
 
 	bisexual
 		name = "bisexual pride cape"
@@ -152,10 +161,12 @@ ABSTRACT_TYPE(/obj/item/clothing/suit/flag)
 	rainbow
 		name = "rainbow cape"
 		icon_state = "rainbow-cape"
+		altside_cape = /obj/item/clothing/suit/flag/progressive
 
 	progressive
 		name = "progressive pride cape"
 		icon_state = "progressive-cape"
+		altside_cape = /obj/item/clothing/suit/flag/rainbow
 
 	polysexual
 		name = "polysexual pride cape"
@@ -188,10 +199,12 @@ ABSTRACT_TYPE(/obj/item/clothing/suit/flag)
 	mlmvinc
 		name = "\improper Vincian MLM pride cape"
 		icon_state = "mlmvinc-cape"
+		altside_cape = /obj/item/clothing/suit/flag/mlmachi
 
 	mlmachi
 		name = "\improper Achilean MLM pride cape"
 		icon_state = "mlmachi-cape"
+		altside_cape = /obj/item/clothing/suit/flag/mlmvinc
 
 	ace
 		name = "asexual pride flag"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
add an altside_cape var for the flag capes, and set the associated alts for rainbow<->progressive and mlmvinc<->mlmachi 
swap to altside capes on attack_self just like flags

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21329
