### PR TITLE
Contraband traders will no longer dock with the station

### DIFF
--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -650,7 +650,11 @@
 
 /obj/landmark/spawner/random_trader
 	spawn_the_thing()
+#ifdef RP_MODE
 		var/type = pick(concrete_typesof(/obj/npc/trader/random) - /obj/npc/trader/random/contraband)
+#else
+		var/type = pick(concrete_typesof(/obj/npc/trader/random))
+#endif
 		new type(src.loc)
 		qdel(src)
 

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -650,11 +650,7 @@
 
 /obj/landmark/spawner/random_trader
 	spawn_the_thing()
-#ifdef RP_MODE
 		var/type = pick(concrete_typesof(/obj/npc/trader/random) - /obj/npc/trader/random/contraband)
-#else
-		var/type = pick(concrete_typesof(/obj/npc/trader/random))
-#endif
 		new type(src.loc)
 		qdel(src)
 

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -650,6 +650,12 @@
 
 /obj/landmark/spawner/random_trader
 	spawn_the_thing()
+		var/type = pick(concrete_typesof(/obj/npc/trader/random) - /obj/npc/trader/random/contraband)
+		new type(src.loc)
+		qdel(src)
+
+/obj/landmark/spawner/random_trader/diner
+	spawn_the_thing()
 		var/type = pick(concrete_typesof(/obj/npc/trader/random))
 		new type(src.loc)
 		qdel(src)

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -58521,7 +58521,7 @@
 /area/centcom/lounge)
 "gZG" = (
 /obj/stool/chair/comfy,
-/obj/landmark/spawner/random_trader,
+/obj/landmark/spawner/random_trader/diner,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][events]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Contraband travelling traders will no longer dock with the station. They can still dock at the diner.

Notes:
* This is a big shift in potential odds for contra traders in general since left/right traders have double chances over diner traders. I think the odds go from 1/8 to 1/40.
* nadir/oshan can no longer get contra traders ever, since there is no diner dock on that map.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
NPC traders openly offering contraband on-station puts security in a weird place.