### PR TITLE
Must be on grab intent to make snowballs

### DIFF
--- a/code/datums/components/snowballs.dm
+++ b/code/datums/components/snowballs.dm
@@ -17,6 +17,8 @@ TYPEINFO(/datum/component/snowballs)
 	. = ..()
 
 /datum/component/snowballs/proc/start_snowball(turf/T, mob/user)
+	if (user.a_intent != INTENT_GRAB)
+		return
 	if(!ON_COOLDOWN(source_turf, "snowball", 6 SECONDS))
 		actions.start(new /datum/action/bar/icon/callback(user, T, rand(3 SECONDS, 5 SECONDS), /datum/component/snowballs/proc/form_snowball,
 		list(user), 'icons/misc/xmas.dmi', "snowball", null, null, src), user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[player actions][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
check if user is on grab intent before making a starting the snowball making process

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
From forum thread here: https://forum.ss13.co/showthread.php?tid=23449

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)You must be in grab intent to make a snowball.
```
