### PR TITLE
Mobs change intertia direction when pushed/pulled in space

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2928,6 +2928,9 @@
 
 	if (source && source != src) //we were moved by something that wasnt us
 		last_pulled_time = world.time
+		if ((istype(src.loc, /turf/space) || src.no_gravity) && ismob(source))
+			var/mob/M = source
+			src.inertia_dir = M.inertia_dir
 	else
 		if(src.pulled_by)
 			src.pulled_by.remove_pulling()

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -217,12 +217,6 @@ or don't if it uses a custom topopen overlay
 	var/datum/ai_hologram_data/holoHolder = new
 	var/list/hologramContextActions
 
-/mob/living/silicon/ai/OnMove(source)
-	. = ..()
-	if (source && source != src && (istype(src.loc, /turf/space) || src.no_gravity) && ismob(source))
-		var/mob/M = source
-		src.inertia_dir = M.inertia_dir
-
 /mob/living/silicon/ai/proc/give_feet()
 	animate(src, pixel_y = 14, time = 5, easing = SINE_EASING)
 	has_feet = 1

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -217,6 +217,12 @@ or don't if it uses a custom topopen overlay
 	var/datum/ai_hologram_data/holoHolder = new
 	var/list/hologramContextActions
 
+/mob/living/silicon/ai/OnMove(source)
+	. = ..()
+	if (source && source != src && (istype(src.loc, /turf/space) || src.no_gravity) && ismob(source))
+		var/mob/M = source
+		src.inertia_dir = M.inertia_dir
+
 /mob/living/silicon/ai/proc/give_feet()
 	animate(src, pixel_y = 14, time = 5, easing = SINE_EASING)
 	has_feet = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When mobs are moved in space by another mob, change their inertial direction to match the other mob.

This handles direction changes when being both pushed and pulled by other mobs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #20940
