### PR TITLE
Add accessibility options for colorblindness

### DIFF
--- a/_std/color.dm
+++ b/_std/color.dm
@@ -57,6 +57,29 @@
 																		 0.00, 0.48, 0.53, 0.00,\
 																		 0.00, 0.00, 0.00, 1.00,\
 																		 0.00, 0.00, 0.00, 0.00)
+
+// note: for colorblind accessibility matrices, these are arbitrary values that were found to work well per https://github.com/ParadiseSS13/Paradise/pull/17933
+#define COLOR_MATRIX_PROTANOPIA_ACCESSIBILITY \
+	list(1, 0.475, 0.594, 0, \
+		0, 0.482, -0.68, 0,\
+		0, 0.044, 1.087, 0,\
+		0, 0, 0, 1,\
+		0, 0, 0, 0)
+
+#define COLOR_MATRIX_DEUTERANOPIA_ACCESSIBILITY \
+	list(1.8, 0, -0.14, 0,\
+		-1.05, 1, 0.1, 0,\
+		0.3, 0, 1, 0,\
+		0, 0, 0, 1,\
+		0, 0, 0, 0)
+
+#define COLOR_MATRIX_TRITANOPIA_ACCESSIBILITY \
+	list(0.74, 0.07, 0, 0,\
+		-0.405, 0.593, 0, 0,\
+		0.665, 0.335, 1, 0,\
+		0, 0, 0, 1,\
+		0, 0, 0, 0)
+
 #define COLOR_MATRIX_FLOCKMIND_LABEL "flockmind"
 #define COLOR_MATRIX_FLOCKMIND list(1.00, 0.00, 0.00, 0.00,\
 																		0.00, 1.00, 0.00, 0.00,\
@@ -425,16 +448,16 @@ proc/get_average_color(icon/I, xPixelInterval = 4, yPixelInterval = 4)
 
 /client/proc/set_saturation(s=1)
 	src.saturation_matrix = hsv_transform_color_matrix(0, s, 1)
-	src.color = mult_color_matrix(src.color_matrix, src.saturation_matrix)
+	src.color = mult_color_matrix(mult_color_matrix(src.color_matrix, src.saturation_matrix), src.colorblind_matrix)
 
 /client/proc/set_color(matrix=COLOR_MATRIX_IDENTITY, respect_view_tint_settings = FALSE)
 	if (!respect_view_tint_settings)
 		src.color_matrix = matrix
 	else
 		src.color_matrix = src.view_tint ? matrix : null
-	src.color = mult_color_matrix(src.color_matrix, src.saturation_matrix)
+	src.color = mult_color_matrix(mult_color_matrix(src.color_matrix, src.saturation_matrix), src.colorblind_matrix)
 
 /client/proc/animate_color(matrix=COLOR_MATRIX_IDENTITY, time=5, easing=SINE_EASING)
 	src.color_matrix = matrix
-	matrix = mult_color_matrix(src.color_matrix, src.saturation_matrix)
+	matrix = mult_color_matrix(mult_color_matrix(src.color_matrix, src.saturation_matrix), src.colorblind_matrix)
 	animate(src, color=matrix, time=time, easing=easing)

--- a/code/client.dm
+++ b/code/client.dm
@@ -1451,6 +1451,17 @@ var/global/curr_day = null
 	set name = "set-hand-ghosts"
 	hand_ghosts = winget( src, "menu.use_hand_ghosts", "is-checked" ) == "true"
 
+/client/verb/disable_colorblind_modes()
+	set hidden = TRUE
+	set name = "disable-colorblind-modes"
+
+	if (src.protanopia_toggled)
+		src.toggle_protanopia_mode()
+	else if (src.deuteranopia_toggled)
+		src.toggle_deuteranopia_mode()
+	else if (src.tritanopia_toggled)
+		src.toggle_tritanopia_mode()
+
 /client/verb/toggle_protanopia_mode()
 	set hidden = TRUE
 	set name = "toggle-protanopia-mode"

--- a/code/client.dm
+++ b/code/client.dm
@@ -77,6 +77,7 @@
 	/// color_matrix: the client's game color (tint)
 	var/saturation_matrix = COLOR_MATRIX_IDENTITY
 	var/color_matrix = COLOR_MATRIX_IDENTITY
+	var/colorblind_matrix = COLOR_MATRIX_IDENTITY
 
 	perspective = EYE_PERSPECTIVE
 	// please ignore this for now thanks in advance - drsingh
@@ -113,6 +114,10 @@
 	var/hand_ghosts = 1 //pickup ghosts inhand
 
 	var/dark_screenflash = FALSE
+
+	var/protanopia_toggled = FALSE
+	var/deuteranopia_toggled = FALSE
+	var/tritanopia_toggled = FALSE
 
 /client/proc/audit(var/category, var/message, var/target)
 	if(src.holder && (src.holder.audit & category))
@@ -1445,6 +1450,60 @@ var/global/curr_day = null
 	set hidden = 1
 	set name = "set-hand-ghosts"
 	hand_ghosts = winget( src, "menu.use_hand_ghosts", "is-checked" ) == "true"
+
+/client/verb/toggle_protanopia_mode()
+	set hidden = TRUE
+	set name = "toggle-protanopia-mode"
+
+	if (src.deuteranopia_toggled)
+		src.toggle_deuteranopia_mode()
+	else if (src.tritanopia_toggled)
+		src.toggle_tritanopia_mode()
+
+	if (!src.protanopia_toggled)
+		src.colorblind_matrix = COLOR_MATRIX_PROTANOPIA_ACCESSIBILITY
+	else
+		src.colorblind_matrix = COLOR_MATRIX_IDENTITY
+	src.set_color()
+	src.protanopia_toggled = !src.protanopia_toggled
+	src.deuteranopia_toggled = FALSE
+	src.tritanopia_toggled = FALSE
+
+/client/verb/toggle_deuteranopia_mode()
+	set hidden = TRUE
+	set name = "toggle-deuteranopia-mode"
+
+	if (src.protanopia_toggled)
+		src.toggle_protanopia_mode()
+	else if (src.tritanopia_toggled)
+		src.toggle_tritanopia_mode()
+
+	if (!src.deuteranopia_toggled)
+		src.colorblind_matrix = COLOR_MATRIX_DEUTERANOPIA_ACCESSIBILITY
+	else
+		src.colorblind_matrix = COLOR_MATRIX_IDENTITY
+	src.set_color()
+	src.deuteranopia_toggled = !src.deuteranopia_toggled
+	src.protanopia_toggled = FALSE
+	src.tritanopia_toggled = FALSE
+
+/client/verb/toggle_tritanopia_mode()
+	set hidden = TRUE
+	set name = "toggle-tritanopia-mode"
+
+	if (src.protanopia_toggled)
+		src.toggle_protanopia_mode()
+	else if (src.deuteranopia_toggled)
+		src.toggle_deuteranopia_mode()
+
+	if (!src.tritanopia_toggled)
+		src.colorblind_matrix = COLOR_MATRIX_TRITANOPIA_ACCESSIBILITY
+	else
+		src.colorblind_matrix = COLOR_MATRIX_IDENTITY
+	src.set_color()
+	src.tritanopia_toggled = !src.tritanopia_toggled
+	src.protanopia_toggled = FALSE
+	src.deuteranopia_toggled = FALSE
 
 //These size helpers are invisible browser windows that help with getting client screen dimensions
 /client/proc/initSizeHelpers()

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -366,6 +366,31 @@ menu "menu"
 		can-check = true
 		saved-params = "is-checked"
 	elem
+		name = "&Accessibility"
+		command = ""
+		category = "&Game"
+	elem "Protanopia"
+		name = "Protanopia"
+		command = "toggle-protanopia-mode"
+		category = "&Accessibility"
+		is-checked = false
+		can-check = true
+		saved-params = "is-checked"
+	elem "Deuteranopia"
+		name = "Deuteranopia"
+		command = "toggle-deuteranopia-mode"
+		category = "&Accessibility"
+		is-checked = false
+		can-check = true
+		saved-params = "is-checked"
+	elem "Tritanopia"
+		name = "Tritanopia"
+		command = "toggle-tritanopia-mode"
+		category = "&Accessibility"
+		is-checked = false
+		can-check = true
+		saved-params = "is-checked"
+	elem
 		name = "&Audio"
 		command = ""
 		saved-params = "is-checked"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -369,10 +369,19 @@ menu "menu"
 		name = "&Accessibility"
 		command = ""
 		category = "&Game"
+	elem "None"
+		name = "None"
+		command = "disable-colorblind-modes"
+		category = "&Accessibility"
+		group = "colorblind-accessibility"
+		is-checked = true
+		can-check = true
+		saved-params = "is-checked"
 	elem "Protanopia"
 		name = "Protanopia"
 		command = "toggle-protanopia-mode"
 		category = "&Accessibility"
+		group = "colorblind-accessibility"
 		is-checked = false
 		can-check = true
 		saved-params = "is-checked"
@@ -380,6 +389,7 @@ menu "menu"
 		name = "Deuteranopia"
 		command = "toggle-deuteranopia-mode"
 		category = "&Accessibility"
+		group = "colorblind-accessibility"
 		is-checked = false
 		can-check = true
 		saved-params = "is-checked"
@@ -387,6 +397,7 @@ menu "menu"
 		name = "Tritanopia"
 		command = "toggle-tritanopia-mode"
 		category = "&Accessibility"
+		group = "colorblind-accessibility"
 		is-checked = false
 		can-check = true
 		saved-params = "is-checked"


### PR DESCRIPTION
[UI][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds accessibility options for protanopia, deuteranopia, and tritanopia colorblindness, which works by applying a view tint for the user

Uses color matrix values from https://github.com/ParadiseSS13/Paradise/pull/17933 (not sure if i needed to ask for permission to use them?)

![image](https://github.com/user-attachments/assets/4450e7d9-c5f8-433c-b824-2bdaadc73339)

Protanopia - 
![image](https://github.com/user-attachments/assets/385a795a-5d38-4261-bec2-01372edad760)

Deuteranopia - 
![image](https://github.com/user-attachments/assets/75bb7121-be6d-4590-b359-ec0864b0d6f9)


Tritanopia - 
![image](https://github.com/user-attachments/assets/73e371ea-7a6d-4f4c-aa99-23539b7900d6)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
QoL (also I have no experience with colorblindness, so this is really up to those with colorblindness to say how helpful it is. assumed it was helpful per the paradise station PR)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(*)Added colorblind accessibility options for protanopia, deuteranopia, and tritanopia colorblindness under Game -> Accessibility
```
