### PR TITLE
Cogmap window pipe rupture fix

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -47912,7 +47912,6 @@
 "kYD" = (
 /obj/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
 	dir = 9
 	},
 /obj/cable{
@@ -60143,7 +60142,6 @@
 /area/station/maintenance/west)
 "ukb" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
 	dir = 9
 	},
 /obj/machinery/light/emergency,
@@ -60236,7 +60234,8 @@
 /area/station/crew_quarters/fitness)
 "ume" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
+	dir = 4;
+	can_rupture = 0
 	},
 /obj/cable,
 /obj/cable{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the pipe under the window in cog1's engine unrupturable
Also makes 2 corner pipes in the main loop that werent rupturable, rupturable, because they should be.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![image](https://github.com/user-attachments/assets/084c7877-c896-4233-8e2f-fe553ea8c50a)



## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)That one pipe under the cog1 engine window can no longer burst.
```
