### PR TITLE
prevent AIeyes from using ladders

### DIFF
--- a/code/obj/ladder.dm
+++ b/code/obj/ladder.dm
@@ -142,11 +142,13 @@ ADMIN_INTERACT_PROCS(/obj/ladder/embed, proc/toggle_hidden)
 
 /obj/ladder/attack_hand(mob/user)
 	if (src.unclimbable) return
-	if (user.stat || user.getStatusDuration("knockdown") || BOUNDS_DIST(user, src) > 0)
+	if (is_incapacitated(user) || BOUNDS_DIST(user, src) > 0)
 		return
 	src.climb(user)
 
 /obj/ladder/attack_ai(mob/user)
+	if(isAIeye(user))
+		return
 	return src.Attackhand(user)
 
 /obj/ladder/Click(location, control, params)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* return early if an aieye is trying to climb a ladder
* while i'm nearby, apply `is_incapacitated` check in attack_hand instead of partial check

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #20885

