### PR TITLE
Small fixes for donut2 ranch and janitor office

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -13575,9 +13575,6 @@
 	pixel_x = 24;
 	pixel_y = 4
 	},
-/obj/item/device/radio/intercom{
-	dir = 8
-	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "bwc" = (
@@ -13720,6 +13717,9 @@
 /area/station/hallway/primary/south)
 "bxm" = (
 /obj/storage/secure/closet/civilian/janitor,
+/obj/item/device/radio/intercom{
+	dir = 8
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "bxq" = (
@@ -20497,6 +20497,12 @@
 	},
 /turf/space,
 /area/station/turret_protected/armory_outside)
+"eNC" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "eNH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -21617,6 +21623,9 @@
 /obj/disposalpipe/segment,
 /obj/landmark/start/job/rancher,
 /obj/machinery/light/incandescent,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "fvW" = (
@@ -28744,15 +28753,10 @@
 	id = "ranch_flusher";
 	name = "Kitchen Chute"
 	},
-/obj/machinery/activation_button/flusher_button{
-	id = "ranch_flusher";
-	name = "Kitchen Chute Activation Button";
-	pixel_x = -7;
-	pixel_y = 31
-	},
 /obj/disposalpipe/trunk/produce{
 	dir = 8
 	},
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "jSB" = (
@@ -29107,7 +29111,7 @@
 	dir = 1
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -29492,8 +29496,6 @@
 /obj/railing/orange/reinforced{
 	dir = 8
 	},
-/obj/machinery/light/incandescent,
-/obj/machinery/power/apc/autoname_north,
 /obj/railing/orange/reinforced{
 	dir = 4
 	},
@@ -29501,8 +29503,10 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/activation_button/flusher_button{
+	id = "ranch_flusher";
+	name = "Kitchen Chute Activation Button";
+	pixel_y = 31
 	},
 /turf/simulated/floor/grasstodirt{
 	dir = 8
@@ -31823,6 +31827,16 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hallway/secondary/exit)
+"lHD" = (
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "lHQ" = (
 /mob/living/carbon/human/npc/monkey/stirstir,
 /turf/simulated/floor/grime,
@@ -41305,6 +41319,9 @@
 /area/station/maintenance/west)
 "reb" = (
 /obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "ree" = (
@@ -42483,6 +42500,9 @@
 "rRw" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/grasstodirt{
 	dir = 4
@@ -48165,6 +48185,9 @@
 /obj/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/grasstodirt{
 	dir = 6
 	},
@@ -49981,9 +50004,6 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment/produce,
-/obj/cable{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/grasstodirt{
 	dir = 8
 	},
@@ -72340,7 +72360,7 @@ olI
 etx
 etx
 bGd
-teU
+eNC
 teU
 taR
 bGd
@@ -72642,7 +72662,7 @@ jft
 wrd
 eXL
 bGd
-qEO
+lHD
 fWX
 qEO
 bGd

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -26096,12 +26096,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "iim" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13";
-	tag = ""
-	},
 /obj/indestructible/shuttle_corner{
 	dir = 0
 	},
@@ -26625,10 +26619,6 @@
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "iAq" = (
-/obj/machinery/camera{
-	c_tag = "Custodial Closet";
-	dir = 1
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -81325,7 +81315,7 @@ bCG
 bCG
 nPR
 bCG
-bCG
+kLL
 iim
 apC
 hBd


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Move the ranch APC and a light so the kitchen chute button can be accessed from a turf. Currently, you can't reach over reinforced railings to tap the button.
* Fix a stacked phone and intercom in donut2 janitorial office.
* Remove a camera stuck to a door in donut2 janitorial office.
* Nudge the south arrival shuttle camera so it's not stuck in the wall

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map polish
Fix #21675
Fix #20906