### PR TITLE
prevent ghost critters from using item dispensers

### DIFF
--- a/code/obj/item_dispensers.dm
+++ b/code/obj/item_dispensers.dm
@@ -41,11 +41,13 @@
 			qdel(W)
 
 	attack_hand(mob/user)
+		if (is_dead_or_ghost_role(user))
+			return 1
 		add_fingerprint(user)
 		user.lastattacked = src //prevents spam
 		if (src.cant_withdraw)
 			..()
-			return
+			return 1
 
 		if (src.amount >= 1)
 			if (last_dispense_time + dispense_rate > TIME)
@@ -65,6 +67,7 @@
 					UpdateIcon()
 		else
 			boutput(user, SPAN_ALERT("There's nothing in \the [src] to take!"))
+			return 1
 
 	update_icon()
 		if (src.amount <= 0)
@@ -126,9 +129,8 @@
 	amount = 7
 
 	attack_hand(mob/user)
-		if (!src.cant_withdraw && src.amount >= 1)
+		if(!..())
 			playsound(src.loc, 'sound/machines/printer_dotmatrix.ogg', 25, 1)
-		..()
 
 /obj/item_dispenser/icedispenser
 	name = "ice dispenser"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Add early return for ghost roles when clicking on item dispensers
* Add return values when items are not dispensed
* Only play ID card printing sound when a card is dispensed


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #20513
