### PR TITLE
Fix ghostcritters gibbing into robot parts

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1885,12 +1885,16 @@
 			light.enable()
 			SPAWN(1 SECOND)
 				qdel(light)
+	else if(src.custom_gib_handler)
+		call(src.custom_gib_handler)(src.loc)
+	else if(issilicon(src) || isrobocritter(src))
+		robogibs(src.loc)
+	else
+		gibs(src.loc)
+
 	if ((src.mind || src.client) && !istype(src, /mob/living/carbon/human/npc))
 		var/mob/dead/observer/newmob = ghostize()
 		newmob.corpse = null
-
-	if (!iscarbon(src))
-		robogibs(src.loc)
 
 	if (animation)
 		animation.delaydispose()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][critters]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When not vaporizing a mob, elecgib uses custom gib handler if available, and otherwise only uses robogibs if appropriate.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21685
Fix #20522