### PR TITLE
Fix oil streaks containing more oil than needed to create them

### DIFF
--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -1301,6 +1301,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 
 /obj/decal/cleanable/oil/streak
 	random_icon_states = list("streak1", "streak2", "streak3", "streak4", "streak5")
+	sample_amt = 5
 
 /obj/decal/cleanable/paint
 	name = "marker paint"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][chemistry]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Change the sample amount for oil streaks to 5 (from 10)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You only need 5 units of oil to always create an oil streak cleanable.
Fix #19906