### PR TITLE
Fix all_hearers null turf reference

### DIFF
--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -1258,7 +1258,7 @@ proc/outermost_movable(atom/movable/target)
 	if(T?.vistarget)
 		// this turf is being shown elsewhere through a visual mirror, make sure they get to hear too
 		. |= all_hearers(range, T.vistarget)
-	for (var/turf/listener as anything in T.listening_turfs)
+	for (var/turf/listener as anything in T?.listening_turfs)
 		. |= all_hearers(range, listener)
 
 	for(var/atom/movable/screen/viewport_handler/viewport_handler in T?.vis_locs)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][runtime]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Don't assume the turf exists in all_hearers for the `listening_turfs` call

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stuff can speak in nullspace and that causes a runtime