### PR TITLE
Fix anchored object and self-moving conveyors

### DIFF
--- a/code/modules/disposals/conveyor.dm
+++ b/code/modules/disposals/conveyor.dm
@@ -427,8 +427,6 @@ TYPEINFO(/obj/machinery/conveyor) {
 		return
 	if(!loc)
 		return
-	if (!can_convey(AM))
-		return
 
 	if(src.next_conveyor && src.next_conveyor.loc == AM.loc)
 		//Ok, they will soon walk() according to the new conveyor

--- a/code/modules/disposals/conveyor.dm
+++ b/code/modules/disposals/conveyor.dm
@@ -446,8 +446,7 @@ TYPEINFO(/obj/machinery/conveyor) {
 
 /obj/machinery/conveyor/get_desc()
 	if (src.deconstructable)
-		. += " [SPAN_NOTICE("It's cover seems to be open.")]"
-
+		. += " [SPAN_NOTICE("Its cover seems to be open.")]"
 
 /obj/machinery/conveyor/mouse_drop(over_object, src_location, over_location)
 	if (!usr)

--- a/code/modules/disposals/conveyor.dm
+++ b/code/modules/disposals/conveyor.dm
@@ -427,6 +427,9 @@ TYPEINFO(/obj/machinery/conveyor) {
 		return
 	if(!loc)
 		return
+	if(!can_convey(AM))
+		walk(AM, 0)
+		return
 
 	if(src.next_conveyor && src.next_conveyor.loc == AM.loc)
 		//Ok, they will soon walk() according to the new conveyor

--- a/code/modules/disposals/conveyor.dm
+++ b/code/modules/disposals/conveyor.dm
@@ -52,6 +52,8 @@ TYPEINFO(/obj/machinery/conveyor) {
 	event_handler_flags = USE_FLUID_ENTER
 	/// list of conveyor_switches that have us in their conveyors list
 	var/list/linked_switches
+	/// Stored operating direction for conveyors without linked switches
+	var/stored_operating
 
 	New()
 		. = ..()
@@ -609,6 +611,10 @@ TYPEINFO(/obj/machinery/conveyor) {
 			var/obj/machinery/conveyor_switch/connected_switch = src.linked_switches[1]
 			src.operating = connected_switch.position
 			src.setdir()
+		else
+			src.operating = src.stored_operating
+			src.stored_operating = null
+			src.set_dir()
 		src.update()
 		return 1
 
@@ -617,6 +623,10 @@ TYPEINFO(/obj/machinery/conveyor) {
 		src.deconstructable = TRUE
 		M.show_text("You finish opening \the [src]'s panel.", "blue")
 		if (length(src.linked_switches))
+			src.operating = CONVEYOR_STOPPED
+			src.setdir()
+		else
+			src.stored_operating = src.operating
 			src.operating = CONVEYOR_STOPPED
 			src.setdir()
 		src.update()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* If we can't convey an object, stop any forced movement
* For non-linked conveyors, store the operating direction and set it to stopped while deconstructable.
* Fix a small typo while we're here

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #17486
Fix #20359
Fix #19133
Fix #12194
Fix #18977
Fix #12941