### PR TITLE
Fix flying critters floating after death

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -203,6 +203,8 @@
 	src.remove_ailments()
 	src.lastgasp(allow_dead = TRUE)
 	if (src.ai) src.ai.disable()
+	if (src.isFlying)
+		REMOVE_ATOM_PROPERTY(src, PROP_ATOM_FLOATING, src)
 	if (src.key && VALID_MOB(src))
 		var/datum/eventRecord/Death/deathEvent = new
 		deathEvent.buildAndSend(src, gibbed)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][critter]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
On death, if a living mob has `isFlying`, remove the `PROP_ATOM_FLOATING` property.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #16539
