### PR TITLE
Fix BR not equipping trait items

### DIFF
--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -445,6 +445,9 @@ proc/equip_battler(mob/living/carbon/human/battler)
 
 	battler.equip_if_possible(new /obj/item/device/radio/headset(battler), SLOT_EARS)
 
+	battler.equip_sensory_items()
+	battler.equip_body_traits()
+
 	// Battle royale crewmembers are rainbow flavored
 	var/obj/item/clothing/under/jumpsuit = null
 	var/suit_type = pick(

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -530,6 +530,29 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 			src.stow_in_available(src.ears)
 		src.equip_if_possible(new /obj/item/device/radio/headset/deaf(src), SLOT_EARS)
 
+/// Equip items from body traits
+/mob/living/carbon/human/proc/equip_body_traits()
+	if (src.traitHolder && src.traitHolder.hasTrait("nolegs"))
+		if (src.limbs)
+			if (src.limbs.l_leg)
+				src.limbs.l_leg.delete()
+			if (src.limbs.r_leg)
+				src.limbs.r_leg.delete()
+			var/obj/stool/chair/comfy/chair = new /obj/stool/chair/comfy/wheelchair(get_turf(src))
+			chair.buckle_in(src, src)
+
+	if (src.traitHolder && src.traitHolder.hasTrait("plasmalungs"))
+		if (src.wear_mask && !(src.wear_mask.c_flags & MASKINTERNALS)) //drop non-internals masks
+			src.stow_in_available(src.wear_mask)
+
+		if(!src.wear_mask)
+			src.equip_if_possible(new /obj/item/clothing/mask/breath(src), SLOT_WEAR_MASK)
+
+		var/obj/item/tank/good_air = new /obj/item/tank/mini_plasma(src)
+		src.put_in_hand_or_drop(good_air)
+		if (!good_air.using_internal())//set tank ON
+			good_air.toggle_valve()
+
 /mob/living/carbon/human/proc/Equip_Job_Slots(var/datum/job/JOB)
 	equip_job_items(JOB, src)
 	if (JOB.slot_back)
@@ -674,26 +697,7 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 			if (!equipped) // we've tried most available storage solutions here now so uh just put it on the ground
 				I.set_loc(get_turf(src))
 
-	if (src.traitHolder && src.traitHolder.hasTrait("nolegs"))
-		if (src.limbs)
-			if (src.limbs.l_leg)
-				src.limbs.l_leg.delete()
-			if (src.limbs.r_leg)
-				src.limbs.r_leg.delete()
-			var/obj/stool/chair/comfy/chair = new /obj/stool/chair/comfy/wheelchair(get_turf(src))
-			chair.buckle_in(src, src)
-
-	if (src.traitHolder && src.traitHolder.hasTrait("plasmalungs"))
-		if (src.wear_mask && !(src.wear_mask.c_flags & MASKINTERNALS)) //drop non-internals masks
-			src.stow_in_available(src.wear_mask)
-
-		if(!src.wear_mask)
-			src.equip_if_possible(new /obj/item/clothing/mask/breath(src), SLOT_WEAR_MASK)
-
-		var/obj/item/tank/good_air = new /obj/item/tank/mini_plasma(src)
-		src.put_in_hand_or_drop(good_air)
-		if (!good_air.using_internal())//set tank ON
-			good_air.toggle_valve()
+	src.equip_body_traits()
 
 	// Special mutantrace items
 	if (src.traitHolder && src.traitHolder.hasTrait("pug"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows the following traits to equip their items in BR:
- Blind
- Short Sighted
- Deaf
- Plasma Lungs
Allows stumped to remove legs and grant wheelchair
Fixes #18365

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These traits still grant their downside (outside no legs, but that ones funny and based and I want to play a BR round in a wheelchair) but dont equip their necessary items.