### PR TITLE
Security disk changes

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -38,8 +38,7 @@
 	var/cant_allocate_unwanted = FALSE //! Job cannot be set to "unwanted" in player preferences.
 	var/receives_miranda = FALSE
 	var/list/receives_implants = null //! List of object paths of implant types given on spawn.
-	var/receives_disk = FALSE
-	var/receives_security_disk = FALSE
+	var/receives_disk = FALSE //! Job spawns with cloning data disk, can specify a type
 	var/receives_badge = FALSE
 	var/announce_on_join = FALSE //! On join, send message to all players indicating who is fulfilling the role; primarily for heads of staff
 	var/radio_announcement = TRUE //! The announcement computer will send a message when the player joins after round-start.
@@ -327,8 +326,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	cant_spawn_as_con = TRUE
 	cant_spawn_as_rev = TRUE
 	announce_on_join = TRUE
-	receives_disk = TRUE
-	receives_security_disk = TRUE
+	receives_disk = /obj/item/disk/data/floppy/sec_command
 	receives_badge = TRUE
 	receives_implants = list(/obj/item/implant/health/security/anti_mindhack)
 	items_in_backpack = list(/obj/item/device/flash)
@@ -509,8 +507,7 @@ ABSTRACT_TYPE(/datum/job/security)
 	cant_spawn_as_con = TRUE
 	cant_spawn_as_rev = TRUE
 	receives_implants = list(/obj/item/implant/health/security/anti_mindhack)
-	receives_disk = TRUE
-	receives_security_disk = TRUE
+	receives_disk = /obj/item/disk/data/floppy/security
 	receives_badge = TRUE
 	slot_back = list(/obj/item/storage/backpack/security)
 	slot_belt = list(/obj/item/device/pda2/security)

--- a/code/modules/networks/computer3/disks.dm
+++ b/code/modules/networks/computer3/disks.dm
@@ -205,6 +205,7 @@
 
 /obj/item/disk/data/floppy/security
 	icon_state = "datadiskmed" //yeah its "med" but its not used anywhere
+	random_color = FALSE
 	New()
 		..()
 		var/datum/computer/file/record/authrec = new /datum/computer/file/record {name = "SECAUTH";} (src)
@@ -224,7 +225,6 @@
 
 /obj/item/disk/data/floppy/computer3boot
 	name = "data disk-'ThinkDOS'"
-	random_color = FALSE
 
 	New()
 		. = ..()

--- a/code/modules/networks/computer3/disks.dm
+++ b/code/modules/networks/computer3/disks.dm
@@ -203,8 +203,28 @@
 		boutput(user, SPAN_ALERT("You can't flip the write-protect tab, it's held in place with glue or something!"))
 		return
 
+/obj/item/disk/data/floppy/security
+	icon_state = "datadiskmed" //yeah its "med" but its not used anywhere
+	New()
+		..()
+		var/datum/computer/file/record/authrec = new /datum/computer/file/record {name = "SECAUTH";} (src)
+		authrec.fields = list("SEC"="[netpass_security]")
+		src.root.add_file( authrec )
+
+/obj/item/disk/data/floppy/sec_command
+	icon_state = "datadisksyn" //yeah its "syndie" but its not used anywhere
+	random_color = FALSE
+
+	New()
+		..()
+		var/datum/computer/file/record/authrec = new /datum/computer/file/record {name = "SECAUTH";} (src)
+		authrec.fields = list("HEADS"="[netpass_heads]",
+							"SEC"="[netpass_security]",)
+		src.root.add_file(authrec)
+
 /obj/item/disk/data/floppy/computer3boot
 	name = "data disk-'ThinkDOS'"
+	random_color = FALSE
 
 	New()
 		. = ..()

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -535,11 +535,11 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 	if (JOB.slot_back)
 		if (src.back?.storage)
 			if(JOB.receives_disk)
-				var/obj/item/disk/data/floppy/read_only/D
+				var/obj/item/disk/data/floppy/D
 				if(ispath(JOB.receives_disk))
 					D = new JOB.receives_disk(src)
 				else
-					D = new /obj/item/disk/data/floppy/read_only(src)
+					D = new /obj/item/disk/data/floppy(src)
 				src.equip_if_possible(D, SLOT_IN_BACKPACK)
 				var/datum/computer/file/clone/R = new
 				R.fields["ckey"] = ckey(src.key)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -535,7 +535,11 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 	if (JOB.slot_back)
 		if (src.back?.storage)
 			if(JOB.receives_disk)
-				var/obj/item/disk/data/floppy/read_only/D = new /obj/item/disk/data/floppy/read_only(src)
+				var/obj/item/disk/data/floppy/read_only/D
+				if(ispath(JOB.receives_disk))
+					D = new JOB.receives_disk(src)
+				else
+					D = new /obj/item/disk/data/floppy/read_only(src)
 				src.equip_if_possible(D, SLOT_IN_BACKPACK)
 				var/datum/computer/file/clone/R = new
 				R.fields["ckey"] = ckey(src.key)
@@ -561,12 +565,6 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 				R.fields["imp"] = null
 				R.fields["mind"] = src.mind
 				D.root.add_file(R)
-
-				if (JOB.receives_security_disk)
-					var/datum/computer/file/record/authrec = new /datum/computer/file/record {name = "SECAUTH";} (src)
-					authrec.fields = list("SEC"="[netpass_security]")
-					D.root.add_file( authrec )
-					D.read_only = 1
 
 				D.name = "data disk - '[src.real_name]'"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows jobs to specify ANY disk to be their cloning disk
Adds specific disks for security (and the HoS) that have secauth on them
The HoS' disk contains the head netpass, allowing easier crime of packet hacking armory if there is a HoS
Security disks now have unique icons, the HoS one also, to differentiate them from normal disks
Security disks are **no longer read only**, meaning they can be sabotaged and have their contents wiped


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Security disks are presently really strong, this aims to add more risk to just leaving them lying around in security as they could be sabotaged, or in the HoS' case, used to auth and rob armory.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Security data disks are no longer read-only, allowing them to be sabotaged without needing to be outright destroyed.
(+)The Head of Security's disk contains the Heads netpass.
```
