### PR TITLE
Increase patrol and tourguide robuddy task pathing distance

### DIFF
--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -3085,7 +3085,7 @@ TYPEINFO(/obj/item/device/guardbot_module)
 				if(next_destination)
 					set_destination(next_destination)
 					if(!master.moving && target && (target != master.loc))
-						master.navigate_to(target, max_dist=40)
+						master.navigate_to(target, max_dist=80)
 					return
 				else
 					find_nearest_beacon()
@@ -3642,7 +3642,7 @@ TYPEINFO(/obj/item/device/guardbot_module)
 							return
 
 						if (current_beacon_loc != master.loc)
-							master.navigate_to(current_beacon_loc, max_dist=30)
+							master.navigate_to(current_beacon_loc, max_dist=60)
 						else
 							state = STATE_AT_BEACON
 					return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][critters]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Double the max pathing distance for patrol and tourguide navigation.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Guardbuddies and tourbuddies get stuck navigating the station.
Known problems this fixes:
* Fix #14232 - cogmap1 guardbuddies
* Nadir tourbot