### PR TITLE
QDEL Meteors that hit an unsimmed wall

### DIFF
--- a/code/modules/events/meteor_shower.dm
+++ b/code/modules/events/meteor_shower.dm
@@ -374,6 +374,8 @@ var/global/meteor_shower_active = 0
 				continue
 			//let's not just go straight through unsimmed turfs and total the inside of the listening post
 			if (!issimulatedturf(T) || !istype(T, /turf/unsimulated))
+				if(istype(T, /turf/unsimulated/wall))
+					qdel(src)
 				continue
 			hit_object = 1
 			if (prob(meteorhit_chance))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If a meteor hits an unsimulated wall, qdel it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently they just go through the wall, but unsimmed walls often contain stuff that can be destroyed, e.g. the listening post.
Fixes #17890
Fixes #21596

