### PR TITLE
Craftable Lanyards

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -3186,6 +3186,13 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 
 
 /******************** HOP *******************/
+/datum/manufacture/lanyard
+	name = "Lanyard"
+	item_requirements = list("cloth" = 1)
+	item_outputs = list(obj/item/clothing/lanyard)
+	create = 1
+	time = 5 SECONDS
+	category = "Clothing"
 
 /datum/manufacture/id_card
 	name = "ID card"

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -3188,7 +3188,7 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 /******************** HOP *******************/
 /datum/manufacture/lanyard
 	name = "Lanyard"
-	item_requirements = list("cloth" = 1)
+	item_requirements = list("fabric" = 1)
 	item_outputs = list(/obj/item/clothing/lanyard)
 	create = 1
 	time = 5 SECONDS

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -3189,7 +3189,7 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 /datum/manufacture/lanyard
 	name = "Lanyard"
 	item_requirements = list("cloth" = 1)
-	item_outputs = list(obj/item/clothing/lanyard)
+	item_outputs = list(/obj/item/clothing/lanyard)
 	create = 1
 	time = 5 SECONDS
 	category = "Clothing"

--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -450,6 +450,7 @@
 		/datum/manufacture/satchel_red,
 		/datum/manufacture/satchel_green,
 		/datum/manufacture/satchel_blue,
+		/datum/manufacture/lanyard,
 		/datum/manufacture/handkerchief)
 
 	hidden = list(/datum/manufacture/breathmask,
@@ -493,8 +494,9 @@
 	icon_base = "access"
 	free_resources = list(/obj/item/material_piece/steel = 2,
 		/obj/item/material_piece/copper = 2,
+		/obj/item/material_piece/cloth/cottonfabric = 5,
 		/obj/item/material_piece/glass = 2)
-	available = list(/datum/manufacture/id_card, /datum/manufacture/implant_access,	/datum/manufacture/implanter)
+	available = list(/datum/manufacture/id_card,/datum/manufacture/lanyard, /datum/manufacture/implant_access,	/datum/manufacture/implanter)
 	hidden = list(/datum/manufacture/id_card_gold, /datum/manufacture/implant_access_infinite)
 
 //combine personnel + uniform manufactuer here. this is 'cause destiny doesn't have enough room! arrg!
@@ -550,6 +552,7 @@
 		/datum/manufacture/hat_blue,
 		/datum/manufacture/hat_purple,
 		/datum/manufacture/hat_tophat,
+		/datum/manufacture/lanyard,
 		/datum/manufacture/handkerchief,)
 
 	hidden = list(/datum/manufacture/id_card_gold,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds recipes for lanyards at ID Fabricators, Uniform Fabricators, and the HoPs combo one.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They're useful little buggers and had  no buisness being as weirdly rare as they are.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DukePaulAtreid3s
(*)Added a crafting recipe for lanyards-you can print them anywhere that prints IDs or uniforms.
```
