### PR TITLE
Fix grille icons sometimes disappearing when damaged

### DIFF
--- a/code/obj/mesh.dm
+++ b/code/obj/mesh.dm
@@ -241,11 +241,11 @@ TYPEINFO(/obj/mesh)
 	switch(diff)
 		if(-INFINITY to 25)
 			return "-3"
-		if(26 to 50)
+		if(25 to 50)
 			return "-2"
-		if(51 to 75)
+		if(50 to 75)
 			return "-1"
-		if(76 to INFINITY)
+		if(75 to INFINITY)
 			return "-0"
 
 ///Handle special icon states for cut/corroded/melted meshes


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ensure the grill icon update switch statement covers the entire range of fractional numbers


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sprite disappears at specific damage values between 25-26, 50-51, and 75-76.