### PR TITLE
Fix leaving afterlife bar autocalling shuttle on lowpop

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -199,7 +199,7 @@
 	..()
 
 /mob/living/death(gibbed)
-	#define VALID_MOB(M) (!isVRghost(M) && !isghostcritter(M) && !inafterlife(M))
+	#define VALID_MOB(M) (!isVRghost(M) && !isghostcritter(M) && !inafterlife(M) && !M.hasStatus("in_afterlife"))
 	src.remove_ailments()
 	src.lastgasp(allow_dead = TRUE)
 	if (src.ai) src.ai.disable()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][respawn]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
In `/mob/living/death` add the "in_afterlife" status check, since when they leave the afterlife they're not in the afterlife area.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #13152