### PR TITLE
add gang guns to random weak spawns

### DIFF
--- a/code/obj/random_spawners.dm
+++ b/code/obj/random_spawners.dm
@@ -1887,7 +1887,19 @@
 	/obj/item/gun/kinetic/makarov,
 	/obj/item/gun/kinetic/single_action/mts_255,
 	/obj/item/gun/kinetic/survival_rifle,
-	/obj/item/gun/kinetic/survival_rifle)
+	/obj/item/gun/kinetic/survival_rifle,
+	/obj/item/gun/kinetic/m16,
+	/obj/item/gun/kinetic/m16,
+	/obj/item/gun/kinetic/pumpweapon/ks23,
+	/obj/item/gun/kinetic/striker,
+	/obj/item/gun/kinetic/striker,
+	/obj/item/gun/kinetic/webley,
+	/obj/item/gun/kinetic/lopoint,
+	/obj/item/gun/kinetic/uzi,
+	/obj/item/gun/kinetic/uzi,
+	/obj/item/gun/kinetic/greasegun,
+	/obj/item/gun/kinetic/greasegun
+	)
 
 	one
 		amt2spawn = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS][ENHANCEMENT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds gang firearms to the weak gun spawns. Does not include the highest raw damage hitters (Draco/Razorbill).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Admin gimmick tool doesn't spawn them, though some would be fun. A little plausible deniability on gang shifts, likely fine to find in prefabs too. 