### PR TITLE
Stop hall monitor radios leaking to nearby mobs

### DIFF
--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -723,6 +723,7 @@ TYPEINFO(/obj/item/radiojammer)
 	has_microphone = FALSE
 	frequency = R_FREQ_SECURITY
 	locked_frequency = TRUE
+	speaker_range = 0
 	secure_frequencies = list("g" = R_FREQ_SECURITY)
 	secure_classes = list("g" = RADIOCL_SECURITY)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Set the speaker range on the hall monitor's radio to 0, like headsets


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hall monitors let nearby mobs hear their radio. Oops.