### PR TITLE
Fix atlas having no EVA suits if not voted or terrainifyd

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -685,6 +685,8 @@ var/global/list/mapNames = list(
 	if(!station_repair.station_generator && prob(66))
 		if( !mapSwitcher.thisMapWasVotedFor )
 			logTheThing(LOG_DEBUG, null, "Automatic Atlas Terrainify skipped due to unvoted map change")
+			for_by_tcl(spawner, /obj/eva_suit_spawner)
+				spawner.spawn_gear()
 			return
 
 		var/list/terrainify_options = list(/datum/terrainify/caveify,

--- a/code/map.dm
+++ b/code/map.dm
@@ -712,6 +712,9 @@ var/global/list/mapNames = list(
 #if defined(LIVE_SERVER)
 		T.perform_terrainify(terrain_params, src)
 #endif
+	else
+		for_by_tcl(spawner, /obj/eva_suit_spawner)
+			spawner.spawn_gear()
 
 
 /datum/map_settings/destiny


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Automatically spawn atlas eva gear in 2 cases it would not, the map not being voted, and the map not terrainifying, neither of these cases called spawn_gear on the spawners.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
No EVA suits bad
Fixes #21731