### PR TITLE
Make "Centcom" law modules blue instead of pink

### DIFF
--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -318,7 +318,7 @@
 	if (law_num < 1 || law_num > 9)
 		return
 	else
-		ticker.ai_law_rack_manager.default_ai_rack.SetLawCustom("Centcom Law Module",input,law_num,TRUE,TRUE)
+		ticker.ai_law_rack_manager.default_ai_rack.SetLawCustom("Centcom Law Module",input,law_num,TRUE,TRUE,/obj/item/aiModule/custom/centcom)
 	boutput(usr, "Uploaded '[input]' as law # [law_num]")
 	ticker.ai_law_rack_manager.default_ai_rack.UpdateLaws() //I don't love this, but meh
 
@@ -367,7 +367,7 @@
 					ticker.ai_law_rack_manager.default_ai_rack.ai_abilities |= expansion.ai_abilities
 
 			else
-				ticker.ai_law_rack_manager.default_ai_rack.SetLawCustom("Centcom Law Module", split[i], i, TRUE, TRUE)
+				ticker.ai_law_rack_manager.default_ai_rack.SetLawCustom("Centcom Law Module", split[i], i, TRUE, TRUE,/obj/item/aiModule/custom/centcom)
 	ticker.ai_law_rack_manager.default_ai_rack.UpdateLaws()
 	logTheThing(LOG_ADMIN, usr, "has set the AI laws to [input]")
 	logTheThing(LOG_DIARY, usr, "has set the AI laws to [input]", "admin")

--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -390,6 +390,10 @@ ABSTRACT_TYPE(/obj/item/aiModule/syndicate)
 		. = ..()
 		src.name = "AI Law Module - '"+newname+"'"
 		src.lawText = newtext
+		if(newname = "Centcom Law Module")
+			src.highlight_color = rgb(26, 55, 141, 255)
+			src.desc += "This one was uploaded directly by Central Command, uh oh."
+			src.UpdateIcon()
 
 /********************* EXPERIMENTAL LAWS *********************/
 //at the time of programming this, these experimental laws are *intended* to be spawned by an item spawner

--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -390,10 +390,10 @@ ABSTRACT_TYPE(/obj/item/aiModule/syndicate)
 		. = ..()
 		src.name = "AI Law Module - '"+newname+"'"
 		src.lawText = newtext
-		if(newname = "Centcom Law Module")
-			src.highlight_color = rgb(26, 55, 141, 255)
-			src.desc += "This one was uploaded directly by Central Command, uh oh."
-			src.UpdateIcon()
+
+	centcom
+		highlight_color = rgb(26, 55, 141, 255)
+		desc = "An AI law module uploaded directly by Central Command, uh oh."
 
 /********************* EXPERIMENTAL LAWS *********************/
 //at the time of programming this, these experimental laws are *intended* to be spawned by an item spawner

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -727,10 +727,9 @@
 	 * Does not call UpdateLaws()
 	 * Intended for Admemery
 	 */
-	proc/SetLawCustom(lawName, lawText, slot = 1, screwed_in = FALSE, welded_in = FALSE)
-		var/path = /obj/item/aiModule/custom
-		if(lawName == "Centcom Law Module")
-			path = /obj/item/aiModule/custom/centcom
+	proc/SetLawCustom(lawName, lawText, slot = 1, screwed_in = FALSE, welded_in = FALSE, path)
+		if(!path || !ispath(path))
+			path = /obj/item/aiModule/custom
 		var/mod = new path(lawName,lawText)
 		return src.SetLaw(mod,slot,screwed_in,welded_in)
 

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -728,7 +728,10 @@
 	 * Intended for Admemery
 	 */
 	proc/SetLawCustom(lawName, lawText, slot = 1, screwed_in = FALSE, welded_in = FALSE)
-		var/mod = new /obj/item/aiModule/custom(lawName,lawText)
+		var/path = /obj/item/aiModule/custom
+		if(lawName == "Centcom Law Module")
+			path = /obj/item/aiModule/custom/centcom
+		var/mod = new path(lawName,lawText)
 		return src.SetLaw(mod,slot,screwed_in,welded_in)
 
 	/// Deletes a law in an abritrary slot. Does not call UpdateLaws()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes laws uploaded via admin command blue instead of pink


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pink doesnt feel like a "centcom" colour, blue is much more fitting and not used for any station-laws so is very clear what it is 