### PR TITLE
Fix invalid camera networks

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -64182,14 +64182,8 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname - Mining";
-	network = "Mining";
-	tag = ""
-	},
 /obj/machinery/power/apc/autoname_south,
+/obj/machinery/camera/auto,
 /turf/simulated/floor/yellow/side{
 	dir = 10
 	},

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -16060,12 +16060,8 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
 "cdZ" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	network = "Armory Perimeter";
-	tag = ""
+/obj/machinery/camera/auto{
+	dir = 10
 	},
 /turf/space,
 /area/space)
@@ -28574,14 +28570,10 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
 "jJj" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	network = "autoname - SS13"
-	},
 /obj/item/device/radio/intercom/security{
 	dir = 8
 	},
+/obj/machinery/camera/auto,
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
 "jJu" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -20320,16 +20320,6 @@
 /obj/disposalpipe/junction/left/west,
 /turf/simulated/floor/bluewhite/corner,
 /area/station/medical/medbay/treatment)
-"fZQ" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	network = "Armory Perimeter";
-	tag = ""
-	},
-/turf/space,
-/area/station/turret_protected/armory_outside)
 "fZS" = (
 /mob/living/critter/rockworm,
 /turf/simulated/floor/plating/airless/asteroid,
@@ -59829,15 +59819,7 @@
 /turf/simulated/floor/white/checker,
 /area/station/hallway/primary/south)
 "sbY" = (
-/obj/machinery/camera{
-	c_tag = "Armory Perimeter - West ";
-	dir = 8;
-	name = "autoname  - SS13";
-	network = "Armory Perimeter";
-	pixel_x = 4;
-	pixel_y = -3;
-	tag = ""
-	},
+/obj/machinery/camera/auto,
 /turf/space,
 /area/station/turret_protected/armory_outside)
 "sck" = (
@@ -70578,6 +70560,10 @@
 	},
 /turf/space,
 /area/station/turret_protected/armory_outside)
+"vnQ" = (
+/obj/machinery/camera/auto,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/stockex)
 "vnS" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -75975,16 +75961,6 @@
 /area/station/wreckage{
 	name = "Restricted Area"
 	})
-"wPD" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	network = "Armory Perimeter";
-	tag = ""
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/stockex)
 "wPR" = (
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -100438,7 +100414,7 @@ sIK
 sIK
 sIK
 gYc
-fZQ
+sbY
 jhw
 jhw
 jhw
@@ -111899,7 +111875,7 @@ vyo
 jOl
 gKJ
 dDb
-wPD
+vSe
 lOJ
 tGy
 mkV
@@ -112201,7 +112177,7 @@ waP
 waP
 gKJ
 nHd
-vSe
+vnQ
 lOJ
 lOJ
 lOJ

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -9026,12 +9026,7 @@
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "aEo" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	network = "Pathopost";
-	tag = ""
-	},
+/obj/machinery/camera/auto,
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 8
 	},
@@ -46731,19 +46726,13 @@
 /turf/simulated/floor/stairs/wide,
 /area/station/hallway/secondary/exit)
 "wRK" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname - Mining";
-	network = "Mining";
-	tag = ""
-	},
 /obj/blind_switch/area/west{
 	pixel_y = 4
 	},
 /obj/machinery/light_switch/west{
 	pixel_y = -4
 	},
+/obj/machinery/camera/auto,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "wRN" = (
@@ -47303,12 +47292,7 @@
 /obj/rack,
 /obj/item/clothing/mask/breath,
 /obj/item/tank/emergency_oxygen,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	network = "Pathopost";
-	tag = ""
-	},
+/obj/machinery/camera/auto,
 /turf/simulated/floor,
 /area/shuttle/sea_elevator_room)
 "xFd" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace several cameras with wrong "network" map-edited vars with auto cameras. Per-map notes in commitlog.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wrong network cameras can't be used by security's camera monitor
Fix #17630