### PR TITLE
Replace donut3 telesci decal tile edges with tiles

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -7037,10 +7037,6 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "caq" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 4;
-	icon_state = "tile1"
-	},
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
@@ -7054,7 +7050,9 @@
 	},
 /obj/stool,
 /obj/landmark/start/job/scientist,
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite{
+	dir = 4
+	},
 /area/station/science/teleporter)
 "cax" = (
 /obj/machinery/firealarm/west,
@@ -7568,14 +7566,6 @@
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "chx" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 6;
-	icon_state = "tile1"
-	},
-/obj/decal/tile_edge/line/purple{
-	dir = 9;
-	icon_state = "tile1"
-	},
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -7587,7 +7577,7 @@
 /obj/stool/chair/office/purple{
 	dir = 8
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purple/checker,
 /area/station/science/teleporter)
 "chz" = (
 /obj/cable{
@@ -16096,13 +16086,11 @@
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/medical/morgue)
 "eKX" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 8;
-	icon_state = "tile1"
-	},
 /obj/item/device/radio/beacon,
 /obj/landmark/gps_waypoint,
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite{
+	dir = 8
+	},
 /area/station/science/teleporter)
 "eLa" = (
 /obj/decal/cleanable/rust/jen,
@@ -18419,17 +18407,15 @@
 	pixel_x = -7;
 	pixel_y = 11
 	},
-/obj/decal/tile_edge/line/purple{
-	dir = 8;
-	icon_state = "tile1"
-	},
 /obj/item/clothing/head/helmet/camera/telesci,
 /obj/decal/tile_edge/line/purple{
 	dir = 5;
 	icon_state = "tile1"
 	},
 /obj/item/device/camera_viewer/telesci,
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite{
+	dir = 8
+	},
 /area/station/science/teleporter)
 "fwu" = (
 /obj/decal/cleanable/dirt/jen,
@@ -19175,14 +19161,12 @@
 /turf/simulated/floor/red/checker,
 /area/station/hangar/sec)
 "fHI" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 1;
-	icon_state = "tile1"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite{
+	dir = 1
+	},
 /area/station/science/teleporter)
 "fHK" = (
 /obj/table/auto,
@@ -20530,19 +20514,13 @@
 /obj/machinery/networked/teleconsole{
 	dir = 4
 	},
-/obj/decal/tile_edge/line/purple{
-	dir = 5;
-	icon_state = "tile1"
-	},
-/obj/decal/tile_edge/line/purple{
-	dir = 9;
-	icon_state = "tile1"
-	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite{
+	dir = 1
+	},
 /area/station/science/teleporter)
 "gdc" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -28674,13 +28652,6 @@
 /turf/simulated/floor/white,
 /area/station/medical/asylum/main)
 "iGx" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 1;
-	icon_state = "tile1"
-	},
-/obj/decal/tile_edge/line/purple{
-	icon_state = "tile1"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -28688,7 +28659,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "iGC" = (
 /obj/table/reinforced/auto,
@@ -37888,17 +37859,15 @@
 /area/station/engine/inner)
 "lvY" = (
 /obj/decal/tile_edge/line/purple{
-	dir = 8;
-	icon_state = "tile1"
-	},
-/obj/decal/tile_edge/line/purple{
 	dir = 5;
 	icon_state = "tile1"
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite{
+	dir = 8
+	},
 /area/station/science/teleporter)
 "lwe" = (
 /obj/decal/cleanable/dirt/jen,
@@ -40280,14 +40249,12 @@
 /area/station/maintenance/outer/se)
 "maP" = (
 /obj/decal/tile_edge/line/purple{
-	dir = 8;
-	icon_state = "tile1"
-	},
-/obj/decal/tile_edge/line/purple{
 	dir = 6;
 	icon_state = "tile1"
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite{
+	dir = 8
+	},
 /area/station/science/teleporter)
 "maS" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -40512,18 +40479,11 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
 "mer" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 1;
-	icon_state = "tile1"
-	},
-/obj/decal/tile_edge/line/purple{
-	icon_state = "tile1"
-	},
 /obj/machinery/disposal/mail/small/autoname/research/telescience/south,
 /obj/disposalpipe/trunk/mail{
 	dir = 8
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "meu" = (
 /obj/machinery/computer/solar_control/small_backup1{
@@ -47585,14 +47545,12 @@
 	pixel_y = -2
 	},
 /obj/decal/tile_edge/line/purple{
-	dir = 4;
-	icon_state = "tile1"
-	},
-/obj/decal/tile_edge/line/purple{
 	dir = 9;
 	icon_state = "tile1"
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite{
+	dir = 4
+	},
 /area/station/science/teleporter)
 "orr" = (
 /obj/decal/tile_edge/line/grey{
@@ -51481,17 +51439,6 @@
 	dir = 8
 	},
 /area/station/engine/inner)
-"pBe" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 6;
-	icon_state = "tile1"
-	},
-/obj/decal/tile_edge/line/purple{
-	dir = 8;
-	icon_state = "tile1"
-	},
-/turf/simulated/floor/white,
-/area/station/science/teleporter)
 "pBO" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -52753,15 +52700,9 @@
 /obj/decal/poster/wallsign/poster_sol{
 	pixel_y = 28
 	},
-/obj/decal/tile_edge/line/purple{
-	dir = 5;
-	icon_state = "tile1"
+/turf/simulated/floor/purple/checker{
+	dir = 1
 	},
-/obj/decal/tile_edge/line/purple{
-	dir = 10;
-	icon_state = "tile1"
-	},
-/turf/simulated/floor/white,
 /area/station/science/teleporter)
 "pTL" = (
 /obj/decal/cleanable/dirt/jen,
@@ -53363,14 +53304,6 @@
 	},
 /area/station/crew_quarters/market)
 "qef" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 9;
-	icon_state = "tile1"
-	},
-/obj/decal/tile_edge/line/purple{
-	dir = 5;
-	icon_state = "tile1"
-	},
 /obj/machinery/door_control{
 	id = "telesci_hall";
 	name = "Privacy Shutters";
@@ -53380,7 +53313,9 @@
 /obj/machinery/light/incandescent/harsh{
 	dir = 1
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite{
+	dir = 1
+	},
 /area/station/science/teleporter)
 "qez" = (
 /obj/storage/secure/crate/gear/armory/equipment,
@@ -59739,16 +59674,9 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "sbn" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 1;
-	icon_state = "tile1"
-	},
-/obj/decal/tile_edge/line/purple{
-	icon_state = "tile1"
-	},
 /obj/machinery/disposal/small,
 /obj/disposalpipe/trunk,
-/turf/simulated/floor/white,
+/turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "sbq" = (
 /obj/machinery/power/apc/autoname_north,
@@ -62057,10 +61985,6 @@
 	},
 /area/station/crew_quarters/bar)
 "sMp" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 4;
-	icon_state = "tile1"
-	},
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
@@ -62068,7 +61992,9 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite{
+	dir = 4
+	},
 /area/station/science/teleporter)
 "sMr" = (
 /obj/window_blinds/cog2/right,
@@ -71653,16 +71579,14 @@
 	dir = 10;
 	icon_state = "tile1"
 	},
-/obj/decal/tile_edge/line/purple{
-	dir = 4;
-	icon_state = "tile1"
-	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/computer/telescope,
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite{
+	dir = 4
+	},
 /area/station/science/teleporter)
 "vDo" = (
 /turf/simulated/floor/black,
@@ -71800,10 +71724,7 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "vFt" = (
-/obj/decal/tile_edge/line/purple{
-	icon_state = "tile1"
-	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite,
 /area/station/science/teleporter)
 "vFB" = (
 /obj/machinery/light/incandescent/cool,
@@ -72333,14 +72254,12 @@
 /area/station/hallway/primary/east)
 "vOr" = (
 /obj/decal/tile_edge/line/purple{
-	dir = 4;
-	icon_state = "tile1"
-	},
-/obj/decal/tile_edge/line/purple{
 	dir = 10;
 	icon_state = "tile1"
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite{
+	dir = 4
+	},
 /area/station/science/teleporter)
 "vOy" = (
 /obj/decal/stripe_delivery,
@@ -72711,14 +72630,12 @@
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "vTy" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 8;
-	icon_state = "tile1"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite{
+	dir = 8
+	},
 /area/station/science/teleporter)
 "vTA" = (
 /obj/machinery/light/small/floor/blueish,
@@ -73456,12 +73373,10 @@
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/crew_quarters/arcade/dungeon)
 "wfL" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 10;
-	icon_state = "tile1"
-	},
 /obj/reagent_dispensers/foamtank,
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite/corner{
+	dir = 4
+	},
 /area/station/science/teleporter)
 "wfP" = (
 /obj/cable{
@@ -74167,11 +74082,9 @@
 /turf/simulated/floor/black,
 /area/station/storage/primary)
 "wpQ" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 4;
-	icon_state = "tile1"
+/turf/simulated/floor/purplewhite{
+	dir = 4
 	},
-/turf/simulated/floor/white,
 /area/station/science/teleporter)
 "wpW" = (
 /obj/disposalpipe/segment/mail,
@@ -77129,12 +77042,8 @@
 /area/station/medical/medbay/pharmacy)
 "xfi" = (
 /obj/storage/closet/emergency,
-/obj/decal/tile_edge/line/purple{
-	dir = 6;
-	icon_state = "tile1"
-	},
 /obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite/corner,
 /area/station/science/teleporter)
 "xfj" = (
 /obj/pool/perspective{
@@ -78020,9 +77929,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade/dungeon)
 "xqJ" = (
-/obj/decal/tile_edge/line/purple{
-	icon_state = "tile1"
-	},
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/regular{
 	pixel_x = 1;
@@ -78040,7 +77946,7 @@
 	pixel_x = 5;
 	pixel_y = -1
 	},
-/turf/simulated/floor/white,
+/turf/simulated/floor/purplewhite,
 /area/station/science/teleporter)
 "xqL" = (
 /obj/storage/closet/office,
@@ -129499,7 +129405,7 @@ ipJ
 tYp
 mZl
 sTE
-pBe
+maP
 lvY
 maP
 fwt


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The neat tile decorations in telesci were using decals instead of two-tone tiles. Maintain the design while reducing the number of tile decals where possible.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reduce number of decals

