### PR TITLE
Adds min and max to arithemetic component

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -3291,7 +3291,7 @@ ADMIN_INTERACT_PROCS(/obj/item/mechanics/trigger/button, proc/press)
 		return 1
 
 	proc/setMode(obj/item/W as obj, mob/user as mob)
-		mode = input("Set the math mode to what?", "Mode Selector", mode) in list("add","mul","div","sub","mod","pow","rng","eq","neq","gt","lt","gte","lte")
+		mode = input("Set the math mode to what?", "Mode Selector", mode) in list("add","mul","div","sub","mod","pow","rng","eq","neq","gt","lt","gte","lte", "min", "max")
 		tooltip_rebuild = 1
 		return 1
 

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -3326,7 +3326,7 @@ ADMIN_INTERACT_PROCS(/obj/item/mechanics/trigger/button, proc/press)
 	proc/compSetMode(var/datum/mechanicsMessage/input)
 		LIGHT_UP_HOUSING
 		tooltip_rebuild = 1
-		if(input.signal in list("add","mul","div","sub","mod","pow","rng","eq","neq","gt","lt","gte","lte"))
+		if(input.signal in list("add","mul","div","sub","mod","pow","rng","eq","neq","gt","lt","gte","lte","min","max"))
 			mode = input.signal
 	proc/evaluate()
 		switch(mode)
@@ -3359,6 +3359,10 @@ ADMIN_INTERACT_PROCS(/obj/item/mechanics/trigger/button, proc/press)
 				. = A == B
 			if("neq")
 				. = A != B
+			if("min")
+				. = min(A, B)
+			if("max")
+				. = max(A, B)
 			else
 				return
 

--- a/strings/books/mechanicbook.txt
+++ b/strings/books/mechanicbook.txt
@@ -34,6 +34,40 @@
 	<br>Sends specified signal when both inputs receive a Signal within a specified Time Frame.
 	<br>
 	<br>
+	<br><B>Arithmetic Component:</B>
+	<br>Stores numbers received in signals to variable A or B. By default it will compute the result immediately, then send it on as a signal.
+	<br>Conveniently strips off trailing letters when setting variables.
+	<br>
+	<br>There are several options and inputs.
+	<ul>
+		<li>Set A/Set B: set the variables manually with your multitool, or with with a signal input.</li>
+		<li>Evaluate: immediately send a signal with the result of the current mode and variables.</li>
+		<li>Set Mode: set the operation to apply to the variables, we'll list these below.
+			<br>It can be set by hand or with an input signal.
+		<li>Toggle Auto-Evaluate: toggle evaluating automatically when variables are set.</li>
+		<li>Toggle Auto-Floor: automatically floor() results to the closest integer
+	</ul>
+
+	The following are the modes you can set the component to. Results are passed along as a signal,
+	<br>either when setting a variable with a signal, or when an evaluate signal is recieved.
+	<ul>
+		<li>Add: sends the sum of A and B</li>
+		<li>Sub: subtracts B from A</li>
+		<li>Div: divides A by B, errors if B is zero</li>
+		<li>Mul: multiplies A and b</li>
+		<li>Mod: finds the modulus (remainder) of A divided by B</li>
+		<li>Pow: Power. Gets the result of A to exponent B</li>
+		<li>Rng: Gets a random number between A and B</li>
+		<li>Gt/lt: Greater than, less than. Returns 1 if A is greater than or less than B, respectively. Otherwise returns 0.
+			<br>You'll need a signal check component after this.</li>
+		<li>Gte/lte: Greater than or equal/less than or equal. Same as above but also triggers on equality.</li>
+		<li>Eq: Equal. Returns 1 if A and B are equal, 0 if not.</li>
+		<li>Neq: Not equal. Opposite of equal.</li>
+		<li>Min: Returns A or B, whichever is smaller.</li>
+		<li>Max: Like min but returns whichever is larger.</li>
+
+	</ul>
+
 	<br><B>Button:</B>
 	<br>Sends set Signal when used.
 	<br>

--- a/strings/books/mechanicbook.txt
+++ b/strings/books/mechanicbook.txt
@@ -35,7 +35,7 @@
 	<br>
 	<br>
 	<br><B>Arithmetic Component:</B>
-	<br>Stores numbers received in signals to variable A or B. By default it will compute the result immediately, then send it on as a signal.
+	<br>Stores numbers received in signals to variable A or B, then do mathematical operations on them. By default it will compute the result immediately, then send it on as a signal.
 	<br>Conveniently strips off trailing letters when setting variables.
 	<br>
 	<br>There are several options and inputs.

--- a/strings/books/mechanicbook.txt
+++ b/strings/books/mechanicbook.txt
@@ -35,7 +35,7 @@
 	<br>
 	<br>
 	<br><B>Arithmetic Component:</B>
-	<br>Stores numbers received in signals to variable A or B, then do mathematical operations on them. By default it will compute the result immediately, then send it on as a signal.
+	<br>Store numbers received in signals to variable A or B, then do mathematical operations on them. By default it will compute the result immediately, then send it on as a signal.
 	<br>Conveniently strips off trailing letters when setting variables.
 	<br>
 	<br>There are several options and inputs.

--- a/strings/books/mechanicbook.txt
+++ b/strings/books/mechanicbook.txt
@@ -51,13 +51,13 @@
 	The following are the modes you can set the component to. Results are passed along as a signal,
 	either when setting a variable with a signal, or when an evaluate signal is recieved.
 	<ul>
-		<li>Add: finds the sum of A and B</li>
-		<li>Sub: subtracts B from A</li>
-		<li>Div: divides A by B, errors if B is zero</li>
-		<li>Mul: multiplies A and B</li>
-		<li>Mod: finds the modulus (remainder) of A divided by B</li>
-		<li>Pow: Power. Gets the result of A to exponent B</li>
-		<li>Rng: Gets a random number between A and B</li>
+		<li>Add: Finds the sum of A and B.</li>
+		<li>Sub: Subtracts B from A.</li>
+		<li>Div: Divides A by B, errors if B is zero.</li>
+		<li>Mul: Multiplies A and B.</li>
+		<li>Mod: Finds the modulus (remainder) of A divided by B.</li>
+		<li>Pow: Power. Gets the result of A to exponent B.</li>
+		<li>Rng: Gets a random number between A and B.</li>
 		<li>Gt/lt: Greater than, less than. Returns 1 if A is greater than or less than B, respectively. Otherwise returns 0.
 			<br>You'll need a signal check component after this.</li>
 		<li>Gte/lte: Greater than or equal/less than or equal. Same as above but also triggers on equality.</li>

--- a/strings/books/mechanicbook.txt
+++ b/strings/books/mechanicbook.txt
@@ -49,7 +49,7 @@
 	</ul>
 
 	The following are the modes you can set the component to. Results are passed along as a signal,
-	<br>either when setting a variable with a signal, or when an evaluate signal is recieved.
+	either when setting a variable with a signal, or when an evaluate signal is recieved.
 	<ul>
 		<li>Add: sends the sum of A and B</li>
 		<li>Sub: subtracts B from A</li>

--- a/strings/books/mechanicbook.txt
+++ b/strings/books/mechanicbook.txt
@@ -51,10 +51,10 @@
 	The following are the modes you can set the component to. Results are passed along as a signal,
 	either when setting a variable with a signal, or when an evaluate signal is recieved.
 	<ul>
-		<li>Add: sends the sum of A and B</li>
+		<li>Add: finds the sum of A and B</li>
 		<li>Sub: subtracts B from A</li>
 		<li>Div: divides A by B, errors if B is zero</li>
-		<li>Mul: multiplies A and b</li>
+		<li>Mul: multiplies A and B</li>
 		<li>Mod: finds the modulus (remainder) of A divided by B</li>
 		<li>Pow: Power. Gets the result of A to exponent B</li>
 		<li>Rng: Gets a random number between A and B</li>


### PR DESCRIPTION
[FEATURE]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds min and max as modes for the arithmetic component. Documents the arithmetic component in the mechanic book while we're here.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The specific need I ran into is having a minimum/maximum limit when automatically controlling a SMES unit, right now you'd have to do some awkward chain to accomplish a simple operation

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)patricia
(+)The arithmetic component now supports max and min operations
```
