### PR TITLE
Fixed typo in small_animal.dm

### DIFF
--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -4606,7 +4606,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	speechverb_exclaim = "snaps"
 	health_brute = 15
 	health_burn = 15
-	pet_text = list("gently pets", "rubs", "cuddles, coddles")
+	pet_text = list("gently pets", "rubs", "cuddles", "coddles")
 	player_can_spawn_with_pet = TRUE
 	var/can_hat = TRUE
 


### PR DESCRIPTION
[Critters][Player Actions][[Bug][Trivial]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a typo in small_animal.dm that causes you to sometimes "cuddles, coddles" a crab

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
No longer will you "cuddles, coddles" a crab
