### PR TITLE
Fix donut3 barricaded windows not being destroyable

### DIFF
--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -352,6 +352,7 @@ TYPEINFO(/obj/structure/woodwall)
 	projectile_passthrough_chance = 30
 	_health = 30
 	_max_health = 30
+	flags = ON_BORDER
 	var/builtby = null
 	var/anti_z = 0
 	// for projectile damage component


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add the ON_BORDER flag to barricades

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Windows have this, so even though they're a layer below barricades they stop the attacks from occurring.
Fix #19300