### PR TITLE
Fix map varedit on wrestlemap runtiming camera monitors

### DIFF
--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -39787,7 +39787,6 @@
 /obj/machinery/light,
 /obj/machinery/camera/television{
 	c_tag = "Chapel";
-	c_tag_order = "Chapel camera";
 	dir = 1;
 	name = "Chapel camera"
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[runtime][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
remove map varedit of a string put in for chapel camera `c_tag_order`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
this runtimes the camera viewers on wrestlemap (`c_tag_order` expects a number)