### PR TITLE
Fix mechboots negating jetpackmk2 fluid movespeed boost

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2977,6 +2977,8 @@
 	equipment_proxy.aquatic_movement = GET_ATOM_PROPERTY(src, PROP_MOB_EQUIPMENT_MOVESPEED_FLUID)
 	if(equipment_proxy.aquatic_movement > 0)
 		equipment_proxy.aquatic_movement *= modifier
+		if(modifier == 0) // aquatic_movement requires a positive value to skip added fluid turf delay
+			equipment_proxy.aquatic_movement += 0.01
 
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When the movespeed assist modifier is set to 0 and the equipment movespeed for aquatic movement is more than 0, ensure there's a tiny aquatic movespeed component.

This is because the aquatic_movement variable has to positive to skip adding active liquid and fluid turf delays in the proc `/mob/living/carbon/human/special_movedelay_mod`.

See code\mob\living\carbon\human.dm L3380

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21748
Fix #19933
Fix #21185