### PR TITLE
Prevent artifact power gens from targeting ghosts

### DIFF
--- a/code/obj/artifacts/artifact_objects/power_gen.dm
+++ b/code/obj/artifacts/artifact_objects/power_gen.dm
@@ -101,7 +101,7 @@
 					playsound(O, 'sound/effects/screech2.ogg', 75, TRUE)
 					O.visible_message(SPAN_ALERT("[O] sparks violently!"))
 					for (var/mob/M in view(min(5,gen_level),T))
-						if (isintangible(M)) continue
+						if (M.invisibility >= INVIS_AI_EYE) continue
 						arcFlash(O, M, gen_rate/2)
 						if(!M.disposed)
 							O.ArtifactFaultUsed(M) // in case you weren't already fucked enough lol


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Change the artifact power gen to test for the invisibility applied to AI Eyes and above, preventing it from hitting AI eyes, ghosts, etc. without a bunch of chained checks. Will still hit cloaked mobs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #14671