### PR TITLE
use vis_contents instead of overlays for /obj/vehicles

### DIFF
--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -114,7 +114,7 @@ TYPEINFO(/obj/tug_cart)
 				C.pixel_y += 6
 				if (C.layer < layer)
 					C.layer = layer + 0.1
-				src.UpdateOverlays(C, "load")
+				src.vis_contents += C
 
 	proc/unload()
 		if (!load)
@@ -141,8 +141,8 @@ TYPEINFO(/obj/tug_cart)
 		if(src.load == Obj)
 			src.load.pixel_y -= 6
 			src.load.layer = initial(src.load.layer)
+			src.vis_contents -= src.load
 			src.load = null
-			src.UpdateOverlays(null, "load")
 
 	Move()
 		var/oldloc = src.loc
@@ -247,8 +247,8 @@ TYPEINFO(/obj/vehicle/tug)
 				var/turf/target = get_edge_target_turf(src, src.dir)
 				rider.throw_at(target, 5, 1)
 				rider.buckled = null
+				src.vis_contents -= rider
 				rider = null
-				src.ClearSpecificOverlays("rider")
 				return
 			if (selfdismount)
 				boutput(rider, SPAN_NOTICE("You dismount from [src]."))
@@ -258,8 +258,8 @@ TYPEINFO(/obj/vehicle/tug)
 					C.show_message("<B>[rider]</B> dismounts from [src].", 1)
 			if (rider)
 				rider.buckled = null
+				src.vis_contents -= rider
 			rider = null
-			src.ClearSpecificOverlays("rider")
 			return
 
 	MouseDrop_T(var/atom/movable/C, mob/user)
@@ -304,7 +304,7 @@ TYPEINFO(/obj/vehicle/tug)
 		target.set_loc(src)
 		rider = target
 		rider.pixel_y = 6
-		src.UpdateOverlays(rider, "rider")
+		src.vis_contents += rider
 		if (rider.restrained() || rider.stat)
 			rider.buckled = src
 

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -559,9 +559,6 @@
 			for (var/mob/x in src.observers)
 				if (x.client)
 					src.updateOverlaysClient(x.client)
-		if (istype(src.loc, /obj/vehicle))
-			var/obj/vehicle/riding = src.loc
-			riding.eject_rider()
 
 
 	handle_stamina_updates()

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -559,6 +559,9 @@
 			for (var/mob/x in src.observers)
 				if (x.client)
 					src.updateOverlaysClient(x.client)
+		if (istype(src.loc, /obj/vehicle))
+			var/obj/vehicle/riding = src.loc
+			riding.eject_rider()
 
 
 	handle_stamina_updates()

--- a/code/modules/transport/skateboard.dm
+++ b/code/modules/transport/skateboard.dm
@@ -263,6 +263,7 @@
 	if(rider)
 		if(istype(src.loc, /turf/space))
 			return
+		src.dir = user.dir
 		walk(src, dir, speed_delay)
 	else
 		for(var/mob/M in src.contents)

--- a/code/modules/transport/skateboard.dm
+++ b/code/modules/transport/skateboard.dm
@@ -250,8 +250,8 @@
 	actions.stop(runningAction, src)
 	runningAction = null
 
+	src.vis_contents -= rider
 	rider = null
-	overlays = null
 
 	adjustSickness(-sickness)
 	update()
@@ -284,7 +284,7 @@
 	rider.pixel_x = 0
 	rider.pixel_y = 4
 
-	overlays += rider
+	src.vis_contents += rider
 
 	adjustSickness(-sickness)
 	update()

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -152,7 +152,7 @@ ABSTRACT_TYPE(/obj/vehicle)
 	proc/eject_rider(var/crashed, var/selfdismount, var/ejectall = TRUE)
 		if(src.rider)
 			MOVE_OUT_TO_TURF_SAFE(src.rider, src)
-			src.vis_contents -= rider
+			src.vis_contents -= src.rider
 			ClearSpecificOverlays("booster_image")
 			handle_button_removal()
 			src.rider = null
@@ -195,17 +195,10 @@ ABSTRACT_TYPE(/obj/vehicle)
 	// This handles the code that USED to be defined individually in each vehicle's relaymove() proc
 	// all non-machinery vehicles except forklifts and skateboards use this now
 	relaymove(mob/user as mob, dir)
-		// we reset the overlays to null in case the relaymove() call was initiated by a
-		// passenger rather than the driver (we shouldn't have a rider overlay if there is no rider!)
-		src.vis_contents -= rider
-
 		if(!src.rider || user != src.rider)
 			return
 
 		var/td = max(src.delay, MINIMUM_EFFECTIVE_DELAY)
-
-		if(src.rider_visible)
-			src.vis_contents += rider
 
 		// You can't move in space without the booster upgrade
 		if (src.booster_upgrade)
@@ -344,7 +337,7 @@ TYPEINFO(/obj/vehicle/segway)
 		src.underlays += src.image_under
 	else
 		src.icon_state = src.icon_base
-		src.vis_contents -= rider
+		src.vis_contents -= src.rider
 		src.underlays = null
 
 /obj/vehicle/segway/bump(atom/AM as mob|obj|turf)
@@ -562,7 +555,7 @@ TYPEINFO(/obj/vehicle/segway)
 		handle_button_addition()
 	rider.pixel_x = 0
 	rider.pixel_y = 5
-	src.vis_contents += rider
+	src.vis_contents += src.rider
 
 	for (var/mob/C in AIviewers(src))
 		if(C == user)
@@ -701,7 +694,7 @@ TYPEINFO(/obj/vehicle/floorbuffer)
 		src.underlays += src.image_under
 	else
 		src.icon_state = src.icon_base
-		src.vis_contents -= rider
+		src.vis_contents -= src.rider
 		src.underlays = null
 
 /obj/vehicle/floorbuffer/Move()

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -2342,6 +2342,7 @@ TYPEINFO(/obj/vehicle/forklift)
 
 	//forklift
 	if(src.rider && user == src.rider)
+		src.dir = user.dir
 		var/td = max(src.delay, MINIMUM_EFFECTIVE_DELAY)
 		if (!src.booster_upgrade)
 			if(T.throw_unlimited && istype(T, /turf/space))

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -130,6 +130,11 @@ ABSTRACT_TYPE(/obj/vehicle)
 		if(src.rider_visible && src.rider)
 			return "[src.rider] is currently riding it."
 
+	Move(NewLoc, direct)
+		. = ..()
+		if(src.rider_visible && src.rider)
+			src.rider.dir = direct
+
 	Exited(atom/movable/thing, atom/newloc)
 		. = ..()
 		if(thing == src.rider)
@@ -147,7 +152,7 @@ ABSTRACT_TYPE(/obj/vehicle)
 	proc/eject_rider(var/crashed, var/selfdismount, var/ejectall = TRUE)
 		if(src.rider)
 			MOVE_OUT_TO_TURF_SAFE(src.rider, src)
-			ClearSpecificOverlays("rider")
+			src.vis_contents -= rider
 			ClearSpecificOverlays("booster_image")
 			handle_button_removal()
 			src.rider = null
@@ -192,7 +197,7 @@ ABSTRACT_TYPE(/obj/vehicle)
 	relaymove(mob/user as mob, dir)
 		// we reset the overlays to null in case the relaymove() call was initiated by a
 		// passenger rather than the driver (we shouldn't have a rider overlay if there is no rider!)
-		src.ClearSpecificOverlays("rider")
+		src.vis_contents -= rider
 
 		if(!src.rider || user != src.rider)
 			return
@@ -200,7 +205,7 @@ ABSTRACT_TYPE(/obj/vehicle)
 		var/td = max(src.delay, MINIMUM_EFFECTIVE_DELAY)
 
 		if(src.rider_visible)
-			src.UpdateOverlays(src.rider, "rider")
+			src.vis_contents += rider
 
 		// You can't move in space without the booster upgrade
 		if (src.booster_upgrade)
@@ -339,7 +344,7 @@ TYPEINFO(/obj/vehicle/segway)
 		src.underlays += src.image_under
 	else
 		src.icon_state = src.icon_base
-		src.UpdateOverlays(null, "rider")
+		src.vis_contents -= rider
 		src.underlays = null
 
 /obj/vehicle/segway/bump(atom/AM as mob|obj|turf)
@@ -557,7 +562,7 @@ TYPEINFO(/obj/vehicle/segway)
 		handle_button_addition()
 	rider.pixel_x = 0
 	rider.pixel_y = 5
-	src.UpdateOverlays(rider, "rider")
+	src.vis_contents += rider
 
 	for (var/mob/C in AIviewers(src))
 		if(C == user)
@@ -696,7 +701,7 @@ TYPEINFO(/obj/vehicle/floorbuffer)
 		src.underlays += src.image_under
 	else
 		src.icon_state = src.icon_base
-		src.UpdateOverlays(null, "rider")
+		src.vis_contents -= rider
 		src.underlays = null
 
 /obj/vehicle/floorbuffer/Move()
@@ -881,7 +886,7 @@ TYPEINFO(/obj/vehicle/floorbuffer)
 		handle_button_addition()
 	rider.pixel_x = 0
 	rider.pixel_y = 5
-	src.UpdateOverlays(rider, "rider")
+	src.vis_contents += rider
 
 	for (var/mob/C in AIviewers(src))
 		if(C == user)
@@ -1483,8 +1488,8 @@ TYPEINFO(/obj/vehicle/clowncar)
 			C.show_message(SPAN_ALERT("<b>[rider] is flung over the [src]'s head!</b>"), 1)
 		var/turf/target = get_edge_target_turf(src, src.dir)
 		rider.throw_at(target, 5, 1)
+		src.vis_contents -= rider
 		rider = null
-		ClearSpecificOverlays("rider")
 		return
 	if(selfdismount)
 		boutput(rider, SPAN_NOTICE("You dismount from the [src]."))
@@ -1492,8 +1497,8 @@ TYPEINFO(/obj/vehicle/clowncar)
 			if(C == rider)
 				continue
 			C.show_message("<b>[rider]</b> dismounts from the [src].", 1)
+	src.vis_contents -= rider
 	rider = null
-	ClearSpecificOverlays("rider")
 	return
 
 /obj/vehicle/cat/do_special_on_relay(mob/user as mob, dir)
@@ -1523,7 +1528,7 @@ TYPEINFO(/obj/vehicle/clowncar)
 	rider = target
 	rider.pixel_x = 0
 	rider.pixel_y = 5
-	src.UpdateOverlays(rider, "rider")
+	src.vis_contents += rider
 	src.icon_state = "[src.icon_state]1"
 
 	for (var/mob/C in AIviewers(src))

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -198,6 +198,8 @@ ABSTRACT_TYPE(/obj/vehicle)
 		if(!src.rider || user != src.rider)
 			return
 
+		src.dir = user.dir
+
 		var/td = max(src.delay, MINIMUM_EFFECTIVE_DELAY)
 
 		// You can't move in space without the booster upgrade


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[rework][experimental][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* For /obj/vehicles (and /obj/tug_cart), instead of static overlays add riders to vis_contents.
* When the vehicle changes direction, change the rider's direction

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #10354
Fix #11998
Fix #16021
Fix #16234
Fix #17672
Fix #18264
Fix #20495

Recommend testmerge as there are a lot of potential corner cases and interactions that may need to be covered.
Might need some added anti-cheese for laying down while riding; have one in the wings if it proves to be an issue.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Rideable vehicles update the rider's appearance in realtime.
```
