### PR TITLE
Add help message about the `:in` prefix to intercoms

### DIFF
--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -1080,6 +1080,8 @@ TYPEINFO(/obj/item/device/radio/intercom/loudspeaker/speaker)
 	density = 0
 	desc = "A Loudspeaker."
 
+	HELP_MESSAGE_OVERRIDE("")
+
 	New()
 		..()
 		if(src.pixel_x == 0 && src.pixel_y == 0)

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -17,6 +17,8 @@ TYPEINFO(/obj/item/device/radio/intercom)
 	desc = "A wall-mounted radio intercom, used to communicate with the specified frequency. Usually turned off except during emergencies."
 	hardened = 0
 
+	HELP_MESSAGE_OVERRIDE("Stand next to an intercom and use the prefix <B> :in </B> to speak directly into it.")
+
 /obj/item/device/radio/intercom/proc/update_pixel_offset_dir(obj/item/AM, old_dir, new_dir)
 	src.pixel_x = 0
 	src.pixel_y = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a help message to intercoms letting people know about the `:in` prefix to speak directly into it.
Override this help message for loudspeaker speakers, since it's not relevant

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
No real way to learn about the `:in` prefix for intercom message mode.