### PR TITLE
Jumpy can no longer be used while floating in space

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -333,9 +333,10 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 		var/sleep_time = 1 / linked_power.power
 
 		if (istype(owner.loc,/turf/))
-			if (istype_exact(owner.loc, /turf/space) || owner.no_gravity)
+			var/turf/T = owner.loc
+			if (T.turf_flags & CAN_BE_SPACE_SAMPLE || T.throw_unlimited || owner.no_gravity)
 				var/push_off = FALSE
-				for(var/atom/A in view(1, owner.loc))
+				for(var/atom/A in oview(1, T))
 					if (A.stops_space_move)
 						push_off = TRUE
 						break
@@ -389,9 +390,10 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 		var/sleep_time = 0.5 / linked_power.power
 
 		if (istype(owner.loc,/turf/))
-			if (istype_exact(owner.loc, /turf/space) || owner.no_gravity)
+			var/turf/T = owner.loc
+			if (T.turf_flags & CAN_BE_SPACE_SAMPLE || T.throw_unlimited || owner.no_gravity)
 				var/push_off = FALSE
-				for(var/atom/A in view(1, owner.loc))
+				for(var/atom/A in oview(1, T))
 					if (A.stops_space_move)
 						push_off = TRUE
 						break

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -337,6 +337,7 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 			playsound(owner.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1)
 			var/prevLayer = owner.layer
 			owner.layer = EFFECTS_LAYER_BASE
+			owner.inertia_dir = owner.dir
 
 			animate(owner,
 				pixel_y = pixel_move * jump_tiles / 2,
@@ -385,6 +386,7 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 			playsound(owner.loc, 'sound/impact_sounds/Wood_Hit_1.ogg', 50, 1)
 			var/prevLayer = owner.layer
 			owner.layer = EFFECTS_LAYER_BASE
+			owner.inertia_dir = owner.dir
 			owner.changeStatus("knockdown", 10 SECONDS)
 			owner.changeStatus("stunned", 5 SECONDS)
 

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -333,12 +333,13 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 		var/sleep_time = 1 / linked_power.power
 
 		if (istype(owner.loc,/turf/))
+			if (istype_exact(owner.loc, /turf/space))
+				boutput(usr, SPAN_ALERT("Your leg muscles tense, but there's nothing to push off of!"))
+				return TRUE
 			usr.visible_message(SPAN_ALERT("<b>[owner]</b> takes a huge leap!"))
 			playsound(owner.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1)
 			var/prevLayer = owner.layer
 			owner.layer = EFFECTS_LAYER_BASE
-			if (istype(owner.loc, /turf/space) || owner.no_gravity)
-				owner.inertia_dir = owner.dir
 
 			animate(owner,
 				pixel_y = pixel_move * jump_tiles / 2,
@@ -382,13 +383,14 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 		var/sleep_time = 0.5 / linked_power.power
 
 		if (istype(owner.loc,/turf/))
+			if (istype_exact(owner.loc, /turf/space))
+				boutput(usr, SPAN_ALERT("Your leg muscles tense, but there's nothing to push off of!"))
+				return TRUE
 			usr.visible_message(SPAN_ALERT("<b>[owner]</b> leaps far too high and comes crashing down hard!"))
 			playsound(owner.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1)
 			playsound(owner.loc, 'sound/impact_sounds/Wood_Hit_1.ogg', 50, 1)
 			var/prevLayer = owner.layer
 			owner.layer = EFFECTS_LAYER_BASE
-			if (istype(owner.loc, /turf/space) || owner.no_gravity)
-				owner.inertia_dir = owner.dir
 			owner.changeStatus("knockdown", 10 SECONDS)
 			owner.changeStatus("stunned", 5 SECONDS)
 

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -334,8 +334,14 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 
 		if (istype(owner.loc,/turf/))
 			if (istype_exact(owner.loc, /turf/space))
-				boutput(usr, SPAN_ALERT("Your leg muscles tense, but there's nothing to push off of!"))
-				return TRUE
+				var/push_off = FALSE
+				for(var/atom/A in view(1, owner.loc))
+					if (A.stops_space_move)
+						push_off = TRUE
+						break
+				if(!push_off)
+					boutput(usr, SPAN_ALERT("Your leg muscles tense, but there's nothing to push off of!"))
+					return TRUE
 			usr.visible_message(SPAN_ALERT("<b>[owner]</b> takes a huge leap!"))
 			playsound(owner.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1)
 			var/prevLayer = owner.layer
@@ -384,8 +390,14 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 
 		if (istype(owner.loc,/turf/))
 			if (istype_exact(owner.loc, /turf/space))
-				boutput(usr, SPAN_ALERT("Your leg muscles tense, but there's nothing to push off of!"))
-				return TRUE
+				var/push_off = FALSE
+				for(var/atom/A in view(1, owner.loc))
+					if (A.stops_space_move)
+						push_off = TRUE
+						break
+				if(!push_off)
+					boutput(usr, SPAN_ALERT("Your leg muscles tense, but there's nothing to push off of!"))
+					return TRUE
 			usr.visible_message(SPAN_ALERT("<b>[owner]</b> leaps far too high and comes crashing down hard!"))
 			playsound(owner.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1)
 			playsound(owner.loc, 'sound/impact_sounds/Wood_Hit_1.ogg', 50, 1)

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -337,7 +337,7 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 			playsound(owner.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1)
 			var/prevLayer = owner.layer
 			owner.layer = EFFECTS_LAYER_BASE
-			if ((istype(owner.loc, /turf/space) || owner.no_gravity))
+			if (istype(owner.loc, /turf/space) || owner.no_gravity)
 				owner.inertia_dir = owner.dir
 
 			animate(owner,
@@ -387,7 +387,7 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 			playsound(owner.loc, 'sound/impact_sounds/Wood_Hit_1.ogg', 50, 1)
 			var/prevLayer = owner.layer
 			owner.layer = EFFECTS_LAYER_BASE
-			if ((istype(owner.loc, /turf/space) || owner.no_gravity))
+			if (istype(owner.loc, /turf/space) || owner.no_gravity)
 				owner.inertia_dir = owner.dir
 			owner.changeStatus("knockdown", 10 SECONDS)
 			owner.changeStatus("stunned", 5 SECONDS)

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -333,7 +333,7 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 		var/sleep_time = 1 / linked_power.power
 
 		if (istype(owner.loc,/turf/))
-			if (istype_exact(owner.loc, /turf/space))
+			if (istype_exact(owner.loc, /turf/space) || owner.no_gravity)
 				var/push_off = FALSE
 				for(var/atom/A in view(1, owner.loc))
 					if (A.stops_space_move)
@@ -389,7 +389,7 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 		var/sleep_time = 0.5 / linked_power.power
 
 		if (istype(owner.loc,/turf/))
-			if (istype_exact(owner.loc, /turf/space))
+			if (istype_exact(owner.loc, /turf/space) || owner.no_gravity)
 				var/push_off = FALSE
 				for(var/atom/A in view(1, owner.loc))
 					if (A.stops_space_move)

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -337,7 +337,8 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 			playsound(owner.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1)
 			var/prevLayer = owner.layer
 			owner.layer = EFFECTS_LAYER_BASE
-			owner.inertia_dir = owner.dir
+			if ((istype(owner.loc, /turf/space) || owner.no_gravity))
+				owner.inertia_dir = owner.dir
 
 			animate(owner,
 				pixel_y = pixel_move * jump_tiles / 2,
@@ -386,7 +387,8 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 			playsound(owner.loc, 'sound/impact_sounds/Wood_Hit_1.ogg', 50, 1)
 			var/prevLayer = owner.layer
 			owner.layer = EFFECTS_LAYER_BASE
-			owner.inertia_dir = owner.dir
+			if ((istype(owner.loc, /turf/space) || owner.no_gravity))
+				owner.inertia_dir = owner.dir
 			owner.changeStatus("knockdown", 10 SECONDS)
 			owner.changeStatus("stunned", 5 SECONDS)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][balance][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Check if we're on `/turf/space` (and ONLY `/turf/space`) when using the jumpy gene; if so, check if we're next to something that stops space movement like lattices or a pod. If we're not next to anything, don't jump.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #11634


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Jumpy can no longer be used while floating in space.
```
