### PR TITLE
Allow scuttlebot users to return to body if inside lockers

### DIFF
--- a/code/datums/abilities/critter/scuttlebot.dm
+++ b/code/datums/abilities/critter/scuttlebot.dm
@@ -123,6 +123,7 @@
 	name = "Return to body"
 	desc = "Leave the scuttlebot and return to your body"
 	icon_state = "shutdown"
+	needs_turf = FALSE
 	cast(atom/target)
 		if (..())
 			return 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
For the scuttlebot "Return to body" ability, set `needs_turf` to `FALSE` so you can escape to your body when someone lockers your walking hat.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #13378
