### PR TITLE
Prevent obj-critter parrots from picking up deployed bodybags

### DIFF
--- a/_std/macros/items.dm
+++ b/_std/macros/items.dm
@@ -23,4 +23,7 @@
 /// Returns TRUE if item is worn by a human other than `user`, FALSE otherwise
 #define IS_WORN_BY_SOMEONE_OTHER_THAN(item, user) (istype(item.loc, /mob/living/carbon/human) && user != item.loc)
 
-
+/// Returns TRUE if the item is something that NPCs should not be able to pick up
+#define IS_NPC_ILLEGAL_ITEM(x) ( \
+		istype(x, /obj/item/body_bag) && x.w_class >= W_CLASS_BULKY \
+	)

--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -5,11 +5,6 @@
 		x:block_vision \
 	)
 
-//Put any items that NPCs physically cannot pickup here
-#define IS_NPC_ILLEGAL_ITEM(x) ( \
-		istype(x, /obj/item/body_bag) && x.w_class >= W_CLASS_BULKY \
-	)
-
 #define IS_NPC_CLOTHING(x) ( \
 		( \
 			istype(x, /obj/item/clothing) || \
@@ -985,4 +980,3 @@
 
 #undef IS_NPC_HATED_ITEM
 #undef IS_NPC_CLOTHING
-#undef IS_NPC_ILLEGAL_ITEM

--- a/code/obj/critter/pets_small_animals.dm
+++ b/code/obj/critter/pets_small_animals.dm
@@ -246,6 +246,8 @@
 				continue
 			if (I.anchored || I.density)
 				continue
+			if(I.w_class >= W_CLASS_GIGANTIC || IS_NPC_ILLEGAL_ITEM(I))
+				continue
 			stuff_near_me += I
 		if (stuff_near_me.len)
 			src.new_treasure = pick(stuff_near_me)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][critters]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Move IS_NPC_ILLEGAL_ITEM up to item macros
* Implement for /obj/critter/parrot's treasure selection code

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #13400
