### PR TITLE
Filter out deployed body bags from matter eater

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -161,8 +161,8 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 				if (istype(A, mattereater.target_path))
 					items += A
 
-		for(var/atom/item in items) // augh body bags
-			if(istype(item, /obj/item/body_bag) && item:w_class >= W_CLASS_BULKY)
+		for(var/obj/item/item as anything in items) // augh body bags
+			if(istype(item, /obj/item/body_bag) && item.w_class >= W_CLASS_BULKY)
 				items -= item
 
 		if (linked_power.power > 1)

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -161,6 +161,10 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 				if (istype(A, mattereater.target_path))
 					items += A
 
+		for(var/atom/item in items) // augh body bags
+			if(istype(item, /obj/item/body_bag) && item:w_class >= W_CLASS_BULKY)
+				items -= item
+
 		if (linked_power.power > 1)
 			items += get_filtered_atoms_in_touch_range(owner, /obj/the_server_ingame_whoa)
 			//So people can still get the meat ending


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][player actions][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Filter out deployed body bags from matter eater's list of items to eat.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
augh body bags
Fix #20464