### PR TITLE
Add new generic trader commodity types: shoes, instruments, kitchen utensils

### DIFF
--- a/code/modules/economy/traders/generic.dm
+++ b/code/modules/economy/traders/generic.dm
@@ -189,7 +189,7 @@
 /datum/commodity/trader/generic/instrument
 	comname = "Instruments"
 	comtype = /obj/item/instrument
-	price_boundary = list(PAY_UNTRAINED, PAY_TRADESMAN)
+	price_boundary = list(PAY_UNTRAINED/2, PAY_UNTRAINED)
 	possible_names = list("We need some instruments to 'increase' staff morale.",
 	"The captain's latest team-building exercise requires a large number of instruments.")
 

--- a/code/modules/economy/traders/generic.dm
+++ b/code/modules/economy/traders/generic.dm
@@ -186,13 +186,6 @@
 	possible_names = list("We need some more furniture to spice up our ship.",
 	"We're building a new lounge, and we need whatever furniture you have.")
 
-/datum/commodity/trader/generic/pens
-	comname = "Writing Utensils"
-	comtype = /obj/item/pen
-	price_boundary = list(PAY_UNTRAINED/3,PAY_TRADESMAN)
-	possible_names = list("We can't take notes! Send us something to write with, and make it snappy.",
-	"Our crew's been really starved creatively. Give us something we can doodle with.")
-
 /datum/commodity/trader/generic/instrument
 	comname = "Instruments"
 	comtype = /obj/item/instrument

--- a/code/modules/economy/traders/generic.dm
+++ b/code/modules/economy/traders/generic.dm
@@ -186,7 +186,7 @@
 	possible_names = list("We need some more furniture to spice up our ship.",
 	"We're building a new lounge, and we need whatever furniture you have.")
 
-/datum/commodity/trader/generic/instrument
+/datum/commodity/trader/generic/instruments
 	comname = "Instruments"
 	comtype = /obj/item/instrument
 	price_boundary = list(PAY_UNTRAINED/2, PAY_UNTRAINED)

--- a/code/modules/economy/traders/generic.dm
+++ b/code/modules/economy/traders/generic.dm
@@ -13,7 +13,9 @@
 			/datum/commodity/trader/generic/shipcomponents,
 			/datum/commodity/trader/generic/jumpsuits,
 			/datum/commodity/trader/generic/furniture,
-			/datum/commodity/trader/generic/pens
+			/datum/commodity/trader/generic/shoes,
+			/datum/commodity/trader/generic/instruments,
+			/datum/commodity/trader/generic/utensils
 		),
 		TRADER_RARITY_UNCOMMON = list(),
 		TRADER_RARITY_RARE = list()
@@ -136,7 +138,7 @@
 
 /datum/commodity/trader/generic/anyore
 	comname = "Ore"
-	comtype = /obj/item/raw_material/
+	comtype = /obj/item/raw_material
 	price_boundary = list(PAY_UNTRAINED/3,PAY_TRADESMAN)
 	possible_names = list("I'm looking to buy any kind of ore you might have.",
 	"Our ore supplies are critically low - I'll buy any kind of ore for this price.")
@@ -170,10 +172,16 @@
 	possible_names = list("We're drafting in some new staff soon, and need new jumpsuits.",
 	"We need any jumpsuits you can spare. Don't ask.")
 
+/datum/commodity/trader/generic/shoes
+	comname = "Shoes"
+	comtype = /obj/item/clothing/shoes
+	price_boundary = list(PAY_UNTRAINED/3,PAY_UNTRAINED)
+	possible_names = list("We're had a run-in with a rather unsavory type, and need new shoes.",
+	"We need any shoes you can spare. Don't ask.")
 
 /datum/commodity/trader/generic/furniture
 	comname = "Furniture Parts"
-	comtype = /obj/item/furniture_parts/
+	comtype = /obj/item/furniture_parts
 	price_boundary = list(PAY_UNTRAINED/3,PAY_TRADESMAN)
 	possible_names = list("We need some more furniture to spice up our ship.",
 	"We're building a new lounge, and we need whatever furniture you have.")
@@ -184,3 +192,17 @@
 	price_boundary = list(PAY_UNTRAINED/3,PAY_TRADESMAN)
 	possible_names = list("We can't take notes! Send us something to write with, and make it snappy.",
 	"Our crew's been really starved creatively. Give us something we can doodle with.")
+
+/datum/commodity/trader/generic/instrument
+	comname = "Instruments"
+	comtype = /obj/item/instrument
+	price_boundary = list(PAY_UNTRAINED, PAY_TRADESMAN)
+	possible_names = list("We need some instruments to 'increase' staff morale.",
+	"The captain's latest team-building exercise requires a large number of instruments.")
+
+/datum/commodity/trader/generic/utensils
+	comname = "Kitchen Utensils"
+	comtype = /obj/item/kitchen/utensil
+	price_boundary = list(PAY_UNTRAINED/3, PAY_UNTRAINED)
+	possible_names = list("Our staff require kitchen utensils to eat our chef's food.",
+	"We need some kitchen utensils to prepare for a feast.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][game objects][balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add three new commodity types to generic traders:
* Shoes (you know, shoes)
* Instruments (e.g. harmonicas, saxaphones, trumpets)
* Kitchen Utensils (knives, forks, spoons)

Removes one commodity type from generic traders:
* Pens

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More variety in generic trader wanted goods.

There's a minor exploit with pens wherein spacebux purchase crayon creator crayons count for the pens commodity.