### PR TITLE
Wizards with plasmalungs get little a plasma (as a treat)

### DIFF
--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -50,7 +50,11 @@
 		H.equip_if_possible(new /obj/item/clothing/suit/wizrobe(H), SLOT_WEAR_SUIT)
 		H.equip_if_possible(new /obj/item/clothing/head/wizard(H), SLOT_HEAD)
 		H.equip_if_possible(new /obj/item/clothing/shoes/sandal/magic/wizard(H), SLOT_SHOES)
-		H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended(H), SLOT_L_STORE)
+		if("plasmalungs" in H.client?.preferences.traitPreferences.traits_selected)
+			H.equip_if_possible(new /obj/item/clothing/mask/breath(H), SLOT_WEAR_MASK)
+			H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended/plasma(H), SLOT_L_STORE)
+		else
+			H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended(H), SLOT_L_STORE)
 		H.equip_if_possible(new /obj/item/paper/Wizardry101(H), SLOT_R_STORE)
 		H.equip_if_possible(new /obj/item/staff(H), SLOT_R_HAND)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game modes]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Wizards with plasmalungs trait get an extended plasma tank and a breath mask, instead of just oxygen.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #18896