### PR TITLE
stop woodwalls from duping on projectile damage

### DIFF
--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -359,7 +359,7 @@ TYPEINFO(/obj/structure/woodwall)
 	var/projectile_gib_streak = FALSE
 
 	New()
-		src.AddComponent(/datum/component/obj_projectile_damage, src.type, src.projectile_gib, src.projectile_gib_streak)
+		src.AddComponent(/datum/component/obj_projectile_damage, /obj/decal/cleanable/wood_debris, src.projectile_gib, src.projectile_gib_streak)
 		. = ..()
 
 	virtual


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
For barricades, change the gib_type passed into obj_projectile_damage to the wood debris cleanable

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
barricades have a chance of duping with low damage gunfire e.g. from minigun