### PR TITLE
Fix some fake asteroid woodwalls

### DIFF
--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -449,6 +449,39 @@ TYPEINFO(/obj/structure/woodwall)
 		return TRUE
 	return (!density)
 
+/obj/structure/woodwall/fake_asteroid
+	name = "odd asteroid wall"
+	icon = 'icons/turf/walls/asteroid.dmi'
+	icon_state = "asteroid-map"
+	projectile_gib = FALSE
+	color = "#d1e6ff"
+	plane = PLANE_WALL
+
+	New()
+		..()
+		var/image/top_overlay = mutable_appearance('icons/turf/walls/asteroid.dmi', pick("top1", "top2", "top3"))
+		var/icon/top_icon = icon('icons/turf/walls/asteroid.dmi',"mask2[src.icon_state]")
+		top_overlay.filters += filter(type="alpha", icon=top_icon)
+		top_overlay.layer = src.layer + 0.1
+		AddOverlays(top_overlay, "ast_top_rock")
+
+	updateHealth()
+		if (_health <= 0)
+			src.visible_message(SPAN_ALERT("<b>[src] collapses!</b>"))
+			src.onDestroy()
+
+	disposing()
+		var/turf/T = src.loc
+		. = ..()
+		for (var/turf/simulated/wall/auto/asteroid/A in orange(T,1))
+			A.UpdateIcon()
+
+/obj/structure/woodwall/fake_asteroid/left_edge
+	icon_state = "asteroid-55"
+
+/obj/structure/woodwall/fake_asteroid/right_edge
+	icon_state = "asteroid-3"
+
 /datum/action/bar/icon/wood_repair_wall
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	#ifdef HALLOWEEN

--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -444,6 +444,12 @@ TYPEINFO(/obj/structure/woodwall)
 		hit_twitch(src)
 		return
 
+	disposing()
+		var/turf/T = src.loc
+		. = ..()
+		for (var/turf/simulated/wall/auto/asteroid/A in orange(T,1))
+			A.UpdateIcon()
+
 /obj/structure/woodwall/Cross(obj/projectile/mover)
 	if (istype(mover) && !mover.proj_data.always_hits_structures && prob(src.projectile_passthrough_chance))
 		return TRUE
@@ -469,12 +475,6 @@ TYPEINFO(/obj/structure/woodwall)
 		if (_health <= 0)
 			src.visible_message(SPAN_ALERT("<b>[src] collapses!</b>"))
 			src.onDestroy()
-
-	disposing()
-		var/turf/T = src.loc
-		. = ..()
-		for (var/turf/simulated/wall/auto/asteroid/A in orange(T,1))
-			A.UpdateIcon()
 
 /obj/structure/woodwall/fake_asteroid/left_edge
 	icon_state = "asteroid-55"

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -10439,11 +10439,7 @@
 /turf/space,
 /area/h7/asteroid)
 "aUY" = (
-/obj/structure/woodwall{
-	color = "#CCCCCC";
-	name = "odd asteroid wall";
-	plane = -105
-	},
+/obj/structure/woodwall/fake_asteroid/left_edge,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
 "aUZ" = (
@@ -15518,6 +15514,10 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/diner/jucer_trader)
+"bud" = (
+/obj/structure/woodwall/fake_asteroid/right_edge,
+/turf/simulated/floor/plating/airless/asteroid,
+/area/space)
 "buU" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 6;
@@ -102225,7 +102225,7 @@ aab
 aab
 aab
 aab
-aUY
+bud
 aab
 aab
 aab


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Add a new woodwall barricade subtype fake_asteroid
  * Move the map varedits to this new subtype
  * Mimic newer asteroid rendering
  * Override updateHealth since there are no partials
* All woodwalls update nearby asteroid walls on disposing (they are in the asteroid wall `connects_to` list)
* Replace existing fake asteroid woodwalls

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #13550