### PR TITLE
Fixes material rcds being able to remove a tile of the wrong type.

### DIFF
--- a/code/obj/item/rcd/rcd.dm
+++ b/code/obj/item/rcd/rcd.dm
@@ -224,6 +224,7 @@ TYPEINFO(/obj/item/rcd)
 		var/turf/simulated/floor/T = A.ReplaceWithFloor()
 		T.inherit_area()
 		T.setMaterial(getMaterial(material_name))
+		T.default_material = getMaterial(material_name)
 		return
 
 	proc/handle_build_wall(turf/A, mob/user)
@@ -331,6 +332,12 @@ TYPEINFO(/obj/item/rcd)
 			return
 
 		if (istype(A, /turf/simulated/floor))
+			var/turf/simulated/floor/T = A
+			if(T.intact)
+				var/datum/material/mat = istext(T.default_material) ? getMaterial(T.default_material) : T.default_material
+				if(!(mat?.getID() in restricted_materials))
+					boutput(user, "Target object is not made of a material this RCD can deconstruct.")
+					return
 			src.do_rcd_action(user, A, "removing \the [A]", matter_remove_floor, time_remove_floor, PROC_REF(do_delete_floor), src)
 			return
 


### PR DESCRIPTION
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Material rcds now place a tile that both are tiled and plated with the correct material.
Material rcds no longer can remove a tile that is merely tiled with the material, but instead need to plated with it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad
