### PR TITLE
Restrict fishing rod storage to food items

### DIFF
--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -24,8 +24,7 @@
 	New()
 		..()
 		RegisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE, PROC_REF(attackby_pre))  // Storage for a single lure item
-		var/list/fishing_rods = list(/obj/item/fishing_rod, /obj/item/fishing_rod/basic, /obj/item/fishing_rod/upgraded, /obj/item/fishing_rod/master)
-		src.create_storage(/datum/storage, max_wclass = W_CLASS_NORMAL, slots = 1, prevent_holding = fishing_rods)
+		src.create_storage(/datum/storage, can_hold = list(/obj/item/reagent_containers/food), max_wclass = W_CLASS_NORMAL, slots = 1)
 
 	disposing()
 		UnregisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE)

--- a/code/modules/fishing/fishing_lootpools.dm
+++ b/code/modules/fishing/fishing_lootpools.dm
@@ -13,8 +13,8 @@
 	var/minimum_rod_tier = 0
 	/// what tier of rod is the highest to have access to the lootable?
 	var/maximum_rod_tier = INFINITY
-	/// what kind of item is needed as a lure
-	var/obj/item/required_lure = null
+	/// what kind of food item is needed as a lure
+	var/obj/item/reagent_containers/food/required_lure = null
 
 /// This proc checks for all the conditionals that could apply to a fishing spot. Modify that for special conditions.
 /datum/fishing_lootpool/proc/check_conditionals(var/mob/user, var/obj/item/fishing_rod/fishing_rod)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Restrict fishing rod bait storage to food items.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Civilian cyborgs can currently store any normal or lighter weight class item in their fishing rod. Moving it to food keeps it closer to tongs behavior.