### PR TITLE
Add a cap of 3 microbomb purchases

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -415,6 +415,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	items = list(/obj/item/implanter/uplink_microbomb)
 	cost = 1
 	vr_allowed = FALSE
+	max_buy = 3
 	desc = "This miniaturized explosive packs a decent punch and will detonate upon the unintentional death of the host. Do not swallow and keep out of reach of children."
 
 /datum/syndicate_buylist/traitor/lightbreaker


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Limits the amount of microbombs purchasable in each uplink to 3


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The macrobomb was removed for being too easy but you can still just buy 12 microbombs in maints, grab a bible, biblefart in medbay and destroy an entire department less than 15 minutes into the round, what is intended to be a "fuck you" to whoever kills you is often weaponised on classic and this heavily limits that usage.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)You may now only purchase a maximum of 3 microbombs
```
