### PR TITLE
Stun batons turn off themselves when not wielded and activating has a slight action bar

### DIFF
--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2362,6 +2362,25 @@
 		var/mob/M = owner
 		M.mind?.remove_antagonist(ROLE_MINDHACK, ANTAGONIST_REMOVAL_SOURCE_EXPIRED)
 
+/datum/statusEffect/beton_decharging
+	id = "baton_decharging"
+	visible = FALSE
+	unique = TRUE
+
+	onRemove()
+		. = ..()
+		if(duration <= 0 && istype(owner, /obj/item/baton)) // if timed out, we turn the baton off
+			var/obj/item/baton/the_baton = owner
+			var/check_failed = TRUE
+			if (ismob(the_baton.loc))
+				var/mob/baton_owner = the_baton.loc
+				if(the_baton in baton_owner.equipped_list()) //if we picked it up while we stashed it, it should not depower
+					check_failed = FALSE
+			if (check_failed)
+				the_baton.is_active = FALSE
+				the_baton.UpdateIcon()
+				playsound(the_baton, "sparks", 75, 1, -1)
+
 /datum/statusEffect/defib_charged
 	id = "defib_charged"
 	visible = FALSE

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -249,10 +249,13 @@ TYPEINFO(/obj/item/baton)
 			src.switch_status(user)
 		else
 			user.visible_message(SPAN_ALERT("[user] activates their [src.name]."), SPAN_NOTICE("You activate your [src.name]."))
-			SETUP_GENERIC_ACTIONBAR(user, src, 0.5 SECONDS, PROC_REF(switch_status), user, src.icon, src.flick_baton_active, null, INTERRUPT_NONE)
+			SETUP_GENERIC_ACTIONBAR(user, src, 0.5 SECONDS, PROC_REF(switch_status), user, src.icon, src.flick_baton_active, null, INTERRUPT_STUNNED | INTERRUPT_ACTION | INTERRUPT_ACT)
 
 
 	proc/switch_status(mob/user)
+		if(!(src in user.equipped_list()))
+			return
+
 		src.is_active = !src.is_active
 
 		if (src.can_stun() == 1 && user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50))


### PR DESCRIPTION
[Game Objects][Balance]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR introduces two changes to stun batons and stun canes:

- If the stun baton is not wielded in hand for more than 5 seconds, it turns off
- Turning on a stun baton requires a 0.5 second action bar that is not interrupted by moving

This change does not apply to the ntso baton or the one dropped by beepsky
 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The stun baton is a very powerfull melee weapon that very quickly ends encounters if pulled out in surprise mid-RP. This kind of behaviour is the expected gameplay loop of antags (see: all their stun gear or stealth poison options), but not of security. This PR aims to drastically cut down on surprise batons and gives people a warning if someone pulls out a baton in front of them. 

The 5 second deactivation timer gives enough wiggle room to get not punished by slipping or inventory management. 

the NTSO baton is not encompassed by this change because HOS-whitelisted players are trusted enough to not pull off such bullshit behaviour. Securitron batons are exception because of their use in the respectable mobs.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(*)Stun batons and canes are equipment with special safety switches that turn them off when they are not wielded for 5 seconds
(+)Activating a stun baton now requires a 0.5 second action bar that is not interrupted by moving.
```
