### PR TITLE
Make singulos gravitate towards gravity well artifacts

### DIFF
--- a/_std/types.dm
+++ b/_std/types.dm
@@ -205,6 +205,7 @@ var/list/list/by_cat = list()
 #define TR_CAT_STAMINA_MOBS "stamina_mobs"
 #define TR_CAT_BUGS "bugs"
 #define TR_CAT_POSSIBLE_DEAD_DROP "dead_drops"
+#define TR_CAT_SINGULO_MAGNETS "singulo_magnets"
 // powernets? processing_items?
 // mobs? ai-mobs?
 

--- a/code/obj/artifacts/artifact_machines/grav_well.dm
+++ b/code/obj/artifacts/artifact_machines/grav_well.dm
@@ -4,10 +4,10 @@
 
 	New()
 		..()
-		START_TRACKING
+		START_TRACKING_CAT(TR_CAT_SINGULO_MAGNETS)
 
 	disposing()
-		STOP_TRACKING
+		STOP_TRACKING_CAT(TR_CAT_SINGULO_MAGNETS)
 		. = ..()
 
 /obj/effect/grav_pulse

--- a/code/obj/artifacts/artifact_machines/grav_well.dm
+++ b/code/obj/artifacts/artifact_machines/grav_well.dm
@@ -2,6 +2,14 @@
 	name = "artifact gravity well generator"
 	associated_datum = /datum/artifact/gravity_well_generator
 
+	New()
+		..()
+		START_TRACKING
+
+	disposing()
+		STOP_TRACKING
+		. = ..()
+
 /obj/effect/grav_pulse
 	icon='icons/effects/overlays/lensing.dmi'
 	icon_state="blank" //haha such hackery

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -300,8 +300,10 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 ///Returns a 2D vector representing the resultant force acting on the singulo by all gravity wells, scaled by their distance
 /obj/machinery/the_singularity/proc/calc_direction()
 	var/list/total_vector = list(0,0) //if only we had vector primitives...
+	var/turf/singulo_turf = get_turf(src)
 	for_by_tcl(artifact, /obj/machinery/artifact/gravity_well_generator)
-		if (artifact.z != src.z)
+		var/turf/artifact_turf = get_turf(artifact)
+		if (artifact_turf.z != singulo_turf.z)
 			continue
 		var/datum/artifact/gravity_well_generator/artifact_datum = artifact.artifact //parallel inheritence moment
 		if (!artifact_datum.activated)
@@ -310,8 +312,8 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 		var/sign = artifact_datum.gravity_type ? 1 : -1
 		//our actual offset from this artifact
 		var/list/vector = list(0,0)
-		vector[1] = ((src.x - artifact.x) * sign)
-		vector[2] = ((src.y - artifact.y) * sign)
+		vector[1] = ((singulo_turf.x - artifact_turf.x) * sign)
+		vector[2] = ((singulo_turf.y - artifact_turf.y) * sign)
 		//no need to root, we can reuse the squared value (I'm basically a doom programmer)
 		var/length_squared = (vector[1] ** 2) + (vector[2] ** 2)
 		//inverse square law I guess? gravity is radial

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -283,7 +283,12 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 		return
 
 	if (selfmove)
+		var/list/vector = src.calc_direction()
 		var/dir = pick(cardinal)
+		var/vector_length = (vector[1] ** 2 + vector[2] ** 2) ** (1/2)
+		if (prob(vector_length * 400)) //scale the chance to move in the direction of resultant force by the strength of that force
+			var/angle = arctan(vector[2], vector[1])
+			dir = angle2dir(angle)
 
 		for (var/dist = max(0,radius-1), dist <= radius+1, dist++)
 			var/turf/checkloc = get_ranged_target_turf(src.get_center(), dir, dist)
@@ -292,6 +297,27 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 
 		step(src, dir)
 
+///Returns a 2D vector representing the resultant force acting on the singulo by all gravity wells, scaled by their distance
+/obj/machinery/the_singularity/proc/calc_direction()
+	var/list/total_vector = list(0,0) //if only we had vector primitives...
+	for_by_tcl(artifact, /obj/machinery/artifact/gravity_well_generator)
+		if (artifact.z != src.z)
+			continue
+		var/datum/artifact/gravity_well_generator/artifact_datum = artifact.artifact //parallel inheritence moment
+		if (!artifact_datum.activated)
+			continue
+		//pushing or pulling
+		var/sign = artifact_datum.gravity_type ? 1 : -1
+		//our actual offset from this artifact
+		var/list/vector = list(0,0)
+		vector[1] = ((src.x - artifact.x) * sign)
+		vector[2] = ((src.y - artifact.y) * sign)
+		//no need to root, we can reuse the squared value (I'm basically a doom programmer)
+		var/length_squared = (vector[1] ** 2) + (vector[2] ** 2)
+		//inverse square law I guess? gravity is radial
+		total_vector[1] += vector[1] * 1/length_squared
+		total_vector[2] += vector[2] * 1/length_squared
+	return total_vector
 
 /obj/machinery/the_singularity/ex_act(severity, last_touched, power)
 	if (severity == 1 && prob(power * 5)) //need a big bomb (TTV+ sized), but a big enough bomb will always clear it

--- a/code/obj/shieldgen.dm
+++ b/code/obj/shieldgen.dm
@@ -175,6 +175,14 @@ TYPEINFO(/obj/gravity_well_generator)
 
 /obj/gravity_well_generator
 
+	New()
+		. = ..()
+		START_TRACKING_CAT(TR_CAT_SINGULO_MAGNETS)
+
+	disposing()
+		STOP_TRACKING_CAT(TR_CAT_SINGULO_MAGNETS)
+		. = ..()
+
 	meteorhit(obj/O as obj)
 		if(prob(75))
 			qdel(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Singularities will now move towards or away from gravity well artifacts, with a chance each tick scaling by how far away the gravity well is.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People have wanted a way to direct rogue singulos around for a while, gravity wells make sense and are easy, if somewhat inconsistent to obtain.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Loose singularities now gravitate towards or away from active gravity well artifacts and gravity generators.
```
