### PR TITLE
Add adjustable range to wifi component

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -1893,13 +1893,16 @@
 		. += {"<br><span class='notice'>[forward_all ? "Sending full unprocessed Signals.":"Sending only processed sendmsg and pda Message Signals."]<br>
 		[only_directed ? "Only reacting to Messages directed at this Component.":"Reacting to ALL Messages received."]<br>
 		Current Frequency: [frequency]<br>
+		Current Range: [isnull(range) ? "Unlimited":range]<br>
 		Current NetID: [net_id]</span>"}
 
 	New()
 		..()
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"send radio message", PROC_REF(send))
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"set frequency", PROC_REF(setfreq))
+		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"set range", PROC_REF(setrange))
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_CONFIG,"Set Frequency",PROC_REF(setFreqManually))
+		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_CONFIG,"Set Range",PROC_REF(setRangeManually))
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_CONFIG,"Toggle NetID Filtering",PROC_REF(toggleAddressFiltering))
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_CONFIG,"Toggle Forward All",PROC_REF(toggleForwardAll))
 
@@ -1917,6 +1920,23 @@
 			return 1
 		return 0
 
+	proc/setRangeManually(obj/item/W as obj, mob/user as mob)
+		var/inp = input(user,"Please enter the range (-1 for unlimited):","Range setting",isnull(range)?-1:range) as num
+		if(!in_interact_range(src, user) || user.stat)
+			return 0
+		inp = text2num_safe(inp)
+		if(isnull(inp)) return 0
+		if(inp == -1)
+			src.range = null
+			boutput(user, "Range set to unlimited")
+			tooltip_rebuild = 1
+			return 1
+		inp = clamp(inp, 0, 512)
+		src.range = inp
+		boutput(user, "Range set to [inp]")
+		tooltip_rebuild = 1
+		return 1
+
 	proc/toggleAddressFiltering(obj/item/W as obj, mob/user as mob)
 		only_directed = !only_directed
 		get_radio_connection_by_id(src, "main").update_all_hearing(!only_directed)
@@ -1929,6 +1949,20 @@
 		boutput(user, "[forward_all ? "Now forwarding all Radio Messages as they are.":"Now processing only sendmsg and normal PDA messages."]")
 		tooltip_rebuild = 1
 		return 1
+
+	proc/setrange(var/datum/mechanicsMessage/input)
+		if(level == OVERFLOOR) return
+		LIGHT_UP_HOUSING
+		var/newrange = text2num_safe(input.signal)
+		if(isnull(newrange)) return
+		if(newrange == -1)
+			src.range = null
+			tooltip_rebuild = 1
+			return
+		newrange = clamp(newrange, 0, 512)
+		src.range = newrange
+		tooltip_rebuild = 1
+		return
 
 	proc/setfreq(var/datum/mechanicsMessage/input)
 		if(level == OVERFLOOR) return

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -1893,7 +1893,7 @@
 		. += {"<br><span class='notice'>[forward_all ? "Sending full unprocessed Signals.":"Sending only processed sendmsg and pda Message Signals."]<br>
 		[only_directed ? "Only reacting to Messages directed at this Component.":"Reacting to ALL Messages received."]<br>
 		Current Frequency: [frequency]<br>
-		Current Range: [isnull(range) ? "Unlimited":range]<br>
+		Current Range: [isnull(range) ? "Unlimited" : range]<br>
 		Current NetID: [net_id]</span>"}
 
 	New()
@@ -1921,7 +1921,7 @@
 		return 0
 
 	proc/setRangeManually(obj/item/W as obj, mob/user as mob)
-		var/inp = input(user,"Please enter the range (-1 for unlimited):","Range setting",isnull(range)?-1:range) as num
+		var/inp = input(user, "Please enter the range (-1 for unlimited):", "Range setting", isnull(range) ? -1 : range) as num
 		if(!in_interact_range(src, user) || user.stat)
 			return 0
 		inp = text2num_safe(inp)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Wifi component's range can be adjusted both manually and with signals
The range is unlimited by default as how it is currently


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Useful with stuff like `command=report_pda`


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Valtsu0
(+)The WiFi component's range can now be adjusted.
```
