### PR TITLE
Require mining access for mineral magnet controls and rockbox

### DIFF
--- a/code/modules/transport/pods/communications.dm
+++ b/code/modules/transport/pods/communications.dm
@@ -56,6 +56,9 @@
 		External()
 			for(var/obj/machinery/mining_magnet/MM in range(7,src.ship))
 				linked_magnet = MM
+				if (!linked_magnet.allowed(usr))
+					boutput(usr, SPAN_ALERT("Access Denied."))
+					return
 				ui_interact(usr)
 				return null
 			boutput(usr, SPAN_ALERT("No magnet found in range of seven meters."))

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -372,6 +372,7 @@
 	opacity = 0
 	density = 0 // collision is dealt with by the chassis
 	anchored = ANCHORED_ALWAYS
+	req_access = list(access_mining, access_mining_outpost)
 	var/obj/machinery/magnet_chassis/linked_chassis = null
 	var/health = 100
 	var/attract_time = 300
@@ -747,7 +748,7 @@
 				else
 					var/mob/living/carbon/human/H = usr
 					if(!src.allowed(H))
-						boutput(usr, SPAN_ALERT("Access denied. Please contact the Chief Engineer or Captain to access the override."))
+						boutput(usr, SPAN_ALERT("Access denied."))
 					else
 						src.cooldown_override = !src.cooldown_override
 					. = TRUE

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -767,7 +767,7 @@
 	var/temp = null
 	var/list/linked_magnets = list()
 	var/obj/machinery/mining_magnet/linked_magnet = null
-	req_access = list(access_engineering_chief)
+	req_access = list(access_mining)
 	object_flags = CAN_REPROGRAM_ACCESS | NO_GHOSTCRITTER
 	can_reconnect = 1 //IDK why you'd want to but for consistency's sake
 
@@ -777,6 +777,9 @@
 			src.connection_scan()
 
 	ui_interact(mob/user, datum/tgui/ui)
+		if(!src.allowed(user))
+			boutput(user, SPAN_ALERT("Access Denied."))
+			return
 		ui = tgui_process.try_update_ui(user, src, ui)
 		if(!ui)
 			ui = new(user, src, "MineralMagnet", src.name)

--- a/code/obj/mining_cloud_storage.dm
+++ b/code/obj/mining_cloud_storage.dm
@@ -16,6 +16,7 @@
 	density = TRUE
 	anchored = ANCHORED
 	event_handler_flags = USE_FLUID_ENTER | NO_MOUSEDROP_QOL
+	req_access = list(access_mining)
 
 	var/sound_destroyed = 'sound/impact_sounds/Machinery_Break_1.ogg'
 	var/list/datum/ore_cloud_data/ores = list()
@@ -382,6 +383,9 @@
 	ui_interact(mob/user, datum/tgui/ui)
 		if (src.is_broken())
 			boutput(user, SPAN_ALERT("The [src] seems to be broken and inoperable!"))
+			return
+		if(!src.allowed(user))
+			boutput(user, SPAN_ALERT("Access Denied."))
 			return
 
 		ui = tgui_process.try_update_ui(user, src, ui)

--- a/maps/z5.dmm
+++ b/maps/z5.dmm
@@ -2196,6 +2196,7 @@
 "ww" = (
 /obj/machinery/ore_cloud_storage_container,
 /obj/machinery/light/incandescent,
+/obj/mapping_helper/access/mining_outpost,
 /turf/simulated/floor/grime,
 /area/mining/magnet_control)
 "wx" = (
@@ -5522,6 +5523,7 @@
 /obj/machinery/computer/magnet{
 	dir = 8
 	},
+/obj/mapping_helper/access/mining_outpost,
 /turf/simulated/floor/scorched2,
 /area/mining/magnet_control)
 "SR" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Require mining access to use the mineral magnet computer and rockbox UIs.
* Mining outpost access is added to the outpost magnet/rockbox; if you just have mining outpost access you can still use the entire outpost.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* It's *dangerous mining equipment*, the access should matter.
* Salvagers can pull up and heist an unstationed rockbox. Kill a miner first please.
* Don't allow literally anyone to change price settings by breaking/sneaking in.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)The mineral magnet computer and Rockbox require mining access to use.
```
