### PR TITLE
Forward audible messages heard at mainframe to AIeye

### DIFF
--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -1051,6 +1051,11 @@
 // it was about time we had this instead of just visible_message()
 /atom/proc/audible_message(var/message, var/alt, var/alt_type, var/group = "", var/just_maptext, var/image/chat_maptext/assoc_maptext = null)
 	for (var/mob/M in all_hearers(null, src))
+		if (istype(M, /mob/living/silicon/ai) && !M.client) // ai mainframes can still hear even if they're in aieye
+			var/mob/living/silicon/ai/mainframe = M
+			var/mob/message_mob = mainframe.get_message_mob()
+			message_mob.show_message(message, null, alt, alt_type, group, just_maptext, assoc_maptext) // skip type checks on hearing
+			continue
 		if (!M.client)
 			continue
 		M.show_message(message, 2, alt, alt_type, group, just_maptext, assoc_maptext)

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -1051,10 +1051,11 @@
 // it was about time we had this instead of just visible_message()
 /atom/proc/audible_message(var/message, var/alt, var/alt_type, var/group = "", var/just_maptext, var/image/chat_maptext/assoc_maptext = null)
 	for (var/mob/M in all_hearers(null, src))
-		if (istype(M, /mob/living/silicon/ai) && !M.client) // ai mainframes can still hear even if they're in aieye
+		if (istype(M, /mob/living/silicon/ai) && !M.client && M.hearing_check(1)) //if heard, relay msg to client mob if they're in aieye form
 			var/mob/living/silicon/ai/mainframe = M
 			var/mob/message_mob = mainframe.get_message_mob()
-			message_mob.show_message(message, null, alt, alt_type, group, just_maptext, assoc_maptext) // skip type checks on hearing
+			if(isAIeye(message_mob))
+				message_mob.show_message(message, null, alt, alt_type, group, just_maptext, assoc_maptext) // type=null as AIeyes can't hear directly
 			continue
 		if (!M.client)
 			continue


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][silicons]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
For audible messages, if the hearer is an ai mainframe and they don't have a client, see if we can forward the message to their aieye.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Things using audible messages, like PDA alerts, aren't forwarded to the AI eye, even when they should be. 