### PR TITLE
Tweak donut2 sci outpost access

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -1097,6 +1097,7 @@
 "afZ" = (
 /obj/machinery/chem_dispenser/chemical,
 /obj/machinery/light/incandescent,
+/obj/mapping_helper/access/heads,
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},
@@ -28255,11 +28256,11 @@
 /obj/machinery/door/airlock/pyro/command/alt{
 	dir = 8
 	},
-/obj/mapping_helper/access/research_director,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/heads,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "jzx" = (
@@ -33236,6 +33237,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/mapping_helper/access/research,
 /turf/simulated/floor,
 /area/station/hangar/science)
 "mxb" = (
@@ -38249,6 +38251,7 @@
 	dir = 4
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/research_foyer,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "poJ" = (
@@ -50000,7 +50003,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass/command,
-/obj/mapping_helper/access/research_director,
+/obj/mapping_helper/access/heads,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "wiL" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Add foyer access to the front doors of science
* Add general science access to the science podbay
* Change computer core access from RD to heads

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* You don't need to hack a door for chem access, just break a window. 
* Only one door hack & breaking a window for plasma access.
* Anyone can shuttle over and take science's pods.
* Match computer core access with core-in-sci setups on other maps (Oshan, Nadir)