### PR TITLE
Use dark blue edges for command areas on donut2 & small fixes

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -1097,7 +1097,6 @@
 "afZ" = (
 /obj/machinery/chem_dispenser/chemical,
 /obj/machinery/light/incandescent,
-/obj/mapping_helper/access/heads,
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},
@@ -7800,7 +7799,7 @@
 	mail_tag = "captain";
 	name = "captain mail router"
 	},
-/turf/simulated/floor/red/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
@@ -8354,7 +8353,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/red/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
@@ -8431,7 +8430,7 @@
 	},
 /area/station/crew_quarters/fitness)
 "aTc" = (
-/turf/simulated/floor/red/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
@@ -8747,7 +8746,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/red/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
@@ -10320,7 +10319,7 @@
 	mail_tag = "bridge";
 	name = "bridge mail router"
 	},
-/turf/simulated/floor/red/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
@@ -11786,6 +11785,13 @@
 	dir = 4
 	},
 /area/station/crew_quarters/kitchen)
+"blk" = (
+/obj/disposalpipe/segment/mail,
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/darkblue/side{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
 "bll" = (
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -15894,7 +15900,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/purple,
 /area/station/janitor/supply)
 "bZd" = (
 /obj/machinery/atmospherics/pipe/manifold{
@@ -19658,7 +19664,7 @@
 	name = "autoname  - SS13";
 	tag = ""
 	},
-/turf/simulated/floor/red/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
@@ -19719,6 +19725,12 @@
 /obj/landmark/kudzu,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"enq" = (
+/obj/decal/cleanable/dirt/dirt5,
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/machinery/light/small/sticky/frostedred,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "enT" = (
 /obj/stool/chair/syndicate,
 /obj/npc/trader/exclown,
@@ -31585,6 +31597,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/north)
+"lAw" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/darkblue/side{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
 "lAW" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -31700,7 +31718,7 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
-/turf/simulated/floor/red/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
@@ -34393,7 +34411,7 @@
 	dir = 0;
 	name = "autoname - SS13"
 	},
-/turf/simulated/floor/blue/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 1
 	},
 /area/station/hallway/primary/south)
@@ -36253,7 +36271,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/grass/leafy,
+/turf/simulated/floor/dirt,
 /area/station/ranch)
 "olV" = (
 /obj/machinery/light/incandescent,
@@ -37464,7 +37482,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/red/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
@@ -39669,7 +39687,7 @@
 	dir = 10
 	},
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/blue/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 1
 	},
 /area/station/hallway/primary/south)
@@ -42742,7 +42760,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/red/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
@@ -45188,7 +45206,7 @@
 	},
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/red/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
@@ -48366,9 +48384,7 @@
 /obj/disposalpipe/segment/produce{
 	dir = 4
 	},
-/turf/simulated/floor/grasstodirt{
-	dir = 5
-	},
+/turf/simulated/floor/dirt,
 /area/station/ranch)
 "vmR" = (
 /obj/cable,
@@ -51224,7 +51240,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/red/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
@@ -70004,8 +70020,8 @@ lPU
 lPU
 aXp
 rPd
-hWx
-gRF
+arN
+enq
 xOv
 tHK
 xuC
@@ -94140,20 +94156,20 @@ aSs
 wXs
 aTc
 aUr
-aQM
+lAw
 tuE
-aQM
-aQf
+lAw
+blk
 rWe
 aPx
-aQf
+blk
 oMA
 bbZ
-aQM
+lAw
 lDi
-aQM
-aQf
-aQM
+lAw
+blk
+lAw
 ekD
 lLB
 aXV

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -2050,7 +2050,9 @@
 	network = "Zeta"
 	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/bluegreen/corner,
+/turf/simulated/floor/darkblue/side{
+	dir = 4
+	},
 /area/station/science/lobby)
 "alE" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -2101,7 +2103,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/blue/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/science/lobby)
@@ -2133,12 +2135,6 @@
 /obj/item/disk/data/tape/master/readonly,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
-"alY" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/blue/side{
-	dir = 4
-	},
-/area/station/science/lobby)
 "alZ" = (
 /obj/securearea{
 	desc = "A warning sign which reads 'SECURE AREA, Violators WILL be shot.'"
@@ -2189,7 +2185,7 @@
 "amF" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/blue/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/science/lobby)
@@ -22939,7 +22935,7 @@
 /area/station/medical/medbay)
 "gni" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/blue/corner{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/science/lobby)
@@ -49455,7 +49451,7 @@
 "vMe" = (
 /obj/machinery/light_switch/east,
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/blue/side{
+/turf/simulated/floor/darkblue/side{
 	dir = 4
 	},
 /area/station/science/lobby)
@@ -125201,10 +125197,10 @@ ajK
 oyr
 alD
 alM
-alY
+gni
 vMe
 amF
-alY
+gni
 gni
 epT
 rxi

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -19842,7 +19842,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/darkblue/side{
+	dir = 5
+	},
 /area/station/science/lobby)
 "eqa" = (
 /obj/disposalpipe/segment{
@@ -36873,8 +36875,8 @@
 "oyr" = (
 /obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/neutral/side{
-	dir = 4
+/turf/simulated/floor/darkblue/side{
+	dir = 10
 	},
 /area/station/science/lobby)
 "oys" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Dark blue tile edge for hallways by bridge, AI, and computer core
* light not against wall in south-west maintenance
* Remove errant access helper on chem machine (oops)
* add some flooring under doors in janitor's supply closet and ranch

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
dark blue tiling for command areas looks pretty
some other small fixes batched together