### PR TITLE
Include the magnet boundary when minng magnet checks for unacceptable content

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -198,7 +198,7 @@
 		// this used to use an area, which meant it only checked
 		var/turf/origin = get_turf(src)
 		var/unacceptable = FALSE
-		for (var/turf/T in block(origin, locate(origin.x + width - 1, origin.y + height - 1, origin.z)))
+		for (var/turf/T in block(locate(origin.x-1, origin.y-1, origin.z), locate(origin.x + width, origin.y + height, origin.z)))
 
 			for (var/mob/living/L in T)
 				if(ismobcritter(L)) // we don't care about critters


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Expand the mining magnet's unacceptable turf check to include the turfs where the magnet force-field is located.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The magnet's origin turf is the bottom left corner of empty space. The magnet force-field generates on the turfs bordering the origin + height/width, requiring us to expand the block outwards from the origin by 1.

Fix #20423
Fix #21815
