### PR TITLE
Fix up tour bots

### DIFF
--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -3662,11 +3662,14 @@ TYPEINFO(/obj/item/device/guardbot_module)
 						awaiting_beacon = max(awaiting_beacon, 1) //This will just serve as a delay so the buddy isn't zipping around at light speed between stops.
 					else
 						state = STATE_POST_TOUR_IDLE
-						master.speak("And that concludes the tour session.  Please visit the gift shop on your way out.")
 						var/obj/machinery/guardbot_dock/dock = null
 						dock = locate() in master.loc
 						if(dock && istype(dock))
-							dock.connect_robot(master,0)
+							// Check for tour console, manual wake if present, auto wake if not
+							if (locate(/obj/machinery/computer/tour_console) in orange(1, src.master))
+								dock.connect_robot(master,0)
+							else
+								dock.connect_robot(master,2)
 							return
 						else
 							desired_emotion = "angry"

--- a/code/obj/machinery/navbeacon.dm
+++ b/code/obj/machinery/navbeacon.dm
@@ -860,8 +860,18 @@ TYPEINFO(/obj/machinery/wirenav)
 		codes_txt = "tour;next_tour=tour18;desc=I hope you all have an excellent, safe and productive shift onboard this station! If you've enjoyed the tour, please put in a nice word about Murray if you see your captain."
 
 	tour18
-		name = "tour beacon - home"
+		name = "tour beacon - return"
 		location = "tour18"
+		codes_txt = "tour;next_tour=tour19;desc="
+
+	tour19
+		name = "tour beacon - return"
+		location = "tour19"
+		codes_txt = "tour;next_tour=tour20;desc="
+
+	tour20
+		name = "tour beacon - home"
+		location = "tour20"
 		codes_txt = "tour"
 
 /obj/machinery/navbeacon/tour/cog2

--- a/code/obj/machinery/navbeacon.dm
+++ b/code/obj/machinery/navbeacon.dm
@@ -862,12 +862,12 @@ TYPEINFO(/obj/machinery/wirenav)
 	tour18
 		name = "tour beacon - return"
 		location = "tour18"
-		codes_txt = "tour;next_tour=tour19;desc="
+		codes_txt = "tour;next_tour=tour19;"
 
 	tour19
 		name = "tour beacon - return"
 		location = "tour19"
-		codes_txt = "tour;next_tour=tour20;desc="
+		codes_txt = "tour;next_tour=tour20;"
 
 	tour20
 		name = "tour beacon - home"

--- a/code/z_adventurezones/luna.dm
+++ b/code/z_adventurezones/luna.dm
@@ -617,6 +617,10 @@ Contents:
 
 	tour17
 		location = "tour17"
+		codes_txt = "tour;next_tour=tour18;desc=And that concludes the tour session.  Please visit the gift shop on your way out."
+
+	tour18
+		location = "tour18"
 		codes_txt = "tour;"
 
 #define NT_DISCOUNT   (1<<0)

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -13740,7 +13740,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour14;desc=I hope you all have an excellent, safe and productive shift onboard this station! If you've enjoyed the tour, please put in a nice word about Mary if you see your captain.";
+	codes_txt = "tour;next_tour=tour14;desc=I hope you all have an excellent, safe and productive shift onboard this station! If you've enjoyed the tour, please put in a nice word about Marco if you see your captain.";
 	freq = 1443;
 	location = "tour13";
 	name = "tour13 - end"
@@ -17188,8 +17188,8 @@
 /obj/machinery/navbeacon{
 	codes_txt = "tour";
 	freq = 1443;
-	location = "tour14";
-	name = "tour14 - home"
+	location = "tour15";
+	name = "tour15 - home"
 	},
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
@@ -20605,6 +20605,12 @@
 	},
 /obj/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour15;desc=";
+	freq = 1443;
+	location = "tour14";
+	name = "tour14 - return"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -1283,7 +1283,7 @@
 	name = "Murray";
 	req_access_txt = ""
 	},
-/obj/machinery/navbeacon/tour/cog1/tour18,
+/obj/machinery/navbeacon/tour/cog1/tour20,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
@@ -19194,7 +19194,6 @@
 /obj/machinery/atmospherics/unary/outlet_injector/active{
 	dir = 4
 	},
-/obj/machinery/navbeacon/tour/cog1/tour17,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -30238,12 +30237,6 @@
 	},
 /area/station/medical/medbay/lobby)
 "cgU" = (
-/turf/simulated/floor/carpet{
-	icon_state = "red2"
-	},
-/area/station/medical/medbay/lobby)
-"cgV" = (
-/obj/machinery/navbeacon/tour/cog1/tour13,
 /turf/simulated/floor/carpet{
 	icon_state = "red2"
 	},
@@ -44289,6 +44282,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
+"ify" = (
+/obj/machinery/navbeacon/tour/cog1/tour13,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "ifM" = (
 /obj/lattice{
 	dir = 4;
@@ -48231,6 +48228,10 @@
 /obj/cable/yellow,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
+"loD" = (
+/obj/machinery/navbeacon/tour/cog1/tour17,
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "lpn" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -56140,6 +56141,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
+"rom" = (
+/obj/machinery/navbeacon/tour/cog1/tour19,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "roQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -61882,6 +61887,13 @@
 	},
 /turf/space,
 /area/supply/delivery_point)
+"vzz" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/navbeacon/tour/cog1/tour18,
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "vAd" = (
 /obj/machinery/firealarm/south,
 /obj/machinery/light/small,
@@ -100796,7 +100808,7 @@ bWD
 bWD
 cCl
 cfC
-cgV
+cgU
 cia
 fKR
 mrY
@@ -101701,7 +101713,7 @@ cfJ
 cbQ
 leZ
 ces
-cev
+ify
 cev
 cev
 cev
@@ -101995,7 +102007,7 @@ bPR
 bPR
 bSS
 bWU
-bLO
+loD
 bWY
 bYb
 bZF
@@ -102242,7 +102254,7 @@ aEh
 aUu
 aUu
 aVI
-aWT
+vzz
 aEh
 aVI
 bai
@@ -112495,7 +112507,7 @@ atw
 aBQ
 aqP
 cRg
-aqP
+rom
 aFO
 aIr
 aJD

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -6029,6 +6029,7 @@
 /obj/machinery/bot/guardbot/old/tourguide/lunar{
 	beacon_freq = 1441
 	},
+/obj/machinery/navbeacon/lunar/tour18,
 /turf/unsimulated/floor/grey/checker,
 /area/moon/museum)
 "aDu" = (
@@ -24048,21 +24049,16 @@
 /area/crunch)
 "bRc" = (
 /obj/machinery/navbeacon{
-	codes_txt = "tour";
+	codes_txt = "tour;next_tour=tour9";
 	location = "tour8"
 	},
 /turf/unsimulated/floor/blue/checker,
 /area/crunch)
 "bRd" = (
-/obj/overlay{
-	density = 1;
-	desc = "It wont budge.";
-	dir = 4;
+/obj/fakeobject/airlock_broken{
 	icon = 'icons/obj/doors/SL_doors.dmi';
 	icon_state = "door_closed";
-	layer = 6;
-	name = "broken door";
-	opacity = 1
+	dir = 4
 	},
 /turf/unsimulated/floor/blue/checker,
 /area/crunch)
@@ -24283,6 +24279,10 @@
 	name = "old docking station"
 	},
 /obj/machinery/bot/guardbot/old/tourguide,
+/obj/machinery/navbeacon{
+	codes_txt = "tour";
+	location = "tour9"
+	},
 /turf/unsimulated/floor/blue/checker,
 /area/crunch)
 "bRW" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Fix tour bots being unable to complete their route on Cogmap1 and Clarion.
- Add docking behaviour to reset the tour instead of just looping. If the dock is missing the bot will grump then loop. If there is no tour console the bot will dock and set autoeject.
- Improved tip behavior to minimise tour bots talking over their advice.

Checked Oshan, Cogmap1, Clarion.
Checked Luna (slightly different behavior, bot now goes to the dock) and void discount dan factory.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Tour bots get stuck and stand there repeating tips due to distance between tour beacons and a problem pathing through a windoor.

Existing issues not touched in this PR:
- Pathing issue with thindoors that broke pathing into cog1 medbay.
- Handling of tour beacon being missing or otherwise unpathable.
- Neat stuff can overlap with tour chat.
- Sometimes bots say their tour chat twice.