### PR TITLE
add smes units to cogmap2 ai/mining solar panel arrays

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -336,6 +336,9 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/airless/plating/damaged3,
 /area/station/solar/small_backup2)
 "abz" = (
@@ -1321,9 +1324,6 @@
 /area/station/turret_protected/ai_upload)
 "aeD" = (
 /obj/machinery/power/apc/autoname_north,
-/obj/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -1357,9 +1357,6 @@
 /obj/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/cable/yellow{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/airless/plating/damaged3,
 /area/station/solar/small_backup2)
 "aeJ" = (
@@ -1386,6 +1383,7 @@
 /obj/machinery/computer/solar_control/small_backup2{
 	dir = 8
 	},
+/obj/machinery/power/terminal,
 /turf/simulated/floor/plating/airless,
 /area/station/solar/small_backup2)
 "aeM" = (
@@ -51166,14 +51164,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/magnet)
 "dav" = (
-/obj/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/cable,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
 	pixel_x = -24
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/airless/plating/damaged3,
 /area/station/mining/magnet)
@@ -51417,7 +51415,7 @@
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
 "dbq" = (
-/obj/cable/yellow{
+/obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
@@ -51647,9 +51645,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "dci" = (
-/obj/machinery/computer/magnet{
-	dir = 8;
-	icon_state = "QMreq"
+/obj/machinery/power/smes,
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/mining/magnet)
@@ -51939,6 +51937,9 @@
 	},
 /obj/machinery/computer/solar_control/small_backup1{
 	dir = 8
+	},
+/obj/machinery/power/terminal{
+	dir = 1
 	},
 /turf/simulated/floor/airless/plating/damaged3,
 /area/station/mining/magnet)
@@ -58219,6 +58220,13 @@
 /obj/mapping_helper/access/maint,
 /turf/simulated/floor,
 /area/station/hallway/primary/northwest)
+"gEl" = (
+/obj/machinery/computer/magnet{
+	dir = 8;
+	icon_state = "QMreq"
+	},
+/turf/simulated/floor/airless/plating/damaged3,
+/area/station/mining/magnet)
 "gEY" = (
 /obj/machinery/firealarm/west,
 /obj/disposalpipe/segment,
@@ -63201,6 +63209,12 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor,
 /area/station/maintenance/outer/ne)
+"lfp" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless/plating/damaged3,
+/area/station/mining/magnet)
 "lgq" = (
 /obj/cable/orange{
 	icon_state = "0-8"
@@ -64868,6 +64882,13 @@
 	},
 /turf/simulated/floor/blueblack,
 /area/station/hallway/primary/west)
+"mJx" = (
+/obj/machinery/power/smes,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/airless/plating/damaged3,
+/area/station/solar/small_backup2)
 "mKE" = (
 /obj/table/auto,
 /obj/decal/cleanable/cobweb{
@@ -65497,8 +65518,8 @@
 	},
 /area/station/security/detectives_office)
 "nrh" = (
-/obj/cable/yellow{
-	icon_state = "1-2"
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/airless/plating/damaged3,
 /area/station/mining/magnet)
@@ -69989,9 +70010,6 @@
 "rSO" = (
 /obj/mesh/catwalk,
 /obj/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
@@ -71666,6 +71684,12 @@
 /obj/mapping_helper/access/maint,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
+"txe" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/solar/small_backup2)
 "tys" = (
 /obj/table/reinforced/auto,
 /obj/machinery/firealarm/east,
@@ -136699,7 +136723,7 @@ cYA
 cYA
 cYA
 cYA
-cYB
+lfp
 dwN
 lIC
 cGZ
@@ -136880,7 +136904,7 @@ wwk
 oic
 oic
 aeJ
-afw
+txe
 afw
 afw
 afw
@@ -137001,7 +137025,7 @@ cYA
 cYA
 cYA
 cYA
-cYB
+lfp
 ddx
 dau
 aaB
@@ -137182,7 +137206,7 @@ aaB
 aaB
 adr
 aeK
-afw
+txe
 afw
 afx
 afw
@@ -137302,7 +137326,7 @@ wDH
 cXi
 cYA
 cYA
-cYB
+gEl
 dci
 ddy
 dbs
@@ -137484,7 +137508,7 @@ aaa
 aaa
 aea
 aeL
-afx
+mJx
 afw
 afw
 afw


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The solar panels north of AI and south of mining are directly wired into the grid on cogmap2. This causes an issue during the solar flare event where it will hotwire cogmap2's grid due to the power boost.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Roundstart wiring shouldn't cause a hotwire
Fix #21671