### PR TITLE
Lets you make a data terminal out of a wire and a metal sheet

### DIFF
--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -252,9 +252,23 @@ MATERIAL
 			boutput(user, SPAN_NOTICE("You whittle [src] down to make a useful stick."))
 			new /obj/item/stick(get_turf(src))
 			src.change_stack_amount(-1)
+		else if (istype(W, /obj/item/cable_coil) && (src.material?.getMaterialFlags() & MATERIAL_METAL) && ((src in user) && (W in user)))
+			var/turf/T = get_turf(user)
+			if (T.intact)
+				boutput(user, SPAN_ALERT("You must remove the plating first."))
+				return
+			boutput(user, SPAN_NOTICE("You begin assembling a data terminal."))
+			SETUP_GENERIC_ACTIONBAR(user, src, 4 SECONDS, PROC_REF(build_terminal), list(W, user),\
+				/obj/machinery/power/data_terminal::icon, /obj/machinery/power/data_terminal::icon_state,\
+				SPAN_NOTICE("[user] assembles a data terminal."), INTERRUPT_MOVE | INTERRUPT_STUNNED)
 		else
 			..()
-		return
+
+	proc/build_terminal(obj/item/cable_coil/cable, mob/user)
+		if ((src in user) && (cable in user))
+			new /obj/machinery/power/data_terminal(get_turf(user))
+			src.change_stack_amount(-1)
+			cable.change_stack_amount(-1)
 
 	before_stack(atom/movable/O as obj, mob/user as mob)
 		user.visible_message(SPAN_NOTICE("[user] begins gathering up [src]!"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Using a wire on a metal sheet now assembles a data terminal.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Data terminals are annoying and make any repair/rebuilding process involving wired machines harder than it needs to be due to the necessity to scan, print and carry them around.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Data terminals can now be constructed by using a cable on a metal sheet.
```
