### PR TITLE
Prevent item special effects from falling into the trench

### DIFF
--- a/code/modules/items/specials/ItemSpecials.dm
+++ b/code/modules/items/specials/ItemSpecials.dm
@@ -1996,6 +1996,7 @@ ABSTRACT_TYPE(/datum/item_special/spark)
 	icon = 'icons/effects/160x160.dmi'
 	icon_state = ""
 	anchored = ANCHORED
+	event_handler_flags = IMMUNE_TRENCH_WARP
 	pass_unstable = FALSE
 	layer = EFFECTS_LAYER_1
 	pixel_x = -64


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Make item special effects immune to trench warp


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21824
