### PR TITLE
Add Faustian Bargain Kit to Lawyer Syndicate Items

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -586,7 +586,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 	items = list(/obj/item/storage/briefcase/satan)
 	cost = 8
 	desc = "Comes complete with three soul binding contracts, three extra-pointy pens, and one suit provided by Lucifer himself."
-	job = list("Chaplain")
+	job = list("Chaplain", "Lawyer")
 	not_in_crates = TRUE
 	vr_allowed = FALSE
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Simple change, just adds the Faustian Bargain Kit to the Lawyer as a traitor item. Now that you can start the round as a Lawyer antagonist, I think this would be a fun addition for them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The item is already thematic to a lawyer. I could see it being a shared item for both Chaplain and Lawyer. It's nice for the gimmick job antagonists to get a couple more job-specific items.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)KevinFromHP
(*)The Faustian Bargain kit can now be obtained by Lawyer Traitors.
```
