### PR TITLE
Removes the security alert HUD button

### DIFF
--- a/code/obj/item/device/pda2/modules.dm
+++ b/code/obj/item/device/pda2/modules.dm
@@ -288,7 +288,6 @@ TYPEINFO(/obj/item/device/pda_module)
 	desc = "A PDA module that lets you quickly send PDA alerts to the security department."
 	icon_state = "pdamod_alert"
 	setup_use_menu_badge = 1
-	abilities = list(/obj/ability_button/pda_security_alert)
 	var/list/mailgroups = list(MGD_SECURITY)
 
 	return_menu_badge()
@@ -330,13 +329,3 @@ TYPEINFO(/obj/item/device/pda_module)
 			user.visible_message(SPAN_ALERT("[user] presses a red button on the side of their [src.host]."),
 			SPAN_NOTICE("You press the \"Alert\" button on the side of your [src.host]."),
 			SPAN_ALERT("You see [user] press a button on the side of their [src.host]."))
-
-
-/obj/ability_button/pda_security_alert
-	name = "Send Security Alert"
-	icon_state = "alert"
-
-	execute_ability()
-		var/obj/item/device/pda_module/alert/J = the_item
-		if (J.host)
-			J.send_alert(src.the_mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the security alert HUD button from security PDAs. The alert can still be sent from the menu, the same way as any other PDA.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This feature was added a few years ago without any particular justification (#3017 I think?) and seems to be generally disliked for promoting the well known security swarm descending on a location the instant one of their officers is in trouble.

You can always call for help the old fashioned way, but hopefully this will lead to more opportunities for antags to take out isolated security officers without them suddenly turning into [Cuccos](https://zelda-archive.fandom.com/wiki/Cucco).

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Removed the security alert HUD button.
```
