### PR TITLE
Alert ACKs now work no matter your open PDA program

### DIFF
--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -575,10 +575,7 @@
 							return
 
 					if("ack")
-						if(src.message_last + 20 > TIME) //Message sending delay
-							return
 						src.CrisisAck(href_list["alert_group"], href_list["caller"], href_list["noreply"])
-						src.master.add_fingerprint(usr)
 						return
 
 					if("rename")
@@ -1201,6 +1198,9 @@
 		/// * caller_id: The PDA ID who called the alert
 		/// * noreply: `noreply` data from alert message signal
 		proc/CrisisAck(group_id, caller_id, noreply)
+			if(src.message_last + 20 > TIME) //Message sending delay
+				return
+			src.master.add_fingerprint(usr)
 			var/message = "ACK: Responding to crisis alert!"
 
 			var/caller_reply = TRUE

--- a/code/obj/item/device/pda2/base_program.dm
+++ b/code/obj/item/device/pda2/base_program.dm
@@ -167,6 +167,9 @@
 			return 1
 		if((!istype(holder)) || (!istype(master)))
 			return 1
+		if (src.master.active_program != src && href_list["input"] && href_list["input"] == "ack")
+			src.master.host_program.CrisisAck(href_list["alert_group"], href_list["caller"], href_list["noreply"])
+			return 1
 		if((src.master.active_program != src) && !(href_list["input"] && href_list["input"] == "message")) // Disgusting but works
 			return 1
 		if ((!usr.contents.Find(src.master) && (!in_interact_range(src.master, usr) || !istype(src.master.loc, /turf) || !isAI(usr))) && (!issilicon(usr) && !isAI(usr)))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a check to the base program to intercept "ACK" links, call the crisis ack on the host program, and then bail. The established pattern is for programs to call the parent first and return early.

Move the message_last and fingerprint code inside of the CrisisAck proc so we don't have to repeat that overhead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Make acking crisis alerts work from any program, making them more reliable to use.
Fix #18673

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Crisis Alert ACKs are much more responsive.
```
