### PR TITLE
Add research/engine access helpers to Nadir's siphon rockbox

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -18418,6 +18418,7 @@
 "hOr" = (
 /obj/machinery/ore_cloud_storage_container,
 /obj/mapping_helper/access/research,
+/obj/mapping_helper/access/engineering_engine,
 /turf/simulated/floor/engine,
 /area/station/science/construction{
 	name = "Extraction Nexus"

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -18417,6 +18417,7 @@
 /area/abandonedmedicalship/robot_trader)
 "hOr" = (
 /obj/machinery/ore_cloud_storage_container,
+/obj/mapping_helper/access/research,
 /turf/simulated/floor/engine,
 /area/station/science/construction{
 	name = "Extraction Nexus"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
add two access helpers to the siphon rockbox


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
scientists and engineers can't access the siphon rockbox on nadir, but they have access to everything else in the area