### PR TITLE
Fix martian and blob tourists dropping all their equipment on spawn

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2739,20 +2739,46 @@ ABSTRACT_TYPE(/datum/job/daily)
 		..()
 		if (!M)
 			return
+
+		var/morph = null
 		if(prob(33))
-			var/morph = pick(/datum/mutantrace/lizard,/datum/mutantrace/skeleton,/datum/mutantrace/ithillid,/datum/mutantrace/martian,/datum/mutantrace/amphibian,/datum/mutantrace/blob,/datum/mutantrace/cow)
-			M.set_mutantrace(morph)
-		if (istype(M.mutantrace, /datum/mutantrace/martian) || istype(M.mutantrace, /datum/mutantrace/blob))
+			morph = pick(/datum/mutantrace/lizard,/datum/mutantrace/skeleton,/datum/mutantrace/ithillid,/datum/mutantrace/martian,/datum/mutantrace/amphibian,/datum/mutantrace/blob,/datum/mutantrace/cow)
+
+		if (morph && (morph == /datum/mutantrace/martian || morph == /datum/mutantrace/blob)) // doesn't wear human clothes
+			M.equip_if_possible(new /obj/item/storage/backpack/empty(src), SLOT_BACK)
+			var/obj/item/backpack = M.back
+
+			var/obj/item/storage/fanny/belt_storage = M.belt
+			if(istype(belt_storage))
+				for(var/obj/item/I in belt_storage.storage.get_contents())
+					belt_storage.storage.transfer_stored_item(I, backpack, TRUE, M)
+			qdel(belt_storage)
+
 			M.equip_if_possible(new /obj/item/device/speech_pro(src), SLOT_IN_BACKPACK)
+
+			M.stow_in_available(M.l_store, FALSE)
+			M.stow_in_available(M.r_store, FALSE)
+
+			var/obj/item/shirt = M.get_slot(SLOT_W_UNIFORM)
+			M.drop_from_slot(shirt)
+			qdel(shirt)
+
+			var/obj/item/shoes = M.get_slot(SLOT_SHOES)
+			M.drop_from_slot(shoes)
+			qdel(shoes)
+
 		else
+			var/obj/item/clothing/lanyard/L = new /obj/item/clothing/lanyard(M.loc)
+			var/obj/item/card/id = locate() in M
+			if (id)
+				L.storage.add_contents(id, M, FALSE)
 			if (M.l_store)
 				M.stow_in_available(M.l_store)
 			M.equip_if_possible(new /obj/item/device/speech_pro(src), SLOT_L_STORE)
-		var/obj/item/clothing/lanyard/L = new /obj/item/clothing/lanyard(M.loc)
-		M.equip_if_possible(L, SLOT_WEAR_ID, FALSE)
-		var/obj/item/card/id = locate() in M
-		if (id)
-			L.storage.add_contents(id, M, FALSE)
+			M.equip_if_possible(L, SLOT_WEAR_ID, TRUE)
+
+		if(morph) // now that we've handled weird mutantrace cases, morph them
+			M.set_mutantrace(morph)
 
 /datum/job/daily/musician
 	day = "Saturday"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][respawning]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Since martian and blob tourists can't wear human clothes, we need to make some changes to the tourist's special setup:
* Give them a backpack
* Cannot wear a belt, so transfer the fanny pack contents to the backpack
* Slot the speech pro and their pocket items in the backpack
* Remove their shirt and shoes

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #17842