### PR TITLE
Add "innate" bioeffect flag, allowing them to be copied by cloning/changeling/strange mutagent/dna scrambler

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -802,8 +802,8 @@ ABSTRACT_TYPE(/datum/trait/job)
 
 	onAdd(var/mob/owner)
 		owner.AddComponent(/datum/component/death_confetti)
-		owner.bioHolder?.AddEffect("accent_comic", magical = TRUE)
-		owner.bioHolder?.AddEffect("clumsy", magical = TRUE)
+		owner.bioHolder?.AddEffect("accent_comic", innate = TRUE)
+		owner.bioHolder?.AddEffect("clumsy", innate = TRUE)
 
 /datum/trait/job/mime
 	name = "Mime Training"
@@ -811,8 +811,8 @@ ABSTRACT_TYPE(/datum/trait/job)
 	id = "training_mime"
 
 	onAdd(var/mob/owner)
-		owner.bioHolder?.AddEffect("mute", magical = TRUE)
-		owner.bioHolder?.AddEffect("blankman", magical = TRUE)
+		owner.bioHolder?.AddEffect("mute", innate = TRUE)
+		owner.bioHolder?.AddEffect("blankman", innate = TRUE)
 
 /datum/trait/job/miner
 	name = "Miner Training"
@@ -1391,7 +1391,7 @@ TYPEINFO(/datum/trait/partyanimal)
 	icon_state = "hair"
 
 	onAdd(mob/owner)
-		owner.bioHolder.AddEffect("hair_growth", magical = TRUE)
+		owner.bioHolder.AddEffect("hair_growth", innate = TRUE)
 
 	onRemove(mob/owner)
 		owner.bioHolder.RemoveEffect("hair_growth")

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -736,7 +736,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 
 		age += (toCopy.age - age) / (11 - progress)
 
-	proc/AddEffect(var/idToAdd, var/power = 0, var/timeleft = 0, var/do_stability = 1, var/magical = 0, var/safety = 0, var/for_scanning=0)
+	proc/AddEffect(var/idToAdd, var/power = 0, var/timeleft = 0, var/do_stability = 1, var/magical = 0, var/safety = 0, var/for_scanning=0, innate = 0)
 		//Adds an effect to this holder. Returns the newly created effect if succesful else 0.
 		if(issilicon(src.owner))
 			return 0
@@ -760,14 +760,17 @@ var/list/datum/bioEffect/mutini_effects = list()
 
 			if(power) newEffect.power = power
 			if(timeleft) newEffect.timeLeft = timeleft
-			if(magical)
+			if(magical || innate)
 				newEffect.curable_by_mutadone = FALSE
 				newEffect.stability_loss = 0
 				newEffect.can_scramble = FALSE
+				newEffect.scanner_visibility = FALSE
 				newEffect.can_reclaim = FALSE
 				newEffect.degrade_to = null
 				newEffect.can_copy = FALSE
 				newEffect.is_magical = TRUE
+			if(innate)
+				newEffect.can_copy = TRUE
 
 			if(safety && istype(newEffect, /datum/bioEffect/power))
 				// Only powers have safety ("synced" i.e. safe for user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][gamemodes]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Prevent magical genes from showing on gene scanners
* Add new flag when adding bioEffects: "Innate", which is just like magical except the gene can be copied.
* Mark clown/mime job trait, and hairy trait, genes as "Innate"

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Fix #17421 
* Changelings that absorb clowns/mimes and then transform into them won't get their mutations, potentially outing them
* Same with Changeling-Hairy gene interaction
* Arcfiends who visit genetics will already have SMES enabled, potentially outing them to the geneticist

This will also prevent geneticists from forcibly de-clowning the clown and de-miming the mime, acts which are definitely a violation of natural law.