### PR TITLE
Fix RCD going into negative ammo

### DIFF
--- a/code/obj/item/rcd/rcd_action_bar.dm
+++ b/code/obj/item/rcd/rcd_action_bar.dm
@@ -77,6 +77,11 @@
 	onEnd()
 		..()
 
+		if(!src.rcd.ammo_check(src.user, src.ammo_cost))
+			boutput(src.user, "Insufficient ammo to complete operation!")
+			interrupt(INTERRUPT_ALWAYS)
+			return
+
 		src.rcd.ammo_consume(src.owner, src.ammo_cost)
 		var/datum/callback/cb = CALLBACK(src.callback_owner, src.callback_path)
 		cb.arguments = list(src.target, src.owner) + src.additionalArguments


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a final ammo check in the RCD action bar's `onEnd` proc to make sure we still have enough ammo to complete the construction.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #21853 