### PR TITLE
Gives a firearms carry permit to bartenders

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -317,7 +317,7 @@
 		if("Chef", "Sous-Chef")
 			return list(access_kitchen)
 		if("Bartender")
-			return list(access_bar)
+			return list(access_bar, access_carrypermit)
 		if("Waiter")
 			return list(access_bar, access_kitchen)
 		if("Clown", "Boxer", "Barber", "Mime", "Dungeoneer")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives a firearms carry permit to bartenders.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Firearms carry is never used separately from contraband carry and I find it sad.
Also bartenders spawn with the shotgun, probably should have a permit issued by NT.
And gives a bit more spice to treasonous bartenders.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chatauscours
(*)After some slight bureaucratic delays, the bartender has finally managed to acquire themselves a firearms carry permit.
```
