### PR TITLE
Require hauntium for printing wrestling belts

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -284,7 +284,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	name = "Wrestling Belt"
 	items = list(/obj/item/storage/belt/wrestling)
 	cost = 7
-	desc = "A haunted antique wrestling belt, imbued with the spirits of wrestlers past. Wearing it unlocks a number of wrestling moves, which can be accessed in a separate command tab."
+	desc = "A haunted antique wrestling belt, imbued with the spirits of wrestlers past. Wearing it unlocks a number of wrestling moves."
 	not_in_crates = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_NUKE_OP
 

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -1084,7 +1084,7 @@ ABSTRACT_TYPE(/obj/item/storage/belt/gun)
 TYPEINFO(/obj/item/storage/belt/wrestling)
 	mats = list("metal_dense" = 5,
 				"dense_super" = 10,
-				"fabric" = 5)
+				"hauntium" = 20)
 /obj/item/storage/belt/wrestling
 	name = "championship wrestling belt"
 	desc = "A haunted antique wrestling belt, imbued with the spirits of wrestlers past."
@@ -1106,6 +1106,11 @@ TYPEINFO(/obj/item/storage/belt/wrestling)
 		if (!user.mind?.get_antagonist(ROLE_WRESTLER))
 			user.remove_wrestle_powers(src.fake)
 
+TYPEINFO(/obj/item/storage/belt/wrestling/fake)
+	mats = list("metal_dense" = 5,
+				"dense_super" = 10,
+				"fabric" = 5
+	)
 /obj/item/storage/belt/wrestling/fake
 	name = "fake wrestling belt"
 	desc = "A haunted antique wrestling belt, imbued with the spirits of wrestlers past."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Change the fabric requirement on the wrestling belt to the hauntium alloy, and increase the amount required from 0.5 to 2.
The fake wrestling belt keeps the old reproduction values.
Clean up an outdated bit of text referencing a wrestling commands tab that no longer exists.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
high-impact rampage items should not be trivially reproducable. also the belt is haunted, it says so right in the description