### PR TITLE
Replace censorium material properties with actual combination properies

### DIFF
--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -1751,10 +1751,12 @@ ABSTRACT_TYPE(/datum/material/fabric)
 
 	New()
 		..()
-		setProperty("flammable", 2)
-		setProperty("density", 2)
+		setProperty("electrical", 4)
+		setProperty("thermal", 4)
 		setProperty("hard", 2)
-		setProperty("thermal", 1)
+		setProperty("density", 2)
+		setProperty("flammable", 3)
+		setProperty("chemical", 4)
 
 /datum/material/fabric/hauntium
 	mat_id = "hauntium"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][materials]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Make the censorium properties match the result of combining rock and char.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Censorium was given some arbitrary properties when introduced. As a result it's currently one of the better alloys for engine plating despite the proprties of its components.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Censorium's material properties reflect the composition of its materials.
```
