### PR TITLE
Device analyzer shows scanned items

### DIFF
--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -453,7 +453,7 @@
 		for (var/obj/item_type as anything in src.scanned)
 			if (initial(item_type.is_syndicate))
 				continue
-			. += "<br>-\proper[initial(item_type.name)]"
+			. += "<br>-" + "\proper[initial(item_type.name)]"
 
 	proc/pre_attackby(obj/item/parent_item, atom/A, mob/user)
 		if (user.a_intent == INTENT_HARM)

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -446,6 +446,14 @@
 		// We display this on a separate line and with a different color to show emphasis
 		. = ..()
 		. += "<br>[SPAN_NOTICE("Use the Help, Disarm, or Grab intents to scan objects when you click them. Switch to Harm intent do other things.")]"
+		. += "<br>Scanned items:"
+		if (!length(src.scanned))
+			. += " None"
+			return
+		for (var/obj/item_type as anything in src.scanned)
+			if (initial(item_type.is_syndicate))
+				continue
+			. += "<br>-\proper[initial(item_type.name)]"
 
 	proc/pre_attackby(obj/item/parent_item, atom/A, mob/user)
 		if (user.a_intent == INTENT_HARM)


### PR DESCRIPTION
[GAME OBJECTS][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so the device analyzer shows non-syndicate scanned items


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
-Easier to tell what you've scanned
-Allows security to confiscate an analyzer only if needed


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)Device analyzers can be inspected to show scanned objects, excluding Syndicate objects.
```
