### PR TITLE
Make Donut3's aquarium door block fluids

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -11826,11 +11826,7 @@
 /turf/simulated/wall/auto/jen/blue,
 /area/station/maintenance/inner/sw)
 "dty" = (
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
-	},
+/obj/forcefield/energyshield/perma/doorlink,
 /obj/machinery/door/airlock/pyro/glass/command,
 /obj/mapping_helper/access/engineering_chief,
 /turf/simulated/floor/black,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove the var-edits from the door shield under donut3 CE office aquarium's door so it blocks liquids.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
it lets the water out :(
