### PR TITLE
Doubles HE Torpedo Cost (5000 -> 10000)

### DIFF
--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -1999,7 +1999,7 @@ datum/commodity/drugs/sell/poppies
 	comtype = /obj/torpedo_tray/hiexp_loaded
 	desc = "A highly explosive torpedo, ready for your sick, destructive needs."
 	onmarket = 0
-	price = PAY_EMBEZZLED
+	price = PAY_EMBEZZLED*3
 
 /datum/commodity/sketchy_press_upgrade
 	comname = "Sketchy press upgrade"

--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -1999,7 +1999,7 @@ datum/commodity/drugs/sell/poppies
 	comtype = /obj/torpedo_tray/hiexp_loaded
 	desc = "A highly explosive torpedo, ready for your sick, destructive needs."
 	onmarket = 0
-	price = PAY_EMBEZZLED*3
+	price = PAY_EMBEZZLED*2
 
 /datum/commodity/sketchy_press_upgrade
 	comname = "Sketchy press upgrade"


### PR DESCRIPTION
[BALANCE] [OBJECT]

## About the PR 
Raises the cost of the High Explosive Torpedoes from 5000 Credits to 10000 Credits, doubling it. 

## Why's this needed? 
While you can't run Toxins on Nadir and it can be troubling on Oshan, I don't believe that justifies the cost. 10000 is expensive but in the reach of higher paying jobs and should be easy enough to hit with stealing money from cargo or space/trench. Large explosives should be just a tad more uncommon. Willing to edit the value if needed, feels like a good fit though. Was previously considering 15k.

## Changelog 

```changelog
(u)444
(+)Due to a materials shortage, HE Torpedos now cost 10,000 Credits
```
