### PR TITLE
Fix set mutantrace not being scannable in gene console

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -608,7 +608,7 @@ ABSTRACT_TYPE(/datum/mutantrace)
 			return
 		var/datum/bioEffect/mutantrace/mr = src.race_mutation
 		if(!H.bioHolder.HasEffect(initial(mr.id)))
-			H.bioHolder.AddEffect(initial(mr.id), 0, 0, 0, 1)
+			H.bioHolder.AddEffect(initial(mr.id), 0, 0, 0, 1, scannable=TRUE)
 
 	/// Copies over female variants of mutant heads and organs
 	proc/MakeMutantDimorphic(var/mob/living/carbon/human/H)

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -736,7 +736,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 
 		age += (toCopy.age - age) / (11 - progress)
 
-	proc/AddEffect(var/idToAdd, var/power = 0, var/timeleft = 0, var/do_stability = 1, var/magical = 0, var/safety = 0, var/for_scanning=0, innate = 0)
+	proc/AddEffect(var/idToAdd, var/power = 0, var/timeleft = 0, var/do_stability = 1, var/magical = 0, var/safety = 0, scannable=0, innate = 0)
 		//Adds an effect to this holder. Returns the newly created effect if succesful else 0.
 		if(issilicon(src.owner))
 			return 0
@@ -771,6 +771,8 @@ var/list/datum/bioEffect/mutini_effects = list()
 				newEffect.is_magical = TRUE
 			if(innate)
 				newEffect.can_copy = TRUE
+			if(scannable)
+				newEffect.scanner_visibility = TRUE
 
 			if(safety && istype(newEffect, /datum/bioEffect/power))
 				// Only powers have safety ("synced" i.e. safe for user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mutantrace]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When I added innate genes, I made magical genes no longer show up in the console. However the MutateMutant code path makes the mutantrace gene magical. This fixes the issue by redefining and using one of the other AddEffect flags that I did not see any usage of `for_scanning` -> `scannable`, and implements it for the MutateMutant code path.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix mutantrace set via gene console not showing the gene in the console.