### PR TITLE
Wraith whispers show maptext to targeted person

### DIFF
--- a/code/WorkInProgress/salvager/salvager_magpie.dm
+++ b/code/WorkInProgress/salvager/salvager_magpie.dm
@@ -66,8 +66,7 @@ var/datum/magpie_manager/magpie_man = new
 			SPAWN(1.5 SECONDS)
 				UpdateOverlays(null, "bot_speech_bubble")
 			if(!src.bot_speech_color)
-				var/num = hex2num(copytext(md5("[src.name][TIME]"), 1, 7))
-				src.bot_speech_color = hsv2rgb(num % 360, (num / 360) % 10 + 18, num / 360 / 10 % 15 + 85)
+				src.bot_speech_color = living_maptext_color("[src.name][TIME]")
 			var/maptext_color
 			if (sing)
 				maptext_color ="#D8BFD8"

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1163,8 +1163,7 @@
 	if (!message_range && speechpopups && src.chat_text)
 		var/heard_name = src.get_heard_name(just_name_itself=TRUE)
 		if(!last_heard_name || heard_name != src.last_heard_name)
-			var/num = hex2num(copytext(md5(heard_name), 1, 7))
-			src.last_chat_color = hsv2rgb(num % 360, (num / 360) % 10 + 18, num / 360 / 10 % 15 + 85)
+			src.last_chat_color = living_maptext_color(heard_name)
 			src.last_heard_name = heard_name
 
 		var/turf/T = get_turf(say_location)

--- a/code/modules/antagonists/wraith/abilties/trickster/mass_whisper.dm
+++ b/code/modules/antagonists/wraith/abilties/trickster/mass_whisper.dm
@@ -15,11 +15,21 @@
 		if (!message)
 			return CAST_ATTEMPT_FAIL_NO_COOLDOWN
 		message = ghostify_message(copytext(html_encode(message), 1, MAX_MESSAGE_LEN))
+
+		var/image/chat_maptext/whisper_text = null
+		var/num = hex2num(copytext(md5(src.holder.owner.name), 1, 7))
+		var/maptext_color = hsv2rgb((num % 360)%40+240, (num / 360) % 15+5, (((num / 360) / 10) % 15) + 55)
+
 		var/hearers = 0
 		for (var/mob/living/carbon/human/H in range(8, src.holder.owner))
 			if (isdead(H))
 				continue
 			logTheThing(LOG_SAY, holder.owner, "WRAITH WHISPER TO [key_name(H)]: [message]")
+			whisper_text = make_chat_maptext(H, "<span style='text-shadow: 0 0 3px black; -dm-text-outline: 2px black;'>[message]</span>", alpha = 180)
+			if(whisper_text)
+				whisper_text.show_to(src.holder.owner.client)
+				whisper_text.show_to(H.client)
+				oscillate_colors(whisper_text, list(maptext_color, "#c482d1"))
 			boutput(H, "<b>A netherworldly voice whispers into your ears... </b> \"[message]\"")
 			H.playsound_local(H, "sound/voice/wraith/wraithwhisper[rand(1, 4)].ogg", 65)
 			hearers++

--- a/code/modules/antagonists/wraith/abilties/trickster/mass_whisper.dm
+++ b/code/modules/antagonists/wraith/abilties/trickster/mass_whisper.dm
@@ -17,8 +17,7 @@
 		message = ghostify_message(copytext(html_encode(message), 1, MAX_MESSAGE_LEN))
 
 		var/image/chat_maptext/whisper_text = null
-		var/num = hex2num(copytext(md5(src.holder.owner.name), 1, 7))
-		var/maptext_color = hsv2rgb((num % 360)%40+240, (num / 360) % 15+5, (((num / 360) / 10) % 15) + 55)
+		var/maptext_color = dead_maptext_color(src.holder.owner.name)
 
 		var/hearers = 0
 		for (var/mob/living/carbon/human/H in range(8, src.holder.owner))

--- a/code/modules/antagonists/wraith/abilties/whisper.dm
+++ b/code/modules/antagonists/wraith/abilties/whisper.dm
@@ -11,24 +11,39 @@
 		return message
 
 	cast(atom/target)
-		if (..())
-			return 1
+		. = ..()
+		if (.)
+			return .
 
-		if (ishuman(target))
-			var/mob/living/carbon/human/H = target
-			if (isdead(H))
-				boutput(usr, SPAN_ALERT("They can hear you just fine without the use of your abilities."))
-				return 1
-			else
-				var/message = html_encode(tgui_input_text(usr, "What would you like to whisper to [target]?", "Whisper"))
-				logTheThing(LOG_SAY, usr, "WRAITH WHISPER TO [constructTarget(target,"say")]: [message]")
-				message = ghostify_message(trimtext(copytext(sanitize(message), 1, 255)))
-				if (!message)
-					return 1
-				boutput(usr, "<b>You whisper to [target]:</b> [message]")
-				boutput(target, "<b>A netherworldly voice whispers into your ears... </b> [message]")
-				usr.playsound_local(usr.loc, "sound/voice/wraith/wraithwhisper[rand(1, 4)].ogg", 65, 0)
-				H.playsound_local(H.loc, "sound/voice/wraith/wraithwhisper[rand(1, 4)].ogg", 65, 0)
-		else
+		if (!ishuman(target))
 			boutput(usr, SPAN_ALERT("It would be futile to attempt to force your voice to the consciousness of that."))
-			return 1
+			return CAST_ATTEMPT_FAIL_NO_COOLDOWN
+
+		var/mob/living/carbon/human/H = target
+		if (isdead(H))
+			boutput(usr, SPAN_ALERT("They can hear you just fine without the use of your abilities."))
+			return CAST_ATTEMPT_FAIL_NO_COOLDOWN
+
+		var/message = html_encode(tgui_input_text(usr, "What would you like to whisper to [target]?", "Whisper"))
+		if (!message)
+			return CAST_ATTEMPT_FAIL_NO_COOLDOWN
+
+		logTheThing(LOG_SAY, usr, "WRAITH WHISPER TO [constructTarget(target,"say")]: [message]")
+		message = ghostify_message(trimtext(copytext(sanitize(message), 1, MAX_MESSAGE_LEN)))
+
+		var/image/chat_maptext/whisper_text = null
+		var/num = hex2num(copytext(md5(src.holder.owner.name), 1, 7))
+		var/maptext_color = hsv2rgb((num % 360)%40+240, (num / 360) % 15+5, (((num / 360) / 10) % 15) + 55)
+		whisper_text = make_chat_maptext(H, "<span style='text-shadow: 0 0 3px black; -dm-text-outline: 2px black;'>[message]</span>", alpha = 180)
+		if(whisper_text)
+			whisper_text.show_to(src.holder.owner.client)
+			whisper_text.show_to(H.client)
+			oscillate_colors(whisper_text, list(maptext_color, "#c482d1"))
+
+		boutput(usr, "<b>You whisper to [target]:</b> [message]")
+		boutput(target, "<b>A netherworldly voice whispers into your ears... </b> [message]")
+		usr.playsound_local(usr.loc, "sound/voice/wraith/wraithwhisper[rand(1, 4)].ogg", 65, 0)
+		H.playsound_local(H.loc, "sound/voice/wraith/wraithwhisper[rand(1, 4)].ogg", 65, 0)
+		return CAST_ATTEMPT_SUCCESS
+
+

--- a/code/modules/antagonists/wraith/abilties/whisper.dm
+++ b/code/modules/antagonists/wraith/abilties/whisper.dm
@@ -32,8 +32,7 @@
 		message = ghostify_message(trimtext(copytext(sanitize(message), 1, MAX_MESSAGE_LEN)))
 
 		var/image/chat_maptext/whisper_text = null
-		var/num = hex2num(copytext(md5(src.holder.owner.name), 1, 7))
-		var/maptext_color = hsv2rgb((num % 360)%40+240, (num / 360) % 15+5, (((num / 360) / 10) % 15) + 55)
+		var/maptext_color = dead_maptext_color(src.holder.owner.name)
 		whisper_text = make_chat_maptext(H, "<span style='text-shadow: 0 0 3px black; -dm-text-outline: 2px black;'>[message]</span>", alpha = 180)
 		if(whisper_text)
 			whisper_text.show_to(src.holder.owner.client)

--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -176,8 +176,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/bot, proc/admin_command_speak)
 				SPAWN(1.5 SECONDS)
 					ClearSpecificOverlays("bot_speech_bubble")
 			if(!src.bot_speech_color)
-				var/num = hex2num(copytext(md5("[src.name][TIME]"), 1, 7))
-				src.bot_speech_color = hsv2rgb(num % 360, (num / 360) % 10 + 18, num / 360 / 10 % 15 + 85)
+				src.bot_speech_color = living_maptext_color("[src.name][TIME]")
 			var/singing_italics = sing ? " font-style: italic;" : ""
 			var/maptext_color
 			if (sing)

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -231,8 +231,7 @@
 
 	var/image/chat_maptext/chat_text = null
 	if (speechpopups && src.chat_text)
-		var/num = hex2num(copytext(md5(src.get_heard_name(just_name_itself=TRUE)), 1, 7))
-		var/maptext_color = hsv2rgb((num % 360)%40+240, (num / 360) % 15+5, (((num / 360) / 10) % 15) + 55)
+		var/maptext_color = dead_maptext_color(src.get_heard_name(just_name_itself=TRUE))
 
 		var/turf/T = get_turf(src)
 		for(var/i = 0; i < 2; i++) T = get_step(T, WEST)
@@ -1175,3 +1174,13 @@
 
 		if(thisR != "")
 			boutput(M, thisR)
+
+/// Generate a hue for maptext from a given name
+/proc/living_maptext_color(given_name)
+	var/num = hex2num(copytext(md5(given_name), 1, 7))
+	return hsv2rgb(num % 360, (num / 360) % 10 + 18, num / 360 / 10 % 15 + 85)
+
+/// Generate a desatureated hue for maptext from a given name
+/proc/dead_maptext_color(given_name)
+	var/num = hex2num(copytext(md5(given_name), 1, 7))
+	return hsv2rgb((num % 360)%40+240, (num / 360) % 15+5, (((num / 360) / 10) % 15) + 55)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[gamemodes][player actions][feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* restructure wraith whisper ability to use early returns and use return defines
* generate maptext for whisper and mass whisper that appears above the target(s)
* the maptext is outlined in black and oscilates in purple like deadchat
* show maptext to both the person affected and the wraith
* for trickster's mass whispers, each person gets their own maptext. This shows the wraith exactly who heard the message.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wraith whispers currently only show up in the sidebar, and can be easy to miss in the high-pop rounds that wraiths spawn in.

## Demo

https://github.com/user-attachments/assets/f28e9ec4-6c01-4699-8e25-a197bc2da845

