### PR TITLE
Capitalize + shorten cash briefcase in syndicate_buylist.dm

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -147,7 +147,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	desc = "A counterfeit identification card, designed to prevent tracking by the station's AI systems. It features a one-time programmable identification circuit, allowing the entry of a custom false identity. It is also capable of scanning other ID cards and replicating their access credentials."
 
 /datum/syndicate_buylist/generic/cashcase
-	name = "Syndicate Cash Briefcase"
+	name = "Cash Briefcase"
 	items = list(/obj/item/cash_briefcase/syndicate/loaded)
 	cost = 2
 	max_buy = 2

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -147,7 +147,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	desc = "A counterfeit identification card, designed to prevent tracking by the station's AI systems. It features a one-time programmable identification circuit, allowing the entry of a custom false identity. It is also capable of scanning other ID cards and replicating their access credentials."
 
 /datum/syndicate_buylist/generic/cashcase
-	name = "Syndicate briefcase full of cash"
+	name = "Syndicate Cash Briefcase"
 	items = list(/obj/item/cash_briefcase/syndicate/loaded)
 	cost = 2
 	max_buy = 2


### PR DESCRIPTION
[Bug][Trivial]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Capitalizes and shortens the syndicate cash briefcase name in the syndicate buylist to make it more in line with the other items.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #21913 
