### PR TITLE
Fixes Cleanable Gang Tags Having Incorrect Icons

### DIFF
--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -1603,7 +1603,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	density = 0
 	anchored = ANCHORED
 	layer = OBJ_LAYER
-	icon = 'icons/obj/decals/graffiti.dmi'
+	icon = 'icons/obj/decals/gang_tags.dmi'
 	icon_state = "gangtag0"
 	var/datum/gang/owners = null
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][GAME OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

every instance of the cleanable gang tags (ie: the ones in the space diner bathroom) were using an incorrect icon, causing the icon states to point to a state that doesn't exist in the icon! this was because gang tags were moved to a different .dmi file in #18986, except for the cleanable ones

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

working icons are good!