### PR TITLE
Tweak donut2 kitchen

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -16598,9 +16598,6 @@
 /obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 4
 	},
-/obj/table/reinforced/auto{
-	icon_state = "3"
-	},
 /obj/mapping_helper/access/kitchen,
 /obj/window_blinds/cog2/middle{
 	dir = 4;
@@ -16612,6 +16609,8 @@
 	dir = 8;
 	icon_state = "line1"
 	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/table/reinforced/auto,
 /turf/simulated/bar,
 /area/station/crew_quarters/kitchen)
 "cwM" = (
@@ -27145,9 +27144,8 @@
 	icon_state = "line1"
 	},
 /obj/machinery/light/small/floor,
-/obj/table/reinforced/auto{
-	icon_state = "3"
-	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/table/reinforced/auto,
 /turf/simulated/bar,
 /area/station/crew_quarters/kitchen)
 "iNJ" = (
@@ -34742,9 +34740,7 @@
 	dir = 9;
 	icon_state = "line2"
 	},
-/obj/table/reinforced/auto{
-	icon_state = "2"
-	},
+/obj/table/reinforced/auto,
 /obj/item/shaker/ketchup{
 	pixel_x = 3;
 	pixel_y = -7
@@ -34762,6 +34758,7 @@
 /obj/disposalpipe/segment/food{
 	dir = 8
 	},
+/obj/mapping_helper/firedoor_spawn,
 /turf/simulated/bar,
 /area/station/crew_quarters/kitchen)
 "nnN" = (
@@ -45132,6 +45129,9 @@
 	pixel_y = -3
 	},
 /obj/table/glass/auto,
+/obj/decal/poster/wallsign/teaparty{
+	pixel_y = -32
+	},
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
 "tsG" = (
@@ -46282,9 +46282,8 @@
 	dir = 8;
 	icon_state = "line1"
 	},
-/obj/table/reinforced/auto{
-	icon_state = "1"
-	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/table/reinforced/auto,
 /turf/simulated/bar,
 /area/station/crew_quarters/kitchen)
 "tXu" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -16601,7 +16601,6 @@
 /obj/table/reinforced/auto{
 	icon_state = "3"
 	},
-/obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/kitchen,
 /obj/window_blinds/cog2/middle{
 	dir = 4;
@@ -25924,6 +25923,7 @@
 "ieq" = (
 /obj/item/device/radio/intercom/catering{
 	dir = 4;
+	pixel_x = -21;
 	pixel_y = 5
 	},
 /turf/simulated/floor/specialroom/freezer{
@@ -27133,10 +27133,6 @@
 /obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 4
 	},
-/obj/table/reinforced/auto{
-	icon_state = "1"
-	},
-/obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/kitchen,
 /obj/window_blinds/cog2/middle{
 	dir = 4;
@@ -27149,6 +27145,9 @@
 	icon_state = "line1"
 	},
 /obj/machinery/light/small/floor,
+/obj/table/reinforced/auto{
+	icon_state = "3"
+	},
 /turf/simulated/bar,
 /area/station/crew_quarters/kitchen)
 "iNJ" = (
@@ -34738,7 +34737,6 @@
 /obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 4
 	},
-/obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/kitchen,
 /obj/decal/tile_edge/line/black{
 	dir = 9;
@@ -46273,8 +46271,6 @@
 /obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 4
 	},
-/obj/table/auto,
-/obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/kitchen,
 /obj/window_blinds/cog2/left{
 	dir = 4;
@@ -46285,6 +46281,9 @@
 /obj/decal/tile_edge/line/black{
 	dir = 8;
 	icon_state = "line1"
+	},
+/obj/table/reinforced/auto{
+	icon_state = "1"
 	},
 /turf/simulated/bar,
 /area/station/crew_quarters/kitchen)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Fix floating intercom in freezer by setting `pixel_x`
* Replace serving counter regular table with reinforced table to make one long table

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix floating intercom, easier to use serving table

## Screenshots
### Current / Before
![Screenshot 2025-01-09 121950](https://github.com/user-attachments/assets/2c709bc6-793f-4b5d-821c-5e108a6f8d96)
![Screenshot 2025-01-09 121955](https://github.com/user-attachments/assets/195208ec-0aff-4581-b88e-52117683b27e)

### This PR / After

![Screenshot 2025-01-09 121802](https://github.com/user-attachments/assets/773421d0-9885-4a61-b107-8bf5da5003b3)
![Screenshot 2025-01-09 121809](https://github.com/user-attachments/assets/7fa9ef09-dec8-47da-906e-3c4143909ad3)
