### PR TITLE
Prevent infinite bible recursion

### DIFF
--- a/code/modules/storage/items/bible.dm
+++ b/code/modules/storage/items/bible.dm
@@ -18,7 +18,7 @@ var/global/list/bible_contents = list()
 		var/obj/item/W = src.linked_item
 		W.tooltip_rebuild = TRUE
 
-	LAZYLISTADD(src.prevent_holding, /obj/item/bible)
+	LAZYLISTADDUNIQUE(src.prevent_holding, /obj/item/bible)
 
 /datum/storage/bible/add_contents(obj/item/I, mob/user = null, visible = TRUE)
 	if (I in user?.equipped_list())

--- a/code/modules/storage/items/bible.dm
+++ b/code/modules/storage/items/bible.dm
@@ -18,6 +18,8 @@ var/global/list/bible_contents = list()
 		var/obj/item/W = src.linked_item
 		W.tooltip_rebuild = TRUE
 
+	LAZYLISTADD(src.prevent_holding, /obj/item/bible)
+
 /datum/storage/bible/add_contents(obj/item/I, mob/user = null, visible = TRUE)
 	if (I in user?.equipped_list())
 		user.u_equip(I)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Add bibles to the restricted items for `/datum/storage/bible` because it turns out if you manage to do this it starts triggering infinite loop runtimes and breaks your inventory permanently

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #21912 