### PR TITLE
Add maxcap canbomb medal

### DIFF
--- a/code/obj/item/assembly/detonator.dm
+++ b/code/obj/item/assembly/detonator.dm
@@ -286,8 +286,8 @@
 	src.attachedTo.visible_message(SPAN_ALERT("<b>The ruptured canister shatters from the pressure, and the hot gas ignites.</b>"))
 
 	var/power = min(850 * (MIXTURE_PRESSURE(attachedTo.air_contents) + attachedTo.air_contents.temperature - 107000) / 233196469.0 + 200, 7000) //the second arg is the max explosion power
-	//if (power == 150000) //they reached the cap SOMEHOW? well dang they deserve a medal
-		//src.builtBy.unlock_medal("", 1) //WIRE TODO: make new medal for this
+	if (power == 7000) //max explosion power
+		src.builtBy.unlock_medal("Consign a million souls to oblivion", 1)
 	explosion_new(attachedTo, epicenter, power)
 
 /obj/item/assembly/detonator/proc/setDescription()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Medal][feature][wiki]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Unlocked when detonating a max cap canbomb

Name: Consign a million souls to oblivion
[Reference to Warhammer 40k Dawn of War 2](https://www.youtube.com/watch?v=h67JpMyrOVE)
Pic:
![ConsignAMillionSoulsToOblivionMedal](https://github.com/user-attachments/assets/b510e225-d48d-4bb2-9728-64c9408b82de)

Could be secret due to the difficulty
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![image](https://github.com/user-attachments/assets/7af377d4-9cce-4016-bb89-984735ca2ba6)

