### PR TITLE
Feature: RecordTraks create bank accounts for unregistered users

### DIFF
--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -845,7 +845,19 @@ TYPEINFO(/obj/item/device/prisoner_scanner)
 			src.active1["p_stat"] = "Active"
 			src.active1["m_stat"] = "Stable"
 			data_core.general.add_record(src.active1)
-			found = 0
+
+			// Bank Records
+			var/bank_record = new/datum/db_record()
+			bank_record["name"] = src.active1["name"]
+			bank_record["id"] = src.active1["id"]
+			bank_record["job"] = src.active1["rank"]
+			bank_record["current_money"] = 0
+			bank_record["wage"] = 0
+			bank_record["notes"] = "No notes."
+			if(istype(target.wear_id, /obj/item/device/pda2))
+				var/obj/item/device/pda2/worn_pda = target.wear_id
+				bank_record["pda_net_id"] = worn_pda.net_id
+			data_core.bank.add_record(bank_record)
 
 		////Security Records
 		var/datum/db_record/E = data_core.security.find_record("name", src.active1["name"])
@@ -868,6 +880,7 @@ TYPEINFO(/obj/item/device/prisoner_scanner)
 			E["sec_flag"] = src.sechud_flag
 			target.update_arrest_icon()
 			return
+
 
 		src.active2 = new /datum/db_record()
 		src.active2["name"] = src.active1["name"]

--- a/code/obj/machinery/computer/bank_records.dm
+++ b/code/obj/machinery/computer/bank_records.dm
@@ -147,6 +147,8 @@
 				dat += {"
 				</tbody>
 			</table>
+			<hr>
+			New bank records can be added by scanning in an unregistered person with a security RecordTrak.
 				"}
 		user.Browse(dat.Join(), "window=secure_bank;size=500x700;title=Bank Records")
 		onclose(user, "secure_bank")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* When there's no general records match found for someone, in addition to creating a general record, also create a bank record
* If the unregistered user is wearing a PDA in their ID slot, add that as their `pda_net_id` for payroll and fine notifications.
* Add a note to the bank computer UI explaining how to add new accounts.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There's currently no way to add bank accounts for unregistered crew like salvagers, stowaways, nukie infiltrators, or people who use DNA scramblers. If they are willing to get registered by sec, they'll get a bank account which can be given a job title and income from the HOP.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Scanning in unregistered persons with a RecordTrak will make them a new bank account.
```
