### PR TITLE
Output GPS coords in signal list format

### DIFF
--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -289,6 +289,8 @@ TYPEINFO(/obj/item/device/gps)
 		reply.source = src
 		reply.data["sender"] = src.net_id
 		reply.data["identifier"] = "[src.serial]-[src.identifier]"
+		reply.data["x"] = "[T.x]"
+		reply.data["y"] = "[T.y]"
 		reply.data["coords"] = "[T.x],[T.y]"
 		reply.data["location"] = "[src.get_z_info(T)]"
 		reply.data["distress_alert"] = "[distressAlert]"

--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -350,7 +350,8 @@ TYPEINFO(/obj/item/device/gps)
 				if ("status")
 					var/turf/T = get_turf(src)
 					reply.data["identifier"] = "[src.serial]-[src.identifier]"
-					reply.data["coords"] = "[T.x],[T.y]"
+					reply.data["x"] = "[T.x]"
+					reply.data["y"] = "[T.y]"
 					reply.data["location"] = "[src.get_z_info(T)]"
 					reply.data["distress"] = "[src.distress]"
 				else

--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -291,7 +291,6 @@ TYPEINFO(/obj/item/device/gps)
 		reply.data["identifier"] = "[src.serial]-[src.identifier]"
 		reply.data["x"] = "[T.x]"
 		reply.data["y"] = "[T.y]"
-		reply.data["coords"] = "[T.x],[T.y]"
 		reply.data["location"] = "[src.get_z_info(T)]"
 		reply.data["distress_alert"] = "[distressAlert]"
 		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, reply)


### PR DESCRIPTION
[Feature] [Add to wiki] [Station systems]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Outputs x and y as their own signals on GPS units and tracking implants

![image](https://github.com/user-attachments/assets/7d784f67-beef-4f0b-abfa-0d9dd1b27643)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Signals in weird formats are hard to parse this just standardizes it so that components like the signal splitter and the dispatch module and whatnot can access this data

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)patricia
(+)GPS coordinates in packets are now in x=, y= format compatible with signal splitters
```
