### PR TITLE
Remove maintenance areas from possible gang duffle objectives

### DIFF
--- a/code/datums/controllers/process/gang.dm
+++ b/code/datums/controllers/process/gang.dm
@@ -182,14 +182,6 @@
 		possible_departments += /area/station/science/lobby
 		possible_departments += /area/station/crew_quarters
 		possible_departments += /area/station/hydroponics
-		possible_departments += /area/station/maintenance/north
-		possible_departments += /area/station/maintenance/northeast
-		possible_departments += /area/station/maintenance/northwest
-		possible_departments += /area/station/maintenance/east
-		possible_departments += /area/station/maintenance/south
-		possible_departments += /area/station/maintenance/southeast
-		possible_departments += /area/station/maintenance/southwest
-		possible_departments += /area/station/maintenance/central
 		possible_departments += /area/station/hallway/arrivals
 		possible_departments += /area/station/hallway/centralhallway
 		possible_departments += /area/station/hallway/primary
@@ -202,6 +194,7 @@
 		possible_departments += /area/station/janitor
 		possible_departments += /area/station/medical/robotics
 		possible_departments += /area/station/medical/research // and GENETICS too.
+		possible_departments += /area/station/hangar/main
 		for (var/area in station_areas)
 			var/area/test = station_areas[area]
 			if (test.type in possible_departments)

--- a/code/datums/controllers/process/gang.dm
+++ b/code/datums/controllers/process/gang.dm
@@ -172,7 +172,6 @@
 	var/duffle_spawn_repeats = 0
 	var/list/unvandalised_departments = list()
 	var/list/possible_departments = list()
-	var/list/smaller_departments = list()
 	setup()
 		name = "Gang_Duffle_Objectives"
 		schedule_interval = GANG_LOOT_INITIAL_DROP


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][gamemodes]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Remove maintenace areas from potential duffle bag areas
* Remove unused variable `smaller_departments`
* Add main podbay as potential duffle bag area

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gangs should be engaging with areas crew is more likely to be in, not rewarded for skulking in lesser-used maint tunnels.