### PR TITLE
Cash briefcase fixes

### DIFF
--- a/code/obj/item/misc_junk.dm
+++ b/code/obj/item/misc_junk.dm
@@ -723,7 +723,7 @@ TYPEINFO(/obj/item/reagent_containers/vape)
 		BLOCK_SETUP(BLOCK_ROPE)
 
 /obj/item/cash_briefcase
-	name = "Briefcase full of cash"
+	name = "Cash Briefcase"
 	desc = "A foldable briefcase that can hold a large amount of cash. "
 	icon = 'icons/obj/items/storage.dmi'
 	icon_state = "briefcase"
@@ -792,6 +792,7 @@ TYPEINFO(/obj/item/reagent_containers/vape)
 					user.u_equip(W)
 					qdel(W)
 				src.UpdateIcon()
+				src.tooltip_rebuild = TRUE
 		else
 			. = ..()
 
@@ -807,6 +808,7 @@ TYPEINFO(/obj/item/reagent_containers/vape)
 				src.balance -= amount
 				user.put_in_hand_or_drop(taken_cash)
 				src.UpdateIcon()
+				src.tooltip_rebuild = TRUE
 		else
 			..(user)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Renames the "briefcase full of cash" to "Cash Briefcase" because it isnt always "full of cash"
Updates tooltip whenever cash is added or taken out of the case.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
FIxes #21965
Fixes #21968

