### PR TITLE
Add explicit version of .net to OD lint

### DIFF
--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -73,6 +73,10 @@ jobs:
     name: Lint with OpenDream
     runs-on: ubuntu-22.04
     steps:
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4.2.0
+        with:
+          dotnet-version: 9.0.100
       - uses: actions/checkout@v4
       - uses: robinraju/release-downloader@v1.11
         with:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Needed because the github ubuntu 22 image only has .net 8 and OD just updated to .net 9
