### PR TITLE
output nuclear turbine power in arithemetic component compatible format

### DIFF
--- a/code/obj/nuclearreactor/turbine.dm
+++ b/code/obj/nuclearreactor/turbine.dm
@@ -239,7 +239,7 @@
 
 			src.network1?.update = TRUE
 			src.network2?.update = TRUE
-		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "rpm=[src.RPM]&stator=[src.stator_load]&power=[src.lastgen]&powerfmt=[engineering_notation(src.lastgen)]W")
+		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "rpm=[src.RPM]&stator=[src.stator_load]&power=[num2text(round(src.lastgen), 50)]&powerfmt=[engineering_notation(src.lastgen)]W")
 
 	suicide(mob/user)
 		user.visible_message(SPAN_ALERT("<b>[user] puts their head into blades of \the [src]!</b>"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bugfix] [station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

![image](https://github.com/user-attachments/assets/9a4069c0-acee-40b7-a421-f458e8d85d7f)


Fix the nuclear turbine's power signal so that the arithmetic component can accept it.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The number is supposed to be usable in mechcomp, and it works from the TEG etc (that's where I got this)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)patricia
(+)The nuclear turbine's power signal now works correctly with mechcomp arithmetic components
```
