### PR TITLE
Move cleanbles to floor plane when covered by a wall or false wall

### DIFF
--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -201,6 +201,8 @@ ADMIN_INTERACT_PROCS(/turf/simulated/wall/false_wall, proc/open, proc/close)
 			else
 				src.set_opacity(1)
 		src.setIntact(TRUE)
+		for(var/obj/decal/cleanable/clean in src)
+			clean.plane = PLANE_FLOOR
 		update_nearby_tiles()
 		SPAWN(delay)
 			//we want to return 1 without waiting for the animation to finish - the textual cue seems sloppy if it waits

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -32,6 +32,8 @@ TYPEINFO(/turf/simulated/wall)
 
 		src.AddComponent(/datum/component/bullet_holes, 15, 10)
 
+		for(var/obj/decal/cleanable/clean in src)
+			clean.plane = PLANE_FLOOR
 		src.selftilenotify() // displace fluid
 
 		#ifdef XMAS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a wall is created or a false wall is closed, set any cleanable on the same turf to the floor plane.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Visually hides cleanables under walls, without removing them.
Fix #21978