### PR TITLE
Fix chopping weapons not leaving glass shards

### DIFF
--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -474,7 +474,7 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 			attack_particle(user,src)
 			playsound(src.loc, src.hitsound , 75, 1)
 			if (ischoppingtool(W))
-				src.damage_blunt(W.force*4, user)
+				src.damage_blunt(W.force*4)
 			else
 				src.damage_blunt(W.force)
 			..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove an erranous pass of `user` to the `damage_blunt` proc. This is interpreted by the `damage_blunt` proc as `nosmash`, preventing it from shattering when it otherwise would.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21961
