### PR TITLE
Gang gun minor balance pass

### DIFF
--- a/code/modules/projectiles/laser.dm
+++ b/code/modules/projectiles/laser.dm
@@ -765,9 +765,10 @@ toxic - poisons
 	shot_sound = 'sound/weapons/laser_a.ogg'
 	icon_state = "lasergat_laser"
 	shot_volume = 50
+	dissipation_rate = 2
 	name = "single"
 	sname = "single"
-	damage = 14
+	damage = 10
 
 /datum/projectile/laser/lasergat/burst
 	name = "burst laser"

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1733,8 +1733,8 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 /obj/item/ammo/power_cell/lasergat
 	name = "Mod. 93R Repeating Laser Cell"
 	desc = "This single-use cell has a proprietary port for injecting liquid coolant into a laser firearm."
-	charge = 120
-	max_charge = 120
+	charge = 180
+	max_charge = 180
 	icon_state = "burst_laspistol"
 	rechargable = FALSE
 	New()

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -2335,7 +2335,7 @@ TYPEINFO(/obj/item/gun/energy/makeshift)
 
 
 /obj/item/gun/energy/lasergat
-	name = "\improper Hafgan Mod.93R Repeating Laser"
+	name = "\improper HAFGAN Mod.93R Repeating Laser"
 	rechargeable = 0
 	icon_state = "burst_laser_idle"
 	cell_type = /obj/item/ammo/power_cell/lasergat
@@ -2346,8 +2346,13 @@ TYPEINFO(/obj/item/gun/energy/makeshift)
 	muzzle_flash = "muzzle_flash_elec"
 	uses_charge_overlay = TRUE
 	charge_icon_state = "burst_laser"
-	shoot_delay = 6
-	spread_angle = 6
+	shoot_delay = 4
+	spread_angle = 2
+	recoil_enabled = TRUE
+	recoil_max = 50
+	recoil_inaccuracy_max = 10
+	icon_recoil_enabled = TRUE
+
 	restrict_cell_type = /obj/item/ammo/power_cell/lasergat
 	New()
 		set_current_projectile(new/datum/projectile/laser/lasergat/burst)

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1154,11 +1154,11 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 			src.on_spin_emote(user)
 			animate_spin(src, prob(50) ? "L" : "R", 1, 0)
 			locked_shut = TRUE
-			shoot_delay = 1
+			shoot_delay = 2
 			spread_angle = 15
 			user.show_message(SPAN_ALERT("[user] whips \the [src] out of [his_or_her(user)] pocket, seating their free hand over the hammer!"), 1)
 			src.current_projectile.power *= 0.7 //a full pelting puts you INCHES from death
-			SPAWN (2 SECONDS)
+			SPAWN (4 SECONDS)
 				locked_shut = FALSE
 				spread_angle = 2
 				shoot_delay = 4


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[OBJECTS][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Buffs the burst laser's firerate and gives it 'recoil' (not camera recoil, as it doesnt actually have recoil)

Nerfs the firerate for webley hammer fanning, as it's a bit too quick at vaporizing, well, anything.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Webley instakills were a bit much

Laser gat is probably the weakest gang gun, lacking the reliability of the lo-point, and the instakill potential of the Webley.

Lore for the laser gat implies it shudders a lot in your hand (which was the intended goal) - so it shudders more as you blast it faster.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(+)Gangs' webley shoots slower when fanning the hammer. Hammer fanning lasts 2x as long.
(+)The HAFGAN burst laser shoots faster and has more ammo, but now gains spread as you do so.
```
