### PR TITLE
Crit gasps now subtly indicate flatlining

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -870,8 +870,11 @@
 
 				if (src.emote_check(voluntary,20))
 					if (act == "gasp")
-						if (src.health <= 0)
-							var/dying_gasp_sfx = "sound/voice/gasps/[src.gender]_gasp_[pick(1,5)].ogg"
+						if (src.find_ailment_by_type(/datum/ailment/malady/flatline))
+							var/dying_gasp_sfx = "sound/voice/gasps/[src.gender]_gasp_[pick(1,3)].ogg"
+							playsound(src, dying_gasp_sfx, 40, FALSE, 0, src.get_age_pitch())
+						else if (src.health <= 0)
+							var/dying_gasp_sfx = "sound/voice/gasps/[src.gender]_gasp_[pick(4,5)].ogg"
 							playsound(src, dying_gasp_sfx, 40, FALSE, 0, src.get_age_pitch())
 						else
 							playsound(src, src.sound_gasp, 15, 0, 0, src.get_age_pitch())


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MEDICAL][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Splits the two types of crit sounds.
Only flatlined patients now perform the rattle-y gasp

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Unless you're constantly scanning or defibbing, you can miss flatlining and instantly have your patient hit with 100+ OXY damage in 2 ticks. This should give an auditory indicator to trained doctors.