### PR TITLE
Fix Nukeop wrench repair

### DIFF
--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -277,9 +277,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 
 		if (istype(W, /obj/item/wrench/battle))
 			if(src._health < src._max_health)
-				SETUP_GENERIC_ACTIONBAR(user, src, 5 SECONDS, /obj/machinery/nuclearbomb/proc/repair_nuke, null, 'icons/obj/items/tools/wrench.dmi', "battle-wrench", "[user] repairs the [src]!", null)
+				SETUP_GENERIC_ACTIONBAR(user, src, 5 SECONDS, /obj/machinery/nuclearbomb/proc/repair_nuke, null, 'icons/obj/items/tools/wrench.dmi', "battle-wrench", "[user] repairs [src]!", null)
 			else
-				boutput(user, SPAN_NOTICE("The [src] is already fully repaired!"))
+				boutput(user, SPAN_NOTICE("[src] is already fully repaired!"))
 			return
 
 		if (isnukeop(user) && !src.anyone_can_activate)

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -275,6 +275,13 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 							SPAWN(R.recharge)
 								R.recharging = 0
 
+		if (istype(W, /obj/item/wrench/battle))
+			if(src._health < src._max_health)
+				SETUP_GENERIC_ACTIONBAR(user, src, 5 SECONDS, /obj/machinery/nuclearbomb/proc/repair_nuke, null, 'icons/obj/items/tools/wrench.dmi', "battle-wrench", "[user] repairs the [src]!", null)
+			else
+				boutput(user, SPAN_NOTICE("The [src] is already fully repaired!"))
+			return
+
 		if (isnukeop(user) && !src.anyone_can_activate)
 			if (src.armed == 1)
 				boutput(user, SPAN_NOTICE("You don't need to do anything else with the bomb."))
@@ -288,10 +295,6 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 				// Give the player a notice so they realize what has happened
 				boutput(user, SPAN_ALERT("The screws are all weird safety-bit types! You can't turn them!"))
 				return
-
-		if (istype(W, /obj/item/wrench/battle) && src._health <= src._max_health)
-			SETUP_GENERIC_ACTIONBAR(user, src, 5 SECONDS, /obj/machinery/nuclearbomb/proc/repair_nuke, null, 'icons/obj/items/tools/wrench.dmi', "battle-wrench", "[user] repairs the [src]!", null)
-			return
 
 		if (W && !(istool(W, TOOL_SCREWING | TOOL_SNIPPING) || istype(W, /obj/item/disk/data/floppy/read_only/authentication)))
 			switch (W.force)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the battle wrench check to before the nukeop trying to harm the bomb check, fixing only non-nukeops being able to repair the nuke.
Adds a check that health is below maximum before setting up the action bar (previously less than or equal to)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes nuclear operative engineers being unable to repair the nuke with their wrench
Fixes being able to repair a full health nuke.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Fixed nuclear operatives being unable to fix the bomb with the battle wrench.
```
