### PR TITLE
vent scrubbers now indicate scrub status as 0 or 1 for each gas

### DIFF
--- a/code/modules/atmospherics/machinery/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/unary/vent_scrubber.dm
@@ -108,9 +108,9 @@
 	signal.data["sender"] = src.net_id
 	signal.data["power"] = src.on ? "on": "off"
 	signal.data["mode"] = src.scrubbing ? "scrubbing" : "siphoning"
-	#define COMPILE_GAS_MOLES(GAS, ...) if(scrub_##GAS) {signal.data[#GAS] = "1"}
-	APPLY_TO_GASES(COMPILE_GAS_MOLES)
-	#undef COMPILE_GAS_MOLES
+	#define GET_GAS_SCUB_STATUS(GAS, ...) signal.data[#GAS] = scrub_##GAS;
+	APPLY_TO_GASES(GET_GAS_SCUB_STATUS)
+	#undef GET_GAS_SCUB_STATUS
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, signal)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* The vent scrubber's `broadcast_status` packet now better indicates which gases they are scrubbing and which they are not
* Example packet trace of a PDA sending the `broadcast_status` command and reply on freq `143.9` in which several gas scrubs have been disabled:
```
[10:05:1]:address_1=0200098a; command=broadcast_status; sender=02001330; 
[10:05:7]:tag=; sender=0200098a; power=off; mode=scrubbing; oxygen=0; nitrogen=1; carbon_dioxide=1; toxins=1; farts=0; radgas=1; nitrous_oxide=0; oxygen_agent_b=1; 
```

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* The previous implementation would only list `gas_being_scrubbed=1` and gases that were not being scrubbed were hidden from the list. This change makes it clearer to the user what gases are being scrubbed, and which can be toggled back on


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sovexe
(+)Vent scrubber broadcast_status packets will now provide a full list of which gases are and are not being scrubbed.
```
