### PR TITLE
Buffer component doesn't break when increasing the buffer size

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -1928,8 +1928,6 @@
 		ring_reader = 1
 		ring_writer = 1
 		boutput(user,"You set the buffer size to [inp]")
-		qdel(buffer)
-		buffer = list()
 
 	proc/toggleDefault(obj/item/W as obj, mob/user as mob)
 		changesig = !changesig

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -1924,6 +1924,9 @@
 		inp = clamp(inp, 1, buffer_max_size)
 		buffer_size = inp
 		tooltip_rebuild = 1
+		buffer.len = 0
+		ring_reader = 1
+		ring_writer = 1
 		boutput(user,"You set the buffer size to [inp]")
 		qdel(buffer)
 		buffer = list()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bugfix] [station systems]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Resets the buffer component buffer correctly when the buffer sized is changed

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It was still using the more wasteful qdel + didn't work because the reader and writer weren't reset