### PR TITLE
Fix DWAINE scripts eventually breaking the whole mainframe

### DIFF
--- a/code/modules/networks/computer3/mainframe2/shell.dm
+++ b/code/modules/networks/computer3/mainframe2/shell.dm
@@ -495,7 +495,7 @@
 
 				pipetemp = ""
 				var/datum/computer/file/mainframe_program/toRun = signal_program(1, siglist)
-				if (istype(toRun))
+				if (istype(toRun) && !QDELETED(toRun))
 					scriptprocess = toRun.progid
 
 				//qdel(siglist)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [STATION SYSTEMS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Don't store the PID of a spawned child process if it's already exited, fixes #13271 and fixes #15300 and fixes #14710

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently every time you run a shell script in DWAINE it spawns a new child shell to run the script but then never exits that shell and actually puts you into it instead so if you run DWAINE scripts enough times the mainframe ends up with a million shells in one big nested tree and then it hits the process limit and shits the bed

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u) TealSeer
(*) Repeatedly running DWAINE scripts will no longer crash the entire mainframe forever
```
