### PR TITLE
Fix reinforced glass sheets being reinforced with glass

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -664,7 +664,7 @@
 	modify_output(var/obj/machinery/manufacturer/M, var/atom/A, var/list/materials)
 		..()
 		var/obj/item/sheet/S = A
-		var/obj/item/material_piece/applicable_material = locate(materials[getManufacturingRequirement("crystal")])
+		var/obj/item/material_piece/applicable_material = locate(materials[getManufacturingRequirement("metal_dense")])
 		S.set_reinforcement(applicable_material.material)
 
 /datum/manufacture/rods2


### PR DESCRIPTION
[Bug][Materials]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes the reinforced glass sheet manufacturer recipe correctly use the metal for its reinforcement instead of the glass used for it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Glass reinforced glass sheets kinda don't make sense, especially if they need metal to produce that gets consumed.