### PR TITLE
Vent scrubbers don't scrub any gasses by default

### DIFF
--- a/code/modules/atmospherics/machinery/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/unary/vent_scrubber.dm
@@ -191,6 +191,9 @@
 	on = FALSE
 
 /obj/machinery/atmospherics/unary/vent_scrubber/breathable
+	#define _DEF_SCRUBBER_VAR(GAS, ...) var/scrub_##GAS = 1;
+	APPLY_TO_GASES(_DEF_SCRUBBER_VAR)
+	#undef _DEF_SCRUBBER_VAR
 	scrub_oxygen = FALSE
 	scrub_nitrogen = FALSE
 

--- a/code/modules/atmospherics/machinery/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/unary/vent_scrubber.dm
@@ -21,7 +21,7 @@
 	/// Are we sucking in all gas or only some?
 	var/scrubbing = SCRUBBING
 	// Sets up vars to scrub gases
-	#define _DEF_SCRUBBER_VAR(GAS, ...) var/scrub_##GAS = 1;
+	#define _DEF_SCRUBBER_VAR(GAS, ...) var/scrub_##GAS = 0;
 	APPLY_TO_GASES(_DEF_SCRUBBER_VAR)
 	#undef _DEF_SCRUBBER_VAR
 	/// Volume of gas to take from turf.

--- a/code/modules/atmospherics/machinery/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/unary/vent_scrubber.dm
@@ -191,7 +191,7 @@
 	on = FALSE
 
 /obj/machinery/atmospherics/unary/vent_scrubber/breathable
-	#define _DEF_SCRUBBER_VAR(GAS, ...) var/scrub_##GAS = 1;
+	#define _DEF_SCRUBBER_VAR(GAS, ...) scrub_##GAS = 1;
 	APPLY_TO_GASES(_DEF_SCRUBBER_VAR)
 	#undef _DEF_SCRUBBER_VAR
 	scrub_oxygen = FALSE


### PR DESCRIPTION
[Station Systems]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Vent scrubbers are no longer set to scrub any gasses by default.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Scrubbing all gasses is just siphoning mode, with #22020 users can now see the names of gasses in the status command even when off, so this will be more convenient in general.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)patricia
(+)Vent scrubbers are no longer set to scrub any gasses when built
```
