### PR TITLE
Fix PDA device scanners saving wrong name for scans

### DIFF
--- a/code/obj/item/device/pda2/scanners.dm
+++ b/code/obj/item/device/pda2/scanners.dm
@@ -122,8 +122,9 @@
 				return SPAN_ALERT("Unable to scan.")
 
 			var/datum/computer/file/electronics_scan/theScan = new
-			theScan.scannedName = initial(O.name)
 			theScan.scannedPath = O.mechanics_type_override ? O.mechanics_type_override : O.type
+			var/atom/atom_cast = theScan.scannedPath
+			theScan.scannedName = initial(atom_cast.name)
 			var/typeinfo/obj/typeinfo = O.get_typeinfo()
 			theScan.scannedMats = typeinfo.mats
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Use the name of the scanned type path in blueprints, not the name of the object itself. This fixes a bug where if something had a `mechanic_type_override` var set, the PDA scanner would save the blueprint under the objects actual name, instead of the name of the type override

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug fix
