### PR TITLE
Add extra items to on-station security closets

### DIFF
--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -406,13 +406,23 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 
 /obj/storage/secure/closet/security/equipment
 	name = "\improper Security equipment locker"
-	spawn_contents = list(/obj/item/clothing/suit/armor/vest,
+	spawn_contents = list(/obj/item/clothing/under/rank/security,
+	/obj/item/clothing/suit/armor/vest,
 	/obj/item/clothing/head/helmet/hardhat/security,
+	/obj/item/clothing/shoes/swat,
 	/obj/item/clothing/glasses/sunglasses/sechud,
 	/obj/item/handcuffs,
 	/obj/item/handcuffs,
 	/obj/item/device/flash,
 	/obj/item/barrier)
+
+	make_my_stuff()
+		if (..()) // make_my_stuff is called multiple times due to lazy init, so the parent returns 1 if it actually fired and 0 if it already has
+			if (prob(15))
+				new /obj/item/gun/kinetic/riot40mm(src)
+			else
+				new /obj/item/chem_grenade/flashbang(src)
+			return 1
 
 /obj/storage/secure/closet/security/forensics
 	name = "Forensics equipment locker"

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -425,6 +425,18 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 				new /obj/item/chem_grenade/flashbang(src)
 			return 1
 
+/obj/storage/secure/closet/security/equipment/derelict
+name = "derelict Security equipment locker"
+	spawn_contents = list(/obj/item/clothing/head/helmet/hardhat/security,
+	/obj/item/clothing/glasses/sunglasses/sechud,
+	/obj/item/handcuffs,
+	/obj/item/handcuffs,
+	/obj/item/device/flash,
+	/obj/item/barrier)
+
+	make_my_stuff()
+		..()
+
 /obj/storage/secure/closet/security/forensics
 	name = "Forensics equipment locker"
 	req_access = list(access_forensics_lockers)

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -426,7 +426,7 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 			return 1
 
 /obj/storage/secure/closet/security/equipment/derelict
-name = "derelict Security equipment locker"
+	name = "derelict Security equipment locker"
 	spawn_contents = list(/obj/item/clothing/head/helmet/hardhat/security,
 	/obj/item/clothing/glasses/sunglasses/sechud,
 	/obj/item/handcuffs,

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -407,6 +407,7 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 /obj/storage/secure/closet/security/equipment
 	name = "\improper Security equipment locker"
 	spawn_contents = list(/obj/item/clothing/under/rank/security,
+	/obj/item/device/radio/headset/security,
 	/obj/item/clothing/suit/armor/vest,
 	/obj/item/clothing/head/helmet/hardhat/security,
 	/obj/item/clothing/shoes/swat,

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -9215,7 +9215,7 @@
 	},
 /area/fermid_hive)
 "aRH" = (
-/obj/storage/secure/closet/security/equipment,
+/obj/storage/secure/closet/security/equipment/derelict,
 /turf/simulated/floor/red/side{
 	dir = 9
 	},
@@ -9559,7 +9559,7 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/fermid_hive)
 "aSI" = (
-/obj/storage/secure/closet/security/equipment,
+/obj/storage/secure/closet/security/equipment/derelict,
 /turf/simulated/floor/red/side{
 	dir = 10
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS][BALANCE][INPUT WANTED]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR (re-)adds security uniforms, radio headsets, and boots to security equipment lockers, as well as flashbangs, which have a 15% chance to be replaced by a riot launcher. 

**_Security lockers in the debris field have been replaced with a derelict subtype which contains only the current items (no uniform, headset, etc.)_**

This is my first mapping PR, so I might've missed something.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There was a conversation in the Discord's RP chat on these lockers being rather underpowered, considering the risk that an antag would have to take to break into a sec checkpoint, steal the locker, and somehow open it. Suggestions were made to add a headset and uniform, as well as boots, since these are things that would make sense to keep in an equipment locker. I'm open to changing the riot launcher probability, or maybe downright removing it from the possible loot pool.
Additionally, this would put more importance on the sec badge for verification.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chasu
(+)On station Security equipment lockers now feature more equipment, such as uniforms and headsets.
```
