### PR TITLE
Fix various mapping issues on Donut3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2585,7 +2585,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 1
 	},
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "aIU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -6928,7 +6928,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/seven,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "bZs" = (
 /obj/machinery/computer/tanning{
 	pixel_y = 32
@@ -7982,7 +7982,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/seven,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "cmE" = (
 /obj/stool/chair/comfy,
 /obj/cable{
@@ -12466,7 +12466,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/green/fancy/edge,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "dEr" = (
 /obj/disposalpipe/segment/transport,
 /obj/disposalpipe/segment/mail{
@@ -13964,12 +13964,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
-"eaG" = (
-/obj/disposalpipe/segment/food{
-	dir = 4
-	},
-/turf/simulated/wall/auto/jen,
-/area/station/chapel/sanctuary)
 "eaL" = (
 /obj/machinery/light/incandescent/warm,
 /obj/table/auto,
@@ -14514,9 +14508,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/jen,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "eis" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -17767,9 +17759,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/six,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "flK" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
 /obj/machinery/light/small/sticky{
@@ -21748,7 +21738,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 5
 	},
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "gwZ" = (
 /obj/storage/closet/dresser,
 /obj/item/clothing/under/jersey,
@@ -23713,7 +23703,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 10
 	},
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "hcX" = (
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
@@ -26723,7 +26713,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 9
 	},
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "iaJ" = (
 /obj/table/glass/reinforced/auto,
 /obj/random_item_spawner/desk_stuff/one_or_zero,
@@ -27130,7 +27120,7 @@
 /area/station/science/storage)
 "igQ" = (
 /turf/simulated/floor/wood/seven,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "iha" = (
 /obj/indestructible/shuttle_corner{
 	dir = 4
@@ -27549,7 +27539,7 @@
 	icon_state = "5-10"
 	},
 /turf/simulated/floor/wood/seven,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "iof" = (
 /obj/item/storage/wall/clothingrack/clothes4{
 	dir = 2
@@ -30101,9 +30091,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/six,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "jdn" = (
 /obj/submachine/foodprocessor,
 /obj/disposalpipe/segment/morgue{
@@ -31694,11 +31682,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"jCk" = (
-/turf/simulated/wall/auto/jen,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
 "jCs" = (
 /obj/machinery/disposal/mail/small/autoname/bridge/east,
 /obj/cable{
@@ -38038,11 +38021,6 @@
 	icon_state = "fblue1"
 	},
 /area/station/crew_quarters/cafeteria)
-"lyl" = (
-/turf/simulated/floor/wood/six,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
 "lyo" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -40047,9 +40025,7 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/wood/six,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/sanctuary)
 "lXZ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -44616,7 +44592,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/green/fancy/edge,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "nxO" = (
 /obj/machinery/vending/player/chemicals,
 /obj/disposalpipe/trunk/mail,
@@ -45765,7 +45741,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 6
 	},
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "nOU" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -45945,9 +45921,7 @@
 	req_access = null
 	},
 /turf/simulated/floor/plating/jen,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "nRW" = (
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/specialroom/chapel{
@@ -48879,9 +48853,7 @@
 "oMm" = (
 /obj/storage/closet/wardrobe/black,
 /turf/simulated/floor/wood/six,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "oMn" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle,
@@ -49870,7 +49842,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "pdD" = (
 /obj/table/auto,
 /obj/decal/cleanable/dirt/jen,
@@ -51501,9 +51473,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/six,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "pDI" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
@@ -53498,7 +53468,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "qiF" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
@@ -56641,7 +56611,7 @@
 "rgr" = (
 /obj/mesh/grille/steel,
 /turf/simulated/floor/plating/jen,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "rgS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -70110,7 +70080,7 @@
 	icon_state = "5-8"
 	},
 /turf/simulated/floor/wood/seven,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "vjv" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -72884,7 +72854,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood/seven,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "vZU" = (
 /obj/machinery/portableowl/attached{
 	name = "Jowls"
@@ -73542,9 +73512,7 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/wood/six,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "wkc" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/window_blinds/cog2/right{
@@ -74150,7 +74118,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/seven,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "wst" = (
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/medical/medbooth)
@@ -76479,7 +76447,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/seven,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "wZH" = (
 /obj/stool/chair,
 /obj/machinery/power/apc/autoname_north,
@@ -78688,9 +78656,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood/six,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "xEj" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/random_item_spawner/junk/one_or_zero,
@@ -80815,7 +80781,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 1
 	},
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "yja" = (
 /obj/decal/stripe_delivery,
 /obj/mapping_helper/firedoor_spawn,
@@ -118611,7 +118577,7 @@ khe
 khe
 khe
 tLp
-eaG
+lNg
 wZE
 igQ
 igQ
@@ -119217,7 +119183,7 @@ cEv
 dQu
 shH
 pDy
-lyl
+cEv
 oMm
 bAD
 mWR
@@ -119822,7 +119788,7 @@ tVB
 shH
 pDy
 flF
-lyl
+cEv
 bAD
 bJZ
 aaz
@@ -120124,7 +120090,7 @@ uHa
 lNg
 vXX
 eic
-jCk
+uCX
 mpU
 mpU
 mpU

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2061,12 +2061,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "aBa" = (
@@ -4830,9 +4824,7 @@
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "btk" = (
 /obj/item/clothing/suit/bedsheet/blue,
 /obj/stool/bed,
@@ -5537,7 +5529,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "bCd" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -6287,9 +6279,7 @@
 "bMf" = (
 /obj/shrub,
 /turf/simulated/floor/grass/random,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "bMm" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/left{
@@ -9112,9 +9102,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 9
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "cBb" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -9373,6 +9361,9 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/wood/seven,
 /area/station/security/detectives_office)
+"cEv" = (
+/turf/simulated/floor/wood/six,
+/area/station/chapel/funeral_parlor)
 "cEz" = (
 /obj/cable,
 /obj/cable{
@@ -10925,7 +10916,7 @@
 	},
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "dfr" = (
 /obj/mesh/catwalk{
 	dir = 4
@@ -10980,7 +10971,7 @@
 /area/station/crew_quarters/heads)
 "dfM" = (
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "dfW" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/firealarm/west,
@@ -11811,6 +11802,12 @@
 "dsw" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/maintenance/inner/sw)
+"dsD" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/medical/crematorium)
 "dsW" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
@@ -11917,9 +11914,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/carpet/green/fancy/edge,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "duN" = (
 /turf/simulated/wall/auto/reinforced/jen/yellow,
 /area/station/quartermaster/office)
@@ -11939,7 +11934,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "dve" = (
 /obj/decal/tile_edge/line/white{
 	icon_state = "line1"
@@ -12217,7 +12212,7 @@
 "dAn" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "dAv" = (
 /turf/space,
 /area/shuttle/asylum/pathology)
@@ -12646,7 +12641,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "dHM" = (
 /obj/table/auto,
 /obj/item/decoration/ashtray{
@@ -13248,9 +13243,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/six,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "dQz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -15261,7 +15254,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "evr" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/arrival{
@@ -17810,9 +17803,7 @@
 /turf/simulated/floor/carpet/green/fancy/innercorner{
 	dir = 5
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "fmA" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/white,
@@ -18505,9 +18496,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 1
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "fyq" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -18584,9 +18573,7 @@
 "fzD" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "fzE" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
@@ -19671,9 +19658,7 @@
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "fPh" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -20681,7 +20666,7 @@
 	},
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "ggr" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/mesh/catwalk/jen,
@@ -20999,7 +20984,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "gln" = (
 /obj/disposalpipe/trunk/mail,
 /obj/machinery/disposal/mail/small/autoname/hydroponics/north{
@@ -21710,7 +21695,7 @@
 "gwq" = (
 /obj/disposalpipe/segment/food,
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "gws" = (
 /obj/fakeobject/bookcase{
 	dir = 4;
@@ -25275,9 +25260,7 @@
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "hzO" = (
 /obj/fakeobject{
 	anchored = 1;
@@ -26073,7 +26056,7 @@
 	},
 /obj/mapping_helper/access/chapel_office,
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "hNp" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -26369,9 +26352,7 @@
 "hTU" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "hTW" = (
 /obj/decal/stripe_caution,
 /obj/machinery/sheet_extruder,
@@ -26646,7 +26627,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "iaa" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/random_item_spawner/junk/one_or_zero,
@@ -26876,9 +26857,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/green/fancy/narrow/northsouth,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "icx" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -27847,9 +27826,7 @@
 /turf/simulated/floor/carpet/green/fancy/junction{
 	dir = 9
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "iuz" = (
 /obj/table/wood/round/auto,
 /obj/item/device/light/candle/haunted{
@@ -28423,7 +28400,7 @@
 "iDB" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "iDD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -29544,9 +29521,7 @@
 /area/station/maintenance/outer/north)
 "iUS" = (
 /turf/simulated/floor/carpet/green/fancy/narrow/T_west,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "iVe" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail,
@@ -30262,9 +30237,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/six,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "jgj" = (
 /obj/table/glass/auto,
 /obj/machinery/coffeemaker/medbay{
@@ -31136,7 +31109,6 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
 "juB" = (
-/obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -31150,6 +31122,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/cable,
 /turf/simulated/floor/wood/six,
 /area/station/library)
 "juD" = (
@@ -31185,11 +31158,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
-"jvj" = (
-/turf/simulated/wall/auto/reinforced/jen,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
 "jvq" = (
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/maintenance/inner/south)
@@ -31976,7 +31944,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "jGq" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -32001,13 +31969,6 @@
 /area/station/engine/engineering)
 "jGx" = (
 /obj/storage/closet/emergency,
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "mining_shutters";
-	name = "Mining Blast Shutters";
-	opacity = 0
-	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "jGC" = (
@@ -33773,6 +33734,9 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
+"khe" = (
+/turf/simulated/wall/auto/reinforced/jen,
+/area/station/chapel/funeral_parlor)
 "khw" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -34767,9 +34731,7 @@
 /area/station/medical/robotics)
 "kxi" = (
 /turf/simulated/floor/carpet/green/fancy,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "kxj" = (
 /mob/living/critter/small_animal/walrus,
 /turf/simulated/floor/pool/no_animate,
@@ -34901,9 +34863,7 @@
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "kyV" = (
 /obj/machinery/door_control/podbay/qm{
 	pixel_y = 10;
@@ -35932,9 +35892,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 5
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "kPy" = (
 /obj/stool/chair/green{
 	dir = 4
@@ -36966,7 +36924,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "lhv" = (
 /obj/table/auto,
 /obj/item/storage/box/evidence{
@@ -36980,8 +36938,9 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "lhw" = (
 /obj/storage/secure/closet/civilian/kitchen,
 /obj/item/hand_labeler,
@@ -38846,9 +38805,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/green/fancy/narrow/south,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "lHL" = (
 /obj/landmark/random_room/size3x5,
 /turf/simulated/floor/plating/jen,
@@ -39095,9 +39052,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/green/fancy/narrow/east,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "lLX" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -39208,9 +39163,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/jen,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "lNh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -40048,9 +40001,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/six,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "lXG" = (
 /obj/cable/yellow{
 	icon_state = "0-2"
@@ -40292,9 +40243,7 @@
 /area/station/hangar/arrivals)
 "mbM" = (
 /turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "mbO" = (
 /obj/landmark/magnet_shield,
 /obj/securearea{
@@ -41491,9 +41440,7 @@
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/access/chapel_office,
 /turf/simulated/floor/carpet/grime,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "mxG" = (
 /obj/cable/orange{
 	icon_state = "1-2"
@@ -41904,12 +41851,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
-"mEh" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/wood/six,
-/area/station/library)
 "mEj" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor,
@@ -44244,7 +44185,7 @@
 	},
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "nqy" = (
 /obj/table/reinforced/auto,
 /obj/machinery/computer3/generic/personal/personel_alt,
@@ -44639,9 +44580,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/wood/six,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "nxd" = (
 /obj/stool,
 /obj/disposalpipe/segment/brig,
@@ -45419,9 +45358,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 5
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "nKx" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail,
@@ -47489,9 +47426,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/six,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "oqJ" = (
 /obj/stool/chair/comfy/shuttle{
 	dir = 4
@@ -48599,7 +48534,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "oHS" = (
 /obj/decal/stripe_delivery,
 /obj/cable{
@@ -49124,9 +49059,7 @@
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "oPf" = (
 /turf/simulated/wall/auto/reinforced/jen/purple,
 /area/station/science/lobby)
@@ -49174,9 +49107,7 @@
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "oPR" = (
 /obj/cable{
 	icon_state = "5-8"
@@ -49288,9 +49219,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 6
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "oSz" = (
 /obj/rack,
 /obj/item/clothing/suit/space{
@@ -49379,9 +49308,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/narrow/northsouth,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "oTW" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -49458,9 +49385,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 9
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "oVh" = (
 /turf/simulated/floor/yellow/corner{
 	dir = 4
@@ -50205,7 +50130,7 @@
 	},
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "phT" = (
 /turf/unsimulated/floor/shuttle/red{
 	dir = 4
@@ -52040,9 +51965,7 @@
 	powerlevel = 1
 	},
 /turf/simulated/floor/plating/jen,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "pJL" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/landmark/antagonist/blob,
@@ -53192,7 +53115,7 @@
 "qcT" = (
 /obj/machinery/traymachine/morgue,
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "qcZ" = (
 /obj/decal/tile_edge/line/white{
 	color = "#ffccff";
@@ -54122,7 +54045,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "qsJ" = (
 /obj/decal/tile_edge/line/red{
 	icon_state = "line1"
@@ -54678,7 +54601,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "qBU" = (
 /obj/stool/chair/dining/wood{
 	dir = 8
@@ -55737,7 +55660,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "qSx" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -55950,6 +55873,9 @@
 /area/station/maintenance/inner/se)
 "qVE" = (
 /obj/machinery/light_switch/north,
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/wood/six,
 /area/station/library)
 "qVM" = (
@@ -56107,9 +56033,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/grass/random,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "qXP" = (
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 10
@@ -60105,9 +60029,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "shN" = (
 /obj/machinery/launcher_loader{
 	dir = 8
@@ -62097,7 +62019,7 @@
 /obj/machinery/traymachine/morgue,
 /obj/machinery/light/incandescent/cool/very,
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "sOf" = (
 /obj/landmark/magnet_shield,
 /obj/securearea{
@@ -62294,9 +62216,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 1
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "sSb" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 1;
@@ -62307,9 +62227,7 @@
 /area/station/ranch)
 "sSA" = (
 /turf/simulated/floor/carpet/green/fancy/narrow/eastwest,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "sSC" = (
 /obj/stool/chair/pew/fancy/right{
 	dir = 1
@@ -62610,9 +62528,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/jen,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "sVZ" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -63614,7 +63530,7 @@
 	},
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "tlF" = (
 /obj/decal/poster/wallsign/poster_cool{
 	pixel_x = 5;
@@ -63940,6 +63856,12 @@
 	},
 /turf/simulated/wall/auto/reinforced/jen/red,
 /area/station/security/detectives_office)
+"tqY" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/auto/reinforced/jen,
+/area/station/medical/crematorium)
 "tqZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -65298,7 +65220,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/jen,
-/area/station/chapel/sanctuary)
+/area/station/chapel/funeral_parlor)
 "tLr" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/mesh/catwalk/jen,
@@ -65871,7 +65793,7 @@
 /obj/machinery/disposal/morgue,
 /obj/disposalpipe/trunk/morgue,
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "tTM" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -65989,9 +65911,7 @@
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "tVE" = (
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
@@ -67677,11 +67597,15 @@
 /turf/simulated/floor/black/grime,
 /area/station/science/storage)
 "uzh" = (
+/obj/cable,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "uzm" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -67957,6 +67881,9 @@
 	icon_state = "fblue6"
 	},
 /area/station/crew_quarters/courtroom)
+"uCX" = (
+/turf/simulated/wall/auto/jen,
+/area/station/chapel/funeral_parlor)
 "uDb" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -68292,9 +68219,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "uHc" = (
 /obj/machinery/door/airlock/pyro/alt{
 	dir = 4;
@@ -68581,9 +68506,7 @@
 /area/station/mining/staff_room)
 "uLm" = (
 /turf/simulated/floor/carpet/green/fancy/edge,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "uLI" = (
 /obj/mesh/catwalk/jen,
 /obj/disposalpipe/segment/transport,
@@ -69153,7 +69076,7 @@
 /obj/machinery/light/incandescent/cool/very,
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "uUo" = (
 /obj/machinery/light/lamp/green{
 	pixel_y = 8
@@ -69729,14 +69652,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
-"vdA" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall/auto/jen,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
 "vdB" = (
 /obj/stool/chair{
 	dir = 4
@@ -74270,7 +74185,7 @@
 	},
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "wsU" = (
 /obj/decal/stage_edge{
 	layer = 2.8
@@ -76648,7 +76563,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "xah" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -76753,9 +76668,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 1
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "xbF" = (
 /obj/railing/orange,
 /obj/decal/cleanable/dirt/jen,
@@ -78035,7 +77948,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor/sanitary,
-/area/station/chapel/sanctuary)
+/area/station/medical/crematorium)
 "xsX" = (
 /obj/table/wood/auto,
 /turf/simulated/floor/carpet/grime,
@@ -78270,9 +78183,7 @@
 "xxd" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "xxf" = (
 /obj/decal/tile_edge/line/grey{
 	dir = 8;
@@ -79667,6 +79578,9 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/yellowblack,
 /area/station/engine/engineering)
+"xRy" = (
+/turf/simulated/wall/auto/reinforced/jen,
+/area/station/medical/crematorium)
 "xRM" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
@@ -79759,9 +79673,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/jen,
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "xTs" = (
 /obj/stool/bench/auto,
 /turf/simulated/floor/greenwhite/other,
@@ -80678,9 +80590,7 @@
 /turf/simulated/floor/carpet/green/fancy/innercorner{
 	dir = 9
 	},
-/area/station/chapel/sanctuary{
-	name = "Funeral Parlor"
-	})
+/area/station/chapel/funeral_parlor)
 "yfH" = (
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/hor)
@@ -106044,11 +105954,11 @@ vIm
 lGO
 sGu
 qVE
-mEh
+gcw
 gcw
 juB
-gcw
 dpm
+quz
 fUD
 sIK
 fJg
@@ -115076,13 +114986,13 @@ rdj
 rdj
 rdj
 rdj
-qxz
-pdw
+xRy
+tqY
 duV
 evq
-qxz
-qxz
-qxz
+xRy
+xRy
+xRy
 cvD
 dSJ
 gdE
@@ -115378,13 +115288,13 @@ rdj
 rdj
 rdj
 rdj
-qxz
+xRy
 qSp
 lhv
 uzh
 qcT
 sNX
-qxz
+xRy
 heD
 gIj
 pzE
@@ -115683,10 +115593,10 @@ rdj
 oHQ
 jGi
 dHg
-uzh
+dsD
 dfM
 dfM
-qxz
+xRy
 blY
 dSJ
 gdE
@@ -115982,7 +115892,7 @@ rdj
 rdj
 rdj
 rdj
-pdw
+tqY
 xaf
 bBZ
 glb
@@ -116284,7 +116194,7 @@ rdj
 rdj
 rdj
 rdj
-pdw
+tqY
 tTt
 deW
 dAn
@@ -116586,7 +116496,7 @@ rdj
 rdj
 rdj
 rdj
-pdw
+tqY
 qBC
 nqc
 tlf
@@ -116888,13 +116798,13 @@ rdj
 rdj
 rdj
 rdj
-pdw
+tqY
 lhi
 duV
-qxz
+xRy
 hNm
-qxz
-qxz
+xRy
+xRy
 wRc
 eaQ
 oOC
@@ -118697,9 +118607,9 @@ rdj
 rdj
 rdj
 rdj
-jvj
-jvj
-qxz
+khe
+khe
+khe
 tLp
 eaG
 wZE
@@ -118998,8 +118908,8 @@ rdj
 rdj
 rdj
 rdj
-jvj
-jvj
+khe
+khe
 jfL
 jfL
 lXC
@@ -119295,15 +119205,15 @@ rdj
 rdj
 rdj
 fNJ
-jvj
-jvj
-jvj
-jvj
-jvj
-jvj
+khe
+khe
+khe
+khe
+khe
+khe
 nwY
-lyl
-lyl
+cEv
+cEv
 dQu
 shH
 pDy
@@ -119597,7 +119507,7 @@ rdj
 rdj
 rdj
 vLJ
-jvj
+khe
 bMf
 cAY
 iuv
@@ -119899,7 +119809,7 @@ rdj
 rdj
 rdj
 vLJ
-jvj
+khe
 qXJ
 xbC
 uLm
@@ -120511,8 +120421,8 @@ hTU
 sSA
 kyM
 hzG
-jCk
-vdA
+uCX
+tLp
 lNg
 yeH
 rcW
@@ -120813,7 +120723,7 @@ hTU
 sSA
 fOY
 fzD
-jCk
+uCX
 aAA
 xbF
 gKg
@@ -121115,7 +121025,7 @@ hTU
 sSA
 oPQ
 hzG
-jCk
+uCX
 gtk
 euw
 gKg
@@ -121417,7 +121327,7 @@ hTU
 lLR
 oPb
 mbM
-jCk
+uCX
 aAA
 oIC
 xUL
@@ -121714,12 +121624,12 @@ xxd
 xxd
 xxd
 xxd
-jvj
-jvj
-jvj
-jvj
-jvj
-jvj
+khe
+khe
+khe
+khe
+khe
+khe
 cqD
 ewH
 gKg

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -36922,6 +36922,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "lhw" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Fix Library reading rooms not connected to station pnet
* Replace varedited Funeral Parlor area with `/area/station/chapel/funeral_parlor`
* Add Crematorium area & APC
* Remove duplicate camera in command teleporter room
* Remove errant mining shutter in inner north maints

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Station rooms should be connected to grid by default
Map quality and consistency