### PR TITLE
Add Bureaucratic Error event

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -1,0 +1,88 @@
+#define BUREAUCRATIC_JOBS_IGNORE list("Staff Assistant", "Cyborg", "AI")
+
+/datum/random_event/major/bureaucratic_error
+	name = "Bureaucratic Error"
+	customization_available = TRUE
+	centcom_headline = "Bureaucratic Error"
+	centcom_message = "A bureaucratic error at Central Command has caused an error in job openings at the station."
+	centcom_origin = ALERT_STATION
+	var/job_to_increase = null
+	var/job_to_decrease = null
+	var/amount = null
+
+	admin_call(var/source)
+		if (..())
+			return
+		var/list/jobs = src.get_valid_jobs()
+		src.job_to_increase = tgui_input_list(usr, "Pick a job to increase", src.name, jobs)
+		src.job_to_increase = tgui_input_list(usr, "Pick a job to decrease", src.name, jobs)
+		src.amount = tgui_input_number(usr, "Pick an amount to change by", src.name, 3, 10, -1)
+		//confirmation
+		if (tgui_alert(usr, "Are you sure?", src.name, list("Yes" "No")) == "Yes")
+			event_effect(source)
+		else
+			src.cleanup()
+
+	cleanup()
+		src.job_to_decrease = null
+		src.job_to_increase = null
+		src.amount = null
+
+	event_effect(source)
+		. = ..()
+
+		//How much are we changing each job by?
+		if(!src.amount)
+			src.amount = rand(1, 10)
+			if (prob(20))
+				src.amount = -1
+
+		src.determine_jobs()
+
+		var/datum/job/job_up = find_job_in_controller_by_string(job_to_increase)
+		var/newcap_up = job_up.limit + src.amount
+		if (src.amount == -1)
+			newcap_up = -1
+		job_up.limit = newcap_up
+
+
+		var/datum/job/job_down = find_job_in_controller_by_string(job_to_decrease)
+		var/newcap_down = job_down.limit - src.amount
+		if (src.amount == -1 || newcap_down <= 0)
+			if(job_down.assigned == 0)
+				job_down.assigned = 1
+			job_down.limit = job_down.assigned
+			newcap_down = 0
+		else
+			job_down.limit = newcap_down
+
+		message_admins("Bureaucratic Error event increased [src.job_to_increase] slots to [newcap_up] and decreased [src.job_to_decrease] to [newcap_down].")
+		logTheThing(LOG_ADMIN, null, "Bureaucratic Error event increased [src.job_to_increase] slots to [newcap_up] and decreased [src.job_to_decrease] to [newcap_down].")
+
+		src.cleanup()
+
+	proc/get_valid_jobs()
+		var/list/valid_jobs = list()
+		for(var/datum/job/job in job_controls.staple_jobs)
+			if (job.name in BUREAUCRATIC_JOBS_IGNORE || job.admin_set_limit)
+				continue
+			valid_jobs += job.name
+		return valid_jobs
+
+	proc/determine_jobs()
+		var/list/valid_jobs = src.get_valid_jobs()
+
+		//Remove decrease job early if set by admin call
+		if(src.job_to_decrease)
+			valid_jobs -= src.job_to_decrease
+
+		//Pick job to increase then remove from list if called by admin
+		if(!src.job_to_increase)
+			src.job_to_increase = pick(valid_jobs)
+			valid_jobs -= src.job_to_increase
+
+		//Pick a victim job
+		if(!src.job_to_decrease)
+			src.job_to_decrease = pick(valid_jobs)
+
+#undef BUREAUCRATIC_JOBS_IGNORE

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -18,7 +18,7 @@
 		src.job_to_increase = tgui_input_list(usr, "Pick a job to decrease", src.name, jobs)
 		src.amount = tgui_input_number(usr, "Pick an amount to change by", src.name, 3, 10, -1)
 		//confirmation
-		if (tgui_alert(usr, "Are you sure?", src.name, list("Yes" "No")) == "Yes")
+		if (tgui_alert(usr, "Are you sure?", src.name, list("Yes", "No")) == "Yes")
 			event_effect(source)
 		else
 			src.cleanup()

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -1,4 +1,4 @@
-#define BUREAUCRATIC_JOBS_IGNORE list("Staff Assistant", "Cyborg", "AI")
+#define BUREAUCRATIC_JOBS_IGNORE list("Staff Assistant", "Security Officer", "Cyborg", "AI")
 
 /datum/random_event/major/bureaucratic_error
 	name = "Bureaucratic Error"

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1141,6 +1141,7 @@
 #include "code\modules\events\battle_storm.dm"
 #include "code\modules\events\black_hole.dm"
 #include "code\modules\events\blowout.dm"
+#include "code\modules\events\bureaucratic_error.dm"
 #include "code\modules\events\crew_spawn.dm"
 #include "code\modules\events\faults.dm"
 #include "code\modules\events\ion_storm.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the "Bureaucratic Error" event, changing open job slots for random jobs for example, it could close all doctor slots and open infinite captain slots, or close a QM slot and open an extra genetecist slot. Staff Assistant and Security Officer are blacklisted from being affected by this event (so are borg and AI because you build those.)
![image](https://github.com/user-attachments/assets/86fe86ea-bb94-4e7e-bac6-8a05042df644)

Ive been playing a lot of goobstation on ss14 and while I don't know precisely how this event works there this is heavily inspired by it.

I would like to see the latejoin menu improved to show job slots over 6 better, presently it just keeps expanding to the right if you have more than 6 for any non-assistant job. Also a "locker teleporter" type item for extra amounts of the jobs may be nice (so for example each HoS can get a cape).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fun event that can create fun scenarios such as joint command of a department.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Added Bureaucratic Error event, which can randomly open and close job slots.
```
