### PR TITLE
Fix VR GANG.VEND having the wrong D-Saber

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -3450,6 +3450,6 @@ TYPEINFO(/obj/machinery/vending/janitor)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/c_45, 1, infinite=TRUE)
 
 		product_list += new/datum/data/vending_product(/obj/item/switchblade, 1, infinite=TRUE)
-		product_list += new/datum/data/vending_product(/obj/item/sword/discount, 1, infinite=TRUE)
+		product_list += new/datum/data/vending_product(/obj/item/sword/discount/gang, 1, infinite=TRUE)
 		product_list += new/datum/data/vending_product(/obj/item/gang_machete, 1, infinite=TRUE)
 		product_list += new/datum/data/vending_product(/obj/item/swords/katana/reverse, 1, infinite=TRUE)


### PR DESCRIPTION
[bug] [objects]

## About the PR 
VRGang Vendor uses the Battle Royale D-saber, changes it to the proper subtype.
/obj/item/sword/discount > /obj/item/sword/discount/gang


## Why's this needed? 
love me fixes, simple as
