### PR TITLE
Fix help message for port-a-genes

### DIFF
--- a/code/modules/medical/genetics/portagene.dm
+++ b/code/modules/medical/genetics/portagene.dm
@@ -24,6 +24,13 @@
 			occupant = null
 		..()
 
+	get_help_message(dist, mob/user)
+		. = ..()
+		if(src.status & BROKEN)
+			return "Use <b>2 glass sheets</b> to repair [src]."
+		else
+			return ""
+
 	examine()
 		. = ..()
 		. += "Home turf: [get_area(src.homeloc)]."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Port-a-genes currently use the computer help text stating to unscrew/pulse the machine.
This adds help text specific to port-a-genes that explain how to fix when broken.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Incorrect help instructions