### PR TITLE
Adds a snippet to most UI windows to prevent some default browser shortcuts

### DIFF
--- a/browserassets/tgui/tgui.html
+++ b/browserassets/tgui/tgui.html
@@ -47,7 +47,12 @@
 
 			// Backwards compatibility
 			window.__windowId__ = Byond.windowId;
-
+			// Prevent some default window shortcuts that annoy people
+			window.addEventListener("keydown", function(event){
+				if (event.ctrlKey && ["o", "l", "n"].includes(event.key)) {
+					event.preventDefault()
+				}
+			})
 			// Trident engine version
 			Byond.TRIDENT = (function () {
 				var groups = navigator.userAgent.match(/Trident\/(\d+).+?;/i);

--- a/code/chui/window.dm
+++ b/code/chui/window.dm
@@ -153,6 +153,12 @@ chui/window
 		window.addEventListener("beforeunload", updateScroll);
 		window.addEventListener("scroll", updateScroll);
 		window.addEventListener("load", function() {document.documentElement.scrollTop = document.body.scrollTop = window.name;});
+		// Prevent some default window shortcuts that annoy people
+		window.addEventListener("keydown", function(event){
+			if (event.ctrlKey && "oln".indexOf(event.key) > -1) {
+				event.preventDefault()
+			}
+		})
 	</script>
 </head>
 <body>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[UI] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an event listener that kills `crtl + o, l, n` shortcuts before they reach the browser.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
How many times have you pressed `ctrl + n` to nod and gotten flashbanged by internet explorer for having a UI window focused?
~~Currently this just fixes it for TGUI but it might be possible to make it into a macro that can be inserted into the old-style UIs as well?~~
Added it into the Browse wrapper injection so it should work for *most* non-TGUI windows too.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)The `ctrl + o, l, n` shortcuts will no longer work on <em>most</em> UI windows.
```
