### PR TITLE
Stop decon tools from beating up manufacturers

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -877,6 +877,8 @@ TYPEINFO(/obj/machinery/manufacturer)
 			if (src.shock(user, 33))
 				return
 
+		if (istype(W, /obj/item/deconstructor)) return  // handled in decon afterattack
+
 		// Handling for getting the satchel of an ore scoop
 		if (istype(W, /obj/item/ore_scoop))
 			var/obj/item/ore_scoop/scoop = W


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add an early return in the manufacturer attackby for decon tools

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Trying to deconstruct a manufacturer feels a little weird as you attack it one or more times with the decon tool saw, creating loud sounds and damage, as you break it down.