### PR TITLE
516 caller reserved word compatability

### DIFF
--- a/_std/pathfinding.dm
+++ b/_std/pathfinding.dm
@@ -31,7 +31,7 @@
  * This is the proc you use whenever you want to have pathfinding more complex than "try stepping towards the thing".
  *
  * Arguments:
- * * caller: The movable atom that's trying to find the path
+ * * caller_am: The movable atom that's trying to find the path
  * * ends: What we're trying to path to. It doesn't matter if this is a turf or some other atom, we're gonna just path to the turf it's on anyway
  * * max_distance: The maximum number of steps we can take in a given path to search (default: 30, 0 = infinite)
  * * mintargetdistance: Minimum distance to the target before path returns, could be used to get near a target, but not right to it - for an AI mob with a gun, for example.
@@ -43,16 +43,16 @@
  * * required_goals: How many goals to find to succeed. Null for all.
  * * do_doorcheck: Whether or not to check if doors are blocked (welded, out of power, locked, etc...)
  *
- * Returns: List of turfs from the caller to the end or a list of lists of the former if multiple ends are specified.
+ * Returns: List of turfs from the caller_am to the end or a list of lists of the former if multiple ends are specified.
  * If no paths were found, returns an empty list, which is important for bots like medibots who expect an empty list rather than nothing.
  */
-/proc/get_path_to(caller, ends, max_distance = 30, max_seen = null, mintargetdist, id=null, simulated_only=TRUE, turf/exclude=null, skip_first=FALSE, cardinal_only=TRUE, required_goals=null, do_doorcheck=FALSE)
+/proc/get_path_to(caller_am, ends, max_distance = 30, max_seen = null, mintargetdist, id=null, simulated_only=TRUE, turf/exclude=null, skip_first=FALSE, cardinal_only=TRUE, required_goals=null, do_doorcheck=FALSE)
 	if(isnull(ends))
 		return
 	var/single_end = !islist(ends)
 	if(single_end)
 		ends = list(ends)
-	if(!caller || !length(ends))
+	if(!caller_am || !length(ends))
 		return
 
 	var/list/options = list(
@@ -65,13 +65,13 @@
 		POP_CARDINAL_ONLY=cardinal_only,
 		POP_DOOR_CHECK=do_doorcheck,
 	)
-	if(istype(caller, /obj/machinery/bot) && isnull(id)) // Stonepillar: remove this when amy finishes mob-ifying /obj/machinery/bot
-		var/obj/machinery/bot/bot = caller
+	if(istype(caller_am, /obj/machinery/bot) && isnull(id)) // Stonepillar: remove this when amy finishes mob-ifying /obj/machinery/bot
+		var/obj/machinery/bot/bot = caller_am
 		options[POP_ID] = bot.botcard
-	if(istype(caller, /obj/machinery/vehicle))
+	if(istype(caller_am, /obj/machinery/vehicle))
 		options[POP_IGNORE_CACHE] = TRUE
 
-	var/datum/pathfind/pathfind_datum = new(caller, ends, options)
+	var/datum/pathfind/pathfind_datum = new(caller_am, ends, options)
 	if(!isnull(required_goals))
 		pathfind_datum.n_target_goals = required_goals
 	pathfind_datum.search()
@@ -104,7 +104,7 @@
  * Note that this can only be used inside the [datum/pathfind][pathfind datum] since it uses variables from said datum.
  * If you really want to optimize things, optimize this, cuz this gets called a lot.
  */
-#define CAN_STEP(cur_turf, next) (next && jpsTurfPassable(next, cur_turf, caller, options) && !(simulated_only && !istype(next, /turf/simulated)) && (next != avoid))
+#define CAN_STEP(cur_turf, next) (next && jpsTurfPassable(next, cur_turf, caller_am, options) && !(simulated_only && !istype(next, /turf/simulated)) && (next != avoid))
 /// Another helper macro for JPS, for telling when a node has forced neighbors that need expanding
 #define STEP_NOT_HERE_BUT_THERE(cur_turf, dirA, dirB) ((!CAN_STEP(cur_turf, get_step(cur_turf, dirA)) && CAN_STEP(cur_turf, get_step(cur_turf, dirB))))
 
@@ -164,7 +164,7 @@
 /// The datum used to handle the JPS pathfinding, completely self-contained
 /datum/pathfind
 	/// The thing that we're actually trying to path for
-	var/atom/movable/caller
+	var/atom/movable/caller_am
 	/// The turf where we started at
 	var/turf/start
 	/// The number of goals we need to find to succeed
@@ -197,9 +197,9 @@
 	/// Raw associative list of options passed from get_path_to.
 	var/list/options
 
-/datum/pathfind/New(atom/movable/caller, list/atom/goals, list/options)
+/datum/pathfind/New(atom/movable/caller_am, list/atom/goals, list/options)
 	..()
-	src.caller = caller
+	src.caller_am = caller_am
 	ends = list()
 	n_target_goals = length(goals)
 	for(var/goal in goals)
@@ -229,7 +229,7 @@
  * return null, which [/proc/get_path_to] translates to an empty list (notable for simple bots, who need empty lists)
  */
 /datum/pathfind/proc/search()
-	start = get_turf(caller)
+	start = get_turf(caller_am)
 	if(!start || !length(ends))
 		stack_trace("Invalid A* start or destination")
 		return
@@ -258,7 +258,7 @@
 		if (src.max_seen && (src.total_seen > src.max_seen))
 			// boutput(world, "ending search early due to total_seen limit")
 			return
-		if(!caller)
+		if(!caller_am)
 			return
 		current_processed_node = open.pop() //get the lower f_value turf in the open list
 		if(max_distance && (current_processed_node.number_tiles > max_distance))//if too many steps, don't process that path

--- a/code/modules/admin/banshark.dm
+++ b/code/modules/admin/banshark.dm
@@ -27,7 +27,7 @@
 			var/turf/pickedstart = locate(startx, starty, sharktarget.z)
 			var/obj/banshark/Q = new /obj/banshark(pickedstart)
 			Q.sharktarget2 = sharktarget
-			Q.caller = usr
+			Q.caller_mob = usr
 			Q.data = data
 			Q.timelimit = time
 			Q.sharkspeed = speed
@@ -56,7 +56,7 @@
 	var/turf/pickedstart = locate(startx, starty, sharktarget.z)
 	var/obj/gibshark/Q = new /obj/gibshark(pickedstart)
 	Q.sharktarget2 = sharktarget
-	Q.caller = usr
+	Q.caller_mob = usr
 	Q.sharkspeed = speed
 
 /obj/banshark
@@ -69,7 +69,7 @@
 	anchored = UNANCHORED
 	var/mob/sharktarget2 = null
 	var/data = null
-	var/caller = null
+	var/caller_mob = null
 	var/sharkcantreach = 0
 	var/timelimit = 6
 	var/sharkspeed = 1
@@ -120,11 +120,11 @@
 			playsound(src.loc, 'sound/items/eatfood.ogg', 30, 1, -2)
 			sharktarget2.gib()
 			boutput(sharktarget2, SPAN_ALERT("<BIG><B>You have been eaten by the banshark!</B></BIG>"))
-			logTheThing(LOG_ADMIN, caller:client, "has been eaten by the banshark!")
+			logTheThing(LOG_ADMIN, sharktarget2, "has been eaten by the banshark!")
 			message_admins(SPAN_INTERNAL("[sharktarget2.ckey] has been eaten by the banshark!"))
 		else
 			boutput(sharktarget2, SPAN_ALERT("<BIG><B>You can escape the banshark, but not the ban!</B></BIG>"))
-			logTheThing(LOG_ADMIN, caller:client, "has evaded the shark by ceasing to exist!  Banning them anyway.")
+			logTheThing(LOG_ADMIN, sharktarget2, "has evaded the shark by ceasing to exist!  Banning them anyway.")
 			message_admins(SPAN_INTERNAL("[data["ckey"]] has evaded the shark by ceasing to exist!  Banning them anyway."))
 		bansHandler.add(
 			data["akey"],
@@ -148,7 +148,7 @@
 	anchored = UNANCHORED
 	var/mob/sharktarget2 = null
 	var/sharkspeed = 1
-	var/mob/caller = null
+	var/mob/caller_mob = null
 
 	New()
 		SPAWN(0) process()
@@ -186,9 +186,9 @@
 				O.show_message(SPAN_ALERT("<B>[src]</B> gibs [sharktarget2] in one bite!"), 1)
 			playsound(src.loc, 'sound/items/eatfood.ogg', 30, 1, -2)
 			if(sharktarget2?.client)
-				logTheThing(LOG_ADMIN, caller:client, "sharkgibbed [constructTarget(sharktarget2,"admin")]")
-				logTheThing(LOG_DIARY, caller:client, "sharkgibbed [constructTarget(sharktarget2,"diary")]", "admin")
-				message_admins(SPAN_INTERNAL("[caller?.client?.ckey] has sharkgibbed [sharktarget2.ckey]."))
+				logTheThing(LOG_ADMIN, caller_mob, "sharkgibbed [constructTarget(sharktarget2,"admin")]")
+				logTheThing(LOG_DIARY, caller_mob, "sharkgibbed [constructTarget(sharktarget2,"diary")]", "admin")
+				message_admins(SPAN_INTERNAL("[key_name(caller_mob)] has sharkgibbed [key_name(sharktarget2)]."))
 				sharktarget2.gib()
 			sleep(0.5 SECONDS)
 			playsound(src.loc, pick('sound/voice/burp_alien.ogg'), 50, 0)

--- a/code/modules/admin/gibverbs.dm
+++ b/code/modules/admin/gibverbs.dm
@@ -368,7 +368,7 @@
 				var/obj/bantyson/Q = new /obj/bantyson(pickedstart)
 				Q.tysonmins2 = tysonmins
 				Q.tysontarget2 = tysontarget
-				Q.caller = usr
+				Q.caller_mob = usr
 				Q.tysonreason = reason
 				Q.timelimit = time
 				Q.tysonspeed = speed
@@ -395,7 +395,7 @@
 	var/turf/pickedstart = locate(startx, starty, tysontarget.z)
 	var/obj/gibtyson/Q = new /obj/gibtyson(pickedstart)
 	Q.tysontarget2 = tysontarget
-	Q.caller = usr
+	Q.caller_mob = usr
 	Q.tysonspeed = speed
 
 /obj/bantyson
@@ -408,7 +408,7 @@
 	anchored = UNANCHORED
 	var/mob/tysontarget2 = null
 	var/tysonmins2 = null
-	var/mob/caller = null
+	var/mob/caller_mob = null
 	var/tysonreason = null
 	var/tysoncantreach = 0
 	var/timelimit = 6
@@ -463,7 +463,7 @@
 				qdel(src)
 				return
 			bansHandler.add(
-				caller:ckey,
+				caller_mob.ckey,
 				null,
 				tysontarget2.ckey,
 				tysontarget2.computer_id,
@@ -473,9 +473,9 @@
 			)
 			boutput(tysontarget2, SPAN_ALERT("<BIG><B>You have been tysoned by [usr.client.ckey].<br>Reason: [tysonreason] and he couldn't escape the tyson.</B></BIG>"))
 			boutput(tysontarget2, SPAN_ALERT("This is a temporary tysonban, it will be removed in [tysonmins2] minutes."))
-			logTheThing(LOG_ADMIN, caller:client, "has tysonbanned [constructTarget(tysontarget2,"admin")]. Reason: [tysonreason] and he couldn't escape the tyson. This will be removed in [tysonmins2] minutes.")
-			logTheThing(LOG_DIARY, caller:client, "has tysonbanned [constructTarget(tysontarget2,"diary")]. Reason: [tysonreason] and he couldn't escape the tyson. This will be removed in [tysonmins2] minutes.", "admin")
-			message_admins(SPAN_INTERNAL("[caller?.client?.ckey] has tysonbanned [tysontarget2.ckey].<br>Reason: [tysonreason] and he couldn't escape the tyson.<br>This will be removed in [tysonmins2] minutes."))
+			logTheThing(LOG_ADMIN, caller_mob, "has tysonbanned [constructTarget(tysontarget2,"admin")]. Reason: [tysonreason] and he couldn't escape the tyson. This will be removed in [tysonmins2] minutes.")
+			logTheThing(LOG_DIARY, caller_mob, "has tysonbanned [constructTarget(tysontarget2,"diary")]. Reason: [tysonreason] and he couldn't escape the tyson. This will be removed in [tysonmins2] minutes.", "admin")
+			message_admins(SPAN_INTERNAL("[key_name(caller_mob)] has tysonbanned [key_name(tysontarget2)].<br>Reason: [tysonreason] and he couldn't escape the tyson.<br>This will be removed in [tysonmins2] minutes."))
 			del(tysontarget2.client)
 			tysontarget2.gib()
 		playsound(src.loc, pick('sound/misc/Boxingbell.ogg'), 50, 0)
@@ -491,7 +491,7 @@
 	anchored = UNANCHORED
 	var/mob/tysontarget2 = null
 	var/tysonspeed = 1
-	var/mob/caller = null
+	var/mob/caller_mob = null
 
 	New()
 		SPAWN(0) process()
@@ -531,9 +531,9 @@
 			for(var/mob/O in AIviewers(src, null))
 				O.show_message(SPAN_ALERT("<B>[src]</B> KOs [tysontarget2] in one punch!"), 1)
 			playsound(src.loc, 'sound/impact_sounds/generic_hit_3.ogg', 30, 1, -2)
-			logTheThing(LOG_ADMIN, caller:client, "tysongibbed [constructTarget(tysontarget2,"admin")]")
-			logTheThing(LOG_DIARY, caller:client, "tysongibbed [constructTarget(tysontarget2,"diary")]", "admin")
-			message_admins(SPAN_INTERNAL("[caller?.client?.ckey] has tysongibbed [tysontarget2] ([tysontarget2.ckey])."))
+			logTheThing(LOG_ADMIN, caller_mob, "tysongibbed [constructTarget(tysontarget2,"admin")]")
+			logTheThing(LOG_DIARY, caller_mob, "tysongibbed [constructTarget(tysontarget2,"diary")]", "admin")
+			message_admins(SPAN_INTERNAL("[key_name(caller_mob)] has tysongibbed [key_name(tysontarget2)]."))
 			tysontarget2.gib()
 			sleep(0.5 SECONDS)
 			playsound(src.loc, pick('sound/misc/knockout.ogg'), 50, 0)

--- a/code/modules/networks/computer3/base_program.dm
+++ b/code/modules/networks/computer3/base_program.dm
@@ -22,8 +22,8 @@
 		executable = 0
 		var/tmp/setup_string = null
 
-		os_call(var/list/call_list, var/datum/computer/file/terminal_program/caller, var/datum/computer/file/file)
-			return (!master || master.status & (NOPOWER|BROKEN) || !caller || !call_list)
+		os_call(var/list/call_list, var/datum/computer/file/terminal_program/caller_prog, var/datum/computer/file/file)
+			return (!master || master.status & (NOPOWER|BROKEN) || !caller_prog || !call_list)
 
 	termapp //Small applications for the "termos" computer3s.
 		name = "blank terminal app"

--- a/code/modules/networks/computer3/mainframe2/_base_os.dm
+++ b/code/modules/networks/computer3/mainframe2/_base_os.dm
@@ -114,7 +114,7 @@
 #define DWAINE_COMMAND_DSCAN	10
 
 /**
- *	Instruct the caller to exit the current running program.
+ *	Instruct the caller_prog to exit the current running program.
  *	No applicable data fields.
  */
 #define DWAINE_COMMAND_EXIT		11
@@ -474,17 +474,17 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 			if (!sendid)
 				return ESIG_GENERIC
 
-			var/datum/computer/file/mainframe_program/caller = src.master.processing[sendid]
-			if (!caller || !data["name"])
+			var/datum/computer/file/mainframe_program/caller_prog = src.master.processing[sendid]
+			if (!caller_prog || !data["name"])
 				return ESIG_GENERIC
 
 			if (data["data"] && (data["name"] == "TEMP"))
-				return (src.login_temp_user(data["data"], null, caller)) ? ESIG_GENERIC : ESIG_SUCCESS
+				return (src.login_temp_user(data["data"], null, caller_prog)) ? ESIG_GENERIC : ESIG_SUCCESS
 
-			if (!caller.useracc)
+			if (!caller_prog.useracc)
 				return ESIG_NOUSR
 
-			if (src.login_user(caller.useracc, data["name"], data["sysop"], (data["service"] != 1)))
+			if (src.login_user(caller_prog.useracc, data["name"], data["sysop"], (data["service"] != 1)))
 				return ESIG_GENERIC
 
 			return ESIG_SUCCESS
@@ -493,14 +493,14 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 			if (!sendid)
 				return ESIG_GENERIC
 
-			var/datum/computer/file/mainframe_program/caller = src.master.processing[sendid]
-			if (!caller || !isnum(data["group"]))
+			var/datum/computer/file/mainframe_program/caller_prog = src.master.processing[sendid]
+			if (!caller_prog || !isnum(data["group"]))
 				return ESIG_GENERIC
 
-			if (!caller.useracc || !caller.useracc.user_file)
+			if (!caller_prog.useracc || !caller_prog.useracc.user_file)
 				return ESIG_NOUSR
 
-			caller.useracc.user_file.fields["group"] = clamp(0, data["group"], 255)
+			caller_prog.useracc.user_file.fields["group"] = clamp(0, data["group"], 255)
 			return ESIG_SUCCESS
 
 		if (DWAINE_COMMAND_ULIST)
@@ -529,11 +529,11 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 			return user_list
 
 		if (DWAINE_COMMAND_UMSG)
-			var/datum/computer/file/mainframe_program/caller = src.master.processing[sendid]
-			if (!caller || !caller.useracc)
+			var/datum/computer/file/mainframe_program/caller_prog = src.master.processing[sendid]
+			if (!caller_prog || !caller_prog.useracc)
 				return ESIG_NOUSR
 
-			var/sender_name = caller.useracc.user_name
+			var/sender_name = caller_prog.useracc.user_name
 			if (!sender_name)
 				return ESIG_NOUSR
 
@@ -565,7 +565,7 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 			else if (!istype(target.user_file))
 				return ESIG_NOTARGET
 
-			if (caller.useracc == target)
+			if (caller_prog.useracc == target)
 				return ESIG_NOTARGET
 
 			if (!(target.user_file.fields["accept_msg"] == "1"))
@@ -687,23 +687,23 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 			if (!sendid)
 				return ESIG_GENERIC
 
-			var/datum/computer/file/mainframe_program/caller = src.master.processing[sendid]
-			if (!caller || (caller == src))
+			var/datum/computer/file/mainframe_program/caller_prog = src.master.processing[sendid]
+			if (!caller_prog || (caller_prog == src))
 				return ESIG_GENERIC
 
-			if (!caller.useracc)
-				caller.handle_quit()
+			if (!caller_prog.useracc)
+				caller_prog.handle_quit()
 				return ESIG_NOUSR
 
-			var/datum/mainframe2_user_data/user = caller.useracc
+			var/datum/mainframe2_user_data/user = caller_prog.useracc
 			var/datum/computer/file/mainframe_program/shellbase = src.get_file_name(src.setup_progname_shell, src.sys_folder)
-			var/shellexit = (shellbase && (shellbase.type == caller.type) && (caller.parent_id == src.progid))
+			var/shellexit = (shellbase && (shellbase.type == caller_prog.type) && (caller_prog.parent_id == src.progid))
 
-			var/datum/computer/file/mainframe_program/quitparent = caller.parent_task
-			caller.handle_quit()
+			var/datum/computer/file/mainframe_program/quitparent = caller_prog.parent_task
+			caller_prog.handle_quit()
 
 			if (istype(quitparent) && (quitparent != src) && !istype(quitparent, /datum/computer/file/mainframe_program/driver/mountable/radio)) // Hello, this last istype() is a dirty hack.
-				if (user.current_prog == caller)
+				if (user.current_prog == caller_prog)
 					user.current_prog = quitparent
 				quitparent.useracc = user
 				quitparent.receive_progsignal(TRUE, list("command" = DWAINE_COMMAND_TEXIT, "id" = sendid))
@@ -729,15 +729,15 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 
 			var/pass_user = (data["passusr"] == 1)
 
-			var/datum/computer/file/mainframe_program/caller = src.master.processing[sendid]
-			if (!caller)
+			var/datum/computer/file/mainframe_program/caller_prog = src.master.processing[sendid]
+			if (!caller_prog)
 				return ESIG_GENERIC
 
 			var/datum/computer/file/mainframe_program/task_model = src.parse_file_directory(data["path"], src.holder.root, FALSE)
 			if (!task_model?.executable)
 				return ESIG_NOTARGET
 
-			task_model = src.master.run_program(task_model, (pass_user ? caller.useracc : null), caller, data["args"])
+			task_model = src.master.run_program(task_model, (pass_user ? caller_prog.useracc : null), caller_prog, data["args"])
 			if (!task_model)
 				return ESIG_GENERIC
 
@@ -747,11 +747,11 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 			if (!sendid)
 				return ESIG_GENERIC
 
-			var/datum/computer/file/mainframe_program/caller = src.master.processing[sendid]
-			if (!caller)
+			var/datum/computer/file/mainframe_program/caller_prog = src.master.processing[sendid]
+			if (!caller_prog)
 				return ESIG_GENERIC
 
-			var/datum/computer/file/mainframe_program/fork = src.master.run_program(caller, null, caller, data["args"], TRUE)
+			var/datum/computer/file/mainframe_program/fork = src.master.run_program(caller_prog, null, caller_prog, data["args"], TRUE)
 			if (!fork)
 				return ESIG_GENERIC
 
@@ -765,21 +765,21 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 			if (!isnum(target_id) || (target_id < 0) || (target_id > length(src.master.processing)))
 				return ESIG_NOTARGET
 
-			var/datum/computer/file/mainframe_program/caller = src.master.processing[sendid]
-			if (!caller)
+			var/datum/computer/file/mainframe_program/caller_prog = src.master.processing[sendid]
+			if (!caller_prog)
 				return ESIG_GENERIC
 
 			var/datum/computer/file/mainframe_program/target_task = src.master.processing[target_id]
 			if (!target_task)
 				return ESIG_SUCCESS
 
-			if (target_task.parent_task != caller)
+			if (target_task.parent_task != caller_prog)
 				return ESIG_GENERIC
 
 			var/datum/mainframe2_user_data/target_user = target_task.useracc
-			if (target_user && (!caller.useracc || (target_user.current_prog == target_task)))
-				target_user.current_prog = caller
-				caller.useracc = target_user
+			if (target_user && (!caller_prog.useracc || (target_user.current_prog == target_task)))
+				target_user.current_prog = caller_prog
+				caller_prog.useracc = target_user
 
 			target_task.handle_quit()
 
@@ -789,8 +789,8 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 			if (!sendid)
 				return ESIG_GENERIC
 
-			var/datum/computer/file/mainframe_program/caller = src.master.processing[sendid]
-			if (!caller)
+			var/datum/computer/file/mainframe_program/caller_prog = src.master.processing[sendid]
+			if (!caller_prog)
 				return ESIG_GENERIC
 
 			var/list/datum/computer/file/mainframe_program/progs = list()
@@ -798,7 +798,7 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 
 			for (var/i in 1 to length(src.master.processing))
 				var/datum/computer/file/mainframe_program/MP = src.master.processing[i]
-				if (MP && (MP.parent_task == caller))
+				if (MP && (MP.parent_task == caller_prog))
 					progs[i] = MP
 
 			return progs
@@ -807,11 +807,11 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 			if (!sendid)
 				return ESIG_GENERIC
 
-			var/datum/computer/file/mainframe_program/caller = src.master.processing[sendid]
-			if (!data["path"] || !caller)
+			var/datum/computer/file/mainframe_program/caller_prog = src.master.processing[sendid]
+			if (!data["path"] || !caller_prog)
 				return ESIG_NOTARGET
 
-			var/datum/computer/target_file = src.parse_datum_directory(data["path"], src.holder.root, FALSE, caller.useracc)
+			var/datum/computer/target_file = src.parse_datum_directory(data["path"], src.holder.root, FALSE, caller_prog.useracc)
 			if (!target_file)
 				return ESIG_NOFILE
 
@@ -821,11 +821,11 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 			if (!sendid)
 				return ESIG_GENERIC
 
-			var/datum/computer/file/mainframe_program/caller = src.master.processing[sendid]
-			if (!data["path"] || !caller)
+			var/datum/computer/file/mainframe_program/caller_prog = src.master.processing[sendid]
+			if (!data["path"] || !caller_prog)
 				return ESIG_NOTARGET
 
-			var/datum/mainframe2_user_data/user = caller.useracc
+			var/datum/mainframe2_user_data/user = caller_prog.useracc
 			var/datum/computer/target_file = src.parse_datum_directory(data["path"], src.holder.root, FALSE, user)
 
 			if (!target_file || (target_file.holding_folder == src.master.runfolder) || (target_file == src.master.runfolder) || (target_file == src.holder.root))
@@ -848,15 +848,15 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 			if (!isnum(data["permission"]))
 				return ESIG_GENERIC
 
-			var/datum/computer/file/mainframe_program/caller = src.master.processing[sendid]
-			if (!data["path"] || !caller)
+			var/datum/computer/file/mainframe_program/caller_prog = src.master.processing[sendid]
+			if (!data["path"] || !caller_prog)
 				return ESIG_NOTARGET
 
-			var/datum/computer/target_file = src.parse_datum_directory(data["path"], src.holder.root, FALSE, caller.useracc)
+			var/datum/computer/target_file = src.parse_datum_directory(data["path"], src.holder.root, FALSE, caller_prog.useracc)
 			if (!istype(target_file))
 				return ESIG_NOFILE
 
-			if (caller.useracc && !src.check_mode_permission(target_file, caller.useracc))
+			if (caller_prog.useracc && !src.check_mode_permission(target_file, caller_prog.useracc))
 				return ESIG_GENERIC
 
 			src.change_metadata(target_file, "permission", data["permission"])
@@ -869,15 +869,15 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 			if (!isnum(data["group"]) && !data["owner"])
 				return ESIG_GENERIC
 
-			var/datum/computer/file/mainframe_program/caller = src.master.processing[sendid]
-			if (!data["path"] || !caller)
+			var/datum/computer/file/mainframe_program/caller_prog = src.master.processing[sendid]
+			if (!data["path"] || !caller_prog)
 				return ESIG_NOTARGET
 
-			var/datum/computer/target_file = src.parse_datum_directory(data["path"], src.holder.root, FALSE, caller.useracc)
+			var/datum/computer/target_file = src.parse_datum_directory(data["path"], src.holder.root, FALSE, caller_prog.useracc)
 			if (!istype(target_file))
 				return ESIG_NOFILE
 
-			if (caller.useracc && !src.check_mode_permission(target_file, caller.useracc))
+			if (caller_prog.useracc && !src.check_mode_permission(target_file, caller_prog.useracc))
 				return ESIG_GENERIC
 
 			if (data["owner"])
@@ -892,14 +892,14 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 			if (!sendid)
 				return ESIG_GENERIC
 
-			var/datum/computer/file/mainframe_program/caller = src.master.processing[sendid]
-			if (!file || !data["path"] || !caller)
+			var/datum/computer/file/mainframe_program/caller_prog = src.master.processing[sendid]
+			if (!file || !data["path"] || !caller_prog)
 				return ESIG_NOTARGET
 
 			if (src.is_name_invalid(file.name))
 				return ESIG_GENERIC
 
-			var/datum/mainframe2_user_data/user = caller.useracc
+			var/datum/mainframe2_user_data/user = caller_prog.useracc
 			var/datum/computer/folder/destination = src.parse_directory(data["path"], src.holder.root, (data["mkdir"] == 1), user)
 			if (!destination || (destination == src.master.runfolder))
 				return ESIG_NOTARGET
@@ -1060,7 +1060,7 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 	return FALSE
 
 /// Log a connection in as a temporary user, starting the full login program, or logging in fully if a valid login record is provided.
-/datum/computer/file/mainframe_program/os/kernel/proc/login_temp_user(user_netid, datum/computer/file/record/login_record, datum/computer/file/mainframe_program/caller_override)
+/datum/computer/file/mainframe_program/os/kernel/proc/login_temp_user(user_netid, datum/computer/file/record/login_record, datum/computer/file/mainframe_program/caller_prog_override)
 	if (length(src.users) >= src.max_users)
 		return TRUE
 
@@ -1079,10 +1079,10 @@ var/global/list/generic_exit_list = list("command" = DWAINE_COMMAND_EXIT)
 	if (istype(login_record) && login_record.fields && login_record.fields["registered"] && login_record.fields["assignment"] && !src.login_user(new_user, login_record.fields["registered"], FALSE))
 		var/datum/computer/file/mainframe_program/shellbase = src.get_file_name(src.setup_progname_shell, src.sys_folder)
 		if (istype(shellbase))
-			src.master.run_program(shellbase, new_user, istype(caller_override) ? caller_override : src)
+			src.master.run_program(shellbase, new_user, istype(caller_prog_override) ? caller_prog_override : src)
 			return FALSE
 
-	helloprog = src.master.run_program(helloprog, new_user, istype(caller_override) ? caller_override : src)
+	helloprog = src.master.run_program(helloprog, new_user, istype(caller_prog_override) ? caller_prog_override : src)
 	if (!istype(helloprog))
 		return TRUE
 

--- a/code/modules/networks/computer3/mainframe2/mainframe2.dm
+++ b/code/modules/networks/computer3/mainframe2/mainframe2.dm
@@ -461,7 +461,7 @@
 			src.set_density(0)
 
 	proc
-		run_program(datum/computer/file/mainframe_program/program, var/datum/mainframe2_user_data/user, var/datum/computer/file/mainframe_program/caller, var/runparams, var/allow_fork=0)
+		run_program(datum/computer/file/mainframe_program/program, var/datum/mainframe2_user_data/user, var/datum/computer/file/mainframe_program/caller_prog, var/runparams, var/allow_fork=0)
 			if(!hd || !program || (!program.holder && program.needs_holder))
 				return 0
 
@@ -531,11 +531,11 @@
 				program.useracc = user
 				user.current_prog = program
 
-			if (caller)
+			if (caller_prog)
 				if (!program.useracc)
-					program.useracc = caller.useracc
-				program.parent_task = caller
-				program.parent_id = caller.progid
+					program.useracc = caller_prog.useracc
+				program.parent_task = caller_prog
+				program.parent_id = caller_prog.progid
 
 			program.initialize(runparams)
 			//program.initialized = 1
@@ -580,15 +580,15 @@
 			theFile.dispose()
 			return 1
 
-		relay_progsignal(var/datum/computer/file/mainframe_program/caller, var/progid, var/list/data = null, var/datum/computer/file/file)
-			if (progid < 1 || progid > src.processing.len || !caller)
+		relay_progsignal(var/datum/computer/file/mainframe_program/caller_prog, var/progid, var/list/data = null, var/datum/computer/file/file)
+			if (progid < 1 || progid > src.processing.len || !caller_prog)
 				return ESIG_GENERIC
 
 			var/datum/computer/file/mainframe_program/P = src.processing[progid]
 			if(!istype(P))
 				return ESIG_GENERIC
 
-			var/callID = src.processing.Find(caller)
+			var/callID = src.processing.Find(caller_prog)
 			return P.receive_progsignal(callID, data, file)
 
 		set_broken()

--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -353,18 +353,18 @@
 						. += "Address book is empty!"
 					else
 						. += "<table cellspacing=5>"
-						for(var/caller in src.all_callers)
-							var/muteButton = "<a href='byond://?src=\ref[src];manageBlock=["add"];type=["single"];entry=[src.all_callers[caller]]'>Block</a>"
-							var/callButton = "<a href='byond://?src=\ref[src];input=message;target=[caller]'>Msg</a>"
-							var/sendButton = "<a href='byond://?src=\ref[src];input=send_file;target=[caller]'>Send File</a>"
+						for(var/address in src.all_callers)
+							var/muteButton = "<a href='byond://?src=\ref[src];manageBlock=["add"];type=["single"];entry=[src.all_callers[address]]'>Block</a>"
+							var/callButton = "<a href='byond://?src=\ref[src];input=message;target=[address]'>Msg</a>"
+							var/sendButton = "<a href='byond://?src=\ref[src];input=send_file;target=[address]'>Send File</a>"
 							if(!src.master.fileshare_program)
 								sendButton = ""
 							else if(!src.clipboard || src.clipboard?.dont_copy)
 								sendButton = "<strike>Send File</strike>"
-							var/delButton = "<a href='byond://?src=\ref[src];delAddress=[caller]'>Del</a>"
-							if(src.all_callers[caller] in src.blocked_numbers)
-								muteButton = "<a href='byond://?src=\ref[src];manageBlock=["remove"];type=["single"];entry=[src.all_callers[caller]]'>Unblock</a>"
-							. += "<tr><td>[src.all_callers[caller]]</td><td>[callButton]</td><td>[muteButton]</td><td>[sendButton]</td><td>[delButton]</td></tr>"
+							var/delButton = "<a href='byond://?src=\ref[src];delAddress=[address]'>Del</a>"
+							if(src.all_callers[address] in src.blocked_numbers)
+								muteButton = "<a href='byond://?src=\ref[src];manageBlock=["remove"];type=["single"];entry=[src.all_callers[address]]'>Unblock</a>"
+							. += "<tr><td>[src.all_callers[address]]</td><td>[callButton]</td><td>[muteButton]</td><td>[sendButton]</td><td>[delButton]</td></tr>"
 						. += "</table>"
 					. += "<hr>"
 					. += "<h4>Primary Ringtone</h4><br>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Renames any instances of variables named `caller`
* Cleans up some trash code around tyson gib/ban that was using a var named caller

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* In 516 `caller` and `callee` are newly reserved words