### PR TITLE
Fix build due to `set_broken` dupe def

### DIFF
--- a/code/modules/disposals/disposal_chute.dm
+++ b/code/modules/disposals/disposal_chute.dm
@@ -306,7 +306,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 		else
 			return ..()
 
-	proc/set_broken()
+	set_broken()
 		if(src.status & BROKEN)
 			return
 		src.eject()

--- a/code/modules/disposals/disposal_chute.dm
+++ b/code/modules/disposals/disposal_chute.dm
@@ -307,8 +307,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 			return ..()
 
 	set_broken()
-		if(src.status & BROKEN)
-			return
+		. = ..()
+		if (.) return
 		src.eject()
 		src.loc.assume_air(src.air_contents)
 		playsound(src, 'sound/impact_sounds/locker_break.ogg', 50, TRUE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][internal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
change disposals proc redefinition to an override
have disposals set_broken call parent and return early if broken

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
build broke

`set_broken` got raised in one pr
and i added it as a new proc in another pr
and the both got merged at the same time