### PR TITLE
Doing CPR causes minor losebreath on the performer

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -1427,6 +1427,9 @@
 			..()
 			interrupt(INTERRUPT_ALWAYS)
 			return
+		var/mob/M = owner
+		M.losebreath++ // ♪ give a little bit of your life to me ♪
+		M.emote("gasp")
 
 		target.take_oxygen_deprivation(-15)
 		target.losebreath = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][medical]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When completing a CPR action, the performer gets one (1) losebreath and is forced to gasp emote.

In stable conditions, the losebreath will be cancelled out. However, if there are other sources of losebreath (poison, low oxy) it could then start stacking up.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Make doing CPR more than just an action bar (but not much more).

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)You take deep breaths when doing CPR.
```
