### PR TITLE
Mobifies microman

### DIFF
--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_zoo.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_zoo.dmm
@@ -20,7 +20,7 @@
 	},
 /area/prefab/zoo)
 "f" = (
-/obj/critter/microman,
+/mob/living/critter/microman,
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},

--- a/code/datums/abilities/critter/tackle.dm
+++ b/code/datums/abilities/critter/tackle.dm
@@ -26,38 +26,20 @@
 			return 1
 		playsound(target, 'sound/impact_sounds/Generic_Hit_1.ogg', 50, TRUE, -1)
 		var/mob/MT = target
-		MT.changeStatus("knockdown", 3 SECONDS)
+		src.tackle_effect(MT)
 		holder.owner.visible_message(SPAN_ALERT("<b>[holder.owner] tackles [MT]!</b>"), SPAN_ALERT("You tackle [MT]!"))
 		return FALSE
 
+	proc/tackle_effect(mob/target)
+		target.changeStatus("knockdown", 3 SECONDS)
+
 // weaker tackle, usually stuns but sometimes knocks down
-/datum/targetable/critter/weak_tackle
+/datum/targetable/critter/tackle/weak
 	name = "Weak Tackle"
 	desc = "Tackle a mob, stunning them."
 	cooldown = 7 SECONDS
-	icon_state = "tackle"
-	targeted = TRUE
-	target_anything = TRUE
 
-	cast(atom/target)
-		if (..())
-			return 1
-		if (isobj(target))
-			target = get_turf(target)
-		if (isturf(target))
-			target = locate(/mob/living) in target
-			if (!target)
-				boutput(holder.owner, SPAN_ALERT("Nothing to tackle there."))
-				return 1
-		if (target == holder.owner)
-			return 1
-		if (BOUNDS_DIST(holder.owner, target) > 0)
-			boutput(holder.owner, SPAN_ALERT("That is too far away to tackle."))
-			return 1
-		playsound(target, 'sound/impact_sounds/Generic_Hit_1.ogg', 50, TRUE, -1)
-		var/mob/MT = target
-		MT.changeStatus("stunned", 1 SECOND)
+	tackle_effect(mob/target)
+		target.changeStatus("stunned", 1 SECOND)
 		if (prob(25))
-			MT.changeStatus("knockdown", 2 SECONDS)
-		holder.owner.visible_message(SPAN_ALERT("<b>[holder.owner] tackles [MT]!</b>"), SPAN_ALERT("You tackle [MT]!"))
-		return FALSE
+			target.changeStatus("knockdown", 2 SECONDS)

--- a/code/datums/abilities/critter/tackle.dm
+++ b/code/datums/abilities/critter/tackle.dm
@@ -29,3 +29,35 @@
 		MT.changeStatus("knockdown", 3 SECONDS)
 		holder.owner.visible_message(SPAN_ALERT("<b>[holder.owner] tackles [MT]!</b>"), SPAN_ALERT("You tackle [MT]!"))
 		return FALSE
+
+// weaker tackle, usually stuns but sometimes knocks down
+/datum/targetable/critter/weak_tackle
+	name = "Weak Tackle"
+	desc = "Tackle a mob, stunning them."
+	cooldown = 7 SECONDS
+	icon_state = "tackle"
+	targeted = TRUE
+	target_anything = TRUE
+
+	cast(atom/target)
+		if (..())
+			return 1
+		if (isobj(target))
+			target = get_turf(target)
+		if (isturf(target))
+			target = locate(/mob/living) in target
+			if (!target)
+				boutput(holder.owner, SPAN_ALERT("Nothing to tackle there."))
+				return 1
+		if (target == holder.owner)
+			return 1
+		if (BOUNDS_DIST(holder.owner, target) > 0)
+			boutput(holder.owner, SPAN_ALERT("That is too far away to tackle."))
+			return 1
+		playsound(target, 'sound/impact_sounds/Generic_Hit_1.ogg', 50, TRUE, -1)
+		var/mob/MT = target
+		MT.changeStatus("stunned", 1 SECOND)
+		if (prob(25))
+			MT.changeStatus("knockdown", 2 SECONDS)
+		holder.owner.visible_message(SPAN_ALERT("<b>[holder.owner] tackles [MT]!</b>"), SPAN_ALERT("You tackle [MT]!"))
+		return FALSE

--- a/code/datums/gauntlet/crittergauntlet.dm
+++ b/code/datums/gauntlet/crittergauntlet.dm
@@ -1148,7 +1148,7 @@ var/global/datum/arena/gauntletController/gauntlet_controller = new()
 		name = "Micro Man"
 		point_cost = 3
 		count = 0.1
-		types = list(/obj/critter/microman)
+		types = list(/mob/living/critter/microman)
 
 	spiderbaby
 		name = "Spider Baby"

--- a/code/modules/admin/buildmodes/adventure/adventure_critter.dm
+++ b/code/modules/admin/buildmodes/adventure/adventure_critter.dm
@@ -50,7 +50,7 @@
 		"Martian Warrior" = /mob/living/critter/martian/warrior,
 		"Meat Mutant" = /mob/living/critter/blobman,
 		"Meat Thing" = /mob/living/critter/blobman/meat,
-		"Micro Man" = /obj/critter/microman,
+		"Micro Man" = /mob/living/critter/microman,
 		"Mimic" = /mob/living/critter/mimic,
 		"Plasma Spore" = /obj/critter/spore,
 		"Skeleton" = /mob/living/critter/skeleton,

--- a/code/modules/antagonists/macho_man/abilities/_macho_man_mob.dm
+++ b/code/modules/antagonists/macho_man/abilities/_macho_man_mob.dm
@@ -346,75 +346,69 @@ var/list/snd_macho_idle = list('sound/voice/macho/macho_alert16.ogg', 'sound/voi
 					src.visible_message(SPAN_ALERT("<b>[src] yells out a battle cry!</b>"))
 			else
 				..()
-/obj/critter/microman
+
+/mob/living/critter/microman
 	name = "Micro Man"
 	desc = "All the macho madness you'd ever need, shrunk down to pocket size."
 	icon = 'icons/mob/critter/humanoid/microman.dmi'
 	icon_state = "microman"
-	health = 25
-	aggressive = 1
-	defensive = 1
-	wanderer = 1
-	opensdoors = OBJ_CRITTER_OPENS_DOORS_ANY
-	atkcarbon = 1
-	atksilicon = 1
-	atcritter = 1
-	density = 0
-	angertext = "rages at"
+	is_npc = TRUE
+	ai_type = /datum/aiHolder/aggressive
+	can_lie = FALSE
+	butcherable = BUTCHER_NOT_ALLOWED
+	health_brute = 25
+	health_burn = 25
+	health_brute_vuln = 1
+	health_burn_vuln = 1
+	hand_count = 1
+	add_abilities = list(/datum/targetable/critter/weak_tackle)
+	ai_attacks_per_ability = 1
+	ai_retaliates = TRUE
+	ai_retaliate_patience = 0
+	ai_retaliate_persistence = RETALIATE_UNTIL_INCAP
+	use_stamina = FALSE
 
 	New()
-		..()
+		. = ..()
 		if (prob(50))
 			playsound(src.loc, pick(snd_macho_rage), 50, 1, 0, 1.75)
 
-	ai_think()
-		..()
+	setup_healths()
+		add_hh_flesh(src.health_brute, src.health_brute_vuln)
+		add_hh_flesh_burn(src.health_burn, src.health_burn_vuln)
+
+	// microman does teensy damage, just enough to reliably punch through armor
+	calculate_melee_attack(mob/target, base_damage_low, base_damage_high, extra_damage, stamina_damage_mult, can_crit, can_punch, can_kick, datum/limb/limb)
+		. = ..(target, 2, 3, extra_damage, stamina_damage_mult, can_crit, can_punch, can_kick, limb)
+
+	critter_attack(mob/target)
+		. = ..()
+		playsound(src.loc, "swing_hit", 30, 0)
+		if (prob(10))
+			playsound(src.loc, pick(snd_macho_rage), 50, 1, 0, 1.75)
+
+	critter_ability_attack(mob/target)
+		var/datum/targetable/critter/weak_tackle/pounce = src.abilityHolder.getAbility(/datum/targetable/critter/weak_tackle)
+		if(pounce && !pounce.disabled && pounce.cooldowncheck())
+			pounce.handleCast(target)
+			if (prob(50))
+				playsound(src.loc, pick(snd_macho_rage), 50, 1, 0, 1.75)
+			return TRUE
+
+	valid_target(mob/living/C)
+		if (is_incapacitated(C)) return FALSE
+		return ..()
+
+	Life(datum/controller/process/mobs/parent)
+		. = ..()
 		if (prob(10))
 			playsound(src.loc, pick(snd_macho_idle), 50, 1, 0, 1.75)
 
-	attack_hand(mob/user)
-		if (src.alive && (user.a_intent != INTENT_HARM))
-			src.visible_message(SPAN_ALERT("<b>[user]</b> pets [src]!"))
-			return
-		..()
-
-	CritterAttack(mob/M)
-		if (ismob(M))
-			src.attacking = 1
-			var/attack_message = ""
-			switch(rand(1,3))
-				if (1)
-					attack_message = "<B>[src]</B> punches [src.target] in the stomach!"
-				if (2)
-					attack_message = "<B>[src]</B> kicks [src.target] with his shoes!"
-				if (3)
-					attack_message = "<B>[src]</B> headbutts [src.target]!"
-			for (var/mob/O in viewers(src, null))
-				O.show_message(SPAN_ALERT("[attack_message]"), 1)
-			playsound(src.loc, "swing_hit", 30, 0)
-			if (prob(10))
-				playsound(src.loc, pick(snd_macho_rage), 50, 1, 0, 1.75)
-			random_brute_damage(src.target, rand(0,1))
-			SPAWN(rand(1,3))
-				src.attacking = 0
-
-	ChaseAttack(mob/M)
-		for (var/mob/O in viewers(src, null))
-			O.show_message(SPAN_ALERT("<B>[src]</B> charges at [M]!"), 1)
-		if (prob(50))
-			playsound(src.loc, pick(snd_macho_rage), 50, 1, 0, 1.75)
-		M.changeStatus("stunned", 1 SECOND)
-		if (prob(25))
-			M.changeStatus("knockdown", 2 SECONDS)
-			random_brute_damage(M, rand(1,2))
-	CritterDeath()
-		..()
-		playsound(src.loc, 'sound/impact_sounds/Slimy_Splat_1.ogg', 75, 1)
-		var/obj/decal/cleanable/blood/gibs/gib = null
-		gib = make_cleanable(/obj/decal/cleanable/blood/gibs,src.loc)
-		gib.streak_cleanable(NORTH)
-		qdel(src)
-
+	death(gibbed, do_drop_equipment)
+		if(!gibbed)
+			src.visible_message("[src] explodes in a shower of meat!")
+			return src.gib()
+		. = ..()
 
 /obj/item/clothing/under/gimmick/macho
 	name = "wrestling pants"

--- a/code/modules/antagonists/macho_man/abilities/_macho_man_mob.dm
+++ b/code/modules/antagonists/macho_man/abilities/_macho_man_mob.dm
@@ -361,7 +361,7 @@ var/list/snd_macho_idle = list('sound/voice/macho/macho_alert16.ogg', 'sound/voi
 	health_brute_vuln = 1
 	health_burn_vuln = 1
 	hand_count = 1
-	add_abilities = list(/datum/targetable/critter/weak_tackle)
+	add_abilities = list(/datum/targetable/critter/tackle/weak)
 	ai_attacks_per_ability = 1
 	ai_retaliates = TRUE
 	ai_retaliate_patience = 0
@@ -388,7 +388,7 @@ var/list/snd_macho_idle = list('sound/voice/macho/macho_alert16.ogg', 'sound/voi
 			playsound(src.loc, pick(snd_macho_rage), 50, 1, 0, 1.75)
 
 	critter_ability_attack(mob/target)
-		var/datum/targetable/critter/weak_tackle/pounce = src.abilityHolder.getAbility(/datum/targetable/critter/weak_tackle)
+		var/datum/targetable/critter/tackle/weak/pounce = src.abilityHolder.getAbility(/datum/targetable/critter/tackle/weak)
 		if(pounce && !pounce.disabled && pounce.cooldowncheck())
 			pounce.handleCast(target)
 			if (prob(50))

--- a/code/obj/item/sponge_capsule.dm
+++ b/code/obj/item/sponge_capsule.dm
@@ -27,7 +27,7 @@
 
 /obj/item/toy/sponge_capsule/syndicate
 	colors = list("#FF0000", "#7F0000", "#FF6A00", "#FFD800", "#7F3300", "#7F6A00")
-	animals = list(/obj/critter/microman,
+	animals = list(/mob/living/critter/microman,
 					/mob/living/critter/bear,
 					/mob/living/critter/spider,
 					/mob/living/critter/brullbar,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[critter][feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mobifies microman
* Adds "Weak tackle" ability
* Overrides melee attack damage to be lower

This keeps the overall power level/behavior of microman roughly the same, though it will deal stamina damage now from limb punching.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
more mob-critters, less obj-critters