### PR TITLE
People with angry buddies trait only get arrested if they have at least 1 contraband

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -848,7 +848,7 @@
 			if (src.threatlevel >= 4)
 				src.EngageTarget(C)
 				break
-			if(C.traitHolder.hasTrait("wasitsomethingisaid"))
+			if(C.traitHolder.hasTrait("wasitsomethingisaid") && src.threatlevel >= 1)
 				src.EngageTarget(C)
 			else
 				continue
@@ -1200,7 +1200,7 @@
 			)
 
 		var/say_thing = pick(voice_lines)
-		if(say_thing == 'sound/voice/binsultbeep.ogg' && prob(90))
+		if(say_thing == 'sound/voice/binsultbeep.ogg' && (prob(90)))
 			say_thing = 'sound/voice/bsecureday.ogg'
 		switch(say_thing)
 			if('sound/voice/bgod.ogg')

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -1200,7 +1200,7 @@
 			)
 
 		var/say_thing = pick(voice_lines)
-		if(say_thing == 'sound/voice/binsultbeep.ogg' && (prob(90)))
+		if(say_thing == 'sound/voice/binsultbeep.ogg' && prob(90))
 			say_thing = 'sound/voice/bsecureday.ogg'
 		switch(say_thing)
 			if('sound/voice/bgod.ogg')


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If you have the "Was it something I said?" trait, Beepsky will now only arrest if you have at least 1 level of contraband.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People use this as an excuse to mess with sec and destroy securitrons. Relevant thread
https://forum.ss13.co/showthread.php?tid=23555


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chatauscours
(+)If you have the "Was it something I said?" trait, Beepsky will now only arrest you if you have at least 1 level of contraband on you.
```
