### PR TITLE
Prevent gauntlet infighting

### DIFF
--- a/_std/macros/factions.dm
+++ b/_std/macros/factions.dm
@@ -26,6 +26,8 @@
 #define FACTION_DERELICT		"derelict"
 /// Space Ants
 #define FACTION_FERMID			"fermid"
+/// Gauntlet-spawned
+#define FACTION_GUANTLET		"gauntlet"
 
 /// Returns TRUE if ourguy is enemies with otherguy FALSE otherwise
 proc/faction_check(mob/ourguy, mob/otherguy, attack_neutral)

--- a/code/datums/gauntlet/crittergauntlet.dm
+++ b/code/datums/gauntlet/crittergauntlet.dm
@@ -1034,6 +1034,7 @@ var/global/datum/arena/gauntletController/gauntlet_controller = new()
 			else if (isliving(mob_or_critter))
 				var/mob/living/critter/C = mob_or_critter
 				C.health *= health_multiplier //for critters that don't user health holders
+				C.faction = list(FACTION_GUANTLET)
 				for(var/damage_key in C.healthlist) //for critters that do
 					var/datum/healthHolder/HH = C.healthlist[damage_key]
 					HH.maximum_value *= health_multiplier


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][ai]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Assign all gauntlet mobs to a new gauntlet-specific faction, so they stop infighting.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #15463
