### PR TITLE
Fix bug preventing broken transport chutes from being fixable

### DIFF
--- a/code/modules/disposals/disposal_chute.dm
+++ b/code/modules/disposals/disposal_chute.dm
@@ -735,7 +735,28 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 		return
 
 	attackby(var/obj/item/I, var/mob/user)
-		return
+		if(status & BROKEN)
+			switch(src.repair_step)
+				if(DISPOSAL_REPAIR_STEP_SCREWDRIVER)
+					if(isscrewingtool(I))
+						playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, TRUE)
+						src.visible_message("[user] loosens the jammed retaining screws.")
+						src.repair_step = DISPOSAL_REPAIR_STEP_CROWBAR
+					else
+						boutput(user, SPAN_HINT("You need to <b>loosen</b> the retaining screws."))
+
+				if(DISPOSAL_REPAIR_STEP_CROWBAR)
+					if(ispryingtool(I))
+						playsound(src.loc, 'sound/machines/airlock_pry.ogg', 35, TRUE)
+						src.visible_message("[user] pries the chute locking panels back in place")
+						src.repair_step = DISPOSAL_REPAIR_STEP_FIXED
+						src.status &= ~BROKEN
+						src.mode = DISPOSAL_CHUTE_CHARGING
+						src.icon_state = initial(icon_state)
+						src.update()
+					else
+						boutput(user, SPAN_HINT("You need to <b>pry</b> the locking panels."))
+			return
 
 	Entered()
 		. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
`/obj/machinery/disposal/transport` overrides `attackby` of the parent, preventing the repair steps from being checked.

fix this with a dirty copy/paste of repair code. this should be swapped to using equipment fault component in the future (but that is a more involved PR)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22135