### PR TITLE
Fix cloned puritans not always dropping brain on gib

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1782,6 +1782,10 @@ TYPEINFO(/datum/mutantrace/premature_clone)
 				sleep(rand(40, 120))
 				src.mob.gib()
 
+	disposing()
+		REMOVE_ATOM_PROPERTY(src.mob, PROP_HUMAN_DROP_BRAIN_ON_GIB, "puritan")
+		. = ..()
+
 // some new simple gimmick junk
 
 /datum/mutantrace/gross

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -314,7 +314,7 @@ TYPEINFO(/obj/machinery/clonepod)
 				defects.add_random_cloner_defect(CLONER_DEFECT_SEVERITY_MAJOR)
 				src.occupant.bioHolder?.AddEffect("premature_clone")
 				src.occupant.take_toxin_damage(350)
-				APPLY_ATOM_PROPERTY(src, PROP_HUMAN_DROP_BRAIN_ON_GIB, "puritan")
+				APPLY_ATOM_PROPERTY(src.occupant, PROP_HUMAN_DROP_BRAIN_ON_GIB, "puritan")
 				random_brute_damage(src.occupant, 200, 0)
 				if (ishuman(src.occupant))
 					var/mob/living/carbon/human/P = src.occupant


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[medical][bug][mutantrace]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* apply the `PROP_HUMAN_DROP_BRAIN_ON_GIB` property to the occupant instead of the clone pod
* remove the property when disposing the premature clone mutrace

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22088
Fix #22100
Fix #22114
Ensure cured puriclones don't always drop brain on gib 