### PR TITLE
Add negative light to lamp artifact

### DIFF
--- a/_std/color.dm
+++ b/_std/color.dm
@@ -112,6 +112,9 @@
 								0,0,0,1,\
 								0,0,0,0)
 
+#define COLOR_MATRIX_INVERSE_LABEL "inverse"
+#define COLOR_MATRIX_INVERSE list(-1, 0, 0, 0, -1, 0, 0, 0, -1, 1, 1, 1)
+
 /// Takes two 20-length lists, turns them into 5x4 matrices, multiplies them together, and returns a 20-length list
 /proc/mult_color_matrix(var/list/Mat1, var/list/Mat2) // always 5x4 please
 	if (length(Mat1) != 20 || length(Mat2) != 20)

--- a/code/WorkInProgress/tarmStuff.dm
+++ b/code/WorkInProgress/tarmStuff.dm
@@ -997,7 +997,7 @@ TYPEINFO(/obj/item/device/geiger)
 	cell_type = /obj/item/ammo/power_cell/self_charging/ntso_signifer
 	from_frame_cell_type = /obj/item/ammo/power_cell/self_charging/ntso_signifer/bad
 	can_swap_cell = 0
-	color = list(-1, 0, 0, 0, -1, 0, 0, 0, -1, 1, 1, 1)
+	color = COLOR_MATRIX_INVERSE
 
 	New()
 		set_current_projectile(new/datum/projectile/special/timegun/theBulletThatShootsTheFuture)

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -224,6 +224,7 @@ var/datum/artifact_controller/artifact_controls
 	var/scramblechance = 10 //probability to have "fake" artifact with altered appearance
 	var/list/activation_sounds = list()
 	var/list/instrument_sounds = list()
+	var/list/lightswitch_sounds = list('sound/misc/lightswitch.ogg')
 	var/list/fault_types = list("all")
 	var/list/adjectives = list("strange","unusual","odd","curious","bizarre","weird","abnormal","peculiar")
 	var/list/nouns_large = list("object","machine","artifact","contraption","structure","edifice")
@@ -319,6 +320,7 @@ var/datum/artifact_controller/artifact_controls
 		'sound/musical_instruments/artifact/Artifact_Martian_2.ogg',
 		'sound/musical_instruments/artifact/Artifact_Martian_3.ogg',
 		'sound/musical_instruments/artifact/Artifact_Martian_4.ogg')
+	lightswitch_sounds = list('sound/impact_sounds/Slimy_Splat_1.ogg', 'sound/impact_sounds/Slimy_Hit_4.ogg', 'sound/impact_sounds/Slimy_Hit_3.ogg')
 	impact_reaction_one = 1
 	impact_reaction_two = 0
 	heat_reaction_one = 0.99
@@ -402,6 +404,7 @@ var/datum/artifact_controller/artifact_controls
 		'sound/musical_instruments/artifact/Artifact_Wizard_2.ogg',
 		'sound/musical_instruments/artifact/Artifact_Wizard_3.ogg',
 		'sound/musical_instruments/artifact/Artifact_Wizard_4.ogg')
+	lightswitch_sounds = list('sound/effects/mag_forcewall.ogg', 'sound/effects/MagShieldUp.ogg', 'sound/effects/MagShieldDown.ogg')
 	impact_reaction_one = 8
 	impact_reaction_two = 6
 	heat_reaction_one = 0.75

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -791,7 +791,7 @@ ABSTRACT_TYPE(/datum/material/metal)
 	mat_id = "negativematter"
 	name = "negative matter"
 	desc = "It seems to repel matter."
-	color = list(-1, 0, 0, 0, -1, 0, 0, 0, -1, 1, 1, 1)
+	color = COLOR_MATRIX_INVERSE
 
 	New()
 		..()

--- a/code/obj/artifacts/artifact_objects/lamp.dm
+++ b/code/obj/artifacts/artifact_objects/lamp.dm
@@ -83,7 +83,6 @@
 		src.appearance_flags |= RESET_TRANSFORM
 		RegisterSignal(loc, COMSIG_MOVABLE_MOVED, PROC_REF(update_whacky))
 		update_whacky(loc, null, 0)
-		src.add_filter("test", 1, alpha_mask_filter(0,0,icon('icons/effects/overlays/knockout.dmi',"knockout")))
 
 	proc/update_whacky(var/atom/movable/thing, prev_loc, dir)
 		src.vis_contents.Cut()

--- a/code/obj/artifacts/artifact_objects/lamp.dm
+++ b/code/obj/artifacts/artifact_objects/lamp.dm
@@ -18,9 +18,13 @@
 		light.set_brightness(light_brightness)
 		light.set_color(light_r, light_g, light_b)
 		light.attach(src)
-		if(prob(20)) //20 chance this is an inverting lamp
+		if(prob(100)) //20 chance this is an inverting lamp
 			bonus_light = new /obj/effect/whackylight(src, light.radius)
 			src.vis_contents += bonus_light
+
+	disposing()
+		. = ..()
+		QDEL_NULL(bonus_light) //because it exists on the map, it won't get cleaned up automatically
 
 /datum/artifact/lamp
 	associated_object = /obj/artifact/lamp

--- a/code/obj/artifacts/artifact_objects/lamp.dm
+++ b/code/obj/artifacts/artifact_objects/lamp.dm
@@ -82,6 +82,7 @@
 		else
 			src.color = color
 		src.appearance_flags |= RESET_TRANSFORM
+		RegisterSignal(loc, COMSIG_MOVABLE_SET_LOC, PROC_REF(update_whacky))
 		RegisterSignal(loc, COMSIG_MOVABLE_MOVED, PROC_REF(update_whacky))
 		update_whacky(loc, null, 0)
 
@@ -96,3 +97,5 @@
 					src.vis_contents += T
 					src.pixel_x = min(-world.icon_size*(T.x - src.loc.x), src.pixel_x)
 					src.pixel_y = min(-world.icon_size*(T.y - src.loc.y), src.pixel_y)
+		else
+			src.vis_contents.Cut()

--- a/code/obj/artifacts/artifact_objects/lamp.dm
+++ b/code/obj/artifacts/artifact_objects/lamp.dm
@@ -23,7 +23,7 @@
 		light.set_brightness(light_brightness)
 		light.set_color(light_r, light_g, light_b)
 		light.attach(src)
-		if(prob(100)) //chance this is an inverting lamp
+		if(prob(50)) //chance this is an inverting lamp
 			var/color = pick(possible_color_matrices)
 			bonus_light = new /obj/effect/whackylight(src, light.radius, color)
 			src.vis_flags |= VIS_HIDE

--- a/code/obj/artifacts/artifact_objects/lamp.dm
+++ b/code/obj/artifacts/artifact_objects/lamp.dm
@@ -11,7 +11,6 @@
 	var/static/list/possible_color_matrices = list(
 		COLOR_MATRIX_GRAYSCALE,
 		COLOR_MATRIX_FLOCKMANGLED,
-		COLOR_MATRIX_FLOCKMIND,
 		COLOR_MATRIX_INVERSE)
 
 	New()
@@ -24,10 +23,10 @@
 		light.set_brightness(light_brightness)
 		light.set_color(light_r, light_g, light_b)
 		light.attach(src)
-		if(prob(40)) //chance this is an inverting lamp
+		if(prob(100)) //chance this is an inverting lamp
 			var/color = pick(possible_color_matrices)
 			bonus_light = new /obj/effect/whackylight(src, light.radius, color)
-			src.vis_contents += bonus_light
+			src.vis_flags |= VIS_HIDE
 
 	disposing()
 		. = ..()
@@ -72,6 +71,8 @@
 
 	var/radius
 	var/active = FALSE
+	glide_size = INFINITY //no gliding for you!
+	anchored = TRUE //not really, but we do our own moving thank you very much
 
 	New(loc, radius=2, color=null)
 		.=..(get_turf(loc))
@@ -85,9 +86,11 @@
 		update_whacky(loc, null, 0)
 
 	proc/update_whacky(var/atom/movable/thing, prev_loc, dir)
-		src.vis_contents.Cut()
 		src.loc = get_turf(thing)
 		if(active)
+			for(var/turf/T in src.vis_contents)
+				if(!IN_EUCLIDEAN_RANGE(src.loc, T, src.radius))
+					src.vis_contents -= T
 			for(var/turf/T in range(src.loc, src.radius))
 				if(IN_EUCLIDEAN_RANGE(src.loc, T, src.radius))
 					src.vis_contents += T

--- a/code/obj/artifacts/artifact_objects/lamp.dm
+++ b/code/obj/artifacts/artifact_objects/lamp.dm
@@ -18,7 +18,7 @@
 		light.set_brightness(light_brightness)
 		light.set_color(light_r, light_g, light_b)
 		light.attach(src)
-		if(prob(100)) //20 chance this is an inverting lamp
+		if(prob(20)) //20 chance this is an inverting lamp
 			bonus_light = new /obj/effect/whackylight(src, light.radius)
 			src.vis_contents += bonus_light
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I was nerd sniped.

![image](https://github.com/user-attachments/assets/bd81042a-2dc2-4303-8680-412b3f99822f)
![image](https://github.com/user-attachments/assets/72c5dce6-4500-4261-8619-c4a7d6673878)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lamps are boring.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Amylizzle
(+)Lamp artifacts now have a chance to spawn with negative lighting.

```
