### PR TITLE
Kinetic and piercing projectiles only cause a lastgasp if they deal damage

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -2016,7 +2016,7 @@
 					src.do_disorient(clamp(stun*4, P.proj_data.stun*2, stun+80), knockdown = stun*2, stunned = 0, disorient = 0, remove_stamina_below_zero = 0, target_type = DISORIENT_NONE)
 
 				src.TakeDamage("chest", (damage/rangedprot_mod), 0, 0, P.proj_data.hit_type)
-				if (isalive(src))
+				if (damage > 0 && isalive(src))
 					lastgasp()
 
 			if (D_PIERCING)
@@ -2024,7 +2024,7 @@
 					src.do_disorient(clamp(stun*4, P.proj_data.stun*2, stun+80), knockdown = stun*2, stunned = 0, disorient = 0, remove_stamina_below_zero = 0, target_type = DISORIENT_NONE)
 
 				src.TakeDamage("chest", damage/rangedprot_mod, 0, 0, P.proj_data.hit_type)
-				if (isalive(src))
+				if (damage > 0 && isalive(src))
 					lastgasp()
 
 			if (D_SLASHING)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
check that `D_KINETIC` and `D_PIERCING` projectiles deal damage before doing a lastgasp

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stop cyborg foamdarts from lastgasp-ing while still maintaining their small stun value.

Tested and detective .38 stunners still lastgasp as they're already `D_ENERGY`, for Other Reasons.