### PR TITLE
Make scuttlebot hat immune to acid

### DIFF
--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -303,6 +303,7 @@ proc/filter_trait_hats(var/type)
 //A robot in disguise, ready to go and spy on everyone for you
 /obj/item/clothing/head/det_hat/folded_scuttlebot
 	blocked_from_petasusaphilic = TRUE
+	item_function_flags = IMMUNE_TO_ACID
 	var/inspector = FALSE
 	desc = "Someone who wears this will look very smart. It looks a bit heavier than it should."
 
@@ -332,6 +333,7 @@ proc/filter_trait_hats(var/type)
 /obj/item/clothing/head/det_hat/gadget
 	name = "DetGadget hat"
 	desc = "Detective's special hat you can outfit with various items for easy retrieval!"
+	item_function_flags = IMMUNE_TO_ACID
 	var/phrase = "go go gadget"
 
 	var/list/items

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -333,7 +333,6 @@ proc/filter_trait_hats(var/type)
 /obj/item/clothing/head/det_hat/gadget
 	name = "DetGadget hat"
 	desc = "Detective's special hat you can outfit with various items for easy retrieval!"
-	item_function_flags = IMMUNE_TO_ACID
 	var/phrase = "go go gadget"
 
 	var/list/items


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Marks the syndicate scuttlebot hat as acid-proof.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Chemical acids should not remove unique and irreplacable items from the round.