### PR TITLE
Don't spawn internals in gauntlet backpacks

### DIFF
--- a/code/datums/gauntlet/crittergauntlet.dm
+++ b/code/datums/gauntlet/crittergauntlet.dm
@@ -338,7 +338,7 @@
 		resetting = 0
 
 	proc/spawnGear(var/turf/target, var/mob/forwhom)
-		new /obj/item/storage/backpack/NT(target)
+		new /obj/item/storage/backpack/empty/NT(target)
 		new /obj/item/clothing/suit/armor/tdome/yellow(target)
 		var/list/masks = list(/obj/item/clothing/mask/batman, /obj/item/clothing/mask/clown_hat, /obj/item/clothing/mask/horse_mask, /obj/item/clothing/mask/moustache, /obj/item/clothing/mask/gas/swat, /obj/item/clothing/mask/owl_mask, /obj/item/clothing/mask/hunter, /obj/item/clothing/mask/skull, /obj/item/clothing/mask/spiderman)
 		var/masktype = pick(masks)

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -65,6 +65,12 @@
 		item_state = "backpackg"
 		desc = "A thick, wearable container made of synthetic fibers. The green variation reminds you of a botanist's garden..."
 
+	NT
+		name = "\improper NT backpack"
+		desc = "A stylish blue, thick, wearable container made of synthetic fibers, able to carry a number of objects comfortably on a crewmember's back."
+		icon_state = "NTbackpack"
+		item_state = "NTbackpack"
+
 /obj/item/storage/backpack/withO2
 	spawn_contents = list(/obj/item/storage/box/starter/withO2)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Spawn an empty NT backpack instead of one with internals for the gauntlet

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Internals don't make sense in VR