### PR TITLE
Fix COMPONENT_DUPE_HIGHLANDER 

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -499,8 +499,8 @@ var/datum/signal_holder/global_signal_holder
 						new_comp = new nt(raw_args)
 					if(!QDELETED(new_comp))
 						new_comp.InheritComponent(old_comp, FALSE)
-						qdel(new_comp)
-						new_comp = null
+						qdel(old_comp)
+						old_comp = null
 				if(COMPONENT_DUPE_UNIQUE_PASSARGS)
 					if(!new_comp)
 						var/list/arguments = raw_args.Copy(2)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Fixes `COMPONENT_DUPE_HIGHLANDER` behavior to delete the old component in favor of the new as documented


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* The current behavior sets up the new component to replace the old one and then just deletes it
* This has been broken for over 5 years and is the default behavior, there may exist code reliant on the broken behavior 