### PR TITLE
Fix show item right hand not aligning with shown item

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -2004,6 +2004,7 @@
 		else
 			hand_icon_state = "[hand_icon]_hold_r"
 			src.pixel_x_offset = -src.pixel_x_offset
+			src.pixel_x_hand_offset = -src.pixel_x_hand_offset
 
 		var/image/overlay = src.item.SafeGetOverlayImage("showoff_overlay", src.item.icon, src.item.icon_state, MOB_LAYER + 0.1, src.pixel_x_offset, src.pixel_y_offset)
 		var/image/hand_overlay = src.item.SafeGetOverlayImage("showoff_hand_overlay", 'icons/effects/effects.dmi', hand_icon_state, MOB_LAYER + 0.11, src.pixel_x_hand_offset, src.pixel_y_hand_offset, color=user.get_fingertip_color())


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
for right-handed show item actions, mirror the hand overlay's pixel_x offset to match how the item offset is handled


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
the hand doesnt look like its holding the id/badge/disk
Fix #22007


## Screenshots
### BEFORE / CURRENT
![Screenshot 2025-01-31 225817](https://github.com/user-attachments/assets/b2c0ba4f-4717-4ccf-b8dc-8eb2d3a291bc)

### AFTER / THIS PR
![Screenshot 2025-01-31 234325](https://github.com/user-attachments/assets/437d6dab-040e-4df2-a495-7b4dbba8a3ff)
![Screenshot 2025-01-31 234248](https://github.com/user-attachments/assets/9a9af62d-b20f-4462-ba81-8c1143ead59d)
![Screenshot 2025-01-31 234300](https://github.com/user-attachments/assets/bf898fd8-b219-4aeb-8c8e-301cc5a51fec)
