### PR TITLE
Change the radio station putt frame to the preassembled type

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -1432,12 +1432,11 @@
 	},
 /area/radiostation/podbay)
 "aes" = (
-/obj/structure/vehicleframe/puttframe,
-/obj/item/shipcomponent/life_support,
 /obj/decal/cleanable/oil/streak,
 /obj/machinery/light_switch/north{
 	pixel_y = 30
 	},
+/obj/structure/preassembeled_vehicleframe/puttframe,
 /turf/simulated/floor/shuttlebay,
 /area/radiostation/podbay)
 "aet" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The radio station putt frame still uses the older style putt construction frame. This replaces it with the preassembled frame that podfabs currently print.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22084