### PR TITLE
Close AI Viewports on death

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -941,8 +941,7 @@ or don't if it uses a custom topopen overlay
 	if (deployed_shell)
 		src.return_to(deployed_shell)
 
-	var/list/viewports = src.client?.getViewportsByType(VIEWPORT_ID_AI)
-	for(var/datum/viewport/viewport as anything in viewports)
+	for(var/datum/viewport/viewport as anything in src.client?.getViewportsByType(VIEWPORT_ID_AI))
 		viewport.Close()
 
 	src.lastgasp() // calling lastgasp() here because we just died

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -941,6 +941,10 @@ or don't if it uses a custom topopen overlay
 	if (deployed_shell)
 		src.return_to(deployed_shell)
 
+	var/list/viewports = src.client?.getViewportsByType(VIEWPORT_ID_AI)
+	for(var/datum/viewport/viewport as anything in viewports)
+		viewport.Close()
+
 	src.lastgasp() // calling lastgasp() here because we just died
 	setdead(src)
 	src.canmove = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][silicons]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
After we return to the AI mainframe, close all our current AI viewports.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #8528 - AI viewports shouldn't remain after death