### PR TITLE
Fix reagent transfer targets not being updated properly

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -345,12 +345,13 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 				if ( CI++ == index )
 					var/datum/reagent/current_reagent = reagent_list[reagent_id]
 					if (isnull(current_reagent) || current_reagent.volume == 0)
-						return 0
+						break
 					var/transfer_amt = min(current_reagent.volume,amount)
 					var/receive_amt = transfer_amt * multiplier
 					target_reagents.add_reagent(reagent_id, receive_amt, current_reagent.data, src.total_temperature, TRUE, TRUE)
 					current_reagent.on_transfer(src, target_reagents, receive_amt)
 					src.remove_reagent(reagent_id, transfer_amt, FALSE, FALSE)
+					break
 
 		if (update_self_reagents)
 			src.update_total()

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -351,7 +351,6 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 					target_reagents.add_reagent(reagent_id, receive_amt, current_reagent.data, src.total_temperature, TRUE, TRUE)
 					current_reagent.on_transfer(src, target_reagents, receive_amt)
 					src.remove_reagent(reagent_id, transfer_amt, FALSE, FALSE)
-					return 0
 
 		if (update_self_reagents)
 			src.update_total()
@@ -365,7 +364,7 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 		if (update_target_reagents)
 			target_reagents.update_total()
 			target_reagents.handle_reactions()
-			target_reagents.reagents_changed()
+			target_reagents.reagents_changed(TRUE)
 
 		reagents_transferred()
 		return amount


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][chemistry]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Because we're deferring updates, we don't want to return early in the `for` loop
* Ensure we set `add` to `TRUE` for the target reagent holder so it can run e.g. whitelist checks

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22187
Fix #22151
Fix #22146
Fix #22161
