### PR TITLE
Fix powernet component mangling incoming packets

### DIFF
--- a/code/modules/mechanics/MechanicsNetworkCon.dm
+++ b/code/modules/mechanics/MechanicsNetworkCon.dm
@@ -115,6 +115,8 @@
 		//command=term_message&data=command=trigger&data=yoursignal&adress_1=targetId&sender=senderId
 
 	proc/sendRaw(var/datum/signal/S)
+		for(var/i in S.data) //Normalize the text before we sanitize it again with list2params
+			S.data[i] = html_decode(S.data[i])
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL, list2params(S.data), S.data_file?.copy_file())
 		animate_flash_color_fill(src,"#00AA00",1, 1)
 		return

--- a/code/modules/medical/genetics/bioEffects/speech.dm
+++ b/code/modules/medical/genetics/bioEffects/speech.dm
@@ -427,16 +427,16 @@
 		if (!istext(message))
 			return ""
 
-		message = replacetext(message, "a", vowel_lower)
-		message = replacetext(message, "e", vowel_lower)
-		message = replacetext(message, "i", vowel_lower)
-		message = replacetext(message, "o", vowel_lower)
-		message = replacetext(message, "u", vowel_lower)
-		message = replacetext(message, "A", vowel_upper)
-		message = replacetext(message, "E", vowel_upper)
-		message = replacetext(message, "I", vowel_upper)
-		message = replacetext(message, "O", vowel_upper)
-		message = replacetext(message, "U", vowel_upper)
+		message = replacetextEx(message, "a", vowel_lower)
+		message = replacetextEx(message, "e", vowel_lower)
+		message = replacetextEx(message, "i", vowel_lower)
+		message = replacetextEx(message, "o", vowel_lower)
+		message = replacetextEx(message, "u", vowel_lower)
+		message = replacetextEx(message, "A", vowel_upper)
+		message = replacetextEx(message, "E", vowel_upper)
+		message = replacetextEx(message, "I", vowel_upper)
+		message = replacetextEx(message, "O", vowel_upper)
+		message = replacetextEx(message, "U", vowel_upper)
 
 		return message
 


### PR DESCRIPTION
[Station Systems] [Bugfix] [Trivial]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Similar fix to  #3254 for powernet, use list2params instead of throwing a broken unescaped version together. This results in signals from the powernet always being possible to decode with the signal splitter.

![image](https://github.com/user-attachments/assets/999a13f7-ccd2-49e2-9f69-fd3087a8c7f8)

I pre-decode the signals before using list2params to normalize anything already sanitized.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

If a signal list can't be split it's not much good is it? Saves players from resorting to implementing their own parser in regex.
