### PR TITLE
Deconstructors use Pre-Attack signal instead of afterattack

### DIFF
--- a/code/WorkInProgress/AzrunStuff.dm
+++ b/code/WorkInProgress/AzrunStuff.dm
@@ -4,14 +4,20 @@
 	desc = "A magical saw-like device for unmaking things. Is that a soldering iron on the back?"
 	default_material = "miracle"
 
-	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
+	New()
+		. = ..()
+		RegisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE, PROC_REF(pre_attackby), override=TRUE)
+
+	pre_attackby(source, atom/target, mob/user)
 		if (!isobj(target))
 			return
-		if(istype(target, /obj/item/electronics/frame))
+		if (istype(target, /obj/item/electronics/frame))
 			var/obj/item/electronics/frame/F = target
 			F.deploy(user)
+			return ATTACK_PRE_DONT_ATTACK
 
 		finish_decon(target, user)
+		return ATTACK_PRE_DONT_ATTACK
 
 /obj/item/paper/artemis_todo
 	icon = 'icons/obj/electronics.dmi';

--- a/code/datums/components/transfers.dm
+++ b/code/datums/components/transfers.dm
@@ -114,9 +114,6 @@
 #define CONTAINER_CHOICE_DUMP  "Dump its contents inside"
 
 /datum/component/transfer_input/proc/handle_attackby(comsig_target, atom/movable/incoming, mob/attacker)
-	if (istype(incoming, /obj/item/deconstructor))
-		return
-
 	if(cant_do_shit(attacker))
 		return
 

--- a/code/modules/disposals/disposal_chute.dm
+++ b/code/modules/disposals/disposal_chute.dm
@@ -159,9 +159,6 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 					else
 						boutput(user, SPAN_HINT("You need to <b>pry</b> the locking panels."))
 			return
-		if (istype(I,/obj/item/deconstructor))
-			user.visible_message(SPAN_ALERT("<B>[user] hits [src] with [I]!</B>"))
-			return
 		if (istype(I, /obj/item/handheld_vacuum))
 			return
 		if (istype(I,/obj/item/satchel/) && I.contents.len)

--- a/code/modules/materials/Mat_Fabrication.dm
+++ b/code/modules/materials/Mat_Fabrication.dm
@@ -350,8 +350,6 @@
 		W.set_loc(src)
 
 	attackby(var/obj/item/W , mob/user as mob)
-		if(istype(W, /obj/item/deconstructor))
-			return ..()
 		if(issilicon(user)) // fix bug where borgs could put things into the nanofab and then reject them
 			boutput(user, SPAN_ALERT("You can't put that in, it's attached to you."))
 			return

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -347,8 +347,6 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 		src.scan = null
 
 /obj/machinery/vending/attackby(obj/item/W, mob/user)
-	if (istype(W,/obj/item/electronics/scanner) || istype(W,/obj/item/deconstructor)) // So people don't end up making the vending machines fall on them when they try to scan/deconstruct it
-		return
 	if (istype(W, /obj/item/currency/spacecash))
 		if (src.pay)
 			src.credit += W.amount

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -911,6 +911,11 @@
 	tool_flags = TOOL_SAWING
 	c_flags = ONBELT
 	w_class = W_CLASS_NORMAL
+	HELP_MESSAGE_OVERRIDE("Use the Help, Disarm, or Grab intents to attempt deconstructing objects when you click them. Switch to Harm intent to use as a weapon.")
+
+	New()
+		. = ..()
+		RegisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE, PROC_REF(pre_attackby))
 
 	proc/finish_decon(atom/target,mob/user) // deconstructing work
 		if (!isobj(target))
@@ -946,48 +951,53 @@
 			F.RegisterSignal(O, COMSIG_ATOM_ENTERED, TYPE_PROC_REF(/obj/item/electronics/frame, kickout))
 
 	MouseDrop_T(atom/target, mob/user)
-		if (!isobj(target))
-			return
-		src.AfterAttack(target,user)
+		src.pre_attackby(src, target, user)
 		..()
 
-	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
+	proc/pre_attackby(source, atom/target, mob/user)
+		if (user.a_intent == INTENT_HARM)
+			return
 		if (!isobj(target))
+			return
+		if (iscritter(target))
 			return
 		var/obj/O = target
 
 		var/decon_complexity = O.build_deconstruction_buttons()
 		if (!decon_complexity || !O.can_deconstruct(user))
+			if (istype(O, /obj/item/storage))
+				return // if we're here, it's storage we cannot deconstruct
 			boutput(user, SPAN_ALERT("[target] cannot be deconstructed."))
 			if (O.deconstruct_flags & DECON_NULL_ACCESS)
 				boutput(user, SPAN_ALERT("[target] is under an access lock and must have its access requirements removed first."))
-			return
+			return ATTACK_PRE_DONT_ATTACK
 		if (istext(decon_complexity))
 			boutput(user, SPAN_ALERT("[decon_complexity]"))
-			return
+			return ATTACK_PRE_DONT_ATTACK
 		if (issilicon(user) && (O.deconstruct_flags & DECON_NOBORG))
 			boutput(user, SPAN_ALERT("Cyborgs cannot deconstruct this [target]."))
-			return
+			return ATTACK_PRE_DONT_ATTACK
 		if ((!(O.allowed(user) || O.deconstruct_flags & DECON_NO_ACCESS) || O.is_syndicate) && !(O.deconstruct_flags & DECON_BUILT))
 			boutput(user, SPAN_ALERT("You cannot deconstruct [target] without sufficient access to operate it."))
-			return
+			return ATTACK_PRE_DONT_ATTACK
 
 		if(length(get_all_mobs_in(O)))
 			boutput(user, SPAN_ALERT("You cannot deconstruct [target] while someone is inside it!"))
-			return
+			return ATTACK_PRE_DONT_ATTACK
 
 		if (isrestrictedz(O.z) && !isitem(target) && !istype(get_area(O), /area/salvager)) //let salvagers deconstruct on the magpie
 			boutput(user, SPAN_ALERT("You cannot bring yourself to deconstruct [target] in this area."))
-			return
+			return ATTACK_PRE_DONT_ATTACK
 
 		if (O.decon_contexts && length(O.decon_contexts) <= 0) //ready!!!
 			boutput(user, "Deconstructing [O], please remain still...")
 			playsound(user.loc, 'sound/effects/pop.ogg', 50, 1)
 			actions.start(new/datum/action/bar/icon/deconstruct_obj(target,src,(decon_complexity * 2.5 SECONDS)), user)
+			return ATTACK_PRE_DONT_ATTACK
 		else
 			user.showContextActions(O.decon_contexts, O)
 			boutput(user, SPAN_ALERT("You need to use some tools on [target] before it can be deconstructed."))
-			return
+			return ATTACK_PRE_DONT_ATTACK
 
  // here be extra surgery penalties
 	attack(mob/target, mob/user, def_zone, is_special = FALSE, params = null)

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -917,6 +917,11 @@
 		. = ..()
 		RegisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE, PROC_REF(pre_attackby))
 
+	disposing()
+		UnregisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE)
+		. = ..()
+
+
 	proc/finish_decon(atom/target,mob/user) // deconstructing work
 		if (!isobj(target))
 			return
@@ -966,7 +971,7 @@
 		var/decon_complexity = O.build_deconstruction_buttons()
 		if (!decon_complexity || !O.can_deconstruct(user))
 			if (istype(O, /obj/item/storage))
-				return // if we're here, it's storage we cannot deconstruct
+				return // if we're here, it's storage we cannot deconstruct, so attempt stowing it
 			boutput(user, SPAN_ALERT("[target] cannot be deconstructed."))
 			if (O.deconstruct_flags & DECON_NULL_ACCESS)
 				boutput(user, SPAN_ALERT("[target] is under an access lock and must have its access requirements removed first."))

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -877,8 +877,6 @@ TYPEINFO(/obj/machinery/manufacturer)
 			if (src.shock(user, 33))
 				return
 
-		if (istype(W, /obj/item/deconstructor)) return  // handled in decon afterattack
-
 		// Handling for getting the satchel of an ore scoop
 		if (istype(W, /obj/item/ore_scoop))
 			var/obj/item/ore_scoop/scoop = W

--- a/code/obj/machinery/optable.dm
+++ b/code/obj/machinery/optable.dm
@@ -75,8 +75,6 @@ TYPEINFO(/obj/machinery/optable)
 
 /obj/machinery/optable/attackby(obj/item/W, mob/user)
 	if (issilicon(user)) return
-	if (istype(W, /obj/item/electronics/scanner)) return // hack
-	if (istype(W, /obj/item/deconstructor)) return //deconstruct_flags
 	if (istype(W, /obj/item/grab))
 		if(ismob(W:affecting))
 			var/mob/M = W:affecting


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Convert deconstruction tool `afterattack` into a pre-attackby callback
* Add help text explaining functionality
* Make explicit exception for objcritters (i.e. always attack them) 
* Remove scattered deconstruction tool special-casing in the codebase

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* No longer require special-casing for deconstruction tools
* Make deconstruction tools work like device analyzers i.e. help/disarm/grab is special functionality, harm is regular item usage (i.e. attack with)

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Deconstruction tools will always try to deconstruct objects on help, disarm, and grab intents. On harm intent, deconstruction tools will be used like a normal item on objects.
```
