### PR TITLE
Fix minor typo in z5 prefab audiolog

### DIFF
--- a/code/obj/item/device/audio_log.dm
+++ b/code/obj/item/device/audio_log.dm
@@ -448,7 +448,7 @@ TYPEINFO(/obj/item/device/audio_log)
 								"Re-routing remaaaaaainiiiiiing power to top-deck cyro-sleepers.",
 								"*humming electronics*",
 								"Autopilot disengaged.",
-								"Delopying emergency beacon.",
+								"Deploying emergency beacon.",
 								"Central c-c-cOmpUtEr shut- d-dow-ow-ow-ownnnnn in 5,",
 								"4,",
 								"3-",


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[trivial][game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fix a typo in "Deploying" for sleepership audio log

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
typo bad