### PR TITLE
airbridge turfs and walls block foreground parallax

### DIFF
--- a/code/turf/turf_drawbridge.dm
+++ b/code/turf/turf_drawbridge.dm
@@ -26,7 +26,9 @@
 	// regular white steel floor for now but a good candidate for new sprites!
 	icon_state = "airbridge"
 	name = "airbridge floor"
+	occlude_foreground_parallax_layers = TRUE
 
 /turf/simulated/wall/airbridge
 	icon_state = "airbridge"
 	name = "airbridge wall"
+	occlude_foreground_parallax_layers = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
make airbridge wall and floor turfs block the foreground parallax layers, often used with terrainify

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They feel like they're supposed to be covered like station turfs are.