### PR TITLE
Adds an adjustable instrument volume channel

### DIFF
--- a/_std/defines/sound.dm
+++ b/_std/defines/sound.dm
@@ -23,6 +23,7 @@ var/global/admin_sound_channel = SOUNDCHANNEL_ADMIN_LOW // current admin channel
 #define VOLUME_CHANNEL_ADMIN 4
 #define VOLUME_CHANNEL_EMOTE 5
 #define VOLUME_CHANNEL_MENTORPM 6
+#define VOLUME_CHANNEL_INSTRUMENTS 7
 
 var/global/list/audio_channel_name_to_id = list(
 	"master" = VOLUME_CHANNEL_MASTER,
@@ -31,7 +32,8 @@ var/global/list/audio_channel_name_to_id = list(
 	"radio" = VOLUME_CHANNEL_RADIO,
 	"admin" = VOLUME_CHANNEL_ADMIN,
 	"emote" = VOLUME_CHANNEL_EMOTE,
-	"mentorpm" = VOLUME_CHANNEL_MENTORPM
+	"mentorpm" = VOLUME_CHANNEL_MENTORPM,
+	"instruments" = VOLUME_CHANNEL_INSTRUMENTS
 )
 
 //Area Ambience

--- a/code/modules/items/instruments/instruments.dm
+++ b/code/modules/items/instruments/instruments.dm
@@ -90,7 +90,7 @@
 			player.cooldowns["instrument_play"] += 10 SECONDS
 
 		var/turf/T = get_turf(src)
-		playsound(T, sounds_instrument[note], src.volume, randomized_pitch, pitch = pitch_set)
+		playsound(T, sounds_instrument[note], src.volume, randomized_pitch, pitch = pitch_set, channel = VOLUME_CHANNEL_INSTRUMENTS)
 
 		if (prob(5))
 			if (src.dog_bark)
@@ -191,7 +191,7 @@
 			if("play_note")
 				var/note_to_play = params["note"] + 1 // 0->1 (js->dm) array index change
 				var/volume = params["volume"]
-				playsound(get_turf(src), sounds_instrument[note_to_play], volume, randomized_pitch, pitch = pitch_set)
+				playsound(get_turf(src), sounds_instrument[note_to_play], volume, randomized_pitch, pitch = pitch_set, channel = VOLUME_CHANNEL_INSTRUMENTS)
 				. = TRUE
 			if("play_keyboard_on")
 				usr.client.apply_keybind("instrument_keyboard")

--- a/code/modules/items/instruments/playable_piano.dm
+++ b/code/modules/items/instruments/playable_piano.dm
@@ -363,7 +363,7 @@ TYPEINFO(/obj/player_piano)
 
 			if (concurrent_notes_played < MAX_CONCURRENT_NOTES)
 				var/sound_name = "sound/musical_instruments/piano/notes/[compiled_notes[curr_note]].ogg"
-				playsound(src, sound_name, note_volumes[curr_note],0,10,0)
+				playsound(src, sound_name, note_volumes[curr_note],0,10,0, channel = VOLUME_CHANNEL_INSTRUMENTS)
 
 			var/delays_left = src.note_delays[curr_note]
 

--- a/code/modules/sound/sound.dm
+++ b/code/modules/sound/sound.dm
@@ -61,7 +61,7 @@ var/global/ECHO_CLOSE = list(0,0,0,0,0,0,0,0.25,1.5,1.0,0,1.0,0,0,0,0,1.0,7)
 var/global/list/falloff_cache = list()
 
 //default volumes
-var/global/list/default_channel_volumes = list(1, 1, 1, 0.5, 0.5, 1, 1)
+var/global/list/default_channel_volumes = list(1, 1, 1, 0.5, 0.5, 1, 1, 1)
 
 //volumous hair with l'orial paris
 /client/var/list/volumes
@@ -69,7 +69,7 @@ var/global/list/default_channel_volumes = list(1, 1, 1, 0.5, 0.5, 1, 1)
 
 /// Returns a list of friendly names for available sound channels
 /client/proc/getVolumeNames()
-	return list("Game", "Ambient", "Radio", "Admin", "Emote", "Mentor PM")
+	return list("Game", "Ambient", "Radio", "Admin", "Emote", "Mentor PM", "Instruments")
 
 /// Returns the default volume for a channel, unattenuated for the master channel (0-1)
 /client/proc/getDefaultVolume(channel)
@@ -77,7 +77,7 @@ var/global/list/default_channel_volumes = list(1, 1, 1, 0.5, 0.5, 1, 1)
 
 /// Returns a list of friendly descriptions for available sound channels
 /client/proc/getVolumeDescriptions()
-	return list("This will affect all sounds.", "Most in-game audio will use this channel.", "Ambient background music in various areas will use this channel.", "Any music played from the radio station", "Any music or sounds played by admins.", "Screams and farts.", "Mentor PM notification sound.")
+	return list("This will affect all sounds.", "Most in-game audio will use this channel.", "Ambient background music in various areas will use this channel.", "Any music played from the radio station", "Any music or sounds played by admins.", "Screams and farts.", "Mentor PM notification sound.", "Music from in-game instruments.")
 
 /// Get the friendly description for a specific sound channel.
 /client/proc/getVolumeChannelDescription(channel)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -441,6 +441,11 @@ menu "menu"
 		category = "&Audio"
 		saved-params = "is-checked"
 	elem
+		name = "&Adjust Instrument Volume"
+		command ="change-volume instruments"
+		category = "&Audio"
+		saved-params = "is-checked"
+	elem
 		name = ""
 		command = ""
 		category = "&Audio"


### PR DESCRIPTION
[Feature][QoL][Sound]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an Instruments volume channel that can be adjusted to make instruments louder or quieter. Only effects notes played by instruments and the player piano, not the various bonk noises they make when used as weapons.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Had this requested several times from people who ~~don't appreciate music~~ find it disruptive when people play instruments in-game when they're playing their own music.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)AnomalousPotato
(*)Added an adjustable Instruments volume channel in audio options, on the top left of the screen.
```
