### PR TITLE
remove mech cart floating in space on cog2

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -56595,10 +56595,6 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
-"eSe" = (
-/obj/storage/cart/mechcart/tools,
-/turf/space,
-/area/space)
 "eSC" = (
 /obj/submachine/laundry_machine,
 /turf/simulated/floor/sanitary,
@@ -80299,7 +80295,7 @@ aaa
 aaa
 aaa
 aaa
-eSe
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
remove a mech cart in space west of the research outpost


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
its just a cart in space