### PR TITLE
fix battleroyale death component typeinfo

### DIFF
--- a/code/datums/components/battleroyale_death.dm
+++ b/code/datums/components/battleroyale_death.dm
@@ -1,7 +1,7 @@
 /datum/component/battleroyale_death
 	dupe_mode = COMPONENT_DUPE_UNIQUE
 
-TYPEINFO(/datum/component/cell_holder)
+TYPEINFO(/datum/component/battleroyale_death)
 	initialization_args = list()
 
 /datum/component/battleroyale_death/Initialize()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][internal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
in the battleroyale death component, change the typeinfo declaration to correctly list battleroyal_death instead of cell_holder


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
its a duplicate typeinfo for `cell_holder` which has different init args. i think there's no issue currently becasue cell_holder one overrides this as it's later on in the DME