### PR TITLE
Refactors and simplifies the flamethrower construction

### DIFF
--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -393,155 +393,126 @@ ABSTRACT_TYPE(/obj/item/gun/flamethrower/backtank)
 		..()
 
 // PantsNote: Dumping this shit in here until I'm sure it works.
+// Lord_Earthfire: It worked for a few years, now lets make it look cleaner
 
-/obj/item/assembly/weld_rod
+/obj/item/flamethrower_construction
+	icon = 'icons/obj/items/assemblies.dmi'
+	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	desc = "A welding torch with metal rods attached to the flame tip."
 	name = "Welder/Rods Assembly"
 	icon_state = "welder-rods"
 	item_state = "welder"
-	var/obj/item/weldingtool/welder = null
-	var/obj/item/rods/rod = null
-	status = null
+	var/list/assembly_contents = null
+	var/state = 0
 	flags = TABLEPASS | CONDUCT
 	force = 3
 	throwforce = 5
 	throw_speed = 1
 	throw_range = 5
+	stamina_damage = 10
+	stamina_cost = 10
 	w_class = W_CLASS_SMALL
 
-/obj/item/assembly/weld_rod/New()
+/obj/item/flamethrower_construction/New(var/new_location, var/obj/item/weldingtool/new_welder, var/obj/item/rods/new_rods, var/obj/item/device/igniter/new_igniter)
 	..()
-	welder = new /obj/item/weldingtool
-	rod = new /obj/item/rods
+	if(!new_welder)
+		new_welder = new /obj/item/weldingtool
+	if(!new_rods)
+		new_rods = new /obj/item/rods
+	src.assembly_contents = list(new_rods, new_welder)
+	new_welder.set_loc(src)
+	new_rods.set_loc(src)
+	var/new_state = 0
+	if (new_igniter)
+		src.assembly_contents += new_igniter
+		new_igniter.set_loc(src)
+		new_state = 1
+	src.set_construction_state(new_state)
 
-/obj/item/assembly/w_r_ignite
-	desc = "A welding torch and igniter connected by metal rods."
-	name = "Welder/Rods/Igniter Assembly"
-	icon_state = "welder-rods-igniter"
-	item_state = "welder"
-	var/obj/item/weldingtool/welder = null
-	var/obj/item/rods/rod = null
-	var/obj/item/device/igniter/igniter = null
-	status = null
-	flags = TABLEPASS | CONDUCT
-	force = 3
-	throwforce = 5
-	throw_speed = 1
-	throw_range = 5
-	w_class = W_CLASS_SMALL
+/obj/item/flamethrower_construction/proc/set_construction_state(var/new_state)
+	// reset the assembly-components to readd the ones we want
+	src.RemoveComponentsOfType(/datum/component/assembly)
+	// Welder/Rods Assembly + wrench  -> deconstruction
+	src.AddComponent(/datum/component/assembly, TOOL_WRENCHING, PROC_REF(deconstruction), FALSE)
+	if (new_state == 1)
+		src.state = 1
+		src.name = "Welder/Rods/Igniter Assembly"
+		src.desc = "A welding torch and igniter connected by metal rods."
+		src.icon_state = "welder-rods-igniter"
+		// Welder/Rods/igniter Assembly + screwdriver  -> assembly-completition
+		src.AddComponent(/datum/component/assembly, TOOL_SCREWING, PROC_REF(completition), FALSE)
+	else
+		src.state = 0
+		src.desc = "A welding torch with metal rods attached to the flame tip."
+		src.name = "Welder/Rods Assembly"
+		src.icon_state = "welder-rods"
+		// Welder/Rods Assembly + igniter  -> Welder/Rods/Igniter Assembly
+		src.AddComponent(/datum/component/assembly, /obj/item/device/igniter, PROC_REF(igniter_attachment), TRUE)
+	src.tooltip_rebuild = TRUE
 
-/obj/item/assembly/w_r_ignite/New()
-	..()
-	welder = new /obj/item/weldingtool
-	rod = new /obj/item/rods
-	igniter = new /obj/item/device/igniter
-
-/obj/item/assembly/weld_rod/disposing()
-	qdel(src.welder)
-	qdel(src.rod)
-	..()
-	return
-
-
-/obj/item/assembly/w_r_ignite/disposing()
-
-	qdel(src.welder)
-	qdel(src.rod)
-	qdel(src.igniter)
-	..()
-	return
+/obj/item/flamethrower_construction/disposing()
+	. = ..()
+	for(var/obj/item/affected_object in src.assembly_contents)
+		src.assembly_contents -= affected_object
+		qdel(affected_object)
+	src.assembly_contents = null
 
 
+/obj/item/flamethrower_construction/get_help_message(dist, mob/user)
+	switch(src.state)
+		if (0) // Default state
+			return "You can use a <b>wrench</b> to disassemble this object or a <b>igniter</b> to continue the construction of a flamethrower."
+		if (1) // with igniter
+			return "You can use a <b>wrench</b> to disassemble this object or a <b>screwdriver</b> to finish the construction of a flamethrower."
 
-/obj/item/assembly/weld_rod/attackby(obj/item/W, mob/user)
-	if (iswrenchingtool(W))
-		var/turf/T = src.loc
-		if (ismob(T))
-			T = T.loc
-		user.show_message(SPAN_NOTICE("You remove the rod from the welding tool."), 1)
-		src.welder.set_loc(T)
-		src.rod.set_loc(T)
-		src.welder.master = null
-		src.rod.master = null
-		src.welder = null
-		src.rod = null
 
-		qdel(src)
+// ----------------------- Assembly-procs -----------------------
 
-	if (istype(W, /obj/item/device/igniter))
-		if (src.loc != user)
-			boutput(user, SPAN_ALERT("You need to be holding [src] to work on it!"))
-			return
-		var/obj/item/device/igniter/I = W
-		user.show_message(SPAN_NOTICE("You put the igniter in place, it still needs to be firmly attached."), 1)
-		var/obj/item/assembly/weld_rod/S = src
-		var/obj/item/assembly/w_r_ignite/R = new /obj/item/assembly/w_r_ignite( user )
-		R.welder = S.welder
-		S.welder.set_loc(R)
-		S.welder.master = R
-		R.rod = S.rod
-		S.rod.set_loc(R)
-		S.rod.master = R
-		S.layer = initial(S.layer)
-		user.u_equip(S)
-		user.put_in_hand_or_drop(R)
-		I.master = R
-		I.layer = initial(I.layer)
-		user.u_equip(I)
-		I.set_loc(R)
-		src.set_loc(R)
-		R.igniter = I
-		S.welder = null
-		S.rod = null
-		qdel(S)
+/// igniter attachment
+/obj/item/flamethrower_construction/proc/igniter_attachment(var/atom/to_combine_atom, var/mob/user)
+	boutput(user, SPAN_NOTICE("You put the igniter in place, it still needs to be firmly attached."))
+	var/obj/item/used_igniter = to_combine_atom
+	user.u_equip(used_igniter)
+	src.assembly_contents += used_igniter
+	used_igniter.set_loc(src)
+	src.set_construction_state(1)
+	// Since the assembly was done, return TRUE
+	return TRUE
 
-	src.add_fingerprint(user)
-	return
+/// deconstruction
+/obj/item/flamethrower_construction/proc/deconstruction(var/atom/to_combine_atom, var/mob/user)
+	boutput(user, SPAN_NOTICE("You deconstruct the [src.name]."))
+	var/turf/chosen_turf = get_turf(src)
+	for(var/obj/item/affected_object in src.assembly_contents)
+		affected_object.set_loc(chosen_turf)
+		src.assembly_contents -= affected_object
+	user.u_equip(src)
+	qdel(src)
+	// Since the assembly was done, return TRUE
+	return TRUE
 
-/obj/item/assembly/w_r_ignite/attackby(obj/item/W, mob/user)
-	if (!W)
-		return
-	if (iswrenchingtool(W) && !(src.status))
-		var/turf/T = src.loc
-		if (ismob(T))
-			T = T.loc
-		user.show_message(SPAN_NOTICE("You disassemble the [src.name]"), 1)
-		src.welder.set_loc(T)
-		src.rod.set_loc(T)
-		src.igniter.set_loc(T)
-		src.welder.master = null
-		src.rod.master = null
-		src.igniter.master = null
-		src.welder = null
-		src.rod = null
-		src.igniter = null
+/// securing-completition
+/obj/item/flamethrower_construction/proc/completition(var/atom/to_combine_atom, var/mob/user)
+	boutput(user, SPAN_NOTICE("The igniter is now secured."))
+	user.u_equip(src)
+	var/obj/item/gun/flamethrower/assembled/new_flamethrower = new/obj/item/gun/flamethrower/assembled
+	for(var/obj/item/chosen_item in src.assembly_contents)
+		switch(chosen_item.type)
+			if(/obj/item/weldingtool)
+				new_flamethrower.welder = chosen_item
+			if(/obj/item/rods)
+				new_flamethrower.rod = chosen_item
+			if(/obj/item/device/igniter)
+				new_flamethrower.igniter = chosen_item
+		src.assembly_contents -= chosen_item
+		chosen_item.set_loc(new_flamethrower)
+	user.put_in_hand_or_drop(new_flamethrower)
+	qdel(src)
+	// Since the assembly was done, return TRUE
+	return TRUE
 
-		qdel(src)
-		return
-	if (isscrewingtool(W))
-		user.show_message(SPAN_NOTICE("The igniter is now secured!"), 1)
-		var/obj/item/gun/flamethrower/assembled/R = new /obj/item/gun/flamethrower/assembled(src.loc)
-		var/obj/item/assembly/w_r_ignite/S = src
-		R.welder = S.welder
-		S.welder.set_loc(R)
-		S.welder.master = R
-		R.rod = S.rod
-		S.rod.set_loc(R)
-		S.rod.master = R
-		R.igniter = S.igniter
-		S.igniter.set_loc(R)
-		S.igniter.master = R
-		S.layer = initial(S.layer)
-		S.master = R
-		S.layer = initial(S.layer)
-		user.u_equip(S)
-		user.put_in_hand_or_drop(R)
-		S.set_loc(R)
-		S.welder = null
-		S.rod = null
-		S.igniter = null
-		qdel(S)
-		return
+
+// ----------------------- -------------- -----------------------
 
 /obj/item/gun/flamethrower/process()
 	if(!lit)
@@ -616,23 +587,9 @@ ABSTRACT_TYPE(/obj/item/gun/flamethrower/backtank)
 		var/obj/item/gun/flamethrower/assembled/S = src
 		if (( S.gastank ))
 			return
-		var/obj/item/assembly/w_r_ignite/R = new /obj/item/assembly/w_r_ignite( user )
-		R.welder = S.welder
-		S.welder.set_loc(R)
-		S.welder.master = R
-		R.rod = S.rod
-		S.rod.set_loc(R)
-		S.rod.master = R
-		R.igniter = S.igniter
-		S.igniter.set_loc(R)
-		S.igniter.master = R
-		S.layer = initial(S.layer)
+		var/obj/item/flamethrower_construction/new_construction = new /obj/item/flamethrower_construction (null, S.welder, S.rod, S.igniter)
 		user.u_equip(S)
-		user.put_in_hand_or_drop(R)
-		src.master = R
-		src.layer = initial(src.layer)
-		user.u_equip(src)
-		src.set_loc(R)
+		user.put_in_hand_or_drop(new_construction)
 		S.welder = null
 		S.rod = null
 		S.igniter = null

--- a/code/obj/item/tool/weldingtool.dm
+++ b/code/obj/item/tool/weldingtool.dm
@@ -10,7 +10,6 @@
 	var/item_state_variant_suffix = null
 
 	var/welding = FALSE
-	var/status = 0 // flamethrower construction :shobon:
 	flags = TABLEPASS | CONDUCT
 	c_flags = ONBELT
 	tool_flags = TOOL_WELDING
@@ -39,6 +38,28 @@
 		src.setItemSpecial(/datum/item_special/flame)
 
 		AddComponent(/datum/component/loctargeting/simple_light, 255, 110, 135, 125, src.welding)
+
+		// Welder + rods  -> Welder/Rods Assembly
+		src.AddComponent(/datum/component/assembly, /obj/item/rods, PROC_REF(welder_rod_construction), TRUE)
+
+// ----------------------- Assembly-procs -----------------------
+	///Begin of the flamethrower assembly
+	proc/welder_rod_construction(var/atom/to_combine_atom, var/mob/user)
+		boutput(user, SPAN_NOTICE("You attach the rod to the welding tool."))
+		var/obj/item/rods/handled_rods = to_combine_atom
+		handled_rods.add_fingerprint(user)
+		user.u_equip(src)
+		src.add_fingerprint(user)
+		if(handled_rods.amount > 1)
+			handled_rods = handled_rods.split_stack(1)
+			handled_rods.add_fingerprint(user)
+		else
+			user.u_equip(handled_rods)
+		var/obj/item/flamethrower_construction/new_construction = new /obj/item/flamethrower_construction(null, src, handled_rods, null)
+		user.put_in_hand_or_drop(new_construction)
+		return TRUE
+// ----------------------- -------------- -----------------------
+
 
 	examine()
 		. = ..()
@@ -90,37 +111,6 @@
 			else return ..()
 		else return ..()
 
-	attackby(obj/item/I, mob/user)
-		if (isscrewingtool(I))
-			if (status)
-				status = 0
-				boutput(user, SPAN_NOTICE("You resecure the welder."))
-			else
-				status = 1
-				boutput(user, SPAN_NOTICE("The welder can now be attached and modified."))
-
-		else if (status == 1 && istype(I, /obj/item/rods))
-			if (src.loc != user)
-				boutput(user, SPAN_ALERT("You need to be holding [src] to work on it!"))
-				return
-			boutput(user, SPAN_NOTICE("You attach the rod to the welding tool."))
-			var/obj/item/rods/R = new /obj/item/rods
-			R.amount = 1
-			var/obj/item/rods/S = I
-			S.change_stack_amount(-1)
-			var/obj/item/assembly/weld_rod/F = new /obj/item/assembly/weld_rod( user )
-			src.set_loc(F)
-			F.welder = src
-			user.u_equip(src)
-			user.put_in_hand_or_drop(F)
-			R.master = F
-			src.master = F
-			src.layer = initial(src.layer)
-			user.u_equip(src)
-			src.set_loc(F)
-			F.rod = R
-			src.add_fingerprint(user)
-
 
 	afterattack(obj/O, mob/user)
 		if ((istype(O, /obj/reagent_dispensers/fueltank) || istype(O, /obj/item/reagent_containers/food/drinks/fueltank)) && BOUNDS_DIST(src, O) == 0)
@@ -150,7 +140,6 @@
 				O.reagents.temperature_reagents(4000,50, 100, 100, 1)
 
 	attack_self(mob/user as mob)
-		if (status > 1) return
 		src.firesource = !(src.firesource)
 		tooltip_rebuild = TRUE
 		src.set_state(on = !src.welding, user = user)


### PR DESCRIPTION
[code quality][QoL][game objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR merges the two items for the flamethrower assembly, `/obj/item/assembly/w_r_ignite` and `/obj/item/assembly/weld_rod`, into a single object, `/obj/item/flamethrower_construction`, with two states.

This PR utilizes the assembly component to connect construction steps of the flamethrower, vastly cleaning up the code. Also, it removes the need for the welding tool to be unsecured to be attached to material rods.

Due to use of the assembly component, you can use now rods on a welding tool or vice versa to create the initial assembly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Flamethrower assembly, like most other assemblies, was kinda messy code-wise. Also, it absolutely made no sense for the construction item to be a child of `/obj/item/assembly` when it has no behaviour in common with other assemblies.

This PR is atomized from #22115 and thus needed to properly fulfill that PR's design goals. Due to that one aiming at phasing out unsecuring of small components, this change was implemented in this PR as well.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)You don't need to unsecure a welding tool anymore to begin the construction of a flamethrower. Also, you can start it by either using material rods on a welding tool or using the welding tool on the material rods.
```
