### PR TITLE
Add chemistry access helpers to donut3 chemlab doors/windoors

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -37885,11 +37885,11 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
-/obj/mapping_helper/access/research,
 /obj/mapping_helper/firedoor_spawn,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/access/chemistry,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "lwW" = (
@@ -70709,6 +70709,7 @@
 	id = "chemistry"
 	},
 /obj/table/reinforced/chemistry/auto/clericalsup,
+/obj/mapping_helper/access/chemistry,
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "vrX" = (
@@ -76098,6 +76099,7 @@
 	id = "chemistry"
 	},
 /obj/table/reinforced/chemistry/auto/clericalsup,
+/obj/mapping_helper/access/chemistry,
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "wVy" = (
@@ -78791,7 +78793,6 @@
 /area/station/hangar/science)
 "xFV" = (
 /obj/decal/stripe_delivery,
-/obj/mapping_helper/access/research,
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/sci_alt{
 	dir = 4;
@@ -78800,6 +78801,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/access/chemistry,
 /turf/simulated/floor/black,
 /area/station/science/testchamber)
 "xGu" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
add chemistry access spawners to the doors and windoors of chemistry lab


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
chem doors are general research perms instead of chemistry ones
the chem windoors don't have any permissions right now