### PR TITLE
Fix unbroken vendors not being rightable

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1241,7 +1241,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
-		if(!(src.vendor.status & BROKEN)) //it somehow got fixed while making it go upright??
+		if(!src.vendor.fallen)
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
@@ -1256,7 +1256,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item, proc/admin_command
 
 	onEnd()
 		..()
-		if(src.owner && vendor && (src.vendor.status & BROKEN))
+		if(src.owner && vendor && (src.vendor.fallen))
 			vendor.right()
 			for(var/mob/M in AIviewers(src.owner))
 				M.show_message(SPAN_NOTICE("<B>[src.owner] manages to stand \the [src.vendor] back upright!</B>"), 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[critical]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I missed a BROKEN condition in the righting actionbar, this correctly checks fallen

Tested fix locally and it worked.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
can't right unbroken vendors right now