### PR TITLE
Remove skitter from general genepool, add to small animal cockroaches

### DIFF
--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -2241,6 +2241,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_RADPROT_INT, src, 100)
 		START_TRACKING_CAT(TR_CAT_BUGS)
 		src.bioHolder.AddNewPoolEffect("radioactive", scramble=TRUE)
+		src.bioHolder.AddNewPoolEffect("skitter", scramble=TRUE)
 
 	disposing()
 		STOP_TRACKING_CAT(TR_CAT_BUGS)

--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -1078,6 +1078,7 @@ var/list/radio_brains = list()
 	id = "skitter"
 	name = "Insectoid locomotion"
 	desc = "The subject is capable of skittering across the floor like a bug."
+	occur_in_genepools = 0
 
 	OnAdd()
 		RegisterSignal(src.owner, COMSIG_MOB_SPRINT, PROC_REF(on_sprint))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][medical]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets the skitter gene to no longer occur randomly in genepools.
Small Animal Cockroaches now get the skitter gene alongside radioactive.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Skitter should feel roach-exclusive. This keeps it available for geneticists, but requires them unlocking the critter scanner and finding a cockroach first.