### PR TITLE
Redo the deconstruction access-conditions for airlocks

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -11,7 +11,7 @@ var/global/list/cycling_airlocks = list()
 	name = "airlock"
 	icon = 'icons/obj/doors/SL_doors.dmi'
 	icon_state = "door_closed"
-	deconstruct_flags = DECON_NULL_ACCESS | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_SCREWDRIVER | DECON_MULTITOOL
+	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_SCREWDRIVER | DECON_MULTITOOL
 	object_flags = BOTS_DIRBLOCK | CAN_REPROGRAM_ACCESS
 
 	var/image/panel_image = null
@@ -1157,11 +1157,16 @@ TYPEINFO(/obj/machinery/door/airlock)
 
 /obj/machinery/door/airlock/emag_act(mob/user, obj/item/card/emag/E)
 	. = ..()
+	src.deconstruct_flags |= DECON_NO_ACCESS //emagged doors should be able to be deconstructed by anyone. It's utterly trashed, after all
 	if(src.welded && !src.locked)
 		audible_message(SPAN_ALERT("[src] lets out a loud whirring and grinding noise!"))
 		animate_shake(src, 5, 2, 2, src.pixel_x, src.pixel_y)
 		playsound(src, 'sound/items/mining_drill.ogg', 25, TRUE, 0, 0.8)
 		src.take_damage(src.health * 0.8)
+
+/obj/machinery/door/demag(var/mob/user)
+	. = ..()
+	src.deconstruct_flags &= ~DECON_NO_ACCESS //well, ya got it fixed, somehow
 
 /obj/machinery/door/airlock/receive_silicon_hotkey(var/mob/user)
 	..()


### PR DESCRIPTION
[Balance][Game objects]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR removes the `DECON_NULL_ACCESS`-flag from airlocks and make them add the `DECON_NO_ACCESS` to them when they are emagged.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The need to remove ALL ACCESSES from airlocks when you want to deconstruct them made them one of the few things impossible for engineers to deconstruct without a RCD or the help of the HOP. And doors being harder to deconstruct than reinforced walls is just ridiculous.

Someone who can open a door should be able to get rid of it, if they so desire (e.g. renovations).

Also, the addition of the `DECON_NO_ACCESS` flag to emagged doors make it so you are able to deconstruct them when they are emagged. The `DECON_NULL_ACCESS`-flag made emagged doors the most obnoxious thing to remove/fix and is causing some discussion from time to time. Like this discussion which was the inspiration for this PR https://forum.ss13.co/showthread.php?tid=23597.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Airlocks no longer require all their access to be removed to be able to deconstructed, you just need to have access to them.
(+)Emagging a door removes the need to have access to the door in order to deconstruct it.
```
