### PR TITLE
refactors electric chair construction

### DIFF
--- a/code/obj/electric_chair.dm
+++ b/code/obj/electric_chair.dm
@@ -21,7 +21,7 @@
 	get_help_message(dist, mob/user)
 		. = "You can use a <b>multitool</b> to open the settings menu, or a <b>wrench</b> to disassemble it."
 
-	New(var/atom/new_location, var/obj/item/shock_kit/new_shock_kit)
+	New(atom/new_location, obj/item/shock_kit/new_shock_kit)
 		contextLayout = new /datum/contextLayout/experimentalcircle
 		..()
 		for(var/button in childrentypesof(/datum/contextAction/electric_chair))

--- a/code/obj/item/assembly/shock_kit.dm
+++ b/code/obj/item/assembly/shock_kit.dm
@@ -1,58 +1,87 @@
-/obj/item/assembly/shock_kit
+/obj/item/shock_kit
 	name = "Shock Kit"
+	desc = "An assembly to create an electric chair with."
+	icon = 'icons/obj/items/assemblies.dmi'
+	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
+	item_state = "assembly"
 	icon_state = "shock_kit"
-	var/obj/item/clothing/head/helmet/part1 = null
-	var/obj/item/device/radio/electropack/part2 = null
-	status = 0
+	var/obj/item/clothing/head/helmet/helmet_part = null
+	var/obj/item/device/radio/electropack/electropack_part = null
+	throwforce = 10
+	throw_speed = 4
+	throw_range = 10
+	force = 2
+	stamina_damage = 10
+	stamina_cost = 10
 	w_class = W_CLASS_HUGE
 	flags = TABLEPASS | CONDUCT
 
-/obj/item/assembly/shock_kit/New(atom/newLoc, obj/item/clothing/head/helmet/helmet, obj/item/device/radio/electropack/electropack)
+/obj/item/shock_kit/New(var/atom/new_location, var/obj/item/clothing/head/helmet/new_helmet, var/obj/item/device/radio/electropack/new_electropack)
 	..()
-	helmet ||= new /obj/item/clothing/head/helmet(src)
-	src.part1 = helmet
-	helmet.master = src
-	electropack ||= new /obj/item/device/radio/electropack(src)
-	src.part2 = electropack
-	electropack.master = src
+	//let's create the items if they aren't here already
+	if(!new_helmet)
+		new_helmet = new /obj/item/clothing/head/helmet
+	src.helmet_part = new_helmet
+	if(!new_electropack)
+		new_electropack = new /obj/item/device/radio/electropack
+	src.electropack_part = new_electropack
+	//now, let's move them and set them up
+	for(var/obj/item/affected_object in list(src.helmet_part, src.electropack_part))
+		affected_object.set_loc(src)
+		affected_object.master = src
+	// Shock kit + wrench  -> deconstruction
+	src.AddComponent(/datum/component/assembly, TOOL_WRENCHING, PROC_REF(deconstruction), FALSE)
+	// Shock kit + stool  -> electric chair
+	src.AddComponent(/datum/component/assembly, /obj/stool/chair, PROC_REF(electric_chair_construction), TRUE)
 
-/obj/item/assembly/shock_kit/disposing()
-	if (src.part1)
-		qdel(src.part1)
-		src.part1 = null
-	if (src.part2)
-		qdel(src.part2)
-		src.part2 = null
+/obj/item/shock_kit/disposing()
+	qdel(src.helmet_part)
+	src.helmet_part = null
+	qdel(src.electropack_part)
+	src.electropack_part = null
 	..()
 
-/obj/item/assembly/shock_kit/attackby(obj/item/W, mob/user)
-	src.add_fingerprint(user)
-
-	if (iswrenchingtool(W))
-		var/turf/T = get_turf(src)
-		if (src.part1)
-			src.part1.set_loc(T)
-			src.part1.master = null
-			src.part1 = null
-		if (src.part2)
-			src.part2.set_loc(T)
-			src.part2.master = null
-			src.part2 = null
-		qdel(src)
-		return
-
-	else return ..()
-
-/obj/item/assembly/shock_kit/attack_self(mob/user as mob)
-	src.part1.AttackSelf(user)
-	src.part2.AttackSelf(user)
+/obj/item/shock_kit/attack_self(mob/user as mob)
+	src.electropack_part.AttackSelf(user)
 	src.add_fingerprint(user)
 	return
 
-/obj/item/assembly/shock_kit/receive_signal()
+/obj/item/shock_kit/receive_signal()
 	if (src.master && istype(src.master, /obj/stool/chair/e_chair))
 		var/obj/stool/chair/e_chair/C = src.master
 		if (C.buckled_guy)
 			logTheThing(LOG_SIGNALERS, usr, "signalled an electric chair (setting: [C.lethal ? "lethal" : "non-lethal"]), shocking [constructTarget(C.buckled_guy,"signalers")] at [log_loc(C)].") // Added (Convair880).
 		C.shock()
 	return
+
+
+// ----------------------- Assembly-procs -----------------------
+
+/// deconstruction
+/obj/item/shock_kit/proc/deconstruction(var/atom/to_combine_atom, var/mob/user)
+	src.electropack_part.master = null
+	boutput(user, SPAN_NOTICE("You deconstruct the [src.name]."))
+	var/turf/chosen_turf = get_turf(src)
+	for(var/obj/item/affected_object in list(src.helmet_part, src.electropack_part))
+		affected_object.set_loc(chosen_turf)
+		affected_object.master = null
+	src.helmet_part = null
+	src.electropack_part = null
+	user.u_equip(src)
+	qdel(src)
+	// Since the assembly was done, return TRUE
+	return TRUE
+
+/// electric chair construction
+/obj/item/shock_kit/proc/electric_chair_construction(var/atom/to_combine_atom, var/mob/user)
+	user.u_equip(src)
+	var/obj/stool/to_combine_stool = to_combine_atom
+	var/obj/stool/chair/e_chair/new_chair = new /obj/stool/chair/e_chair(to_combine_stool.loc, src)
+	if (to_combine_stool.material)
+		new_chair.setMaterial(to_combine_stool.material)
+		playsound(to_combine_stool.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+	qdel(to_combine_atom)
+	// Since the assembly was done, return TRUE
+	return TRUE
+
+// ----------------------- -------------- -----------------------

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -807,6 +807,25 @@ TYPEINFO(/obj/item/radiojammer)
 	desc = "A device that, when signaled on the correct frequency, causes a disabling electric shock to be sent to the animal (or human) wearing it."
 	cant_self_remove = 1
 
+// ----------------------- Assembly-procs -----------------------
+
+
+/// shock kit construction
+/obj/item/device/radio/electropack/proc/shock_kit_assembly(var/atom/to_combine_atom, var/mob/user)
+	user.u_equip(src)
+	user.u_equip(to_combine_atom)
+	var/obj/item/shock_kit/new_shock_kit = new /obj/item/shock_kit(get_turf(user), to_combine_atom, src)
+	user.put_in_hand_or_drop(new_shock_kit)
+	// Since the assembly was done, return TRUE
+	return TRUE
+
+// ----------------------- -------------- -----------------------
+
+/obj/item/device/radio/electropack/New()
+	..()
+	// Electropack + sec helmet  -> shock kit
+	src.AddComponent(/datum/component/assembly, /obj/item/clothing/head/helmet, PROC_REF(shock_kit_assembly), TRUE)
+
 /obj/item/device/radio/electropack/update_icon()
 	src.icon_state = "electropack[src.on]"
 
@@ -833,19 +852,6 @@ TYPEINFO(/obj/item/radiojammer)
 			src.on = !(src.on)
 			. = TRUE
 			UpdateIcon()
-
-/obj/item/device/radio/electropack/attackby(obj/item/W, mob/user)
-	if (istype(W, /obj/item/clothing/head/helmet))
-		var/obj/item/assembly/shock_kit/A = new /obj/item/assembly/shock_kit(user, W, src)
-		W.set_loc(A)
-		W.layer = initial(W.layer)
-		user.u_equip(W)
-		user.put_in_hand_or_drop(A)
-		src.layer = initial(src.layer)
-		user.u_equip(src)
-		src.set_loc(A)
-		src.add_fingerprint(user)
-	return
 
 /obj/item/device/radio/electropack/receive_signal(datum/signal/signal)
 	if (!signal || !signal.data || ("[signal.data["code"]]" != "[code]"))//(signal.encryption != code))

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -659,16 +659,6 @@ TYPEINFO(/obj/stool/chair)
 			butt_img.icon_state = "chair_[has_butt.icon_state]"
 			UpdateOverlays(butt_img, "chairbutt")
 			return
-		if (istype(W, /obj/item/assembly/shock_kit))
-			var/obj/stool/chair/e_chair/E = new /obj/stool/chair/e_chair(src.loc, W)
-			if (src.material)
-				E.setMaterial(src.material)
-			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-			W.set_loc(E)
-			user.u_equip(W)
-			W.layer = initial(W.layer)
-			qdel(src)
-			return
 		else
 			return ..()
 


### PR DESCRIPTION
[code quality][QoL][game objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR moves `/obj/item/assembly/shock_kit` onto `/obj/item/shock_kit` and refactors its construction steps and the construction steps of electric chairs to use `/datum/component/assembly`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The code of this assembly looked quite messy and, like with other construction interactions, only worked if you used one specific item on another instead of the other way around. 

This PR is atomized from #22115. At one later point i want to bind the electropack and thus this construction into assemblies again, but that requires a larger rework of this construction.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)You can construct shock packs now starting either with the helmet or the electropack.
```
