### PR TITLE
adds children of `/datum/component/assembly` to check for borg and item arms

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -304,10 +304,6 @@ TYPEINFO(/atom)
 /atom/proc/ex_act(var/severity=0,var/last_touched=0, var/power=0, var/datum/explosion/explosion=null)
 	return
 
-/// Use this proc to check if you can use and permanently change this item via a combination
-/atom/proc/is_combination_consumeable()
-	return TRUE
-
 /atom/proc/reagent_act(var/reagent_id,var/volume,var/datum/reagentsholder_reagents)
 	if (!istext(reagent_id) || !isnum(volume) || volume < 1)
 		return 1
@@ -724,6 +720,10 @@ TYPEINFO(/atom/movable)
 		update_medium_light_visibility()
 	if (src.mdir_lights)
 		update_mdir_light_visibility(src.dir)
+
+/// Use this proc to check if you can't use and permanently change this atom within /datum/component/assembly
+/atom/movable/proc/assembly_cant_be_removed()
+	return FALSE
 
 /atom/proc/get_desc(dist, mob/user)
 	// If we click something on/under the floor, then analyze fluid/smoke as well

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -304,6 +304,10 @@ TYPEINFO(/atom)
 /atom/proc/ex_act(var/severity=0,var/last_touched=0, var/power=0, var/datum/explosion/explosion=null)
 	return
 
+/// Use this proc to check if you can use and permanently change this item via a combination
+/atom/proc/is_combination_consumeable()
+	return TRUE
+
 /atom/proc/reagent_act(var/reagent_id,var/volume,var/datum/reagentsholder_reagents)
 	if (!istext(reagent_id) || !isnum(volume) || volume < 1)
 		return 1

--- a/code/datums/components/assembly_comp.dm
+++ b/code/datums/components/assembly_comp.dm
@@ -69,3 +69,28 @@ TYPEINFO(/datum/component/assembly)
 		//if the assembly is valid, we go and call the proc
 		//we need to return true so onattack does not trigger. Else we would still attack a completed assembly
 		return call(src.parent, src.valid_assembly_proc)(checked_atom, user)
+
+/// this component checks is_combination_consumeable() on the parent, but behaves exactly the same otherwise
+/datum/component/assembly/consumes_self
+
+/datum/component/assembly/consumes_self/try_combination(var/atom/checked_atom, var/mob/user)
+	var/atom/checked_parent = src.parent
+	if(!checked_parent.is_combination_consumeable())
+		return FALSE
+	. = ..(checked_atom, user)
+/// this component checks is_combination_consumeable() on the other atom used, but behaves exactly the same otherwise
+/datum/component/assembly/consumes_other
+
+/datum/component/assembly/consumes_other/try_combination(var/atom/checked_atom, var/mob/user)
+	if(!checked_atom.is_combination_consumeable())
+		return FALSE
+	. = ..(checked_atom, user)
+
+/// this component checks is_combination_consumeable() on all atoms involved, but behaves exactly the same otherwise
+/datum/component/assembly/consumes_all
+
+/datum/component/assembly/consumes_all/try_combination(var/atom/checked_atom, var/mob/user)
+	var/atom/checked_parent = src.parent
+	if(!checked_atom.is_combination_consumeable() || !checked_parent.is_combination_consumeable())
+		return FALSE
+	. = ..(checked_atom, user)

--- a/code/datums/components/assembly_comp.dm
+++ b/code/datums/components/assembly_comp.dm
@@ -70,27 +70,29 @@ TYPEINFO(/datum/component/assembly)
 		//we need to return true so onattack does not trigger. Else we would still attack a completed assembly
 		return call(src.parent, src.valid_assembly_proc)(checked_atom, user)
 
-/// this component checks is_combination_consumeable() on the parent, but behaves exactly the same otherwise
+/// this component checks assembly_cant_be_removed() on the parent, but behaves exactly the same otherwise
 /datum/component/assembly/consumes_self
 
 /datum/component/assembly/consumes_self/try_combination(var/atom/checked_atom, var/mob/user)
-	var/atom/checked_parent = src.parent
-	if(!checked_parent.is_combination_consumeable())
+	var/atom/movable/movable_parent = src.parent
+	if(movable_parent.assembly_cant_be_removed())
 		return FALSE
 	. = ..(checked_atom, user)
-/// this component checks is_combination_consumeable() on the other atom used, but behaves exactly the same otherwise
+/// this component checks assembly_cant_be_removed() on the other atom used, but behaves exactly the same otherwise
 /datum/component/assembly/consumes_other
 
 /datum/component/assembly/consumes_other/try_combination(var/atom/checked_atom, var/mob/user)
-	if(!checked_atom.is_combination_consumeable())
+	var/atom/movable/movable_checked_atom = checked_atom
+	if(movable_checked_atom.assembly_cant_be_removed())
 		return FALSE
 	. = ..(checked_atom, user)
 
-/// this component checks is_combination_consumeable() on all atoms involved, but behaves exactly the same otherwise
+/// this component checks assembly_cant_be_removed() on all atoms involved, but behaves exactly the same otherwise
 /datum/component/assembly/consumes_all
 
 /datum/component/assembly/consumes_all/try_combination(var/atom/checked_atom, var/mob/user)
-	var/atom/checked_parent = src.parent
-	if(!checked_atom.is_combination_consumeable() || !checked_parent.is_combination_consumeable())
+	var/atom/movable/movable_parent = src.parent
+	var/atom/movable/movable_checked_atom = checked_atom
+	if(movable_checked_atom.assembly_cant_be_removed() || movable_parent.assembly_cant_be_removed())
 		return FALSE
 	. = ..(checked_atom, user)

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -51,7 +51,7 @@ ADMIN_INTERACT_PROCS(/obj/item/chem_grenade, proc/arm, proc/explode)
 
 /obj/item/chem_grenade/proc/initialize_assemby()
 	// completed grenade + assemblies -> chemical grenade assembly
-	src.AddComponent(/datum/component/assembly, list(/obj/item/assembly/time_ignite, /obj/item/assembly/prox_ignite, /obj/item/assembly/rad_ignite), PROC_REF(chem_grenade_assemblies), TRUE)
+	src.AddComponent(/datum/component/assembly/consumes_all, list(/obj/item/assembly/time_ignite, /obj/item/assembly/prox_ignite, /obj/item/assembly/rad_ignite), PROC_REF(chem_grenade_assemblies), TRUE)
 	// completed grenade + screwdriver -> adjusting of the arming time
 	src.AddComponent(/datum/component/assembly, TOOL_SCREWING, PROC_REF(adjust_time), FALSE)
 
@@ -327,9 +327,9 @@ TYPEINFO(/obj/item/chem_grenade/custom)
 	src.desc = "An unsecured chemical grenade. It can be modified by adding small beakers into it and secured with a screwdriver."
 	src.stage = 1
 	// unsecured grenade + beaker  -> unsecured grenade with beaker
-	src.AddComponent(/datum/component/assembly, list(/obj/item/reagent_containers/glass), PROC_REF(chem_grenade_filling), TRUE)
+	src.AddComponent(/datum/component/assembly/consumes_other, list(/obj/item/reagent_containers/glass), PROC_REF(chem_grenade_filling), TRUE)
 	// unsecured grenade + wrench -> disassembling of the grenade
-	src.AddComponent(/datum/component/assembly, TOOL_WRENCHING, PROC_REF(disassembly_filled), FALSE)
+	src.AddComponent(/datum/component/assembly/consumes_self, TOOL_WRENCHING, PROC_REF(disassembly_filled), FALSE)
 	src.tooltip_rebuild = 1
 
 /// chem grenade filling proc
@@ -372,11 +372,11 @@ TYPEINFO(/obj/item/chem_grenade/custom)
 	//Since we changed the state, remove all assembly components and add the next state ones
 	src.RemoveComponentsOfType(/datum/component/assembly)
 	// completed grenade + assemblies -> chemical grenade assembly
-	src.AddComponent(/datum/component/assembly, list(/obj/item/assembly/time_ignite, /obj/item/assembly/prox_ignite, /obj/item/assembly/rad_ignite), PROC_REF(chem_grenade_assemblies), TRUE)
+	src.AddComponent(/datum/component/assembly/consumes_all, list(/obj/item/assembly/time_ignite, /obj/item/assembly/prox_ignite, /obj/item/assembly/rad_ignite), PROC_REF(chem_grenade_assemblies), TRUE)
 	// completed grenade + screwdriver -> adjusting of the arming time
 	src.AddComponent(/datum/component/assembly, TOOL_SCREWING, PROC_REF(adjust_time), FALSE)
 	// completed grenade + wrench -> disassembling of the grenade
-	src.AddComponent(/datum/component/assembly, TOOL_WRENCHING, PROC_REF(disassembly_filled), FALSE)
+	src.AddComponent(/datum/component/assembly/consumes_self, TOOL_WRENCHING, PROC_REF(disassembly_filled), FALSE)
 	logTheThing(LOG_CHEMISTRY, user, "Assembles a custom chemical grenade (beaker 1: [beakers[1]]; beaker 2: [beakers[2]])")
 	return TRUE
 

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -277,11 +277,11 @@ ABSTRACT_TYPE(/obj/item)
 			usr.client.tooltipHolder.hideHover()
 		usr.moused_exit(src)
 
-	is_combination_consumeable()
+	assembly_cant_be_removed()
 		. = ..()
 		if((src.temp_flags & IS_LIMB_ITEM) || src.cant_drop)
 			//items on borg hands stay on borg hands as well as item limbs, damnit
-			return FALSE
+			return TRUE
 
 
 	onMaterialChanged()

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -277,6 +277,13 @@ ABSTRACT_TYPE(/obj/item)
 			usr.client.tooltipHolder.hideHover()
 		usr.moused_exit(src)
 
+	is_combination_consumeable()
+		. = ..()
+		if((src.temp_flags & IS_LIMB_ITEM) || src.cant_drop)
+			//items on borg hands stay on borg hands as well as item limbs, damnit
+			return FALSE
+
+
 	onMaterialChanged()
 		..()
 		tooltip_rebuild = 1

--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -53,11 +53,11 @@ Contains:
 /obj/item/assembly/time_ignite/New()
 	..()
 	// Timer-Igniter Assembly + wired pipebomb -> timer-igniter pipebomb
-	src.AddComponent(/datum/component/assembly, /obj/item/pipebomb/frame, PROC_REF(pipebomb_frame_assembly), TRUE)
+	src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/pipebomb/frame, PROC_REF(pipebomb_frame_assembly), TRUE)
 	// Timer-Igniter Assembly + pipebomb -> timer-igniter pipebomb
-	src.AddComponent(/datum/component/assembly, /obj/item/pipebomb/bomb, PROC_REF(pipebomb_assembly), TRUE)
+	src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/pipebomb/bomb, PROC_REF(pipebomb_assembly), TRUE)
 	// Timer-Igniter Assembly + beaker -> timer-igniter beakerbomb
-	src.AddComponent(/datum/component/assembly, /obj/item/reagent_containers/glass/beaker, PROC_REF(beakerbomb_assembly), TRUE)
+	src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/reagent_containers/glass/beaker, PROC_REF(beakerbomb_assembly), TRUE)
 	SPAWN(0)
 		if(!part1)
 			part1 = new(src)
@@ -182,11 +182,11 @@ Contains:
 		boutput(usr, SPAN_NOTICE("You remove the timer/igniter assembly from the beaker."))
 		//since the assembly is free of beakers, let's add the assembly components again
 		// Timer-Igniter Assembly + wired pipebomb -> timer-igniter pipebomb
-		src.AddComponent(/datum/component/assembly, /obj/item/pipebomb/frame, PROC_REF(pipebomb_frame_assembly), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/pipebomb/frame, PROC_REF(pipebomb_frame_assembly), TRUE)
 		// Timer-Igniter Assembly + pipebomb -> timer-igniter pipebomb
-		src.AddComponent(/datum/component/assembly, /obj/item/pipebomb/bomb, PROC_REF(pipebomb_assembly), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/pipebomb/bomb, PROC_REF(pipebomb_assembly), TRUE)
 		// Timer-Igniter Assembly + beaker -> timer-igniter beakerbomb
-		src.AddComponent(/datum/component/assembly, /obj/item/reagent_containers/glass/beaker, PROC_REF(beakerbomb_assembly), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/reagent_containers/glass/beaker, PROC_REF(beakerbomb_assembly), TRUE)
 	else boutput(usr, SPAN_ALERT("That doesn't have a beaker attached to it!"))
 
 // Timer-igniter-assemblies
@@ -297,11 +297,11 @@ Contains:
 /obj/item/assembly/prox_ignite/New()
 	..()
 	// Proximity-Igniter Assembly + wired pipebomb -> Proximity-igniter pipebomb
-	src.AddComponent(/datum/component/assembly, /obj/item/pipebomb/frame, PROC_REF(pipebomb_frame_assembly), TRUE)
+	src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/pipebomb/frame, PROC_REF(pipebomb_frame_assembly), TRUE)
 	// Proximity-Igniter Assembly + pipebomb -> Proximity-igniter pipebomb
-	src.AddComponent(/datum/component/assembly, /obj/item/pipebomb/bomb, PROC_REF(pipebomb_assembly), TRUE)
+	src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/pipebomb/bomb, PROC_REF(pipebomb_assembly), TRUE)
 	// Proximity-Igniter Assembly + beaker -> Proximity-igniter beakerbomb
-	src.AddComponent(/datum/component/assembly, /obj/item/reagent_containers/glass/beaker, PROC_REF(beakerbomb_assembly), TRUE)
+	src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/reagent_containers/glass/beaker, PROC_REF(beakerbomb_assembly), TRUE)
 	SPAWN(0)
 		if(!part1)
 			part1 = new(src)
@@ -432,11 +432,11 @@ Contains:
 		boutput(usr, SPAN_NOTICE("You remove the Proximity/Igniter assembly from the beaker."))
 		//since the assembly is free of beakers, let's add the assembly components again
 		// proximity-Igniter Assembly + wired pipebomb -> proximity-igniter pipebomb
-		src.AddComponent(/datum/component/assembly, /obj/item/pipebomb/frame, PROC_REF(pipebomb_frame_assembly), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/pipebomb/frame, PROC_REF(pipebomb_frame_assembly), TRUE)
 		// proximity-Igniter Assembly + pipebomb -> proximity-igniter pipebomb
-		src.AddComponent(/datum/component/assembly, /obj/item/pipebomb/bomb, PROC_REF(pipebomb_assembly), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/pipebomb/bomb, PROC_REF(pipebomb_assembly), TRUE)
 		// proximity-Igniter Assembly + beaker -> proximity-igniter beakerbomb
-		src.AddComponent(/datum/component/assembly, /obj/item/reagent_containers/glass/beaker, PROC_REF(beakerbomb_assembly), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/reagent_containers/glass/beaker, PROC_REF(beakerbomb_assembly), TRUE)
 	else boutput(usr, SPAN_ALERT("That doesn't have a beaker attached to it!"))
 
 
@@ -538,11 +538,11 @@ Contains:
 /obj/item/assembly/rad_ignite/New()
 	..()
 	// radio-Igniter Assembly + wired pipebomb -> radio-igniter pipebomb
-	src.AddComponent(/datum/component/assembly, /obj/item/pipebomb/frame, PROC_REF(pipebomb_frame_assembly), TRUE)
+	src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/pipebomb/frame, PROC_REF(pipebomb_frame_assembly), TRUE)
 	// radio-Igniter Assembly + pipebomb -> radio-igniter pipebomb
-	src.AddComponent(/datum/component/assembly, /obj/item/pipebomb/bomb, PROC_REF(pipebomb_assembly), TRUE)
+	src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/pipebomb/bomb, PROC_REF(pipebomb_assembly), TRUE)
 	// radio-Igniter Assembly + beaker -> radio-igniter beakerbomb
-	src.AddComponent(/datum/component/assembly, /obj/item/reagent_containers/glass/beaker, PROC_REF(beakerbomb_assembly), TRUE)
+	src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/reagent_containers/glass/beaker, PROC_REF(beakerbomb_assembly), TRUE)
 	SPAWN(0)
 		if(!part1)
 			part1 = new(src)
@@ -651,11 +651,11 @@ Contains:
 		boutput(usr, SPAN_NOTICE("You remove the radio/igniter assembly from the beaker."))
 		//since the assembly is free of beakers, let's add the assembly components again
 		// radio-Igniter Assembly + wired pipebomb -> radio-igniter pipebomb
-		src.AddComponent(/datum/component/assembly, /obj/item/pipebomb/frame, PROC_REF(pipebomb_frame_assembly), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/pipebomb/frame, PROC_REF(pipebomb_frame_assembly), TRUE)
 		// radio-Igniter Assembly + pipebomb -> radio-igniter pipebomb
-		src.AddComponent(/datum/component/assembly, /obj/item/pipebomb/bomb, PROC_REF(pipebomb_assembly), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/pipebomb/bomb, PROC_REF(pipebomb_assembly), TRUE)
 		// radio-Igniter Assembly + beaker -> radio-igniter beakerbomb
-		src.AddComponent(/datum/component/assembly, /obj/item/reagent_containers/glass/beaker, PROC_REF(beakerbomb_assembly), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/reagent_containers/glass/beaker, PROC_REF(beakerbomb_assembly), TRUE)
 	else boutput(usr, SPAN_ALERT("That doesn't have a beaker attached to it!"))
 
 /obj/item/assembly/rad_ignite/c_state()

--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -433,21 +433,21 @@ ABSTRACT_TYPE(/obj/item/gun/flamethrower/backtank)
 	// reset the assembly-components to readd the ones we want
 	src.RemoveComponentsOfType(/datum/component/assembly)
 	// Welder/Rods Assembly + wrench  -> deconstruction
-	src.AddComponent(/datum/component/assembly, TOOL_WRENCHING, PROC_REF(deconstruction), FALSE)
+	src.AddComponent(/datum/component/assembly/consumes_self, TOOL_WRENCHING, PROC_REF(deconstruction), FALSE)
 	if (new_state == 1)
 		src.state = 1
 		src.name = "Welder/Rods/Igniter Assembly"
 		src.desc = "A welding torch and igniter connected by metal rods."
 		src.icon_state = "welder-rods-igniter"
 		// Welder/Rods/igniter Assembly + screwdriver  -> assembly-completition
-		src.AddComponent(/datum/component/assembly, TOOL_SCREWING, PROC_REF(completition), FALSE)
+		src.AddComponent(/datum/component/assembly/consumes_self, TOOL_SCREWING, PROC_REF(completition), FALSE)
 	else
 		src.state = 0
 		src.desc = "A welding torch with metal rods attached to the flame tip."
 		src.name = "Welder/Rods Assembly"
 		src.icon_state = "welder-rods"
 		// Welder/Rods Assembly + igniter  -> Welder/Rods/Igniter Assembly
-		src.AddComponent(/datum/component/assembly, /obj/item/device/igniter, PROC_REF(igniter_attachment), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_other, /obj/item/device/igniter, PROC_REF(igniter_attachment), TRUE)
 	src.tooltip_rebuild = TRUE
 
 /obj/item/flamethrower_construction/disposing()

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1663,9 +1663,9 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 		// unwelded frame + welder -> hollow frame
 		src.AddComponent(/datum/component/assembly, TOOL_WELDING, PROC_REF(pipeframe_welding), FALSE)
 		// unwelded frame + hollow frame -> slamgun
-		src.AddComponent(/datum/component/assembly, /obj/item/pipebomb/frame, PROC_REF(slamgun_crafting), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/pipebomb/frame, PROC_REF(slamgun_crafting), TRUE)
 		// unwelded frame + mousetrap -> mousetrap roller
-		src.AddComponent(/datum/component/assembly, /obj/item/mousetrap, PROC_REF(mousetrap_roller_crafting), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/mousetrap, PROC_REF(mousetrap_roller_crafting), TRUE)
 
 	// Pipebomb/shot assembly procs
 
@@ -1687,9 +1687,9 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 		// hollow frame + cutters  -> unfilled pipeshot
 		src.AddComponent(/datum/component/assembly, TOOL_SNIPPING, PROC_REF(pipeshot_crafting), FALSE)
 		// hollow frame + *stuff*  -> hollow frame + pipebomb special effects
-		src.AddComponent(/datum/component/assembly, src.allowed_items, PROC_REF(pipebomb_stuffing), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_other, src.allowed_items, PROC_REF(pipebomb_stuffing), TRUE)
 		// hollow frame + staple gun  -> zipgun
-		src.AddComponent(/datum/component/assembly, /obj/item/staple_gun, PROC_REF(zipgun_crafting), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/staple_gun, PROC_REF(zipgun_crafting), TRUE)
 		// hollow frame + fuel  -> unwired pipebombs
 		src.AddComponent(/datum/component/assembly, list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/food/drinks,), PROC_REF(pipebomb_filling), FALSE)
 		// Since the assembly was done, return TRUE
@@ -1766,7 +1766,7 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 			if (length(item_mods) == 1)
 				src.RemoveComponentsOfType(/datum/component/assembly)
 				// hollow frame + *stuff*  -> hollow frame + pipebomb special effects
-				src.AddComponent(/datum/component/assembly, src.allowed_items, PROC_REF(pipebomb_stuffing), TRUE)
+				src.AddComponent(/datum/component/assembly/consumes_other, src.allowed_items, PROC_REF(pipebomb_stuffing), TRUE)
 				// hollow frame + fuel  -> unwired pipebombs
 				src.AddComponent(/datum/component/assembly, list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/food/drinks,), PROC_REF(pipebomb_filling), FALSE)
 			// Since the assembly was done, return TRUE
@@ -1863,7 +1863,7 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 		//Since we changed the state, remove all assembly components and add the next state ones
 		src.RemoveComponentsOfType(/datum/component/assembly)
 		// timer + wired pipebomb -> standard pipebomb
-		src.AddComponent(/datum/component/assembly, /obj/item/device/timer, PROC_REF(standard_pipebomb_crafting), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_all, /obj/item/device/timer, PROC_REF(standard_pipebomb_crafting), TRUE)
 		// Since the assembly was done, return TRUE
 		return TRUE
 

--- a/code/obj/item/tool/weldingtool.dm
+++ b/code/obj/item/tool/weldingtool.dm
@@ -40,7 +40,7 @@
 		AddComponent(/datum/component/loctargeting/simple_light, 255, 110, 135, 125, src.welding)
 
 		// Welder + rods  -> Welder/Rods Assembly
-		src.AddComponent(/datum/component/assembly, /obj/item/rods, PROC_REF(welder_rod_construction), TRUE)
+		src.AddComponent(/datum/component/assembly/consumes_self, /obj/item/rods, PROC_REF(welder_rod_construction), TRUE)
 
 // ----------------------- Assembly-procs -----------------------
 	///Begin of the flamethrower assembly


### PR DESCRIPTION
[Internal][Bug]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a proc to movables, `/atom/movable/proc/assembly_cant_be_removed()`. This one returns TRUE when an item should not be able to be turned into a different item in the three newly added children of `/datum/component/assembly`:

- `/datum/component/assembly/consume_self`: checks the proc on the parent of this component on interaction
- `/datum/component/assembly/consume_other` checks the proc on the checked_atom on interaction
- `/datum/component/assembly/consume_all` checks the proc on all atoms on interaction

Currently, this proc only return sTRUE on items used in item arms and items you cannot drop (e.g. borg items)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

With the introduction of #22230, i accidently introduced a bug where borgs can turn their welding tool into a flamethrower in progress, essentially duping flamethrowers.

Like borg arms, item arms can always cause issues with combinations or interactions that make you drop the respectable item. The procs and components should serve as a unified method to catch and prevent these cases during item combinations.
