### PR TITLE
Fix rockbox pda app bricking your pda if any rockbox was disabled

### DIFF
--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1760,13 +1760,13 @@ Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 
 		for_by_tcl(S, /obj/machinery/ore_cloud_storage_container)
 			. += "<b>Location: [get_area(S)]</b><br>"
-			if(S.is_disabled())
-				.= "No response from Rockbox™ Ore Cloud Storage Container!<br><br>"
+			if (S.is_disabled())
+				. += "No response from Rockbox™ Ore Cloud Storage Container!<br><br>"
 				continue
 			if (!length(S.ores))
 				. += "No ores stored in this Rockbox™ Ore Cloud Storage Container.<br><br>"
 				continue
-			.+= "<ul>"
+			. += "<ul>"
 			var/list/ores = S.ores
 			for(var/ore in ores)
 				var/datum/ore_cloud_data/OCD = ores[ore]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The text for is disabled was overwriting the entire return response, nuking the header that has the back/fowrard buttons

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bricking pdas bad
Fixes #21809