### PR TITLE
Player Piano Remove Manual Linking

### DIFF
--- a/_std/defines/component_defines/component_defines_special.dm
+++ b/_std/defines/component_defines/component_defines_special.dm
@@ -159,10 +159,6 @@
 /// When the door was bumped open, send the movable that opened it
 #define COMSIG_DOOR_OPENED "door_opened"
 
-// ---- Player Piano Automatic Linking ----
-
-#define COMSIG_IS_PLAYER_PIANO_AUTO_LINKER_ACTIVE "is_player_piano_auto_linker_active"
-
 // ---- Sniper Scope integration with other gun components ----
 /// Sent to an item when its sniper_scope components scope is toggled, TRUE if on and FALSE if off
 #define COMSIG_SCOPE_TOGGLED "sniper_scope_toggled"

--- a/code/datums/components/player_piano_auto_linker.dm
+++ b/code/datums/components/player_piano_auto_linker.dm
@@ -11,7 +11,6 @@ TYPEINFO(/datum/component/player_piano_auto_linker)
 	. = ..()
 	if (!ispulsingtool(parent) || start_piano == null || user == null || !istype(start_piano, /obj/player_piano) || !istype(user, /mob))
 		return COMPONENT_INCOMPATIBLE
-	RegisterSignal(parent, COMSIG_IS_PLAYER_PIANO_AUTO_LINKER_ACTIVE, PROC_REF(is_active))
 	RegisterSignal(parent, COMSIG_ITEM_ATTACKBY_PRE, PROC_REF(store_piano))
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SELF, PROC_REF(finish_storing_pianos))
 	src.pianos = list()
@@ -56,9 +55,6 @@ TYPEINFO(/datum/component/player_piano_auto_linker)
 	boutput(user, SPAN_NOTICE("Stored piano."))
 	return
 
-/datum/component/player_piano_auto_linker/proc/is_active(atom/pulser)
-	return TRUE
-
 /datum/component/player_piano_auto_linker/proc/store_piano(obj/item/pulser, atom/A, mob/user)
 	if (!istype(A, /obj/player_piano))
 		return FALSE
@@ -82,7 +78,6 @@ TYPEINFO(/datum/component/player_piano_auto_linker)
 	return TRUE
 
 /datum/component/player_piano_auto_linker/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_IS_PLAYER_PIANO_AUTO_LINKER_ACTIVE)
 	UnregisterSignal(parent, COMSIG_ITEM_ATTACKBY_PRE)
 	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_SELF)
 	for (var/obj/player_piano/piano as anything in src.pianos)

--- a/code/modules/items/instruments/playable_piano.dm
+++ b/code/modules/items/instruments/playable_piano.dm
@@ -175,58 +175,9 @@ TYPEINFO(/obj/player_piano)
 		else //just in case
 			return
 
-	mouse_drop(obj/player_piano/piano)
-		if (!istype(usr, /mob/living))
-			return
-		if (usr.stat)
-			return
-		if (!allowChange(usr))
-			boutput(usr, SPAN_ALERT("You can't link pianos without a multitool!"))
-			return
-		ENSURE_TYPE(piano)
-		if (!piano)
-			return
-		if (is_pulser_auto_linking(usr))
-			boutput(usr, SPAN_ALERT("You can't link pianos manually while auto-linking!"))
-			return
-		if (piano == src)
-			boutput(usr, SPAN_ALERT("You can't link a piano with itself!"))
-			return
-		if (piano.is_busy || src.is_busy)
-			boutput(usr, SPAN_ALERT("You can't link a busy piano!"))
-			return
-		if (piano.panel_exposed && panel_exposed)
-			usr.visible_message("[usr] links the pianos.", "You link the pianos!")
-			src.add_piano(piano)
-			piano.add_piano(src)
-
 	disposing() //just to clear up ANY funkiness
 		reset_piano(1)
 		..()
-
-	proc/allowChange(var/mob/M) //copypasted from mechanics code because why do something someone else already did better
-		if(hasvar(M, "l_hand") && ispulsingtool(M:l_hand)) return 1
-		if(hasvar(M, "r_hand") && ispulsingtool(M:r_hand)) return 1
-		if(hasvar(M, "module_states"))
-			for(var/atom/A in M:module_states)
-				if(ispulsingtool(A))
-					return 1
-		return 0
-
-	proc/is_pulser_auto_linking(var/mob/M)
-		if(ispulsingtool(M.l_hand) && SEND_SIGNAL(M.l_hand, COMSIG_IS_PLAYER_PIANO_AUTO_LINKER_ACTIVE)) return TRUE
-		if(ispulsingtool(M.r_hand) && SEND_SIGNAL(M.r_hand, COMSIG_IS_PLAYER_PIANO_AUTO_LINKER_ACTIVE)) return TRUE
-		if(istype(M, /mob/living/silicon/robot))
-			var/mob/living/silicon/robot/silicon_user = M
-			for(var/atom/A in silicon_user.module_states)
-				if(ispulsingtool(A) && SEND_SIGNAL(A, COMSIG_IS_PLAYER_PIANO_AUTO_LINKER_ACTIVE))
-					return TRUE
-		if(istype(M, /mob/living/silicon/hivebot))
-			var/mob/living/silicon/hivebot/silicon_user = M
-			for(var/atom/A in silicon_user.module_states)
-				if(ispulsingtool(A) && SEND_SIGNAL(A, COMSIG_IS_PLAYER_PIANO_AUTO_LINKER_ACTIVE))
-					return TRUE
-		return FALSE
 
 	proc/clean_input() //breaks our big input string into chunks
 		src.is_busy = 1

--- a/strings/books/player_piano.txt
+++ b/strings/books/player_piano.txt
@@ -118,7 +118,7 @@
 <ul style="padding-left: 20px;">
 	<li>You cannot change the duration of a note.</li>
 	<li>If you want to play notes at the same time, you will need to link multiple pianos together. Input notes, make one piano play, and electronics will handle the rest.</li>
-	<li>BE SURE TO LINK ALL PIANOS TOGETHER. IF YOU HAVE THREE, YOU WILL NEED TO LINK THE FIRST AND SECOND, SECOND AND THIRD, AND FIRST AND THIRD.</li>
+	<li>BE SURE TO LINK ALL PIANOS TOGETHER.</li>
 	<li>You can only enter up to 1920 notes.</li>
 </ul>
 
@@ -133,8 +133,6 @@
 	</ul>
 	<li>You can access your piano's internal workings by prying off the front panel.</li>
 	<li>You can use a multitool to reset the piano's memory once you have access to its insides.</li>
-	<li>You can use a multitool to link player pianos together like you would a mechcomp component.</li>
-	<li>If your linked pianos sound weird, you may have linked a set of pianos together multiple times. Use a multitool or key to reset and relink <i>carefully</i>.</li>
 	<li>You can use a wirecutter to disable looping. (WARNING, THIS IS PERMANENT, DON'T LOSE YOUR DAMN KEY)</li>
 	<li>You can use a screwdriver to raise and lower the wheel bolts, making the piano moveable.</li>
 </ul>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[GAME OBJECTS] [REMOVAL] [BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes manual linking, associated checks, and associated references in the `player_piano.txt`.

Auto-linking still remains.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

There may be some edge cases related to manual linking that causes erroneous behavior. See issues #19601 and #8969.

This is more likely to happen when the player has to link a large set of pianos, since manually keeping track of which pianos to link is not easy.

Ever since PR #14878, we had a better way to link pianos that's both faster and easier. There shouldn't be any reason to keep manual linking around.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Facsimile
(+)Removed manual linking from Player Pianos. Instead, use auto-linking as described the in Player Piano book.
```
