### PR TITLE
Fixes fishing rod inhands

### DIFF
--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -124,6 +124,12 @@
 			src.user.update_inhands()
 			return
 
+	onInterrupt(flag)
+		src.rod.is_fishing = FALSE
+		src.rod.UpdateIcon()
+		src.user.update_inhands()
+		. = ..()
+
 	onEnd()
 		if (!(BOUNDS_DIST(src.user, src.rod) == 0) || !(BOUNDS_DIST(src.user, src.target) == 0) || !src.user || !src.target || !src.rod || !src.fishing_spot)
 			..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an onInterrupt check to the fishing action that changes the rod's icon when fishing is interrupted.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fishing is not properly interrupted when the action is interrupted, such as when clicking something else while fishing.

Relatedly closes https://github.com/goonstation/goonstation/issues/22219 as it will now provide clear feedback on what caused it to stop fishing.
