### PR TITLE
TGUI-ify MechComp Signal Editing Windows

### DIFF
--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -308,7 +308,7 @@ TYPEINFO(/datum/component/mechanics_holder)
 		boutput(user, SPAN_ALERT("Components need to be within a range of 14 meters to connect."))
 		return
 
-	var/typesel = input(user, "Use [parent] as:", "Connection Type") in list("Trigger", "Receiver", "*CANCEL*")
+	var/typesel = tgui_input_list(user, "Use [parent] as:", "Connection Type", list("Trigger", "Receiver", "*CANCEL*"))
 	switch(typesel)
 		if("Trigger")
 			SEND_SIGNAL(A, _COMSIG_MECHCOMP_LINK, parent, user)
@@ -360,7 +360,7 @@ TYPEINFO(/datum/component/mechanics_holder)
 	var/pointer_container[1] //A list of size 1, to store the address of the list we want
 	SEND_SIGNAL(trigger, _COMSIG_MECHCOMP_GET_OUTGOING, pointer_container)
 	var/list/trg_outgoing = pointer_container[1]
-	var/selected_input = input(user, "Select \"[receiver.name]\" Input", "Input Selection") in inputs + "*CANCEL*"
+	var/selected_input = tgui_input_list(user, "Select \"[receiver.name]\" Input", "Input Selection", inputs + "*CANCEL*")
 	if(selected_input == "*CANCEL*")
 		return
 
@@ -418,12 +418,12 @@ TYPEINFO(/datum/component/mechanics_holder)
 		if(hacked_vendor.panel_open)
 			return
 	if(length(src.configs))
-		var/selected_config = input("Select a config to modify!", "Config", null) as null|anything in src.configs
+		var/selected_config = tgui_input_list(user, "Select a config to modify!", "Config", src.configs)
 		if (!in_interact_range(parent, user)) return TRUE
 		if(selected_config)
 			switch(selected_config)
 				if(SET_SEND)
-					var/inp = input(user,"Please enter Signal:", "Signal setting", defaultSignal) as text
+					var/inp = tgui_input_text(user, "Please enter Signal:", "Signal setting", defaultSignal)
 					if(!in_interact_range(parent, user) || user.stat)
 						return
 					inp = trimtext(strip_html_tags(inp))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[UI] [FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Replaces `input` with `tgui_input_list` and `tgui_input_text` where appropriate in `mechComp_signals.dm`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

TGUI inputs are better than the default `input` UI.

Also consistency with the ever-increasing list of things that use TGUI.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Facsimile
(+)MechComp signal editing now uses TGUI.
```
