### PR TITLE
Prevent the construction of welder-rod-assemblies while the welding tool is activated

### DIFF
--- a/code/obj/item/tool/weldingtool.dm
+++ b/code/obj/item/tool/weldingtool.dm
@@ -45,6 +45,8 @@
 // ----------------------- Assembly-procs -----------------------
 	///Begin of the flamethrower assembly
 	proc/welder_rod_construction(var/atom/to_combine_atom, var/mob/user)
+		if (src.welding)
+			return
 		boutput(user, SPAN_NOTICE("You attach the rod to the welding tool."))
 		var/obj/item/rods/handled_rods = to_combine_atom
 		handled_rods.add_fingerprint(user)


### PR DESCRIPTION
[Bug][Game Objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This prevents the start of the flamethrower assembly while the welding tool is activated. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

#22230 introduced #22295 because for some ungodly reason applying a welding tool on material rods was assigned a different action as applying material rods onto a welding tool (the same like filled pipebomb-frames on igniter/timer assembly did create pipebombs and the other way around mater igniter/timer/pipebomb assemblies).

Differentiating between the actions by having the activation state of the welder makes the most sense here.

This fixes #22295