### PR TITLE
Add Piano Supply Packs

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -2056,33 +2056,32 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 	contains = list(/obj/item/instrument/bass)
 	containertype = /obj/storage/crate/wooden
 
-/datum/supply_packs/player_piano
+/datum/supply_packs/complex/player_piano
 	name = "Player Piano Kit"
 	desc = "1x Player Piano Kit"
 	category = "Civilian Department"
 	cost = PAY_TRADESMAN*3
 	containername = "Player Piano Kit"
-	contains = list(/obj/player_piano)
+	frames = list(/obj/player_piano)
 	containertype = /obj/storage/crate/wooden
 
-/datum/supply_packs/piano
+/datum/supply_packs/complex/piano
 	name = "Piano Kit"
 	desc = "1x Piano Kit"
 	category = "Civilian Department"
 	cost = PAY_TRADESMAN*3
 	containername = "Piano Kit"
-	contains = list(/obj/item/instrument/large/piano)
+	frames = list(/obj/item/instrument/large/piano)
 	containertype = /obj/storage/crate/wooden
 
-/datum/supply_packs/piano_grand
+/datum/supply_packs/complex/piano_grand
 	name = "Grand Piano Kit"
 	desc = "1x Grand Piano Kit"
 	category = "Civilian Department"
 	cost = PAY_TRADESMAN*3
 	containername = "Grand Piano Kit"
-	contains = list(/obj/item/instrument/large/piano/grand)
+	frames = list(/obj/item/instrument/large/piano/grand)
 	containertype = /obj/storage/crate/wooden
-
 
 //Western
 /datum/supply_packs/west_coats

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -2056,6 +2056,33 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 	contains = list(/obj/item/instrument/bass)
 	containertype = /obj/storage/crate/wooden
 
+/datum/supply_packs/player_piano
+	name = "Player Piano Kit"
+	desc = "1x Player Piano Kit"
+	category = "Civilian Department"
+	cost = PAY_TRADESMAN*3
+	containername = "Player Piano Kit"
+	contains = list(/obj/player_piano)
+	containertype = /obj/storage/crate/wooden
+
+/datum/supply_packs/piano
+	name = "Piano Kit"
+	desc = "1x Piano Kit"
+	category = "Civilian Department"
+	cost = PAY_TRADESMAN*3
+	containername = "Piano Kit"
+	contains = list(/obj/item/instrument/large/piano)
+	containertype = /obj/storage/crate/wooden
+
+/datum/supply_packs/piano_grand
+	name = "Grand Piano Kit"
+	desc = "1x Grand Piano Kit"
+	category = "Civilian Department"
+	cost = PAY_TRADESMAN*3
+	containername = "Grand Piano Kit"
+	contains = list(/obj/item/instrument/large/piano/grand)
+	containertype = /obj/storage/crate/wooden
+
 
 //Western
 /datum/supply_packs/west_coats


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[GAME OBJECTS] [FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds supply packs to cargo for the Player Piano, Piano, and Grand Piano.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

There may be people on a map that want to play piano, but can't since someone else is using it. Since there's a limited amount of pianos on maps.

Also added the Player Piano for maps that don't have one (e.g. Atlas).

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Facsimile
(*)Adds supply packs to cargo for the Player Piano, Piano, and Grand Piano.
```
