### PR TITLE
Bang! guns can gunpoint

### DIFF
--- a/_std/macros/items.dm
+++ b/_std/macros/items.dm
@@ -30,3 +30,5 @@
 #define IS_NPC_ILLEGAL_ITEM(x) ( \
 		istype(x, /obj/item/body_bag) && x.w_class >= W_CLASS_BULKY \
 	)
+
+#define cangunpoint(x) (istype(x, /obj/item/gun) || istype(x, /obj/item/bang_gun))

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -614,12 +614,11 @@
 	if(src.client && !(target in view(src.client.view))) //don't point at things we can't see
 		return
 
-	var/obj/item/gun/G = src.equipped()
 	var/gunpoint = FALSE
-	if(!istype(G) || !ismob(target))
+	if(!cangunpoint(src.equipped()) || !ismob(target))
 		src.visible_message(SPAN_EMOTE("<b>[src]</b> points to [target]."))
 	else
-		src.visible_message("<span style='font-weight:bold;color:#f00;font-size:120%;'>[src] points \the [G] at [target]!</span>")
+		src.visible_message("<span style='font-weight:bold;color:#f00;font-size:120%;'>[src] points \the [src.equipped()] at [target]!</span>")
 		gunpoint = TRUE
 	if (!ON_COOLDOWN(src, "point", 0.5 SECONDS))
 		..()

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -614,11 +614,12 @@
 	if(src.client && !(target in view(src.client.view))) //don't point at things we can't see
 		return
 
+	var/obj/item/I = src.equipped()
 	var/gunpoint = FALSE
-	if(!cangunpoint(src.equipped()) || !ismob(target))
+	if(!cangunpoint(I) || !ismob(target))
 		src.visible_message(SPAN_EMOTE("<b>[src]</b> points to [target]."))
 	else
-		src.visible_message("<span style='font-weight:bold;color:#f00;font-size:120%;'>[src] points \the [src.equipped()] at [target]!</span>")
+		src.visible_message("<span style='font-weight:bold;color:#f00;font-size:120%;'>[src] points \the [I] at [target]!</span>")
 		gunpoint = TRUE
 	if (!ON_COOLDOWN(src, "point", 0.5 SECONDS))
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Add a macro `cangunpoint` including regular guns and bang guns
* use the macro in gunpoint code

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
foam guns can gunpoint, so these gun-like toys should be able to gunpoint too
Fix #21878