### PR TITLE
Rename "Medical Research" area to "Genetic Research"

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -2963,7 +2963,7 @@ ABSTRACT_TYPE(/area/station/medical)
 	station_map_colour = MAPC_ROBOTICS
 
 /area/station/medical/research
-	name = "Medical Research"
+	name = "Genetic Research"
 	icon_state = "medresearch"
 	sound_environment = 3
 	station_map_colour = MAPC_MEDRESEARCH

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -65371,9 +65371,9 @@
 "ygN" = (
 /obj/disposalpipe/segment,
 /obj/machinery/power/apc{
-	areastring = "Medical Research";
+	areastring = "Genetic Research";
 	dir = 8;
-	name = "Medical Research APC";
+	name = "Genetic Research APC";
 	pixel_x = -24
 	},
 /obj/cable,

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -3863,9 +3863,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "amS" = (
 /obj/machinery/power/apc{
 	areastring = "Crematorium";
@@ -46230,9 +46228,7 @@
 	dir = 4;
 	icon_state = "blue2"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cIl" = (
 /obj/disposalpipe/segment/transport,
 /obj/machinery/genetics_booth,
@@ -46521,17 +46517,13 @@
 /turf/simulated/floor/greenwhite{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cJy" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cJF" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10;
@@ -46992,9 +46984,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 5
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cLj" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -47381,9 +47371,7 @@
 	},
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cMI" = (
 /obj/stool/chair{
 	dir = 8
@@ -47392,14 +47380,10 @@
 /turf/simulated/floor/greenwhite{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cMJ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cMK" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/staff)
@@ -47720,9 +47704,7 @@
 	dir = 1;
 	icon_state = "blue2"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cNX" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -47732,26 +47714,20 @@
 	dir = 1;
 	icon_state = "blue2"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cNY" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "blue2"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cNZ" = (
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/greenwhite{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cOb" = (
 /obj/storage/closet/office,
 /turf/simulated/floor/carpet/arcade,
@@ -48173,9 +48149,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "blue1"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cPv" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -48184,9 +48158,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "blue1"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cPA" = (
 /obj/stool/chair/comfy,
 /obj/item/clothing/suit/cardboard_box/head_surgeon,
@@ -48517,9 +48489,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cQT" = (
 /obj/landmark/gps_waypoint,
 /obj/cable{
@@ -48529,9 +48499,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "blue1"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cQU" = (
 /obj/machinery/computer/genetics{
 	dir = 8
@@ -48541,9 +48509,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cQW" = (
 /obj/table/wood/auto,
 /obj/machinery/light/incandescent,
@@ -49009,23 +48975,17 @@
 /turf/simulated/floor/greenwhite{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cSE" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cSF" = (
 /turf/simulated/floor/carpet/arcade,
 /area/station/medical/staff)
 "cSG" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cSH" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/carpet/arcade,
@@ -50015,9 +49975,7 @@
 	dir = 9;
 	icon_state = "blue2"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cWD" = (
 /obj/disposalpipe/segment/transport{
 	icon_state = "pipe-c"
@@ -50544,9 +50502,7 @@
 	dir = 8;
 	icon_state = "blue2"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cYe" = (
 /obj/machinery/door/airlock/pyro/glass/med,
 /obj/disposalpipe/segment/transport,
@@ -51976,9 +51932,7 @@
 /obj/landmark/start/job/geneticist,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ddJ" = (
 /obj/stool/chair/couch{
 	dir = 4
@@ -55565,9 +55519,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "dOL" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/info_map,
@@ -56149,9 +56101,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 10
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "evs" = (
 /obj/mesh/catwalk{
 	dir = 9
@@ -56332,9 +56282,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "eGS" = (
 /obj/machinery/atmospherics/unary/vent{
 	dir = 1
@@ -57005,9 +56953,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "blue2"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "flI" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 1
@@ -57704,9 +57650,7 @@
 /obj/mapping_helper/access/medlab,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "gcD" = (
 /obj/cable/blue{
 	icon_state = "4-8"
@@ -59443,9 +59387,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 9
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "hOR" = (
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/shuttlebay,
@@ -60223,9 +60165,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "iuC" = (
 /obj/rack,
 /obj/item/clothing/suit/space,
@@ -60570,9 +60510,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "iMJ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -61302,9 +61240,7 @@
 	dir = 10;
 	icon_state = "blue2"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "jwG" = (
 /obj/machinery/light{
 	dir = 1;
@@ -61692,9 +61628,7 @@
 "jMq" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/greenwhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "jNc" = (
 /obj/decal/poster/wallsign/hazard_caution,
 /turf/simulated/wall/auto/supernorn,
@@ -61890,9 +61824,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "jUq" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 8
@@ -63050,9 +62982,7 @@
 	},
 /obj/disposalpipe/trunk/transport,
 /turf/simulated/floor/greenwhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "kYb" = (
 /obj/machinery/light/lamp/black,
 /obj/table/reinforced/chemistry/auto/basicsup,
@@ -63458,9 +63388,7 @@
 	},
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/greenwhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "lsl" = (
 /obj/cable/yellow,
 /obj/cable/yellow{
@@ -64194,9 +64122,7 @@
 	dir = 6;
 	icon_state = "blue2"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "mdN" = (
 /obj/mesh/catwalk{
 	dir = 9
@@ -64322,9 +64248,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "mmn" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor,
@@ -65887,9 +65811,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "blue2"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "nJi" = (
 /obj/machinery/computer/operating/small{
 	id = "OR2"
@@ -66813,9 +66735,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 6
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "oKC" = (
 /obj/stool/chair{
 	dir = 1
@@ -67194,9 +67114,7 @@
 	},
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "pcG" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 5;
@@ -68930,9 +68848,7 @@
 	dir = 4;
 	icon_state = "blue2"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "qOn" = (
 /obj/machinery/shuttle/engine/heater/seaheater_right{
 	pixel_y = -14;
@@ -70908,9 +70824,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "blue1"
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "sJn" = (
 /obj/decal/tile_edge/line/blue{
 	icon_state = "noedge-tile1"
@@ -70950,9 +70864,7 @@
 /obj/machinery/disposal/mail/autoname/medbay/genetics,
 /obj/disposalpipe/trunk/mail/north,
 /turf/simulated/floor/greenwhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "sLX" = (
 /obj/stool/chair{
 	dir = 1
@@ -72311,9 +72223,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uao" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail/vertical,
@@ -73414,9 +73324,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vuu" = (
 /obj/cable/yellow,
 /obj/cable/yellow{
@@ -75208,9 +75116,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "xvB" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light/lamp/black,

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -923,9 +923,7 @@
 	},
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "alB" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
@@ -3582,9 +3580,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/greenblack,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aYw" = (
 /obj/disposalpipe/segment/brig,
 /obj/machinery/door/airlock/pyro/engineering,
@@ -5052,9 +5048,7 @@
 	},
 /obj/machinery/light/incandescent/greenish,
 /turf/simulated/floor/greenblack,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "bvI" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -5573,9 +5567,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "bCH" = (
 /turf/simulated/wall/auto/jen/yellow,
 /area/station/maintenance/inner/se)
@@ -6014,9 +6006,7 @@
 /area/station/medical/asylum/main)
 "bJh" = (
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "bJi" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -8409,9 +8399,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "crB" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -8435,9 +8423,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "csf" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -9901,9 +9887,7 @@
 	},
 /obj/item/cloneModule/genepowermodule,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cPl" = (
 /obj/table/wood/round/auto,
 /obj/random_item_spawner/med_kit/one,
@@ -11611,9 +11595,7 @@
 	id = "genetics"
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "doY" = (
 /obj/decal/stripe_caution,
 /obj/machinery/optable,
@@ -11984,9 +11966,7 @@
 "dws" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "dwz" = (
 /turf/simulated/floor/black,
 /area/station/ai_monitored/storage/eva)
@@ -12309,9 +12289,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 10
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "dCw" = (
 /obj/table/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -14657,9 +14635,7 @@
 "elK" = (
 /obj/machinery/genetics_scanner,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "elM" = (
 /turf/simulated/wall/auto/jen/yellow,
 /area/station/storage/auxillary{
@@ -15798,9 +15774,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "eGN" = (
 /obj/mesh/catwalk/jen,
 /obj/disposalpipe/segment/transport,
@@ -16031,9 +16005,7 @@
 /turf/simulated/floor/greenblack/corner{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "eKf" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/stairs/wide/other{
@@ -18032,9 +18004,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "fqB" = (
 /obj/machinery/turret{
 	dir = 5
@@ -22366,9 +22336,7 @@
 /area/station/hangar/science)
 "gHC" = (
 /turf/simulated/wall/auto/jen/blue,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "gHF" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail,
@@ -24985,9 +24953,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/greenblack,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "hvR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -26425,9 +26391,7 @@
 	},
 /obj/landmark/start/job/geneticist,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "hVZ" = (
 /obj/decal/floatingtiles{
 	dir = 4
@@ -27890,9 +27854,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ivU" = (
 /obj/machinery/rkit,
 /obj/machinery/light/incandescent/warm{
@@ -29249,9 +29211,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "iRy" = (
 /turf/simulated/floor/carpet/green/fancy/narrow/se,
 /area/station/crew_quarters/heads)
@@ -30712,9 +30672,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "jnk" = (
 /turf/simulated/wall/auto/jen/yellow,
 /area/station/quartermaster/office)
@@ -33530,9 +33488,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "kfc" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -34326,9 +34282,7 @@
 /turf/simulated/floor/greenblack/corner{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "kqN" = (
 /obj/storage/closet/dresser/random,
 /obj/disposalpipe/segment/mail,
@@ -34853,9 +34807,7 @@
 	},
 /mob/living/carbon/human/npc/monkey,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "kyM" = (
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -35311,9 +35263,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 9
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "kFs" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/red/side{
@@ -35982,9 +35932,7 @@
 	id = "genetics"
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "kQt" = (
 /obj/mesh/catwalk{
 	dir = 4
@@ -36813,9 +36761,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/greenblack,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "leE" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/white,
@@ -43328,9 +43274,7 @@
 	},
 /obj/machinery/light/incandescent/greenish,
 /turf/simulated/floor/greenblack,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ndl" = (
 /obj/decal/tile_edge/line/red{
 	icon_state = "line-broken3"
@@ -56595,9 +56539,7 @@
 /area/station/routing/depot)
 "rfG" = (
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "rfI" = (
 /obj/machinery/light/incandescent/harsh{
 	dir = 1
@@ -56832,9 +56774,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "rkE" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -61051,9 +60991,7 @@
 	},
 /obj/landmark/start/job/geneticist,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "syh" = (
 /obj/stool/chair/red,
 /obj/machinery/bot/medbot/no_camera,
@@ -75089,9 +75027,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wGe" = (
 /obj/machinery/light/small/floor/netural,
 /turf/unsimulated/floor/shuttle{
@@ -76484,9 +76420,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wZJ" = (
 /obj/railing/orange,
 /obj/decal/cleanable/dirt/jen,
@@ -78312,9 +78246,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "xyT" = (
 /obj/decal/cleanable/rust/jen,
 /obj/table/reinforced/auto,

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -9897,9 +9897,7 @@
 /area/station/maintenance/disposal)
 "aNH" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aNI" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/camera{
@@ -10029,9 +10027,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aOD" = (
 /obj/machinery/disposal,
 /obj/machinery/light{
@@ -10043,9 +10039,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aOE" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -10056,9 +10050,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aOF" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -10234,9 +10226,7 @@
 	},
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aPv" = (
 /obj/stool/chair/blue{
 	dir = 8
@@ -10250,9 +10240,7 @@
 	},
 /obj/landmark/start/job/geneticist,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aPw" = (
 /obj/stool/chair/blue{
 	dir = 4
@@ -10266,9 +10254,7 @@
 	},
 /obj/landmark/start/job/geneticist,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aPx" = (
 /obj/machinery/computer/genetics{
 	dir = 8
@@ -10278,9 +10264,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aPz" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/disposalpipe/segment/vertical,
@@ -10469,9 +10453,7 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aQz" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/cable{
@@ -10480,9 +10462,7 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aQA" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -10495,9 +10475,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue/checker,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aQB" = (
 /obj/machinery/genetics_scanner,
 /obj/cable{
@@ -10507,18 +10485,14 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aQD" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aQE" = (
 /obj/table/wood/auto,
 /obj/item/matchbook,
@@ -10823,9 +10797,7 @@
 	},
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/blue/checker,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aRG" = (
 /obj/disposalpipe/segment/mail/bent/north,
 /obj/cable{
@@ -10834,9 +10806,7 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aRH" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment/vertical,
@@ -10853,18 +10823,14 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aRI" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/checker,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aRL" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -11113,18 +11079,14 @@
 /obj/stool/bench/blue/auto,
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aSI" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aSJ" = (
 /obj/table/auto,
 /obj/machinery/cashreg,
@@ -11135,16 +11097,12 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aSK" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aSM" = (
 /obj/disposalpipe/segment/vertical,
 /obj/random_item_spawner/junk/one_or_zero,
@@ -13992,9 +13950,7 @@
 /obj/stool/bench/blue/auto,
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "bgc" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -46656,9 +46612,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "omL" = (
 /obj/disposalpipe/segment/mail/bent/east,
 /obj/cable{
@@ -49421,9 +49375,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "qpA" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -50438,9 +50390,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "qZV" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 8
@@ -53125,9 +53075,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "sTc" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/door/airlock/pyro{
@@ -53370,9 +53318,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "tab" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/left{
@@ -56355,9 +56301,7 @@
 "veN" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vfc" = (
 /obj/machinery/atmospherics/binary/passive_gate/opened{
 	dir = 8;
@@ -57010,9 +56954,7 @@
 /area/station/maintenance/southeast)
 "vzK" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vzU" = (
 /obj/machinery/dispenser,
 /obj/item/device/radio/intercom/engineering,
@@ -57755,9 +57697,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wix" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -2672,9 +2672,7 @@
 /turf/simulated/floor/blackwhite{
 	dir = 6
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "bjU" = (
 /obj/noticeboard/persistent{
 	name = "Cargo persistent notice board";
@@ -5686,9 +5684,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cBP" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/decal/cleanable/dirt/jen,
@@ -5718,9 +5714,7 @@
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cDk" = (
 /obj/machinery/computer/transception{
 	dir = 8
@@ -12565,9 +12559,7 @@
 /turf/simulated/floor/blackwhite{
 	dir = 9
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "fAZ" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 8;
@@ -13989,9 +13981,7 @@
 /turf/simulated/floor/blackwhite{
 	dir = 9
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ghz" = (
 /obj/machinery/light/small,
 /obj/stool/bed,
@@ -17669,9 +17659,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "hyl" = (
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/redblack,
@@ -19362,9 +19350,7 @@
 "igo" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "igp" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -19612,9 +19598,7 @@
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ilD" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -20207,9 +20191,7 @@
 /area/station/crew_quarters/catering)
 "ixn" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ixp" = (
 /obj/stool/chair/blue{
 	dir = 8
@@ -23581,9 +23563,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "jSs" = (
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/redblack{
@@ -28889,9 +28869,7 @@
 /turf/simulated/floor/blackwhite{
 	dir = 9
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "lYy" = (
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
@@ -32303,9 +32281,7 @@
 "nwS" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "nxg" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -35128,9 +35104,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "oIP" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37090,9 +37064,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "pyd" = (
 /obj/decal/poster/wallsign/fuck2,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -39237,9 +39209,7 @@
 /turf/simulated/floor/blackwhite{
 	dir = 9
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "qvZ" = (
 /obj/stool/chair/couch{
 	desc = "It's comfortable, but has an aura of unease about it, like somebody's watching you the moment you sit down.";
@@ -43902,9 +43872,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "sFC" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 5
@@ -44874,9 +44842,7 @@
 /turf/simulated/floor/blackwhite{
 	dir = 6
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "tau" = (
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/sanitary/white,
@@ -45186,9 +45152,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "thf" = (
 /obj/machinery/door/feather/friendly{
 	dir = 4
@@ -47641,9 +47605,7 @@
 /turf/simulated/floor/blackwhite{
 	dir = 6
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uiV" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/disposalpipe/segment/mineral,
@@ -49663,9 +49625,7 @@
 /turf/simulated/floor/blackwhite{
 	dir = 9
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vhP" = (
 /obj/stool/chair/couch{
 	dir = 4;
@@ -55564,9 +55524,7 @@
 /obj/monkeyplant,
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "xOa" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/black/grime,
@@ -56539,9 +56497,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 
 (1,1,1) = {"
 oeA

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -764,9 +764,7 @@
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "acg" = (
 /obj/machinery/light/incandescent/warm,
 /obj/machinery/power/apc/autoname_north,
@@ -824,9 +822,7 @@
 "acy" = (
 /obj/machinery/genetics_scanner,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "acz" = (
 /obj/storage/secure/closet/command/research_director,
 /obj/item/remote/porter/port_a_sci,
@@ -901,9 +897,7 @@
 /obj/item/cloneModule/genepowermodule,
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "acI" = (
 /obj/table/glass/reinforced/auto,
 /obj/item/storage/toolbox/emergency,
@@ -915,9 +909,7 @@
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "acL" = (
 /turf/simulated/floor/shuttlebay,
 /area/shuttle/sea_elevator_room)
@@ -1012,9 +1004,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "adg" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -1666,9 +1656,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "afw" = (
 /obj/machinery/sparker{
 	dir = 2;
@@ -2017,9 +2005,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "agQ" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/caution/corner/ne,
@@ -2081,9 +2067,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ahk" = (
 /obj/stool/chair,
 /turf/simulated/floor/plating/random,
@@ -2150,18 +2134,14 @@
 /area/station/medical/medbay/psychiatrist)
 "ahB" = (
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ahC" = (
 /obj/disposalpipe/segment/produce{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ahD" = (
 /obj/disposalpipe/segment/produce{
 	dir = 4;
@@ -2174,9 +2154,7 @@
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ahE" = (
 /obj/disposalpipe/segment/produce{
 	dir = 4
@@ -2184,9 +2162,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ahG" = (
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
@@ -2305,9 +2281,7 @@
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aig" = (
 /obj/machinery/conveyor/WE/carousel,
 /turf/simulated/floor/plating/random,
@@ -2321,18 +2295,14 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aii" = (
 /obj/disposalpipe/trunk/produce{
 	dir = 1
 	},
 /obj/machinery/disposal/sci,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aij" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge/customs)
@@ -2508,9 +2478,7 @@
 	},
 /obj/monkeyplant,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aiX" = (
 /obj/rack,
 /obj/item/gun/kinetic/riot40mm{
@@ -2545,9 +2513,7 @@
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aiZ" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/bluewhite{
@@ -2786,9 +2752,7 @@
 /area/station/maintenance/north)
 "ajG" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ajJ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery)
@@ -3633,9 +3597,7 @@
 /obj/machinery/genetics_scanner,
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "amx" = (
 /turf/simulated/floor/bluewhite/corner,
 /area/station/medical/medbay)
@@ -13528,9 +13490,7 @@
 "aUO" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aUP" = (
 /obj/decal/cleanable/machine_debris{
 	icon_state = "gib7";
@@ -34004,9 +33964,7 @@
 /obj/landmark/spawner/inside/monkey,
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "fsN" = (
 /obj/machinery/door/airlock/pyro/alt{
 	dir = 4;
@@ -34048,9 +34006,7 @@
 /obj/disposalpipe/segment/produce,
 /obj/window_blinds/cog2/middle,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "fzx" = (
 /obj/stool/chair/comfy{
 	dir = 4
@@ -36281,9 +36237,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "iDU" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating,
@@ -36927,9 +36881,7 @@
 /obj/disposalpipe/segment/mail,
 /obj/machinery/door/airlock/pyro/medical/alt,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "jyd" = (
 /obj/disposalpipe/segment,
 /obj/machinery/firealarm/west,
@@ -37577,9 +37529,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "krS" = (
 /obj/disposalpipe/trunk/south{
 	pixel_z = 1
@@ -37809,9 +37759,7 @@
 /obj/machinery/disposal/small/east,
 /obj/disposalpipe/trunk/south,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "kHg" = (
 /obj/crevice{
 	pixel_y = 30
@@ -39635,9 +39583,7 @@
 	},
 /obj/landmark/start/job/geneticist,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "mTd" = (
 /obj/machinery/firealarm/north,
 /turf/simulated/floor,
@@ -41652,9 +41598,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "pxV" = (
 /turf/simulated/floor/blue/corner{
 	dir = 8
@@ -45031,9 +44975,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uqU" = (
 /obj/landmark/gps_waypoint,
 /obj/cable{
@@ -46888,9 +46830,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wWe" = (
 /obj/kitchenspike,
 /obj/machinery/firealarm/north,

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -12756,9 +12756,9 @@
 "aEF" = (
 /obj/disposalpipe/segment,
 /obj/machinery/power/apc{
-	areastring = "Medical Research";
+	areastring = "Genetic Research";
 	dir = 4;
-	name = "Medical Research APC";
+	name = "Genetic Research APC";
 	pixel_x = 24
 	},
 /obj/cable,

--- a/maps/unused/density.dmm
+++ b/maps/unused/density.dmm
@@ -4567,9 +4567,9 @@
 "kM" = (
 /obj/disposalpipe/segment,
 /obj/machinery/power/apc{
-	areastring = "Medical Research";
+	areastring = "Genetic Research";
 	dir = 8;
-	name = "Medical Research APC";
+	name = "Genetic Research APC";
 	pixel_x = -24
 	},
 /obj/cable{
@@ -5080,7 +5080,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/medical{
-	name = "Medical Research";
+	name = "Genetic Research";
 	req_access = null
 	},
 /obj/mapping_helper/access/robotics,

--- a/maps/unused/destiny.dmm
+++ b/maps/unused/destiny.dmm
@@ -6270,9 +6270,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aCz" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8;
@@ -6831,9 +6829,7 @@
 	pixel_x = 11
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aFu" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 9;
@@ -7197,9 +7193,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aGN" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -7226,9 +7220,7 @@
 /area/station/mining/refinery)
 "aGU" = (
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aGV" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/north)
@@ -7340,9 +7332,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aHo" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -7626,9 +7616,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aIE" = (
 /obj/decal/tile_edge/line/white{
 	icon_state = "line1"
@@ -8199,9 +8187,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aKW" = (
 /obj/cable,
 /obj/cable{
@@ -8244,9 +8230,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aKY" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/decal/tile_edge/line/purple{
@@ -8266,9 +8250,7 @@
 	},
 /obj/machinery/cashreg,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aKZ" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -8479,9 +8461,7 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aMm" = (
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/west{
@@ -8645,9 +8625,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aMB" = (
 /obj/storage/closet/coffin/wood,
 /obj/item/device/radio/intercom/security,
@@ -8683,9 +8661,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aMF" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -11200,9 +11176,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "bdc" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -11248,9 +11222,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "bdm" = (
 /obj/disposalpipe/switch_junction{
 	desc = "An underfloor mail pipe.";
@@ -14216,9 +14188,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "bzy" = (
 /obj/mesh/grille/steel,
 /turf/simulated/floor/plating/airless,
@@ -15544,9 +15514,7 @@
 	},
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "bUr" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -16268,9 +16236,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "clh" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -16359,9 +16325,7 @@
 /obj/cable,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/random,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cmN" = (
 /obj/stool/chair/dining/wood,
 /obj/cable{
@@ -17446,9 +17410,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cKp" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/wood{
@@ -18990,9 +18952,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/medlab,
 /turf/simulated/floor/grass/random,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "drA" = (
 /obj/machinery/conveyor/NS{
 	id = "disposals";
@@ -21937,9 +21897,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/medlab,
 /turf/simulated/floor/plating/random,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "eFx" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -22107,9 +22065,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "eJk" = (
 /obj/landmark/start/job/bartender,
 /obj/decal/tile_edge/stripe/extra_big,
@@ -22920,9 +22876,7 @@
 /area/station/crew_quarters/lounge)
 "eZD" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "eZL" = (
 /obj/cable/yellow{
 	icon_state = "0-8"
@@ -23437,9 +23391,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "flK" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/disposalpipe/segment{
@@ -23508,9 +23460,7 @@
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/random,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "fmX" = (
 /obj/railing/orange/reinforced{
 	dir = 4
@@ -25827,9 +25777,7 @@
 	icon_state = "line2"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "goR" = (
 /obj/table/reinforced/auto,
 /obj/window/reinforced/west,
@@ -30649,9 +30597,7 @@
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/random,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "iSC" = (
 /obj/decal/tile_edge/line/red{
 	dir = 1;
@@ -31167,9 +31113,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 10
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "jgI" = (
 /obj/stool/chair/office/yellow{
 	dir = 8
@@ -35242,9 +35186,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "lnt" = (
 /obj/cable,
 /obj/cable,
@@ -39436,9 +39378,7 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "nsV" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -39653,9 +39593,7 @@
 	pixel_x = 11
 	},
 /turf/simulated/floor/greenwhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "nxN" = (
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -40264,9 +40202,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/medlab,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "nOL" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -42058,9 +41994,7 @@
 /area/station/storage/tools)
 "oRz" = (
 /turf/simulated/floor/greenwhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "oRI" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50634,9 +50568,7 @@
 	},
 /obj/disposalpipe/trunk,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "tmJ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -53073,9 +53005,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uBC" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -53688,9 +53618,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uOM" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/outer/sw)
@@ -54015,9 +53943,7 @@
 /turf/simulated/floor/greenwhite{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uWW" = (
 /obj/item_dispenser/latex_gloves,
 /obj/stool/chair/blue,
@@ -55613,9 +55539,7 @@
 "vKa" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/greenwhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vKh" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -56850,9 +56774,7 @@
 /obj/cable,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/random,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wrw" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/storage/scanner{
@@ -58711,9 +58633,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "xmd" = (
 /obj/stool/chair/office/purple{
 	dir = 4
@@ -59195,9 +59115,7 @@
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/random,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "xxW" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -59317,9 +59235,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "xzT" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -60207,9 +60123,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/medlab,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "xZl" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -60634,9 +60548,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ykI" = (
 /obj/cable{
 	icon_state = "1-2"

--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -8732,9 +8732,7 @@
 	})
 "tT" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "tV" = (
 /obj/table/auto,
 /obj/item/clothing/gloves/latex,
@@ -9032,9 +9030,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blue/checker,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uD" = (
 /obj/machinery/disposal/small/north{
 	pixel_y = 32
@@ -9049,9 +9045,7 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uE" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -9066,9 +9060,7 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uF" = (
 /obj/stool/chair/blue{
 	dir = 4
@@ -9082,9 +9074,7 @@
 	},
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/blue/checker,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uG" = (
 /obj/machinery/computer/genetics{
 	dir = 8
@@ -9097,15 +9087,11 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uH" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uJ" = (
 /obj/iv_stand,
 /obj/item/reagent_containers/iv_drip/saline,
@@ -9409,18 +9395,14 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vo" = (
 /obj/stool/chair/blue,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue/checker,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vp" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -9428,9 +9410,7 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vq" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -9442,9 +9422,7 @@
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vr" = (
 /obj/machinery/genetics_scanner,
 /obj/cable{
@@ -9452,9 +9430,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/blue/checker,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vs" = (
 /obj/cable,
 /obj/cable{
@@ -9784,9 +9760,7 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wa" = (
 /obj/machinery/light,
 /obj/disposalpipe/segment/bent/north,
@@ -9794,18 +9768,14 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wb" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wd" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -10193,9 +10163,7 @@
 	})
 "wP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wQ" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Vessel Restroom"
@@ -18668,9 +18636,7 @@
 	name = "autoname - SS13"
 	},
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "OX" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -21686,9 +21652,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/sanitary/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "VE" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Teleporter Lab"
@@ -21934,9 +21898,7 @@
 	},
 /obj/mapping_helper/access/medical,
 /turf/simulated/floor/blue,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "Wf" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating,

--- a/maps/unused/horizon.dmm
+++ b/maps/unused/horizon.dmm
@@ -11522,9 +11522,7 @@
 /area/station/security/checkpoint/sec_foyer)
 "aIV" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aIW" = (
 /obj/machinery/disposal/transport{
 	name = "transport chute - monkey pen"
@@ -11533,9 +11531,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aIX" = (
 /obj/machinery/light{
 	dir = 1;
@@ -11549,18 +11545,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aIY" = (
 /obj/disposalpipe/segment/transport{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aJa" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating/random,
@@ -12302,18 +12294,14 @@
 /area/station/medical/medbay)
 "aKZ" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aLa" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aLb" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -12321,9 +12309,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 9
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aLc" = (
 /obj/landmark/start/job/geneticist,
 /obj/item/device/radio/intercom/medical,
@@ -12333,9 +12319,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aLd" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/storage/pill_bottle/mutadone,
@@ -12359,9 +12343,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aLe" = (
 /obj/monkeyplant,
 /obj/cable{
@@ -12371,9 +12353,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 5
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aLf" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -13026,18 +13006,14 @@
 /turf/simulated/floor/greenblack{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aNd" = (
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aNe" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -13048,9 +13024,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aNh" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -13858,9 +13832,7 @@
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aPl" = (
 /obj/machinery/genetics_scanner,
 /obj/machinery/light{
@@ -13874,17 +13846,13 @@
 /turf/simulated/floor/greenblack{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aPm" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aPn" = (
 /obj/machinery/genetics_scanner,
 /obj/machinery/light{
@@ -13898,15 +13866,11 @@
 /turf/simulated/floor/greenblack{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aPo" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aPq" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon16,
 /turf/simulated/floor,
@@ -14851,9 +14815,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 10
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aRS" = (
 /obj/stool/chair/office{
 	dir = 8
@@ -14863,9 +14825,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/greenblack,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aRT" = (
 /obj/stool/chair/office{
 	dir = 4
@@ -14875,9 +14835,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/greenblack,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aRU" = (
 /obj/machinery/computer/genetics{
 	dir = 8
@@ -14888,9 +14846,7 @@
 /turf/simulated/floor/greenblack{
 	dir = 6
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aRV" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/decal/poster/wallsign/medbay,
@@ -14898,9 +14854,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aRW" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/clothing/glasses/monocle,
@@ -50132,9 +50086,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "iYj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -51192,9 +51144,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "kOV" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -51718,9 +51668,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "lLh" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe{
 	dir = 1
@@ -55486,9 +55434,7 @@
 	text = "NF"
 	},
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "rKY" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -57405,9 +57351,7 @@
 /obj/disposalpipe/segment,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uQi" = (
 /obj/table/wood/auto,
 /obj/item/ghostboard,
@@ -57904,9 +57848,7 @@
 "vJO" = (
 /obj/disposalpipe/junction/middle/south,
 /turf/simulated/floor/green,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vKa" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe{
 	dir = 1
@@ -59212,9 +59154,7 @@
 "xzj" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "xzz" = (
 /obj/cable{
 	icon_state = "1-2"

--- a/maps/unused/ozymandias.dmm
+++ b/maps/unused/ozymandias.dmm
@@ -1250,9 +1250,7 @@
 	},
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aqT" = (
 /obj/decal/tile_edge/line/white{
 	dir = 8;
@@ -2111,9 +2109,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "aEA" = (
 /obj/machinery/light/small/warm/very{
 	dir = 1;
@@ -4078,9 +4074,7 @@
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "bet" = (
 /obj/storage/closet/wardrobe/orange,
 /obj/disposalpipe/segment/brig{
@@ -6147,9 +6141,7 @@
 	},
 /obj/disposalpipe/segment/mail/bent/west,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "bKe" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
@@ -7678,9 +7670,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ceW" = (
 /obj/machinery/light/small,
 /obj/decal/tile_edge/floorguide/science,
@@ -7778,9 +7768,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cgC" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/emergency{
@@ -10468,9 +10456,7 @@
 /obj/mapping_helper/access/medlab,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "cSz" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/medical/head)
@@ -11613,9 +11599,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "dio" = (
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	dir = 4
@@ -15192,9 +15176,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "eeU" = (
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating/random,
@@ -18107,9 +18089,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "eOv" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -19555,9 +19535,7 @@
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "fkl" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -21705,9 +21683,7 @@
 	},
 /obj/disposalpipe/junction/left/north,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "fME" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/sandytile,
@@ -25301,9 +25277,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "gHb" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/wood/seven,
@@ -25316,9 +25290,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "gHx" = (
 /obj/machinery/conveyor/NS{
 	name = "cargo belt - south";
@@ -27556,9 +27528,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "hjJ" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -32992,9 +32962,7 @@
 /obj/mapping_helper/access/medlab,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/blue,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "iIM" = (
 /obj/table/reinforced/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -41706,9 +41674,7 @@
 /obj/mapping_helper/access/medlab,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "kZp" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/transport{
@@ -46498,9 +46464,7 @@
 	},
 /obj/disposalpipe/junction/right/north,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "mih" = (
 /turf/simulated/floor,
 /area/station/science/artifact)
@@ -47344,9 +47308,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/blue,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "mtX" = (
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -53695,9 +53657,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ofK" = (
 /obj/machinery/light{
 	dir = 4;
@@ -54544,9 +54504,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "opg" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -54628,9 +54586,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "oqB" = (
 /obj/cable{
 	icon_state = "6-8"
@@ -62521,9 +62477,7 @@
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "qtT" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -64387,9 +64341,7 @@
 "qRb" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "qRh" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -68095,9 +68047,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "rPx" = (
 /obj/table/round/auto,
 /obj/item/boardgame/chess,
@@ -68527,9 +68477,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "rTY" = (
 /obj/machinery/chem_dispenser/soda,
 /obj/machinery/camera{
@@ -75095,9 +75043,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "txZ" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 1
@@ -75157,9 +75103,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "tyJ" = (
 /obj/table/auto,
 /obj/item/storage/firstaid/toxin{
@@ -75661,9 +75605,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "tFd" = (
 /obj/machinery/light/small,
 /obj/machinery/shower{
@@ -76013,9 +75955,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "tKw" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -76911,9 +76851,7 @@
 "tWj" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "tWk" = (
 /obj/stool/chair/office/blue{
 	dir = 8
@@ -77106,9 +77044,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "tYA" = (
 /obj/machinery/door/airlock/pyro/glass/command{
 	dir = 4;
@@ -77862,9 +77798,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uib" = (
 /obj/table/round/auto,
 /obj/item/reagent_containers/food/drinks/mug{
@@ -77916,9 +77850,7 @@
 "uiH" = (
 /obj/disposalpipe/segment/mail/bent/east,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uiI" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4
@@ -77983,9 +77915,7 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "ujt" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -78406,9 +78336,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "upQ" = (
 /obj/stool/chair{
 	dir = 1
@@ -78873,9 +78801,7 @@
 	},
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uvm" = (
 /obj/decal/poster/wallsign/poster_rand{
 	pixel_y = 28
@@ -79057,9 +78983,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uyf" = (
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/specialroom/arcade,
@@ -79274,9 +79198,7 @@
 /obj/disposalpipe/segment/mail/bent/west,
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uAE" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -79966,9 +79888,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uHW" = (
 /obj/table/auto,
 /obj/item/peripheral/sound_card,
@@ -80019,9 +79939,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uIW" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor,
@@ -80049,9 +79967,7 @@
 /obj/machinery/light,
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "uJr" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/snacks/bagel{
@@ -81734,9 +81650,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vcV" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -82039,9 +81953,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vgz" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/storage/firstaid/toxin{
@@ -82120,9 +82032,7 @@
 "vhB" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vhG" = (
 /obj/machinery/hydro_growlamp,
 /obj/machinery/power/apc/autoname_north,
@@ -82187,9 +82097,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "viA" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/mining/staff_room)
@@ -82305,9 +82213,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vjZ" = (
 /obj/table/auto,
 /obj/machinery/networked/storage/scanner{
@@ -82810,9 +82716,7 @@
 /obj/machinery/light,
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/bluewhite,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vps" = (
 /obj/stool/chair/yellow{
 	dir = 8
@@ -84877,9 +84781,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vOf" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -84922,9 +84824,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vOI" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -84976,9 +84876,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vPy" = (
 /obj/decal/stage_edge/alt,
 /turf/simulated/floor/black,
@@ -85141,9 +85039,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "vRG" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/industrial,
@@ -86584,9 +86480,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wlo" = (
 /obj/decal/poster/wallsign/warning3,
 /turf/simulated/wall/auto/supernorn,
@@ -87545,9 +87439,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wvY" = (
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/disposal)
@@ -87600,9 +87492,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wwQ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner/ne)
@@ -87619,9 +87509,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wxa" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -87680,9 +87568,7 @@
 	},
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wxB" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/construction2{
@@ -89518,17 +89404,13 @@
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wUl" = (
 /obj/machinery/computer/cloning,
 /obj/machinery/power/data_terminal,
 /obj/cable,
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wUz" = (
 /obj/machinery/atmospherics/binary/valve/notify_admins{
 	dir = 1;
@@ -89562,9 +89444,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wUJ" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -89637,9 +89517,7 @@
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wVB" = (
 /obj/machinery/conveyor/SN{
 	name = "cargo belt - north";
@@ -89833,9 +89711,7 @@
 /area/station/security/detectives_office)
 "wYz" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/medical/research)
 "wYC" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/robotics)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Renames the "Medical Research" area to "Genetic Research"
* Any out-of-area APCs have had their related areastring updated
* Remove map varedits renaming the area.

Several maps were overriding the default area name with "Genetic Research" via map varedits, which is why this name was chosen. These varedits are not used when generating gang objectives, leading to the bug report that spawned this fix.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More accurate area name
Less map varedits
Fixes #22289