### PR TITLE
Roaches can only skitter on non-space turfs

### DIFF
--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -1088,6 +1088,9 @@ var/list/radio_brains = list()
 		set waitfor = FALSE
 		if (!src.owner.lying || is_incapacitated(src.owner) || length(src.owner.grabbed_by))
 			return
+		var/turf/T = get_turf(src.owner)
+		if (!istype(T) || T.throw_unlimited)
+			return
 		if (ON_COOLDOWN(src.owner, "skitter", 7 SECONDS))
 			return
 		src.owner.visible_message(SPAN_ALERT("[src.owner] skitters away!"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][medical]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a check for `throw_unlimited` turfs in roach skitter, and returns early if so.

This allows them to skitter on `/turf/space/fluid` i.e. oshan/nadir

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
roaches feel like they need something to skitter on, not empty space
Fixes #22283