### PR TITLE
Fix attempting to weld loafer and update loafer help text 

### DIFF
--- a/code/modules/disposals/disposal.dm
+++ b/code/modules/disposals/disposal.dm
@@ -194,6 +194,7 @@
 	var/base_icon_state	//! Initial icon state on map
 	var/list/mail_tag = null //! Tag of mail group for switching pipes
 	var/welding_cost = 3 //! Amount of welding fuel it costs to install/remove
+	var/weldable = TRUE
 
 
 	var/image/pipeimg = null
@@ -452,7 +453,7 @@
 			return		// prevent interaction with T-scanner revealed pipes
 
 		if (isweldingtool(I))
-			if (I:try_weld(user, src.welding_cost, noisy = 2))
+			if (src.weldable && I:try_weld(user, src.welding_cost, noisy = 2))
 				// check if anything changed over 2 seconds
 				var/turf/uloc = user.loc
 				var/atom/wloc = I.loc
@@ -1159,7 +1160,9 @@ TYPEINFO(/obj/disposalpipe/loafer)
 	desc = "A pipe segment designed to convert detritus into a nutritionally-complete meal for inmates."
 	icon_state = "pipe-loaf0"
 	is_syndicate = 1
+	weldable = FALSE
 	var/is_doing_stuff = FALSE
+	HELP_MESSAGE_OVERRIDE("The disciplinary loaf processor cannot be detached by welding.")
 
 	horizontal
 		dir = EAST
@@ -1582,7 +1585,9 @@ TYPEINFO(/obj/item/reagent_containers/food/snacks/einstein_loaf)
 	icon_state = "unblockoutlet"
 	anchored = ANCHORED
 	density = 1
+	weldable = FALSE
 	var/turf/stuff_chucking_target
+	HELP_MESSAGE_OVERRIDE("The smart disposal outlet cannot be detached by welding.")
 
 	north
 		dir = NORTH
@@ -1960,6 +1965,8 @@ TYPEINFO(/obj/item/reagent_containers/food/snacks/einstein_loaf)
 
 /obj/disposalpipe/trunk/zlevel
 	icon_state = "pipe-v"
+	weldable = FALSE
+	HELP_MESSAGE_OVERRIDE("This pipe cannot be detached by welding.")
 
 	getlinked()
 		return

--- a/code/obj/machinery/pipe/pipe_dispenser.dm
+++ b/code/obj/machinery/pipe/pipe_dispenser.dm
@@ -118,7 +118,8 @@ TYPEINFO(/obj/machinery/disposal_pipedispenser/mobile)
 			else if(src.removing_pipe)
 				if(!new_loc.intact || istype(new_loc,/turf/space))
 					for(var/obj/disposalpipe/pipe in old_loc)
-						qdel(pipe)
+						if (pipe.weldable)
+							qdel(pipe)
 			prev_dir = direction // might want to actually do this even when old_loc == loc but idk, it sucks with attempted diagonal movement
 
 	proc/connect_pipe(var/turf/new_loc, var/new_dir)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds a new variable "weldable" to disposal pipes, defaulting to TRUE
* Sets variable to FALSE for all unweldable pipes (i.e. all that override `welded()` to do nothing)
* Skips trying to weld pipes that are unweldable
* Add help text to unweldable pipes saying they cannot be detatched by welding
* The mobile pipe dispenser cannot remove unweldable pipes (like loafers)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #22262
Fixes #14045
Fixes #13876
