### PR TITLE
fix silicons losing module use when arms break

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2061,9 +2061,9 @@
 	proc/get_tools()
 		RETURN_TYPE(/list)
 		var/list/tools = src.module.tools.Copy()
-		if (src.part_arm_l.add_to_tools)
+		if (src.part_arm_l?.add_to_tools)
 			tools += src.part_arm_l
-		if (src.part_arm_r.add_to_tools)
+		if (src.part_arm_r?.add_to_tools)
 			tools += src.part_arm_r
 		return tools
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][silicons][runtime]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
the l/r arm parts may not exist so calling the `add_to_tools` property may runtime. use `?.` syntax to avoid.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22306
Fix #22275
Fix #22150
Fix #22118