### PR TITLE
Body bags should not contain closets, crates, or other body bags

### DIFF
--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1072,6 +1072,12 @@ TYPEINFO(/obj/machinery/defib_mount)
 		for (var/obj/O in get_turf(src))
 			if (O.density || O.anchored || O == src)
 				continue
+			if (istype(O, /obj/storage)) // don't eat closets/crates
+				continue
+			if (istype(O, /obj/item/body_bag)) // don't eat other deployed bodybags
+				var/obj/item/body_bag/other_bag = O
+				if (other_bag.w_class == W_CLASS_BULKY)
+					continue
 			O.set_loc(src)
 		for (var/mob/M in get_turf(src))
 			if (!(M.lying || (ismobcritter(M) && isdead(M))) || M.anchored || M.buckled)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevent body bags including storage objects like crates, lockers, or coffins on close.
Prevent body bags including other deployed body bags on close (folded body bags will still be included).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #22311