### PR TITLE
Fix empty light fixtures regenerating bulbs

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -30,6 +30,7 @@ TYPEINFO(/obj/item/light_parts)
 	var/light_type = /obj/item/light/tube
 	var/fitting = "tube"
 	var/install_type = INSTALL_WALL
+	var/has_bulb = TRUE
 
 	New()
 		..()
@@ -37,8 +38,11 @@ TYPEINFO(/obj/item/light_parts)
 
 	update_icon()
 		..()
-		var/image/light_image = SafeGetOverlayImage("light", src.icon, "[fitting]-light")
-		src.AddOverlays(light_image, "light")
+		if (src.has_bulb)
+			var/image/light_image = SafeGetOverlayImage("light", src.icon, "[fitting]-light")
+			src.AddOverlays(light_image, "light")
+			return
+		src.ClearSpecificOverlays("light")
 
 
 // For metal sheets. Can't easily change an item's vars the way it's set up (Convair880).
@@ -65,6 +69,8 @@ TYPEINFO(/obj/item/light_parts)
 	installed_icon_state = target.icon_state
 	installed_base_state = target.base_state
 	light_type = target.light_type
+	if (!target.inserted_lamp)
+		has_bulb = FALSE
 	fixture_type = target.type
 	fitting = target.fitting
 	if (fitting == "tube")
@@ -131,7 +137,10 @@ TYPEINFO(/obj/item/light_parts)
 	newlight.icon_state = src.installed_icon_state
 	newlight.base_state = src.installed_base_state
 	newlight.fitting = src.fitting
-	newlight.status = LIGHT_EMPTY
+	if (!src.has_bulb)
+		newlight.current_lamp.light_status = LIGHT_EMPTY
+		newlight.inserted_lamp = null
+		newlight.update()
 	newlight.add_fingerprint(user)
 	// this does the exact pixel positioning and stuff for the walls to line up with sprites
 	if (src.install_type == INSTALL_WALL)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Light parts keep track of whether there is a bulb installed. (`has_bulb`)
If there is no bulb on installation, ensure the target fixture is empty when the light parts are installed.
Ensure the fixture sprite properly represents whether there is a bulb installed.

Hand-crafted fixtures still start with bulbs, maintaining current behavior.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #22287
Fixes #18872