### PR TITLE
Prevent microbombs implanting in mentor/admin mice and ghost critters

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -717,6 +717,14 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 	big_message = " emits a loud clunk"
 	small_message = " makes a small clicking noise"
 
+	can_implant(mob/target, mob/user)
+		if(!..())
+			return FALSE
+		if (isghostcritter(target) || ishelpermouse(target))
+			return FALSE
+		return TRUE
+
+
 	implanted(mob/target, mob/user)
 		..()
 		if (target == user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
can_implant check for microbombs fails if the target is a ghostcritter or helpermouse (mentor/admin mice)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
player controlled OHKO critters shouldn't be able to explode like a TTV
Fixes #22206
