### PR TITLE
Springboards do damage if you dont land in fluid

### DIFF
--- a/code/obj/pool.dm
+++ b/code/obj/pool.dm
@@ -110,7 +110,6 @@
 						playsound(src.loc, 'sound/impact_sounds/Generic_Snap_1.ogg', 50, 1)
 			user.pixel_y = 0
 			user.pixel_x = 0
-			playsound(user, 'sound/impact_sounds/Liquid_Hit_Big_1.ogg', 60, TRUE)
 			if (istype(user, /mob/living/silicon/ai))
 				src.visible_message(SPAN_ALERT("[user.name]'s bulky frame slams straight into the ground!"))
 				user.emote("scream")
@@ -118,6 +117,24 @@
 				user.TakeDamage(brute=10)
 				for (var/mob/M in viewers(user))
 					shake_camera(M, 4, 16)
+			else
+				if (!istype(get_turf(user), /turf/space) || istype(get_turf(user), /turf/space/fluid))
+					var/underwater = FALSE
+					if (istype(get_turf(user), /turf/space/fluid)) underwater = TRUE
+					else
+						var/turf/T = get_turf(user)
+						if (T?.active_liquid)
+							if(T.active_liquid.last_depth_level > 2)
+								underwater = TRUE
+					if (underwater)
+						playsound(user, 'sound/impact_sounds/Liquid_Hit_Big_1.ogg', 60, TRUE)
+					else
+						if (issilicon(user))
+							playsound(user, 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg', 60, TRUE)
+						else
+							playsound(user, 'sound/impact_sounds/Flesh_Break_1.ogg', 50, TRUE, 0.2, 1)
+						src.visible_message(SPAN_ALERT("[user.name] lands on the ground hard!"))
+						user.TakeDamage(brute = 10)
 			in_use = 0
 			suiciding = 0
 			user.transforming = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Using a springboard to land on something that isnt a fluid turf, a space turf, or doesnt have enough fluid will net you some damage and noise.

Fixes the water noise playing everytime regardless of where you land.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Shouldnt play water noise when you land on something other than water. Flavor.

fixes https://github.com/goonstation/goonstation/issues/13796

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bartimeus973
(+)It is no longer safe to dive outside the pool from a springboard.
```
