### PR TITLE
Adds an icon_states() cache access proc

### DIFF
--- a/code/WorkInProgress/construction/tools.dm
+++ b/code/WorkInProgress/construction/tools.dm
@@ -575,7 +575,7 @@ TYPEINFO(/obj/item/room_planner)
 		// selectedtype gets used as our iconstate for floors or the key to the lists for walls
 		if (mode == "floors")
 			selectedtype = null
-			states += (icon_states('icons/turf/construction_floors.dmi') - list("engine", "catwalk", "catwalk_narrow", "catwalk_cross"))
+			states += (get_icon_states('icons/turf/construction_floors.dmi') - list("engine", "catwalk", "catwalk_narrow", "catwalk_cross"))
 			selectedicon = 'icons/turf/construction_floors.dmi'
 			var/newtype = tgui_input_list(message="What kind?", title="Marking", items=states)
 			if(newtype)

--- a/code/WorkInProgress/customcritter.dm
+++ b/code/WorkInProgress/customcritter.dm
@@ -1812,7 +1812,7 @@ var/global/datum/critterCreatorHolder/critter_creator_controller = new()
 				template.icon = I
 				template.icon_state = null
 		else if (href_list["icon_state"])
-			template.icon_state = getEnum("icon state", "", icon_states(template.icon))
+			template.icon_state = getEnum("icon state", "", get_icon_states(template.icon))
 		else if (href_list["dead_icon"])
 			var/I = input("Select an image file.", "Image file", null) as icon|null
 			if (I)
@@ -1820,7 +1820,7 @@ var/global/datum/critterCreatorHolder/critter_creator_controller = new()
 				template.dead_icon_state = null
 		else if (href_list["dead_icon_state"])
 			if (template.dead_icon)
-				template.dead_icon_state = getEnum("icon state", "", icon_states(template.dead_icon))
+				template.dead_icon_state = getEnum("icon state", "", get_icon_states(template.dead_icon))
 			else
 				alert("Please define an icon first.")
 		else if (href_list["icon_preset"])

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -13,13 +13,10 @@ TYPEINFO(/datum/mutantrace)
 	/// This is used for static icons if the mutant isn't built from pieces
 	/// For chunked mutantraces this must still point to a valid full-body image to generate a staticky sprite for ghostdrones.
 	var/icon = 'icons/effects/genetics.dmi'
-	///The icon states of the above icon, cached because byond is bad
-	var/icon_states
 TYPEINFO_NEW(/datum/mutantrace) ///Load all the clothing override icons, should call parent AFTER populating `clothing_icons`
 	..()
 	for (var/category in src.clothing_icons)
 		src.clothing_icon_states[category] = icon_states(src.clothing_icons[category])
-	src.icon_states = icon_states(src.icon)
 
 ABSTRACT_TYPE(/datum/mutantrace)
 /datum/mutantrace

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -529,7 +529,7 @@
 
 	// does a suit potentially cover our tail?
 	if(our_tail.clothing_image_icon && icon_state)
-		var/tail_overrides = icon_states(our_tail.clothing_image_icon)
+		var/tail_overrides = get_icon_states(our_tail.clothing_image_icon)
 		if (islist(tail_overrides) && (icon_state in tail_overrides))
 			human_tail_image = image(our_tail.clothing_image_icon, icon_state)
 			src.tail_standing.overlays += human_tail_image

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -898,7 +898,7 @@ var/list/update_body_limbs = list("r_leg" = "stump_leg_right", "l_leg" = "stump_
 					if (limb)
 						var/mutantrace_override = null
 						var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
-						if (!limb.decomp_affected && src.mutantrace?.override_limb_icons && (limb.getMobIconState() in typeinfo?.icon_states))
+						if (!limb.decomp_affected && src.mutantrace?.override_limb_icons && (limb.getMobIconState() in get_icon_states(typeinfo?.icon)))
 							mutantrace_override = typeinfo.icon
 						var/image/limb_pic = limb.getMobIcon(src.decomp_stage, mutantrace_override, force)	// The limb, not the hand/foot
 						var/limb_skin_tone = "#FFFFFF"	// So we dont stomp on any limbs that arent supposed to be colorful

--- a/code/modules/hydroponics/plants.dm
+++ b/code/modules/hydroponics/plants.dm
@@ -80,7 +80,7 @@ ABSTRACT_TYPE(/datum/plant)
 				result_icon = icon(initial(crop.icon), initial(crop.icon_state), frame=1)
 			else if(src.plant_icon)
 				var/icon_state = src.getIconState(4)
-				if(icon_state in icon_states(src.plant_icon)) // Only if icon state is valid
+				if(icon_state in get_icon_states(src.plant_icon)) // Only if icon state is valid
 					result_icon = icon(src.plant_icon, icon_state, frame=1)
 
 			if(result_icon)

--- a/code/modules/materials/Mat_ProcsDefines.dm
+++ b/code/modules/materials/Mat_ProcsDefines.dm
@@ -186,6 +186,14 @@ var/global/list/material_cache
 			logTheThing(LOG_DEBUG, src, "is_valid_icon_state took [TIME - start_time] ticks(!!!) to cache [icon]")
 	return state in global.valid_icon_states[icon]
 
+proc/get_icon_states(icon)
+	. = global.valid_icon_states[icon]
+	if(isnull(.))
+		global.valid_icon_states[icon] = list()
+		. = icon_states(icon)
+		for(var/icon_state in .)
+			global.valid_icon_states[icon][icon_state] = 1
+
 /proc/getProcessedMaterialForm(var/datum/material/MAT)
 	if (!istype(MAT))
 		return /obj/item/material_piece // just in case

--- a/code/modules/minimap/minimap_objects/minimap_ui.dm
+++ b/code/modules/minimap/minimap_objects/minimap_ui.dm
@@ -109,7 +109,7 @@
 	. = ..()
 	var/list/placable_marker_states = list()
 	var/list/placable_marker_images = list()
-	for (var/icon_state in icon_states('icons/obj/minimap/minimap_markers.dmi'))
+	for (var/icon_state in get_icon_states('icons/obj/minimap/minimap_markers.dmi'))
 		placable_marker_states.Add(icon_state)
 		var/icon/marker_icon = icon('icons/obj/minimap/minimap_markers.dmi', icon_state)
 		placable_marker_images[icon_state] = icon2base64(marker_icon)

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -2122,10 +2122,10 @@ datum/projectile/bullet/autocannon
 		src.name = corruptText(src.name, 66)
 
 	on_hit(atom/hit)
-		hit.icon_state = pick(icon_states(hit.icon))
+		hit.icon_state = pick(get_icon_states(hit.icon))
 
 		for(var/atom/a in hit)
-			a.icon_state = pick(icon_states(a.icon))
+			a.icon_state = pick(get_icon_states(a.icon))
 
 		playsound(hit, 'sound/machines/glitch3.ogg', 50, TRUE)
 

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1770,7 +1770,7 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 		src.inhand_image = image(src.inhand_image_icon, "", MOB_INHAND_LAYER)
 
 	var/state = src.item_state ? src.item_state + "-[hand]" : (src.icon_state ? src.icon_state + "-[hand]" : hand)
-	if(!(state in icon_states(src.inhand_image_icon)))
+	if(!(state in get_icon_states(src.inhand_image_icon)))
 		// stack_trace("ZeWaka {TEMP}: [src] has no icon state [state] in [src.inhand_image_icon] | iconstate: [src.icon_state] | itemstate: [src.item_state]")
 		state = src.item_state ? src.item_state + "-L" : (src.icon_state ? src.icon_state + "-L" : "L")
 

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1204,7 +1204,7 @@ TYPEINFO(/obj/item/clothing/suit/hazard/fire/armored)
 		..()
 		if(!istype(get_area(src), /area/station))
 			var/nt_wear_state = "[src.wear_state || src.icon_state]-nt"
-			if(nt_wear_state in icon_states(src.wear_image_icon))
+			if(nt_wear_state in get_icon_states(src.wear_image_icon))
 				src.wear_state = nt_wear_state
 
 	setupProperties()
@@ -1539,7 +1539,7 @@ TYPEINFO(/obj/item/clothing/suit/hazard/fire/armored)
 		..()
 		if(!istype(get_area(src), /area/station))
 			var/nt_wear_state = "[src.wear_state || src.icon_state]-nt"
-			if(nt_wear_state in icon_states(src.wear_image_icon))
+			if(nt_wear_state in get_icon_states(src.wear_image_icon))
 				src.wear_state = nt_wear_state
 
 	setupProperties()

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -269,7 +269,7 @@
 
 		New()
 			..()
-			options = icon_states(src.icon) // gonna assume that the dmi will only ever have pride jumpsuits
+			options = get_icon_states(src.icon) // gonna assume that the dmi will only ever have pride jumpsuits
 
 		attack_self(mob/user as mob)
 			if (src.options)

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -528,7 +528,7 @@
 
 			handimage = I.inhand_image
 			var/state = I.item_state ? I.item_state + "-LR" : (I.icon_state ? I.icon_state + "-LR" : "LR")
-			if(!(state in icon_states(I.inhand_image_icon)))
+			if(!(state in get_icon_states(I.inhand_image_icon)))
 				state = I.item_state ? I.item_state + "-L" : (I.icon_state ? I.icon_state + "-L" : "L")
 			handimage.icon_state = state
 
@@ -563,13 +563,13 @@
 			remove_object = null
 
 	getHandIconState()
-		if (handlistPart && !(handlistPart in icon_states(special_icons)))
+		if (handlistPart && !(handlistPart in get_icon_states(special_icons)))
 			.= handimage
 		else
 			.=..()
 
 	getPartIconState()
-		if (partlistPart && !(partlistPart in icon_states(special_icons)))
+		if (partlistPart && !(partlistPart in get_icon_states(special_icons)))
 			.= handimage
 		else
 			.=..()
@@ -657,7 +657,7 @@
 
 			handimage = I.inhand_image
 			var/state = I.item_state ? I.item_state + "-LR" : (I.icon_state ? I.icon_state + "-LR" : "LR")
-			if(!(state in icon_states(I.inhand_image_icon)))
+			if(!(state in get_icon_states(I.inhand_image_icon)))
 				state = I.item_state ? I.item_state + "-R" : (I.icon_state ? I.icon_state + "-R" : "R")
 
 			handimage.pixel_y = H.mutantrace.hand_offset + 6
@@ -689,13 +689,13 @@
 			qdel(remove_object)
 
 	getHandIconState()
-		if (handlistPart && !(handlistPart in icon_states(special_icons)))
+		if (handlistPart && !(handlistPart in get_icon_states(special_icons)))
 			.= handimage
 		else
 			.=..()
 
 	getPartIconState()
-		if (partlistPart && !(partlistPart in icon_states(special_icons)))
+		if (partlistPart && !(partlistPart in get_icon_states(special_icons)))
 			.= handimage
 		else
 			.=..()

--- a/code/procs/Get_Flat_Icon.dm
+++ b/code/procs/Get_Flat_Icon.dm
@@ -34,7 +34,7 @@
 	var/curstate = A.icon_state || defstate
 
 	if(!((noIcon = (!curicon))))
-		var/curstates = icon_states(curicon)
+		var/curstates = get_icon_states(curicon)
 		if(!(curstate in curstates))
 			if("" in curstates)
 				curstate = ""


### PR DESCRIPTION
[PERFORMANCE][INTERNAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an extra proc get_icon_states() to the existing icon_states cache that allows getting the entire list and then places that proc around the place.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
slow bad