### PR TITLE
De-restrict EFIF-1 Construction System

### DIFF
--- a/code/modules/transport/pods/MainWeapon.dm
+++ b/code/modules/transport/pods/MainWeapon.dm
@@ -503,10 +503,6 @@ TYPEINFO(/obj/item/shipcomponent/mainweapon/constructor)
 			if(EFIF_MODE_FLOORS to EFIF_MODE_WALLS)
 				if(ON_COOLDOWN(src, "fire", firerate))
 					return
-				if(src.mode != EFIF_MODE_R_FLOORS && ship.z == Z_LEVEL_STATION) //antigrief
-					boutput(user,SPAN_ALERT("The construction system isn't cleared to operate in this mode within this sector."))
-					src.sadbuzz()
-					return
 				if(length(src.active_fields) >= 1)
 					return
 				if(!src.check_sheets())

--- a/code/modules/writing/papers.dm
+++ b/code/modules/writing/papers.dm
@@ -100,7 +100,7 @@
 	name = "'EFIF-1 Operational Disclaimer'"
 	info = {"Congratulations on your new EFIF-1 Construction System!<BR>\n<BR>\n
 	Operational modes and EZ Sheet Loading may be accessed from the "EFIF-1 Construction System" entry in your pod's computer console.<BR>\n<BR>\n
-	Please be aware that non-repair assembly of walls and standard floors may be restricted within your workplace's vicinity for safety reasons.<BR>\n<BR>\n
+	Please be aware that non-repair assembly of walls and standard floors may obstruct your pod's clearance, and should be constructed with caution.<BR>\n<BR>\n
 	<B>LOAD ONLY STANDARD, NON-REINFORCED NT-SPEC STEEL SHEETS. EFIF-1 IS CALIBRATED FOR NT-SPEC STEEL. EFIF-1 DOES NOT AND SHOULD NOT ACCEPT OTHER METALS.</B>"}
 
 /obj/item/paper/courtroom


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEAT][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes a restriction in the EFIF-1 Construction System (tool for building with pods) that had prohibited construction of walls or non-reinforced floors on the station Z-level (reinforced walls can still not be built by it regardless).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The restriction was introduced in the first place as a safeguard against potential griefing, but the tool has proven niche enough that I think the ability to use it fully on the station level for construction (and hopefully making it more broadly useful in the process) far outweighs the ability to prevent griefing that is likely already prohibited by rules.

Opted for major changelog entry as a "PSA", but minor would be fine too.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(*)The EFIF-1 Construction System usable by pods no longer has a mode restriction on the station Z-level.
```
