### PR TITLE
Prevent launcher loaders from being triggered by

### DIFF
--- a/_std/macros/procs.dm
+++ b/_std/macros/procs.dm
@@ -18,7 +18,7 @@
 #define CONCALL(OBJ, TYPE, CALL, VARNAME) var##TYPE/##VARNAME=OBJ;if(istype(##VARNAME)) ##VARNAME.##CALL
 
 /// returns early if x is an overlay or effect
-#define return_if_overlay_or_effect(x) if (istype(x, /obj/overlay) || istype(x, /obj/effects)) return
+#define return_if_overlay_or_effect(x) if (istype(x, /obj/overlay) || istype(x, /obj/effects) || istype(x, /obj/effect) || istype(x, /obj/itemspecialeffect)) return
 
 /proc/CallAsync(datum/object, delegate, list/callingArguments) // Adapted from /datum/callback/proc/InvokeAsync, which is PD, unlike this proc on tg
 	set waitfor = 0

--- a/code/obj/machinery/launcherloader.dm
+++ b/code/obj/machinery/launcherloader.dm
@@ -89,7 +89,7 @@
 
 	Crossed(atom/movable/A)
 		..()
-		if (istype(A, /mob/dead) || A.anchored || isintangible(A) || iswraith(A) || isflockmob(A)) return
+		if (istype(A, /mob/dead) || A.anchored || isintangible(A) || iswraith(A) || isflockmob(A) || istype(A, /obj/projectile)) return
 		return_if_overlay_or_effect(A)
 		activate()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Add some additional effect types to `return_if_overlay_or_effect`
* launcher loaders are no longer triggered by any projectile

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22353