### PR TITLE
Ship speed is affected by engine and ship size

### DIFF
--- a/code/datums/movement_controller/pod.dm
+++ b/code/datums/movement_controller/pod.dm
@@ -112,8 +112,8 @@
 				if (owner.engine.warp_autopilot)
 					return FALSE
 
-				velocity_x	+= input_x * accel
-				velocity_y  += input_y * accel
+				velocity_x	+= input_x * accel * src.owner.speedmod * src.owner.engine.speedmod
+				velocity_y  += input_y * accel * src.owner.speedmod * src.owner.engine.speedmod
 
 
 				if (owner.rcs && input_x == 0 && input_y == 0)
@@ -122,9 +122,9 @@
 				//braking
 				if (braking)
 					if(input_x * velocity_x <= 0)
-						velocity_x = velocity_x * brake_decel_mult
+						velocity_x = velocity_x * brake_decel_mult * (1 / (src.owner.speedmod * src.owner.engine.speedmod))
 					if(input_y * velocity_y <= 0)
-						velocity_y = velocity_y * brake_decel_mult
+						velocity_y = velocity_y * brake_decel_mult * (1 / (src.owner.speedmod * src.owner.engine.speedmod))
 
 					if (abs(velocity_x) + abs(velocity_y) < 1.3)
 						velocity_x = 0
@@ -138,7 +138,7 @@
 
 				vel_max /= (owner.speed ? owner.speed : 1)
 
-				if (velocity_magnitude > vel_max)
+				if (velocity_magnitude > vel_max * src.owner.speedmod * src.owner.engine.speedmod)
 					velocity_x /= velocity_magnitude
 					velocity_y /= velocity_magnitude
 

--- a/code/datums/movement_controller/pod.dm
+++ b/code/datums/movement_controller/pod.dm
@@ -112,8 +112,8 @@
 				if (owner.engine.warp_autopilot)
 					return FALSE
 
-				velocity_x	+= input_x * accel * src.owner.speedmod * src.owner.engine.speedmod
-				velocity_y  += input_y * accel * src.owner.speedmod * src.owner.engine.speedmod
+				velocity_x += input_x * accel * src.owner.speedmod * src.owner.engine.speedmod
+				velocity_y += input_y * accel * src.owner.speedmod * src.owner.engine.speedmod
 
 
 				if (owner.rcs && input_x == 0 && input_y == 0)

--- a/code/modules/transport/cruisers/cruisers.dm
+++ b/code/modules/transport/cruisers/cruisers.dm
@@ -709,7 +709,7 @@
 		var/base_speed = 5
 
 		if(engine)
-			base_speed = (1.5 * engine.speedmod)
+			base_speed = 1.5 // speed modification by equipped engine not implemented - feel free to change
 
 		var/adjustment = (1 - (power_movement / 100)) * base_speed
 		base_speed += adjustment

--- a/code/modules/transport/pods/engine.dm
+++ b/code/modules/transport/pods/engine.dm
@@ -9,7 +9,8 @@
 	//delay between dropping wormhole and being able to enter it
 	var/portaldelay = 3 SECONDS
 	var/status = "Normal"
-	var/speedmod = 2 // how fast should the vehicle be, lower is faster
+	// multiplicative speed modifier for equipped pod
+	var/speedmod = 1
 	var/wormholeQueued = 0 //so users cant open a million inputs and bypass all cooldowns
 	var/warp_autopilot = 0		//prevents us from mistakenly moving when trying to warp. Checked in pod movement_controller
 	power_used = 0
@@ -182,7 +183,7 @@
 	powergenerated = 300 //how much power for components the engine generates
 	currentgen = 300 //handles engine power debuffs
 	warprecharge = 150 //Interval it takes for warp to be ready again
-	speedmod = 1
+	speedmod = 1.25
 	icon_state = "engine-2"
 
 /obj/item/shipcomponent/engine/hermes
@@ -191,7 +192,7 @@
 	powergenerated = 500
 	currentgen = 500
 	warprecharge = 300
-	speedmod = 3
+	speedmod = 0.5
 	icon_state = "engine-3"
 
 /obj/item/shipcomponent/engine/zero
@@ -200,7 +201,7 @@
 	powergenerated = 190
 	currentgen = 190
 	warprecharge = -1 //This disables the ability to create wormholes completely.
-	speedmod = 2
+	speedmod = 1.1
 	icon_state = "engine-4"
 
 /obj/item/shipcomponent/engine/escape

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -814,6 +814,7 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 	bound_height = 64
 	view_offset_x = 16
 	view_offset_y = 16
+	speedmod = 0.9
 	//luminosity = 5 // will help with space exploration
 	var/maxboom = 0
 
@@ -1223,6 +1224,8 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 /obj/item/podarmor
 	var/overlay_state
 	var/list/vehicle_types
+	/// multiplicative ship speed modifier from weight of this pod armor
+	var/speedmod = 1
 
 /obj/item/podarmor/armor_light
 	name = "Light Pod Armor"

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -36,6 +36,8 @@
 	var/powercapacity = 0 //How much power the ship's components can use, set by engine
 	var/powercurrent = 0 //How much power the components are using
 	var/speed = 1 //FOR PODS : While holding thruster, how much to add on to our max speed. Does nothing for tanks.
+	/// multiplicative ship speed modification from its size
+	var/speedmod = 1
 	var/stall = 0 // slow the ship down when firing
 	var/flying = 0 // holds the direction the ship is currently drifting, or 0 if stopped
 	var/facing = SOUTH // holds the direction the ship is currently facing


### PR DESCRIPTION
[VEHICLES][FEATURE][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that ship acceleration, deceleration, and max velocity are all affected by ship engine and size

Mk II and Mk III engines will now actually change your pod's speed

2x2 pods will now be slightly slower, which I think should make sense given they have 2 weapons essentially?


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Unimplemented feature, engines are supposed to change ship speed

Ship speed affected by size makes you reconsider whether you want a larger or smaller pod rather than larger pods being almost a 100% better choice


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(*)Pod acceleration, deceleration, and maximum velocity are now all affected per engine type and pod size. 2x2 pods will now be slightly slower in regards to the stats.
```
