### PR TITLE
Field generators no longer spawn energy impact particles

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -1409,3 +1409,7 @@ TYPEINFO(/atom/movable)
 ///Returns the y component of the surface normal of the atom relative to an incident direction
 /atom/proc/normal_y(incident_dir)
 	return incident_dir == SOUTH ? -1 : (incident_dir == NORTH ?  1 : 0)
+
+///Should this atom emit particles when hit by a projectile, when the projectile is of the given type
+/atom/proc/does_impact_particles(var/kinetic_impact = TRUE)
+	return TRUE

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -738,8 +738,6 @@ ABSTRACT_TYPE(/datum/projectile)
 
 	var/static/effect_amount = 0
 
-	var/energy_particle_types = list(D_ENERGY, D_BURNING, D_RADIOACTIVE, D_TOXIC)
-
 	New()
 		. = ..()
 		generate_stats()
@@ -871,6 +869,7 @@ ABSTRACT_TYPE(/datum/projectile)
 			if (effect_amount >= 200)
 				return
 			var/kinetic_particles = TRUE
+			var/energy_particle_types = list(D_ENERGY, D_BURNING, D_RADIOACTIVE, D_TOXIC)
 			for (var/type in energy_particle_types)
 				if (src.damage_type == type)
 					kinetic_particles = FALSE

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -891,6 +891,8 @@ ABSTRACT_TYPE(/datum/projectile)
 					new /obj/effects/impact_gunshot/sparks(get_turf(hit), x, y, -O.xo, -O.yo, damage)
 					new /obj/effects/impact_gunshot/smoke(get_turf(hit), x, y, -O.xo, -O.yo, damage)
 			else
+				if (istype(hit, /obj/machinery/field_generator))
+					return
 				//Energy impacts create sparks of the color of the projectile
 				var/avrg_color = O.get_average_color()
 				new /obj/effects/impact_energy/projectile_sparks(get_turf(hit), x, y, -O.xo, -O.yo, damage, avrg_color)

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -738,6 +738,8 @@ ABSTRACT_TYPE(/datum/projectile)
 
 	var/static/effect_amount = 0
 
+	var/energy_particle_types = list(D_ENERGY, D_BURNING, D_RADIOACTIVE, D_TOXIC)
+
 	New()
 		. = ..()
 		generate_stats()
@@ -868,6 +870,13 @@ ABSTRACT_TYPE(/datum/projectile)
 				return
 			if (effect_amount >= 200)
 				return
+			var/kinetic_particles = TRUE
+			for (var/type in energy_particle_types)
+				if (src.damage_type == type)
+					kinetic_particles = FALSE
+					break
+			if (!hit.does_impact_particles(kinetic_particles))
+				return
 			effect_amount ++
 			SPAWN(5 SECONDS)
 				effect_amount --
@@ -879,7 +888,7 @@ ABSTRACT_TYPE(/datum/projectile)
 				if (T?.active_liquid)
 					if(T.active_liquid.last_depth_level > 3)
 						underwater = TRUE
-			if ((src.damage_type != D_ENERGY && src.damage_type != D_BURNING && src.damage_type != D_RADIOACTIVE && src.damage_type != D_TOXIC) && !src.energy_particles_override)
+			if (kinetic_particles && !src.energy_particles_override)
 				var/new_impact_icon = hit.impact_icon
 				var/new_impact_icon_state = hit.impact_icon_state
 				//Bullet impacts create dust of the color of the hit thing
@@ -891,8 +900,6 @@ ABSTRACT_TYPE(/datum/projectile)
 					new /obj/effects/impact_gunshot/sparks(get_turf(hit), x, y, -O.xo, -O.yo, damage)
 					new /obj/effects/impact_gunshot/smoke(get_turf(hit), x, y, -O.xo, -O.yo, damage)
 			else
-				if (istype(hit, /obj/machinery/field_generator))
-					return
 				//Energy impacts create sparks of the color of the projectile
 				var/avrg_color = O.get_average_color()
 				new /obj/effects/impact_energy/projectile_sparks(get_turf(hit), x, y, -O.xo, -O.yo, damage, avrg_color)

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -986,10 +986,7 @@ TYPEINFO(/obj/machinery/field_generator)
 	power = 50
 
 /obj/machinery/field_generator/does_impact_particles(kinetic_impact)
-	if (kinetic_impact == FALSE)
-		return FALSE
-	else
-		return TRUE
+	return kinetic_impact
 
 /////////////////////////////////////////////// Containment field //////////////////////////////////
 

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -985,6 +985,12 @@ TYPEINFO(/obj/machinery/field_generator)
 	Varedit_start = TRUE
 	power = 50
 
+/obj/machinery/field_generator/does_impact_particles(kinetic_impact)
+	if (kinetic_impact == FALSE)
+		return FALSE
+	else
+		return TRUE
+
 /////////////////////////////////////////////// Containment field //////////////////////////////////
 
 /obj/machinery/containment_field


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Field generators work by absorbing the power of an energy shot. As such, they shouldnt create a large puff of energy particles when hit.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Slightly reduce performance draw of 4 field generators being shot all shift. Makes sense in terms of lore.
