### PR TITLE
Tables drop their contents when broken/destroyed 

### DIFF
--- a/code/obj/item/table_rack_parts.dm
+++ b/code/obj/item/table_rack_parts.dm
@@ -22,7 +22,6 @@ ABSTRACT_TYPE(/obj/item/furniture_parts)
 	var/furniture_name = "table"
 	var/reinforced = 0
 	var/build_duration = 50
-	var/list/obj/item/stored_items = list() //! Desk drawer items
 	var/density_check = TRUE //! Do we want to prevent building on turfs with something dense there?
 
 	New(loc)
@@ -44,10 +43,6 @@ ABSTRACT_TYPE(/obj/item/furniture_parts)
 			qdel(src)
 			return
 
-		for(var/obj/item/I in src.stored_items)
-			newThing.storage.add_contents(I, visible=FALSE)
-		src.stored_items.len = 0
-
 		if (newThing)
 			if (src.material)
 				newThing.setMaterial(src.material)
@@ -59,12 +54,6 @@ ABSTRACT_TYPE(/obj/item/furniture_parts)
 		return newThing
 
 	proc/deconstruct(var/reinforcement = 0)
-		if(length(src.stored_items))
-			var/turf/T = get_turf(src)
-			for(var/obj/item/I in src.stored_items)
-				I.set_loc(T)
-			src.stored_items.len = 0
-
 		var/obj/item/sheet/A = new /obj/item/sheet(get_turf(src))
 		if (src.material)
 			A.setMaterial(src.material)
@@ -96,14 +85,6 @@ ABSTRACT_TYPE(/obj/item/furniture_parts)
 		. = ..()
 		if (HAS_ATOM_PROPERTY(usr, PROP_MOB_CAN_CONSTRUCT_WITHOUT_HOLDING) && isturf(target))
 			actions.start(new /datum/action/bar/icon/furniture_build(src, src.furniture_name, src.build_duration, target), usr)
-
-	disposing()
-		if(length(src.stored_items))
-			var/turf/T = get_turf(src)
-			for(var/obj/item/I in src.stored_items)
-				I.set_loc(T)
-			src.stored_items.len = 0
-		..()
 
 /* ---------- Table Parts ---------- */
 #define TABLE_WARNING(user) boutput(user, SPAN_ALERT("You can't build a table under yourself! You'll have to build it somewhere adjacent instead."))

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -136,9 +136,6 @@ TYPEINFO_NEW(/obj/table)
 			P = new src.parts_type(src.loc)
 		else
 			P = new (src.loc)
-		for(var/atom/movable/AM as anything in src.storage.get_contents())
-			AM.set_loc(P)
-			P.stored_items += AM
 		if (P && src.material)
 			P.setMaterial(src.material)
 		var/oldloc = src.loc
@@ -201,6 +198,8 @@ TYPEINFO_NEW(/obj/table)
 		var/turf/OL = get_turf(src)
 		if (!OL)
 			return
+		for(var/atom/movable/AM as anything in src.storage.get_contents())
+			AM.set_loc(OL)
 		if (!(locate(/obj/table) in OL) && !(locate(/obj/rack) in OL))
 			var/area/Ar = OL.loc
 			for (var/obj/item/I in OL)

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -136,6 +136,9 @@ TYPEINFO_NEW(/obj/table)
 			P = new src.parts_type(src.loc)
 		else
 			P = new (src.loc)
+		for(var/atom/movable/AM as anything in src.storage.get_contents())
+			AM.set_loc(P)
+			P.stored_items += AM
 		if (P && src.material)
 			P.setMaterial(src.material)
 		var/oldloc = src.loc


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a table with stored items disposed, it will drop all contained items.

This does not change the behavior of attempting to deconstruct a table with a wrench, which will still be blocked if it has items inside.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If a table is broken by e.g. hulk gene or meteors, the contents inside are lost.
Fix #15032