### PR TITLE
make slip and signs immune to acid

### DIFF
--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -609,6 +609,7 @@ TRASH BAG
 		. = ..()
 
 /obj/item/caution/traitor
+	item_function_flags = IMMUNE_TO_ACID
 	var/obj/item/reagent_containers/payload
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Make the slip and sign (janitor traitor cleaning sign) acid immune.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
having fake cleaner grenades melt slip and signs is anti-synergy
Fix #22356
