### PR TITLE
Fix thindoors not starting with correct icon

### DIFF
--- a/code/obj/machinery/door/window.dm
+++ b/code/obj/machinery/door/window.dm
@@ -70,6 +70,9 @@
 
 	return
 
+/obj/machinery/door/window/update_icon(toggling)
+	src.icon_state = src.base_state
+
 /obj/machinery/door/window/emp_act()
 	..()
 	if (prob(20) && (src.density && src.cant_emag != 1 && src.isblocked() != 1))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
`door/window` has its own format for icon_states/animations, so override update_icon to ensure the parent doesn't set it to a missing icon_state

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22292
Fix #22338
Fix #22334