### PR TITLE
Cancel arcplating if the target item is no longer in the plater

### DIFF
--- a/code/obj/machinery/arc_electroplater.dm
+++ b/code/obj/machinery/arc_electroplater.dm
@@ -172,7 +172,10 @@ TYPEINFO(/obj/machinery/arc_electroplater)
 		if(src.status & BROKEN)
 			return // don't unsubscribe if broken to maintain equipment faults
 
-		if(!src.target_item)
+		if(!src.target_item || src.target_item.loc != src)
+			src.visible_message(SPAN_NOTICE("[src] buzzes as it no longer has anything to plate."))
+			playsound(src.loc, 'sound/machines/buzz-two.ogg', 50)
+			src.eject_contents(FALSE)
 			UnsubscribeProcess()
 			return
 
@@ -189,10 +192,10 @@ TYPEINFO(/obj/machinery/arc_electroplater)
 			animate_shake(src, 3, rand(2,5), rand(2,5))
 			if (status & NOPOWER)
 				playsound(src.loc, 'sound/machines/buzz-two.ogg', 100)
-				src.visible_message("[src] buzzes as it spits out everything inside it, and completely runs out of power.")
+				src.visible_message(SPAN_ALERT("[src] buzzes as it spits out everything inside it, and completely runs out of power."))
 			if (status & BROKEN)
 				playsound(src.loc, 'sound/machines/hydraulic.ogg', 100)
-				src.visible_message("[src] spits out everything inside it as it breaks down!")
+				src.visible_message(SPAN_ALERT("[src] spits out everything inside it as it breaks down!"))
 
 		if(src.my_bar && !src.target_item)
 			src.my_bar.set_loc(src.loc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If the item we're trying to plate is no longer in the arc plater for whatever reason, cancel the plating process and return the material piece.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Closes #22362
Closes #22324
