### PR TITLE
X-drone can also spawn as assault drone instead

### DIFF
--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -797,8 +797,8 @@ TYPEINFO(/obj/critter/gunbot/drone/helldrone)
 		icon = 'icons/mob/critter/robotic/drone/assault.dmi'
 		icon_state = "drone_assault"
 		dead_state = "drone_assault"
-		health = 150
-		maxhealth = 150
+		health = 300
+		maxhealth = 300
 		score = 100
 		projectile_type = /datum/projectile/laser/asslaser
 		current_projectile = new/datum/projectile/laser/asslaser
@@ -951,6 +951,12 @@ ABSTRACT_TYPE(/obj/gunbotdrone_spawner)
 	icon_state = "drone_ballistic"
 	possible_drones = list(/obj/critter/gunbot/drone/minigundrone = 100,
 						   /obj/critter/gunbot/drone/cannondrone = 75)
+
+/obj/gunbotdrone_spawner/very_rare
+	icon = 'icons/mob/critter/robotic/drone/railgun.dmi'
+	icon_state = "drone_railgun"
+	possible_drones = list(/obj/critter/gunbot/drone/raildrone = 100,
+						   /obj/critter/gunbot/drone/assdrone = 50)
 
 TYPEINFO(/obj/critter/gunbot/drone/iridium)
 	mats = null //no

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -12559,7 +12559,7 @@
 /turf/simulated/floor/airless/plating/damaged3,
 /area/abandonedship)
 "bcA" = (
-/obj/critter/gunbot/drone/raildrone,
+/obj/gunbotdrone_spawner/very_rare,
 /turf/simulated/floor/airless/plating/damaged3,
 /area/abandonedship)
 "bcB" = (


### PR DESCRIPTION
[GAME OBJECTS][FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that there's a chance the X-drone in the debris field will instead appear as an assault laser drone


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More syndicate drone variety and the assault laser drone is currently unused


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)The debris field X-drone may instead appear as an assault laser drone.
```
