### PR TITLE
let med and sec notes be longer

### DIFF
--- a/code/datums/preferences/preferences.dm
+++ b/code/datums/preferences/preferences.dm
@@ -585,9 +585,9 @@ var/list/removed_jobs = list(
 			if ("update-securityNote")
 				var/new_text = tgui_input_text(usr, "Please enter new flavor text (appears when examining your security record):", "Character Generation", html_decode(src.security_note), multiline = TRUE, allowEmpty=TRUE)
 				if (!isnull(new_text))
-					if (length(new_text) > FLAVOR_CHAR_LIMIT)
-						tgui_alert(usr, "Your flavor text is too long. It must be no more than [FLAVOR_CHAR_LIMIT] characters long. The current text will be trimmed down to meet the limit.", "Flavor text too long")
-						new_text = copytext(new_text, 1, FLAVOR_CHAR_LIMIT+1)
+					if (length(new_text) > LONG_FLAVOR_CHAR_LIMIT)
+						tgui_alert(usr, "Your flavor text is too long. It must be no more than [LONG_FLAVOR_CHAR_LIMIT] characters long. The current text will be trimmed down to meet the limit.", "Flavor text too long")
+						new_text = copytext(new_text, 1, LONG_FLAVOR_CHAR_LIMIT+1)
 					new_text = html_encode(new_text)
 					src.security_note = new_text || null
 					src.profile_modified = TRUE
@@ -596,9 +596,9 @@ var/list/removed_jobs = list(
 			if ("update-medicalNote")
 				var/new_text = tgui_input_text(usr, "Please enter new flavor text (appears when examining your medical record):", "Character Generation", html_decode(src.medical_note), multiline = TRUE, allowEmpty=TRUE)
 				if (!isnull(new_text))
-					if (length(new_text) > FLAVOR_CHAR_LIMIT)
-						tgui_alert(usr, "Your flavor text is too long. It must be no more than [FLAVOR_CHAR_LIMIT] characters long. The current text will be trimmed down to meet the limit.", "Flavor text too long")
-						new_text = copytext(new_text, 1, FLAVOR_CHAR_LIMIT+1)
+					if (length(new_text) > LONG_FLAVOR_CHAR_LIMIT)
+						tgui_alert(usr, "Your flavor text is too long. It must be no more than [LONG_FLAVOR_CHAR_LIMIT] characters long. The current text will be trimmed down to meet the limit.", "Flavor text too long")
+						new_text = copytext(new_text, 1, LONG_FLAVOR_CHAR_LIMIT+1)
 					new_text = html_encode(new_text)
 					src.medical_note = new_text || null
 					src.profile_modified = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

makes medical notes and security notes have the same wordcount as syndi notes. doesnt touch flavor text length

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

unlike flavor text, these notes arent something you really see unless you're actively looking for them, and as is you can only fit around 2-3 sentences in them. i know many people enjoy digging through notes, and this will give more creative liberty and stuff to read on on slow days.

this also shouldnt cause any issues for either player trying to quick check notes or records (ie checking for puri or something), since important info appears before the flavor text notes

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Retrino
(+)Security and medical notes now have the same word limit as syndicate notes.
```
