### PR TITLE
remove mike dawson jumpsuit from random spawner

### DIFF
--- a/code/obj/random_spawners.dm
+++ b/code/obj/random_spawners.dm
@@ -1342,7 +1342,6 @@
 		/obj/item/clothing/under/gimmick/merchant,
 		/obj/item/clothing/under/gimmick/spiderman,
 		/obj/item/clothing/under/gimmick/birdman,
-		/obj/item/clothing/under/gimmick/dawson,
 		/obj/item/clothing/under/gimmick/chav,
 		/obj/item/clothing/under/gimmick/safari,
 		/obj/item/clothing/under/gimmick/utena,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

title

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

the jumpsuit permanently changes your name, appearance, and sticks to you. its an easy trap for someone who doesnt know what the item is and probably shouldnt be spawning in clothing shops and such
