### PR TITLE
Add new Syndicate acid drone to debris field

### DIFF
--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -33,21 +33,21 @@ ABSTRACT_TYPE(/datum/projectile/special)
 
 /datum/projectile/special/acid
 	name = "acid"
-	icon_state = "radbolt"
-	damage = 45
-	dissipation_rate = 30
+	icon_state = "ecto"
+	damage = 0.001 // to bypass 0 damage checks
 	dissipation_delay = 10
 	sname = "acid"
 
 	on_hit(atom/hit, direction, var/obj/projectile/projectile)
-		var/power = projectile.power
-		hit.damage_corrosive(power)
-
-	potent
-		damage = 100
-
-	weak
-		damage = 15
+		if (istype(hit, /mob))
+			projectile.create_reagents(10)
+			projectile.reagents.add_reagent("pacid", 10)
+			projectile.reagents.reaction(hit, react_volume = 10)
+		else if (istype(hit, /obj/machinery/vehicle))
+			hit.changeStatus("pod_corrosion", 30 SECONDS)
+		else
+			var/power = projectile.power
+			hit.damage_corrosive(power)
 
 /datum/projectile/special/acidspit
 	name = "acid splash"

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -3455,3 +3455,23 @@
 	icon_state = "empulsar"
 	unique = TRUE
 	effect_quality = STATUS_QUALITY_NEUTRAL
+
+/datum/statusEffect/pod_corrosion
+	id = "pod_corrosion"
+	effect_quality = STATUS_QUALITY_NEGATIVE
+	var/dmg_per_tick = 4
+
+	onAdd()
+		..()
+		src.owner.add_filter("corrosion_color", 1, color_matrix_filter(normalize_color_to_matrix("#0c6900")))
+
+	onUpdate(timePassed)
+		..()
+		var/mult = timePassed / LIFE_PROCESS_TICK_SPACING
+		var/obj/machinery/vehicle/pod_hit = src.owner
+		pod_hit.health -= src.dmg_per_tick * mult
+		pod_hit.checkhealth()
+
+	onRemove()
+		..()
+		src.owner.remove_filter("corrosion_color")

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -835,6 +835,7 @@
 /// Callback for welding repair actionbar
 /obj/machinery/vehicle/proc/weld_action(mob/user)
 	src.health += 30
+	src.delStatus("pod_corrosion")
 	src.checkhealth()
 	src.add_fingerprint(user)
 	src.visible_message(SPAN_ALERT("[user] has fixed some of the dents on [src]!"))

--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -936,7 +936,7 @@ ABSTRACT_TYPE(/obj/gunbotdrone_spawner)
 	icon_state = "drone_phaser"
 	possible_drones = list(/obj/critter/gunbot/drone = 90,
 						   /obj/critter/gunbot/drone/buzzdrone = 100,
-						   /obj/critter/gunbot/aciddrone = 25,
+						   /obj/critter/gunbot/drone/aciddrone = 25,
 						   /obj/critter/gunbot/drone/laserdrone = 5)
 
 /obj/gunbotdrone_spawner/uncommon

--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -936,6 +936,7 @@ ABSTRACT_TYPE(/obj/gunbotdrone_spawner)
 	icon_state = "drone_phaser"
 	possible_drones = list(/obj/critter/gunbot/drone = 90,
 						   /obj/critter/gunbot/drone/buzzdrone = 100,
+						   /obj/critter/gunbot/aciddrone = 25,
 						   /obj/critter/gunbot/drone/laserdrone = 5)
 
 /obj/gunbotdrone_spawner/uncommon


### PR DESCRIPTION
[GAME OBJECTS][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new Syndicate acid drone to the debris field. This drone is more meant to be a nuisance rather than a serious threat. It fires bolts of fluorosulfuric acid. Against pods, it adds a new corrosion status effect that reduces the pod's hp by 2 hp per second over 30 seconds, extended by another 30 seconds each time the pod is hit

Using a welding tool on a pod with active corrosion on it will remove the corrosion

Acid corrosion bypasses pod shielding


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More drone variety + adds unused drone


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)Added a new Syndicate acid drone to the debris field, which causes pod corrosion over time that can be removed with a welding tool
```
