### PR TITLE
Fix runtime when whacking plasmastone things

### DIFF
--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -374,10 +374,6 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 			target.air.merge(payload)
 			location.material.setProperty("plasma_offgas", total_plasma)
 
-/datum/materialProc/plasmastone_on_hit
-	execute(var/atom/owner)
-		owner.material.triggerTemp(locate(owner))
-
 /datum/materialProc/molitz_temp
 	max_generations = 1
 

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -930,7 +930,7 @@ ABSTRACT_TYPE(/datum/material/crystal)
 
 		addTrigger(TRIGGERS_ON_TEMP, new /datum/materialProc/plasmastone())
 		addTrigger(TRIGGERS_ON_EXPLOSION, new /datum/materialProc/plasmastone())
-		addTrigger(TRIGGERS_ON_HIT, new /datum/materialProc/plasmastone_on_hit())
+		addTrigger(TRIGGERS_ON_HIT, new /datum/materialProc/plasmastone())
 
 
 /datum/material/crystal/plasmaglass


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Plasmastone items get runtimed when hit. Also just straight up plasmastone. This removes a redirect call to onTemp to not call the special proc that gets called when radioactive items are in hot areas. when things are hit. why did it do this

![image](https://github.com/user-attachments/assets/cda535db-3791-465b-8410-66602a09fcf0)
hrm (this is what the triggerTemp called

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes are not fun times
