### PR TITLE
Prevents players who are handcuffed and grabbed/pulled from diving into disposals.

### DIFF
--- a/code/modules/disposals/disposal_chute.dm
+++ b/code/modules/disposals/disposal_chute.dm
@@ -238,6 +238,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 			return
 		if (src.status & BROKEN)
 			return
+		if(user.restrained() && (user.pulled_by || length(user.grabbed_by)))
+			return
 		if (istype(target, /obj/machinery/bot))
 			var/obj/machinery/bot/bot = target
 			bot.set_loc(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Closes https://github.com/goonstation/goonstation/issues/14242

If a player is handcuffed, and either grabbed or pulled by someone, they cannot jump into disposal chutes by click dragging themselves into it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Besides the fact it makes little sense, it is also a needless source of annoyance if someone decides to abuse this exploit.

```changelog
(u)Bartimeus973
(+)You cannot enter disposal chutes by yourself if you are cuffed and held/pulled.
```
