### PR TITLE
Make mechcomp teles singulo immune

### DIFF
--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -56,6 +56,8 @@
 	var/goes_through_walls = FALSE
 	/// Whether this projectile can freely pass through mobs
 	var/goes_through_mobs = FALSE
+	/// Whether this projectile can freely pass through the singularity
+	var/goes_through_singulo = FALSE
 	/// List of atoms collided with this tick
 	var/list/hitlist = list()
 	/// Number of times this projectile has been reflected off of things. Used to cap reflections
@@ -320,6 +322,7 @@
 		pierces_left = src.proj_data.pierces
 		goes_through_walls = src.proj_data.goes_through_walls
 		goes_through_mobs = src.proj_data.goes_through_mobs
+		goes_through_singulo = src.proj_data.goes_through_singulo
 		set_icon()
 
 		var/len = src.get_len()
@@ -721,6 +724,7 @@ ABSTRACT_TYPE(/datum/projectile)
 	var/hits_wraiths = 0
 	var/goes_through_walls = 0
 	var/goes_through_mobs = 0
+	var/goes_through_singulo = 0
 	var/smashes_glasses = TRUE
 	var/pierces = 0
 	var/ticks_between_mob_hits = 0

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -718,8 +718,9 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	invisibility = INVIS_INFRA
 
 	shot_sound = null
-	goes_through_walls = 1
-	goes_through_mobs = 1
+	goes_through_walls = TRUE
+	goes_through_mobs = TRUE
+	goes_through_singulo = TRUE
 	smashes_glasses = FALSE
 
 	silentshot = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes mech comp teleporters immune to the singularity.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Instantly and permamently deleted anyone who passes over the singulo, which was quite easy on Cog1.
Also was causing runtimes.