### PR TITLE
send-only mechcomp teleporters do not intercept teleport projectiles

### DIFF
--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -741,8 +741,8 @@ ABSTRACT_TYPE(/datum/projectile/special)
 			logTheThing(LOG_STATION, P, "teleport projectile [P] dumped contents at [log_loc(P)] as targeted destination was disposed.")
 			P.die()
 		var/obj/item/mechanics/telecomp/target_tele = P.targets[1]
-		if (!target_tele.anchored)
-			logTheThing(LOG_STATION, P, "teleport projectile [P] dumped contents at [log_loc(P)] as target teleporter at [log_loc(target_tele)] was unanchored.")
+		if (!target_tele.anchored || target_tele.send_only)
+			logTheThing(LOG_STATION, P, "teleport projectile [P] dumped contents at [log_loc(P)] as target teleporter at [log_loc(target_tele)] was [target_tele.anchored ? "de-anchored" : "set to send only"].")
 			P.die()
 		if (get_turf(P) == src.starting_turf) return
 		for (var/obj/item/mechanics/telecomp/tele in get_turf(P))

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -746,7 +746,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 			P.die()
 		if (get_turf(P) == src.starting_turf) return
 		for (var/obj/item/mechanics/telecomp/tele in get_turf(P))
-			if (tele.anchored)
+			if (tele.anchored && !tele.send_only)
 				particleMaster.SpawnSystem(new /datum/particleSystem/tpbeamdown(get_turf(tele.loc))).Run()
 				// Dest. pad gets "from=origin&count=123"
 				SEND_SIGNAL(tele, COMSIG_MECHCOMP_TRANSMIT_SIGNAL,"from=[tele.teleID]&count=[P.special_data["count_sent"]]")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* when checking teleporters in the current turf add a check to see if a teleporter is send only, and if so, do not intercept the projectile

* during transport, if the destination tele is changed to send_only kill the teleport projectile

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
they're send-only
Fix #22416