### PR TITLE
Syndicate Robot Conversion Chamber has a 1 second action bar when click-dragging people inside

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -1116,7 +1116,8 @@ TYPEINFO(/obj/machinery/recharge_station)
 		src.converter = target
 		src.victim = proc_args[2]
 
-	proc/victim_check()
+	canRunCheck(in_start)
+		..()
 		if (BOUNDS_DIST(src.converter, src.victim) > 0 || BOUNDS_DIST(src.victim, src.owner) > 0)
 			src.interrupt(INTERRUPT_ALWAYS)
 		if (isdead(src.victim))
@@ -1125,17 +1126,5 @@ TYPEINFO(/obj/machinery/recharge_station)
 			src.interrupt(INTERRUPT_ALWAYS)
 		if (src.converter.occupant)
 			src.interrupt(INTERRUPT_ALWAYS)
-
-	onStart()
-		. = ..()
-		src.victim_check()
-
-	onUpdate()
-		. = ..()
-		src.victim_check()
-
-	onEnd()
-		. = ..()
-		src.victim_check()
 
 #undef CONVERTER_CLICKDRAG_BAR_DURATION

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -214,6 +214,8 @@ TYPEINFO(/obj/machinery/recharge_station)
 		return
 	if (src.status & (BROKEN | NOPOWER))
 		return
+	if (ishuman(AM))
+		return
 	if (isitem(AM) && can_act(user))
 		src.Attackby(AM, user)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When click-dragging people into the syndicate conversion chamber, there is now a 1 second action bar. Aggressive grabs will still put people into the chamber without an action bar, maintaining current behavior.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There's no reaction time or ability to respond to a click-drag action

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Click-dragging people into a syndicate robot conversion chamber has a 1 second action bar.
```
