### PR TITLE
Make timer and proximity sensors always respect min_time

### DIFF
--- a/code/obj/item/device/prox_sensor.dm
+++ b/code/obj/item/device/prox_sensor.dm
@@ -61,7 +61,7 @@ TYPEINFO(/obj/item/device/prox_sensor)
 			else src.timing = FALSE
 		else
 			src.armed = TRUE
-			src.time = 0
+			src.time = src.min_time
 			src.timing = FALSE
 			src.last_tick = 0
 			src.GetComponent(/datum/component/proximity).set_detection(TRUE)
@@ -156,6 +156,7 @@ TYPEINFO(/obj/item/device/prox_sensor)
 			. = TRUE
 
 		if ("toggle-timing")
+			src.time = max(src.min_time, src.time)
 			src.timing = !src.timing
 			src.UpdateIcon()
 			if(timing || armed) processing_items |= src

--- a/code/obj/item/device/timer.dm
+++ b/code/obj/item/device/timer.dm
@@ -57,7 +57,7 @@ TYPEINFO(/obj/item/device/timer)
 				src.c_state(1)
 		else
 			time()
-			src.time = 0
+			src.time = src.min_time
 			src.timing = FALSE
 			src.last_tick = 0
 
@@ -120,6 +120,7 @@ TYPEINFO(/obj/item/device/timer)
 			src.set_time(round(time))
 			. = TRUE
 		if ("toggle-timing")
+			src.time = max(src.get_min_time(), src.time)
 			src.timing = !src.timing
 			if(src.timing)
 				src.c_state(1)


### PR DESCRIPTION
[Internal][Game objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes it so that whenever a timer or proximity sensor runs out of time or it toggled on/off, it's current time will be set to min_time

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Right now, this more or less only does reset the timer on canbombs to at least 90 seconds when the timer stops (don't know if that is even possible save for it hitting 0).

But right now, grenade, pipebomb or other assemblies in #22115 can be toggled to detonate instantly on use. To have a balance mechanic for that, min_time on timers or proximity sensors can be adjusted accordingly. But for this to be a variable to balance with, it should work, obviously.