### PR TITLE
Fix taking inverted lamps out of test equipment

### DIFF
--- a/code/obj/artifacts/artifact_objects/lamp.dm
+++ b/code/obj/artifacts/artifact_objects/lamp.dm
@@ -100,12 +100,14 @@
 
 	New(loc, radius=2, color=null)
 		.=..(get_turf(loc))
-		src.radius = radius
+		src.radius = ceil(radius)
 		if(isnull(color))
 			src.color = COLOR_MATRIX_INVERSE
 		else
 			src.color = color
 		src.appearance_flags |= RESET_TRANSFORM
+		RegisterSignal(loc, COMSIG_MOVABLE_SET_LOC, PROC_REF(update_whacky))
+		RegisterSignal(loc, COMSIG_MOVABLE_MOVED, PROC_REF(update_whacky))
 		update_whacky(loc, null, 0)
 
 	proc/update_whacky(var/atom/movable/thing)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #22384
Just registers the signals on movement again, it'll catch any forced movement things.
