### PR TITLE
Rectangular minimap support

### DIFF
--- a/code/modules/minimap/minimap_objects/controllers/_minimap_controller_parent.dm
+++ b/code/modules/minimap/minimap_objects/controllers/_minimap_controller_parent.dm
@@ -113,7 +113,8 @@
 	// As the minimap render is transparent to clicks, the minimap will require an overlay which clicks may register on.
 	if (!src.icon || !src.icon_state)
 		var/icon/click_overlay_icon = icon('icons/obj/minimap/minimap.dmi', "blank")
-		click_overlay_icon.Scale(src.displayed_minimap.x_max, src.displayed_minimap.y_max)
+		var/max_dim = max(src.displayed_minimap.x_max, src.displayed_minimap.y_max)
+		click_overlay_icon.Scale(max_dim * src.displayed_minimap.map_scale, max_dim * src.displayed_minimap.map_scale)
 		click_overlay_icon.ChangeOpacity(0)
 		src.icon = click_overlay_icon
 		src.mouse_opacity = 2

--- a/code/modules/minimap/minimap_objects/objects/_minimap_object_parent.dm
+++ b/code/modules/minimap/minimap_objects/objects/_minimap_object_parent.dm
@@ -36,7 +36,8 @@
 	// As the minimap render is transparent to clicks, the minimap will require an overlay which clicks may register on.
 	if (!src.icon || !src.icon_state)
 		var/icon/click_overlay_icon = icon('icons/obj/minimap/minimap.dmi', "blank")
-		click_overlay_icon.Scale(src.map.x_max * map_scale, src.map.y_max * map_scale)
+		var/max_dim = max(src.map.x_max, src.map.y_max)
+		click_overlay_icon.Scale(max_dim * map_scale, max_dim * map_scale)
 		click_overlay_icon.ChangeOpacity(0)
 		src.icon = click_overlay_icon
 		src.mouse_opacity = 2

--- a/code/modules/minimap/minimap_objects/objects/map_computer.dm
+++ b/code/modules/minimap/minimap_objects/objects/map_computer.dm
@@ -15,17 +15,11 @@
 	var/light_g = 1
 	var/light_b = 1
 
-	// Magic numbers to align the minimap with the physical frame of the map.
-	/// map holder x offset to center the map in frame
-	var/minimap_holder_pixel_x = 5
-	/// map holder y offset to center the map in frame
-	var/minimap_holder_pixel_y = 4
-
 /obj/minimap/map_computer/initialise_minimap()
 	. = ..()
 	// Magic numbers to align the minimap with the physical frame of the map.
-	src.map.minimap_holder.pixel_x += minimap_holder_pixel_x
-	src.map.minimap_holder.pixel_y += minimap_holder_pixel_y
+	src.map.minimap_holder.pixel_x += 5
+	src.map.minimap_holder.pixel_y += 4
 
 	src.create_overlays()
 
@@ -90,8 +84,7 @@
 /obj/minimap/map_computer/pod_wars
 	name = "Debris Field Map"
 	desc = "A cutting-edge cathode ray tube monitor, actively rendering many dozens of kilobytes of reconnaissance data on the surrounding debris field."
-	map_scale = 0.25
-	minimap_holder_pixel_y = 55
+	map_scale = 0.3
 
 
 /obj/minimap/map_computer/pod_wars/nanotrasen

--- a/code/modules/minimap/minimap_objects/objects/map_computer.dm
+++ b/code/modules/minimap/minimap_objects/objects/map_computer.dm
@@ -84,7 +84,7 @@
 /obj/minimap/map_computer/pod_wars
 	name = "Debris Field Map"
 	desc = "A cutting-edge cathode ray tube monitor, actively rendering many dozens of kilobytes of reconnaissance data on the surrounding debris field."
-	map_scale = 0.3
+	map_scale = 0.25
 
 
 /obj/minimap/map_computer/pod_wars/nanotrasen

--- a/code/modules/minimap/minimaps/__minimap_parent.dm
+++ b/code/modules/minimap/minimaps/__minimap_parent.dm
@@ -75,9 +75,10 @@ ABSTRACT_TYPE(/datum/minimap)
 /// Create an alpha mask to hide anything outside the bounds of the physical map.
 /datum/minimap/proc/create_alpha_mask()
 	var/icon/mask_icon = icon('icons/obj/minimap/minimap.dmi', "blank")
-	mask_icon.Scale(src.x_max * src.map_scale, src.y_max * src.map_scale)
-	var/x_offset = ((src.x_max * src.map_scale) / 2) - 16
-	var/y_offset = ((src.y_max * src.map_scale) / 2) - 16
+	var/max_dim = max(src.x_max, src.y_max)
+	mask_icon.Scale(max_dim * src.map_scale, max_dim * src.map_scale)
+	var/x_offset = ((max_dim * src.map_scale) / 2) - 16
+	var/y_offset = ((max_dim * src.map_scale) / 2) - 16
 	src.minimap_holder.add_filter("map_cutoff", 1, alpha_mask_filter(x_offset, y_offset, mask_icon))
 
 /// Zooms the minimap by the zoom coefficient while moving the minimap so that the specified point lies at the same position on the displayed minimap as it did prior to the zoom. The alpha mask takes care of any map area scaled outside of the map boundaries.

--- a/code/modules/minimap/minimaps/_area_minimap.dm
+++ b/code/modules/minimap/minimaps/_area_minimap.dm
@@ -123,6 +123,18 @@
 	src.minimap_render.pixel_x += x_offset
 	src.minimap_render.pixel_y += y_offset
 
+	var/max_dim = (max(src.x_max, src.y_max) * zoom * src.map_scale)
+	// Calculate Horizontal Centering Offset
+	var/map_width = src.x_max * zoom * src.map_scale
+	var/horizontal_centering_offset = (max_dim - map_width) / 2
+
+	// Calculate Vertical Centering Offset
+	var/map_height = src.y_max * zoom * src.map_scale
+	var/vertical_centering_offset = (max_dim - map_height) / 2
+
+	src.minimap_render.pixel_x += horizontal_centering_offset
+	src.minimap_render.pixel_y += vertical_centering_offset
+
 	src.zoom_coefficient = zoom
 
 	for (var/atom/target as anything in src.minimap_markers)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds proper support for rectangular minimaps


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Current rectangular minimaps don't have a properly sized click layer or render atom leading to both poor user experience, and dead zones on the map


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sovexe
(+)Rectangular maps (e.g. Podwars) are now properly supported by the minimap computers and floor displays
```
