### PR TITLE
Fix bug with pods not taking fuel when there is no secondary system.

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -35,12 +35,7 @@
 	var/weapon_class = 0 //what weapon class a ship is
 	var/powercapacity = 0 //How much power the ship's components can use, set by engine
 	var/powercurrent = 0 //How much power the components are using
-	/// multiplicative ship speed modification
-	var/speedmod = 1
-	/// acceleration modification provided by afterburner if installed
-	var/afterburner_accel_mod = 1
-	/// speed modification provided by afterburner if installed
-	var/afterburner_speed_mod = 1
+	var/speed = 1 //FOR PODS : While holding thruster, how much to add on to our max speed. Does nothing for tanks.
 	var/stall = 0 // slow the ship down when firing
 	var/flying = 0 // holds the direction the ship is currently drifting, or 0 if stopped
 	var/facing = SOUTH // holds the direction the ship is currently facing
@@ -223,29 +218,11 @@
 
 //each pod part is a var so we have to macro this, yegh
 #define EJECT_PART(part) \
-	src.eject_part(part); \
+	part.deactivate(); \
+	src.components -= part; \
 	usr.put_in_hand_or_drop(part); \
-	src.null_part(part); \
+	part = null; \
 	src.updateDialog()
-
-	/// finds the part in the ship's parts and nulls it
-	proc/null_part(obj/item/shipcomponent/part)
-		if (part == src.engine)
-			src.engine = null
-		else if (part == src.lock)
-			src.lock = null
-		else if (part == src.life_support)
-			src.life_support = null
-		else if (part == src.com_system)
-			src.com_system = null
-		else if (part == src.m_w_system)
-			src.m_w_system = null
-		else if (part == src.sec_system)
-			src.sec_system = null
-		else if (part == src.sensors)
-			src.sensors = null
-		else if (part == src.lights)
-			src.lights = null
 
 	Topic(href, href_list)
 		if (is_incapacitated(usr) || usr.restrained())
@@ -474,20 +451,11 @@
 
 #undef EJECT_PART
 
-	proc/eject_part(obj/item/shipcomponent/part, give_message = TRUE)
-		part.deactivate(give_message)
-		part.set_loc(get_turf(src))
-		src.components -= part
-
 	proc/AmmoPerShot()
 		return 1
 
-	proc/ShootProjectiles(var/mob/user, var/datum/projectile/PROJ, var/shoot_dir, spread = -1)
-		var/obj/projectile/P
-		if (spread == -1)
-			P = shoot_projectile_DIR(src, PROJ, shoot_dir)
-		else
-			P = shoot_projectile_relay_pixel_spread(src, PROJ, get_step(src, shoot_dir), spread_angle = spread)
+	proc/ShootProjectiles(var/mob/user, var/datum/projectile/PROJ, var/shoot_dir)
+		var/obj/projectile/P = shoot_projectile_DIR(src, PROJ, shoot_dir)
 		P.mob_shooter = user
 		if (src.m_w_system?.muzzle_flash)
 			muzzle_flash_any(src, dir_to_angle(shoot_dir), src.m_w_system.muzzle_flash)
@@ -782,21 +750,20 @@
 		..()
 
 	process(mult)
-		if(sec_system)
-			if(sec_system.active)
-				sec_system.run_component(mult)
-			if(src.engine && engine.active)
-				var/usage = src.powercurrent/3000*mult // 0.0333 moles consumed per 100W per tick
-				var/datum/gas_mixture/consumed = src.fueltank?.remove_air(usage)
-				var/toxins = consumed?.toxins
-				if(isnull(toxins))
-					toxins = 0
+		if(sec_system?.active)
+			sec_system.run_component(mult)
+		if(src.engine && engine.active)
+			var/usage = src.powercurrent/3000*mult // 0.0333 moles consumed per 100W per tick
+			var/datum/gas_mixture/consumed = src.fueltank?.remove_air(usage)
+			var/toxins = consumed?.toxins
+			if(isnull(toxins))
+				toxins = 0
 
-				if(usage)
-					src.myhud?.update_fuel()
-					if(abs(usage - toxins)/usage > 0.10) // 5% difference from expectation
-						engine.deactivate()
-				consumed?.dispose()
+			if(usage)
+				src.myhud?.update_fuel()
+				if(abs(usage - toxins)/usage > 0.10) // 5% difference from expectation
+					engine.deactivate()
+			consumed?.dispose()
 
 #ifdef MAP_OVERRIDE_NADIR
 		if(src.acid_damage_multiplier > 0)
@@ -863,7 +830,6 @@
 /// Callback for welding repair actionbar
 /obj/machinery/vehicle/proc/weld_action(mob/user)
 	src.health += 30
-	src.delStatus("pod_corrosion")
 	src.checkhealth()
 	src.add_fingerprint(user)
 	src.visible_message(SPAN_ALERT("[user] has fixed some of the dents on [src]!"))
@@ -900,7 +866,7 @@
 ///////////////////////////////////////////////////////////////////////////
 ////////Install Ship Part////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////
-/obj/machinery/vehicle/proc/Install(obj/item/shipcomponent/S as obj, give_feedback = TRUE)
+/obj/machinery/vehicle/proc/Install(obj/item/shipcomponent/S as obj)
 	switch(S.system)
 		if("Engine")
 			if(!src.engine)
@@ -941,7 +907,7 @@
 				if(uses_weapon_overlays && m_w_system.appearanceString)
 					src.overlays += image('icons/effects/64x64.dmi', "[m_w_system.appearanceString]")
 
-				m_w_system.activate(give_feedback)
+				m_w_system.activate()
 			else
 				boutput(usr, "That system already has a part!")
 				return
@@ -960,8 +926,7 @@
 	S.ship = src
 	if (usr) //This mean it's going on during the game!
 		usr.drop_item(S)
-		if (give_feedback)
-			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 0)
+		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 0)
 	S.set_loc(src)
 	myhud.update_systems()
 	myhud.update_states()
@@ -1828,7 +1793,6 @@
 
 // make ships less destructive (maybe depends on Mass and Speed?)
 
-ABSTRACT_TYPE(/obj/machinery/vehicle/tank)
 /obj/machinery/vehicle/tank
 	name = "tank"
 	icon = 'icons/obj/machines/8dirvehicles.dmi'
@@ -1839,7 +1803,7 @@ ABSTRACT_TYPE(/obj/machinery/vehicle/tank)
 	uses_weapon_overlays = 0
 	health = 100
 	maxhealth = 100
-	speedmod = 0 // speed literally does nothing? what??
+	speed = 0 // speed literally does nothing? what??
 	stall = 0 // slow the ship down when firing
 	weapon_class = 1
 
@@ -2028,7 +1992,7 @@ ABSTRACT_TYPE(/obj/machinery/vehicle/tank)
 	health = 60
 	maxhealth = 60
 	weapon_class = 1
-	speedmod = 0.2
+	speed = 5
 	var/fail_type = 0
 	var/launched = 0
 	var/steps_moved = 0


### PR DESCRIPTION
[VEHICLES][BUG]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes pod fuel code not dependent on having secondary system by moving it down a single indent (and a another change for code quality)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because having pod fuel consumption be dependent on having a secondary system is bad
Fixes #22340 
