### PR TITLE
Separate infrared and meson invisibility

### DIFF
--- a/_std/defines/invisibility.dm
+++ b/_std/defines/invisibility.dm
@@ -1,6 +1,7 @@
 #define INVIS_NONE 0
 #define INVIS_INFRA 1
-#define INVIS_CLOAK 2
+#define INVIS_MESON 2
+#define INVIS_CLOAK 3
 #define INVIS_CONSTRUCTION 8
 #define INVIS_AI_EYE 9
 #define INVIS_FLOCK 10

--- a/code/mob/living/life/sight.dm
+++ b/code/mob/living/life/sight.dm
@@ -143,8 +143,8 @@
 			if (owner.see_in_dark < initial(owner.see_in_dark) + 1)
 				owner.see_in_dark++
 			owner.render_special.set_centerlight_icon("meson", rgb(0.5 * 255, 0.5 * 255, 0.5 * 255), wide = (owner.client?.widescreen))
-			if (owner.see_invisible < INVIS_INFRA)
-				owner.see_invisible = INVIS_INFRA
+			if (owner.see_invisible < INVIS_MESON)
+				owner.see_invisible = INVIS_MESON
 
 		if (human_owner)////Glasses handled separately because i dont have a fast way to get glasses on any mob type
 			if (istype(human_owner.glasses, /obj/item/clothing/glasses/construction) && (T && !isrestrictedz(T.z)))

--- a/code/modules/antagonists/wizard/abilities/phaseshift.dm
+++ b/code/modules/antagonists/wizard/abilities/phaseshift.dm
@@ -235,7 +235,7 @@
 	proc/set_cloaked(var/cloaked = 1)
 		if (use_cloakofdarkness)
 			if (cloaked == 1)
-				src.invisibility = INVIS_INFRA
+				src.invisibility = INVIS_MESON
 				src.alpha = 120
 				//src.UpdateOverlays(overlay_image, "batpoof_cloak")
 			else

--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -1022,7 +1022,7 @@ var/list/radio_brains = list()
 		if (probmult(20))
 			src.active = !src.active
 		if (src.active)
-			APPLY_ATOM_PROPERTY(src.owner, PROP_MOB_INVISIBILITY, src, INVIS_INFRA)
+			APPLY_ATOM_PROPERTY(src.owner, PROP_MOB_INVISIBILITY, src, INVIS_MESON)
 		else
 			REMOVE_ATOM_PROPERTY(src.owner, PROP_MOB_INVISIBILITY, src)
 

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -1979,7 +1979,7 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 
 		var/mob/living/L = owner
 		if (which_way == 1)
-			APPLY_ATOM_PROPERTY(src.owner, PROP_MOB_INVISIBILITY, src, INVIS_INFRA)
+			APPLY_ATOM_PROPERTY(src.owner, PROP_MOB_INVISIBILITY, src, INVIS_MESON)
 			L.UpdateOverlays(overlay_image, id)
 		else
 			REMOVE_ATOM_PROPERTY(src.owner, PROP_MOB_INVISIBILITY, src)
@@ -2085,7 +2085,7 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 			var/mob/living/L = owner
 			if (TIME - last_moved >= 3 SECONDS && can_act(owner))
 				L.UpdateOverlays(overlay_image, id)
-				APPLY_ATOM_PROPERTY(src.owner, PROP_MOB_INVISIBILITY, src, INVIS_INFRA)
+				APPLY_ATOM_PROPERTY(src.owner, PROP_MOB_INVISIBILITY, src, INVIS_MESON)
 
 	proc/decloak()
 		if(isliving(owner))

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -715,7 +715,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	auto_find_targets = 0
 	max_speed = 6
 	start_speed = 0.1
-	invisibility = INVIS_INFRA
+	invisibility = INVIS_MESON
 
 	shot_sound = null
 	goes_through_walls = 1

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -658,7 +658,7 @@
 			for (var/obj/forcefield/mining/M in wall_bits)
 				M.set_opacity(0)
 				M.set_density(0)
-				M.invisibility = INVIS_INFRA
+				M.invisibility = INVIS_MESON
 			active = 0
 			boutput(usr, "Uh oh, something's gotten really fucked up with the magnet system. Please report this to a coder! (ERROR: NO ENCOUNTER)")
 			return

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -784,7 +784,7 @@
 	name = "neutron"
 	icon_state = "neutron"
 	icon = 'icons/obj/projectiles.dmi'
-	invisibility = INVIS_INFRA
+	invisibility = INVIS_MESON
 	override_color = TRUE
 	color_icon = "#00FF00"
 	power = 100

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -784,7 +784,7 @@
 	name = "neutron"
 	icon_state = "neutron"
 	icon = 'icons/obj/projectiles.dmi'
-	invisibility = INVIS_MESON
+	invisibility = INVIS_INFRA
 	override_color = TRUE
 	color_icon = "#00FF00"
 	power = 100


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add new invis level `INVIS_MESON`
Change invis level of the following to INVIS_MESON:
  * Genes: Chameleon, Cloak of Darkness, Unstable Refraction (unused, but for consistency)
  * Vampire: Upgraded bat form
  * MechComp Warp
  * Mining Forcefield

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* It's very easy to get infrared sight:
  * Lizards and roaches (and cats) have infrared vision by default
  * You can pick up infrared vision as a 1 point trait
* These semi-cloaks are less powerful than true cloaking, but require getting meson vision to see. This might be in place of other glasses e.g. SecHUDs, which is a significant buff for vampires.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Infrared vision cannot see through gene-based or vampire cloaking. They can still be revealed by mesons.
```