### PR TITLE
Allow secure briefcases to hold gold bullion

### DIFF
--- a/code/obj/item/storage/secure_safe.dm
+++ b/code/obj/item/storage/secure_safe.dm
@@ -279,6 +279,8 @@ TYPEINFO(/obj/item/storage/secure/sbriefcase)
 	w_class = W_CLASS_BULKY
 	spawn_contents = list(/obj/item/paper,\
 	/obj/item/pen)
+	check_wclass = TRUE
+	can_hold = list(/obj/item/stamped_bullion)
 
 TYPEINFO(/obj/item/storage/secure/ssafe)
 	mats = 8


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add stamped bullion to secure briefcases can_hold
Add check_wclass so it can still hold pens/paper/etc.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
VIPs start with gold bullion in their briefcase, but cannot put it back inside.