### PR TITLE
Prevent roaches and lizards from wasting a point on infravision

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -26,6 +26,7 @@
 		"hemophilia",
 		"nohair",
 		"nowig",
+		"infrared",
 	)
 
 	var/list/traitData = list()
@@ -493,7 +494,7 @@
 	id = "infravision"
 	icon_state = "infravisionG"
 	points = -1
-	category = list("vision")
+	category = list("vision", "infrared")
 
 /datum/trait/wasitsomethingisaid
 	name = "Was It Something I Said?"
@@ -1294,7 +1295,7 @@ TYPEINFO(/datum/trait/partyanimal)
 	desc = "You are an abhorrent humanoid reptile, cold-blooded and ssssibilant."
 	id = "lizard"
 	points = -1
-	category = list("species")
+	category = list("species", "infrared")
 	mutantRace = /datum/mutantrace/lizard
 
 /datum/trait/cow
@@ -1321,7 +1322,7 @@ TYPEINFO(/datum/trait/partyanimal)
 	desc = "One space-morning, on the shuttle-ride to the station, you found yourself transformed in your seat into a horrible vermin. A cockroach, specifically."
 	id = "roach"
 	points = -1
-	category = list("species")
+	category = list("species", "infrared")
 	mutantRace = /datum/mutantrace/roach
 
 /datum/trait/pug


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[traits][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Add a new hidden trait category "infrared"
* Apply to lizard, roach, and infravision traits

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
roaches/lizards get infrared sight for free, so don't let them waste points on infravision