### PR TITLE
De-capitalize banana peel

### DIFF
--- a/code/obj/item/clown_items.dm
+++ b/code/obj/item/clown_items.dm
@@ -8,7 +8,7 @@ VUVUZELA
 */
 
 /obj/item/bananapeel
-	name = "Banana Peel"
+	name = "banana peel"
 	desc = "A peel from a banana."
 	icon = 'icons/obj/foodNdrink/food_produce.dmi'
 	icon_state = "banana-peel"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the name of banana peels from "Banana peel" to "banana peel"

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
"Banana peel" is not a proper name and not an acronym, and therefore probably should not be capitalized

