### PR TITLE
Replaces fishing rod tier requirements with a boutput

### DIFF
--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -51,7 +51,7 @@
 				fishing_spot_type = type2parent(fishing_spot_type)
 			if (fishing_spot)
 				if (fishing_spot.rod_tier_required > src.tier)
-					user.visible_message(SPAN_ALERT("You need a higher tier rod to fish here!"))
+					boutput(user, SPAN_ALERT("You need a higher tier rod to fish here!"))
 					return TRUE
 				actions.start(new /datum/action/fishing(user, src, fishing_spot, target), user)
 				return TRUE //cancel the attack because we're fishing now


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the message that appears when you try to fish in a spot that requires a higher tier fishing rod from a visible message to a boutput.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Simple bugfix, it should only be seen by the user.
Fixes https://github.com/goonstation/goonstation/issues/22450
