### PR TITLE
Add Barbershop supply pack

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1597,6 +1597,21 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 	containertype = /obj/storage/crate
 	containername = "Mechanics Reconstruction Kit"
 
+/datum/supply_packs/complex/barbershop_kit
+	name = "Barbershop Kit"
+	desc = "1x Hair Dye Dispenser frame, 1x Barber chair parts, 2x Hair Dye, 1x Scissors, 1x Razor"
+	category = "Civilian Department"
+	contains = list(/obj/item/electronics/soldering,
+					/obj/item/furniture_parts/barber_chair,
+					/obj/item/dye_bottle,
+					/obj/item/dye_bottle,
+					/obj/item/razor_blade,
+					/obj/item/scissors)
+	frames = list(/obj/machinery/hair_dye_dispenser)
+	cost = PAY_TRADESMAN
+	containertype = /obj/storage/crate
+	containername = "Mechanics Reconstruction Kit"
+
 #ifndef UNDERWATER_MAP
 /datum/supply_packs/complex/mini_magnet_kit
 	name = "Small Magnet Kit"

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1612,7 +1612,7 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 	frames = list(/obj/machinery/hair_dye_dispenser)
 	cost = PAY_TRADESMAN*5
 	containertype = /obj/storage/crate
-	containername = "Mechanics Reconstruction Kit"
+	containername = "Barbershop Kit"
 
 #ifndef UNDERWATER_MAP
 /datum/supply_packs/complex/mini_magnet_kit

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1610,7 +1610,7 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 					/obj/item/clothing/under/misc/barber,
 					/obj/item/clothing/gloves/latex)
 	frames = list(/obj/machinery/hair_dye_dispenser)
-	cost = PAY_TRADESMAN
+	cost = PAY_TRADESMAN*5
 	containertype = /obj/storage/crate
 	containername = "Mechanics Reconstruction Kit"
 

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1599,14 +1599,16 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 
 /datum/supply_packs/complex/barbershop_kit
 	name = "Barbershop Kit"
-	desc = "1x Hair Dye Dispenser frame, 1x Barber chair parts, 2x Hair Dye, 1x Scissors, 1x Razor"
+	desc = "Everything one might need to open up a barbershop!"
 	category = "Civilian Department"
 	contains = list(/obj/item/electronics/soldering,
 					/obj/item/furniture_parts/barber_chair,
 					/obj/item/dye_bottle,
 					/obj/item/dye_bottle,
 					/obj/item/razor_blade,
-					/obj/item/scissors)
+					/obj/item/scissors,
+					/obj/item/clothing/under/misc/barber,
+					/obj/item/clothing/gloves/latex)
 	frames = list(/obj/machinery/hair_dye_dispenser)
 	cost = PAY_TRADESMAN
 	containertype = /obj/storage/crate


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a barbershop kit crate to cargo's list of possible orders
Contains: 
- Hair dye mixer frame
- Soldering iron (for the frame)
- 2 dye bottles
- barber chair parts
- razor
- scissors
- Barber uniform
- latex gloves


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There is presently no way to replace any of these items if they get stolen from the barbershop or if theres no barbershop to obtain these items.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Added barbershop kit to list of cargo orders.
```
