### PR TITLE
Blood smearing instead of footsteps on laying down

### DIFF
--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -315,6 +315,7 @@
 		B.set_sample_reagent_custom(src.tracked_blood["sample_reagent"], 0)
 
 	var/list/states = src.get_step_image_states()
+
 	if (!src.lying && (states[1] || states[2]))
 		if (states[1])
 			B.add_volume(blood_color_to_pass, src.tracked_blood["sample_reagent"], 0.5, 0.5, src.tracked_blood, states[1], src.last_move, 0)

--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -315,14 +315,13 @@
 		B.set_sample_reagent_custom(src.tracked_blood["sample_reagent"], 0)
 
 	var/list/states = src.get_step_image_states()
-
-	if (states[1] || states[2])
+	if (!src.lying && (states[1] || states[2]))
 		if (states[1])
 			B.add_volume(blood_color_to_pass, src.tracked_blood["sample_reagent"], 0.5, 0.5, src.tracked_blood, states[1], src.last_move, 0)
 		if (states[2])
 			B.add_volume(blood_color_to_pass, src.tracked_blood["sample_reagent"], 0.5, 0.5, src.tracked_blood, states[2], src.last_move, 0)
 	else
-		B.add_volume(blood_color_to_pass, src.tracked_blood["sample_reagent"], 1, 1, src.tracked_blood, "smear2", src.last_move, 0)
+		B.add_volume(blood_color_to_pass, src.tracked_blood["sample_reagent"], 1, 1, src.tracked_blood, "smear[min (3, round(src.tracked_blood["count"]/2, 1))]", src.last_move, 0)
 
 	if (src.tracked_blood && isnum(src.tracked_blood["count"])) // mirror from below
 		src.tracked_blood["count"] --


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes forensic code to make mobs leave blood smears rather than footsteps if they're laying down, also very mildly tweaks the visuals for blood smears to get smaller the further the mob goes


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mobs leaving footprints when they are not actually walking looks weird, especially in the case of dragging incapacitated or dead mobs. Potentially also fun for detectives to use in trying to figure out just what happened at a crime scene, by analyzing blood stains.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

