### PR TITLE
Deprecate Chui for 516

### DIFF
--- a/code/chui/window.dm
+++ b/code/chui/window.dm
@@ -337,6 +337,7 @@ chui/window
 //A chui substitute for usr << browse()
 //Mostly the same syntax.
 /client/proc/Browse( var/html, var/opts, var/forceChui )
+	if (byond_version >= 516) forceChui = FALSE // no chui for webview2 users
 	chui.staticinst.bbrowse( src, html, opts, forceChui )
 	var/list/params_list = params2list(opts)
 	if (params_list["window"])

--- a/code/client.dm
+++ b/code/client.dm
@@ -645,8 +645,14 @@
 
 	//tg controls end
 
-	use_chui = winget( src, "menu.use_chui", "is-checked" ) == "true"
-	use_chui_custom_frames = winget( src, "menu.use_chui_custom_frames", "is-checked" ) == "true"
+	if (src.byond_version >= 516)
+		use_chui = FALSE
+		winset(src, "use_chui", "is-checked=false")
+		use_chui_custom_frames = FALSE
+		winset(src, "use_chui_custom_frames", "is-checked=false")
+	else
+		use_chui = winget( src, "menu.use_chui", "is-checked" ) == "true"
+		use_chui_custom_frames = winget( src, "menu.use_chui_custom_frames", "is-checked" ) == "true"
 
 	//wow its the future we can choose between 3 fps values omg
 	if (winget( src, "menu.fps_chunky", "is-checked" ) == "true")
@@ -1413,6 +1419,10 @@ var/global/curr_day = null
 /client/verb/set_chui()
 	set hidden = 1
 	set name = "set-chui"
+	if (byond_version >= 516)
+		tgui_alert(mob, "Error: Chui is deprecated in BYOND 516+ and cannot be enabled.", "Chui Deprecation")
+		winset(src, "use_chui", "is-checked=false")
+		return
 	if (src.use_chui)
 		src.use_chui = 0
 	else
@@ -1421,6 +1431,10 @@ var/global/curr_day = null
 /client/verb/set_chui_custom_frames()
 	set hidden = 1
 	set name = "set-chui-custom-frames"
+	if (byond_version >= 516)
+		tgui_alert(mob, "Error: Chui is deprecated in BYOND 516+ and cannot be enabled.", "Chui Deprecation")
+		winset(src, "use_chui_custom_frames", "is-checked=false")
+		return
 	if (src.use_chui_custom_frames)
 		src.use_chui_custom_frames = 0
 	else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Deprecates Chui for BYOND 516 users and forcibly disables it


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Chui is largely broken in webkit2 and on its way out of the codebase