### PR TITLE
Targeted jailbird trait crimes.

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -128,74 +128,9 @@
 
 	if(H.traitHolder.hasTrait("jailbird"))
 		S["criminal"] = ARREST_STATE_ARREST
-		S["mi_crim"] = pick(\
-								"Public urination.",\
-								"Reading highly confidential private information.",\
-								"Vandalism.",\
-								"Illegal manufacturing of space goods.",\
-								"Tresspassing.",\
-								"Killing a monkey.",\
-								"Negligence.",\
-								"Pushing down and farting on a member of security.",\
-								"Throwing a toolbox at a member of security.",\
-								"Being drunk.",\
-								"Being high.",\
-								"Excessive force.",\
-								"Impersonating a security officer.",\
-								"Stealing shoes.",\
-								"Littering.",\
-								"Existing.",\
-								"Illegal haircutting.",\
-								"Staring at a bee for over an hour.",\
-								"Not showering before entering pool.",\
-								"Rampant idiocy.",\
-								"Never tipping the catering staff.",\
-								"Disregarding previous tickets.",\
-								"Fashion crimes.",\
-								"Gambling.",\
-								"Bribery.",\
-								"Sleeping on the job.",\
-								"Unauthorized stamp collecting.",\
-								"Refusing to wash their hands.",\
-								"Maintenance lurking.",\
-								"Dumpster diving.",\
-								"Not covering their mouth when sneezing.",\
-								"Open mouth chewing.",\
-								"Riding pods without a license.",\
-								"Breathing loudly.",\
-								"Riding a segway directly into the captain.",\
-								"Wearing their shirt backwards.",\
-								"Excessive swearing",\
-								"Cutting in line.",\
-								"Tying the captain's shoelaces together.",\
-								"Forgetting the captain's birthday.")
+		S["mi_crim"] = global.pick_crime(H)
 		S["mi_crim_d"] = "No details provided."
-		S["ma_crim"] = pick(\
-								"Grand theft apidae.",\
-								"Bee murder.",\
-								"Superfarted on the captain.",\
-								"Released the singularity.",\
-								"Stole the captain's spare ID.",\
-								"Arson, murder, jaywalking.",\
-								"Arson.",\
-								"Murder.",\
-								"Jaywalking.",\
-								"Skating right through the bounds of real-space. Wicked sick, but highly illegal.",\
-								"Being a really really bad surgeon.",\
-								"Distributing meth.",\
-								"Dismemberment and decapitation.",\
-								"Running around with a chainsaw.",\
-								"Throwing explosive tomatoes at people.",\
-								"Caused multiple seemingly unrelated accidents.",\
-								"Dabbing.",\
-								"Assembling explosives.",\
-								"Being in the wrong place at the wrong time.",\
-								"Assault.",\
-								"Tossing someone in space.",\
-								"Over-escalation.",\
-								"Manslaughter",\
-								"Refusing to share their meth.",\
-								"Grand larceny.")
+		S["ma_crim"] = global.pick_crime(H, is_major = TRUE)
 		S["ma_crim_d"] = "No details provided."
 		H.update_arrest_icon()
 

--- a/code/modules/traits/jailbird.dm
+++ b/code/modules/traits/jailbird.dm
@@ -28,14 +28,16 @@
 	crime_buffer = list()
 	for (var/token in crime_buffer_tokenised)
 		var/victim = null
+		var/substitute_human = "[pick_string_autokey("names/first.txt")] [pick_string_autokey("names/last.txt")]
+		var/substitute_robot = "[pick_string_autokey("names/ai.txt")]"
 		if (findtext(token, "$HUMAN"))
-			victim = length(humans) ? pick(humans) : "[pick_string_autokey("names/first.txt")] [pick_string_autokey("names/last.txt")]"
+			victim = length(humans) ? pick(humans) : substitute_human
 			token = replacetext(token, "$HUMAN", victim)
 		if (findtext(token, "$ROBOT"))
-			victim = length(robots) ? pick(robots) : pick_string_autokey("names/ai.txt")
+			victim = length(robots) ? pick(robots) : substitute_robot
 			token = replacetext(token, "$ROBOT", victim)
 		if (findtext(token, "$MOB"))
-			victim = length(targets) ? pick(targets) : (prob(50) ? "[pick_string_autokey("names/first.txt")] [pick_string_autokey("names/last.txt")]" : "[pick_string_autokey("names/ai.txt")]")
+			victim = length(targets) ? pick(targets) : (prob(50) ? substitute_human : substitute_robot)
 			token = replacetext(token, "$MOB", victim)
 		crime_buffer += token
 	crime_buffer = jointext(crime_buffer, " ")

--- a/code/modules/traits/jailbird.dm
+++ b/code/modules/traits/jailbird.dm
@@ -35,7 +35,7 @@
 			victim = length(robots) ? pick(robots) : pick_string_autokey("names/ai.txt")
 			token = replacetext(token, "$ROBOT", victim)
 		if (findtext(token, "$MOB"))
-			victim = length(targets) ? pick(targets) : (prob(50) ? [pick_string_autokey("names/first.txt")] [pick_string_autokey("names/last.txt")] : pick_string_autokey("names/ai.txt"))
+			victim = length(targets) ? pick(targets) : (prob(50) ? "[pick_string_autokey("names/first.txt")] [pick_string_autokey("names/last.txt")]" : "[pick_string_autokey("names/ai.txt")]")
 			token = replacetext(token, "$MOB", victim)
 		crime_buffer += token
 	crime_buffer = jointext(crime_buffer, " ")

--- a/code/modules/traits/jailbird.dm
+++ b/code/modules/traits/jailbird.dm
@@ -28,7 +28,7 @@
 	crime_buffer = list()
 	for (var/token in crime_buffer_tokenised)
 		var/victim = null
-		var/substitute_human = "[pick_string_autokey("names/first.txt")] [pick_string_autokey("names/last.txt")]
+		var/substitute_human = "[pick_string_autokey("names/first.txt")] [pick_string_autokey("names/last.txt")]"
 		var/substitute_robot = "[pick_string_autokey("names/ai.txt")]"
 		if (findtext(token, "$HUMAN"))
 			victim = length(humans) ? pick(humans) : substitute_human

--- a/code/modules/traits/jailbird.dm
+++ b/code/modules/traits/jailbird.dm
@@ -1,0 +1,42 @@
+/proc/pick_crime(mob/owner, is_major = FALSE, targeted_override = FALSE, rand_targeted = TRUE)
+	var/targeted = FALSE
+	if (targeted_override)
+		targeted = TRUE
+	else
+		targeted = (prob(33) && rand_targeted) ? TRUE : FALSE
+	var/crime_buffer = pick(strings("crimes.txt", "[is_major ? "major" : "minor"][targeted ? "_targeted" : ""]"))
+	. = crime_buffer
+	if (!targeted)
+		return
+
+	var/list/mob/living/carbon/human/humans = list()
+	var/list/mob/living/silicon/robot/robots = list()
+	for (var/mob/mob in global.mobs)
+		if (mob == owner)
+			continue
+		if (!mob.client)
+			continue
+		if (ishuman(mob))
+			humans += mob
+			continue
+		if (isrobot(mob))
+			robots += mob
+			continue
+	var/list/mob/living/targets = (humans + robots)
+
+	var/crime_buffer_tokenised = splittext(crime_buffer, " ")
+	crime_buffer = list()
+	for (var/token in crime_buffer_tokenised)
+		var/victim = null
+		if (findtext(token, "$HUMAN"))
+			victim = length(humans) ? pick(humans) : "[pick_string_autokey("names/first.txt")] [pick_string_autokey("names/last.txt")]"
+			token = replacetext(token, "$HUMAN", victim)
+		if (findtext(token, "$ROBOT"))
+			victim = length(robots) ? pick(robots) : pick_string_autokey("names/ai.txt")
+			token = replacetext(token, "$ROBOT", victim)
+		if (findtext(token, "$MOB"))
+			victim = length(targets) ? pick(targets) : (prob(50) ? [pick_string_autokey("names/first.txt")] [pick_string_autokey("names/last.txt")] : pick_string_autokey("names/ai.txt"))
+			token = replacetext(token, "$MOB", victim)
+		crime_buffer += token
+	crime_buffer = jointext(crime_buffer, " ")
+	. = crime_buffer

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1797,6 +1797,7 @@
 #include "code\modules\tgui\states\physical.dm"
 #include "code\modules\tgui\states\self.dm"
 #include "code\modules\tgui\states\zlevel.dm"
+#include "code\modules\traits\jailbird.dm"
 #include "code\modules\transport\skateboard.dm"
 #include "code\modules\transport\cruisers\cruiser_console.dm"
 #include "code\modules\transport\cruisers\cruisers.dm"

--- a/strings/crimes.txt
+++ b/strings/crimes.txt
@@ -1,0 +1,100 @@
+minor@=
+	Public urination.
+	Reading highly confidential private information.
+	Vandalism.
+	Illegal manufacturing of space goods.
+	Tresspassing.
+	Killing a monkey.
+	Negligence.
+	Pushing down and farting on a member of security.
+	Throwing a toolbox at a member of security.
+	Being drunk.
+	Being high.
+	Excessive force.
+	Impersonating a security officer.
+	Stealing shoes.
+	Littering.
+	Existing.
+	Illegal haircutting.
+	Staring at a bee for over an hour.
+	Not showering before entering pool.
+	Rampant idiocy.
+	Never tipping the catering staff.
+	Disregarding previous tickets.
+	Fashion crimes.
+	Gambling.
+	Bribery.
+	Sleeping on the job.
+	Unauthorized stamp collecting.
+	Refusing to wash their hands.
+	Maintenance lurking.
+	Dumpster diving.
+	Not covering their mouth when sneezing.
+	Open mouth chewing.
+	Riding pods without a license.
+	Breathing loudly.
+	Riding a segway directly into the captain.
+	Wearing their shirt backwards.
+	Excessive swearing
+	Cutting in line.
+	Tying the captain's shoelaces together.
+	Forgetting the captain's birthday.
+minor_targeted@=
+	Breaking into $HUMAN's house.
+	Burgled $HUMAN's house.
+	Calling $MOB mean names.
+	Cyberbullied $MOB.
+	Drawing on $HUMAN's face while they were sleeping.
+	Eating $HUMAN's appendix after surgery.
+	Forging $HUMAN's signature on divorce papers.
+	Giving $HUMAN a RIDICULOUS haircut.
+	Kept throwing rocks at $MOB.
+	Leaving the stove on in $HUMAN's home.
+	Pickpocketed $HUMAN.
+	Placing a kick me sign on $HUMAN's back.
+	Pushed $HUMAN into a disposal chute.
+	Put $ROBOT through a boot loop.
+	Shoved $HUMAN to the ground and farted in their face.
+	Slipped $HUMAN out of an airlock with a banana peel.
+	Slipped $HUMAN with a banana peel.
+	Stealing $ROBOT's wig.
+	Stole $HUMAN's lunch from the company fridge.
+	Tying $HUMAN's shoelaces together PERMANENTLY!
+	Watching a really scary movie in vicinity of $MOB.
+	Wearing the same outfit as $HUMAN to the work luncheon.
+major@=
+	Grand theft apidae.
+	Bee murder.
+	Superfarted on the captain.
+	Released the singularity.
+	Stole the captain's spare ID.
+	Arson, murder, jaywalking.
+	Arson.
+	Murder.
+	Jaywalking.
+	Skating right through the bounds of real-space. Wicked sick, but highly illegal.
+	Being a really really bad surgeon.
+	Distributing meth.
+	Dismemberment and decapitation.
+	Running around with a chainsaw.
+	Throwing explosive tomatoes at people.
+	Caused multiple seemingly unrelated accidents.
+	Dabbing.
+	Assembling explosives.
+	Being in the wrong place at the wrong time.
+	Assault.
+	Over-escalation.
+	Manslaughter
+	Refusing to share their meth.
+	Grand larceny.
+major_targeted@=
+	Asking $ROBOT to divide by zero.
+	Burning down $HUMAN's house.
+	Dropping a grand piano onto $MOB.
+	Hit $MOB in a vehicular accident.
+	Running over $MOB with a forklift while not certified.
+	Lighting $MOB's hair on fire.
+	Poisoned $HUMAN's lunch.
+	Slipped $HUMAN out of an airlock with a banana peel.
+	Stole $HUMAN's identity.
+	Tossing $MOB into space.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[TRAIT][FEAT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Idea by @TemThrush.

Minor and major crimes set by the Jailbird trait can now randomly target a specific victim which is most likely going to be a mob that's currently on-station.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Funny.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DisturbHerb + TemThrush
(*)Arrest warrants for previously wanted individuals may now contain extra information on the victim.
```
