### PR TITLE
Werewolf Hunter special job

### DIFF
--- a/code/WorkInProgress/MarqStuff.dm
+++ b/code/WorkInProgress/MarqStuff.dm
@@ -533,7 +533,7 @@
 				arrow.clone(src)
 				arrow.change_stack_amount(-1)
 		else
-			user.u_equip(arrow)
+			user?.u_equip(arrow)
 			arrow.set_loc(src)
 		src.updateAppearance()
 
@@ -599,6 +599,20 @@
 	equipped(mob/user, slot)
 		. = ..()
 		src.inventory_counter.show_count()
+
+/obj/item/quiver/leather
+	New()
+		..()
+		src.setMaterial(getMaterial("leather"))
+
+/obj/item/quiver/leather/stocked
+	New()
+		..()
+		var/obj/item/arrow/arrows = new()
+		arrows.amount = 20
+		arrows.setHeadMaterial(getMaterial("silver"))
+		arrows.setShaftMaterial(getMaterial("wood"))
+		src.loadArrow(arrows)
 
 /datum/projectile/arrow
 	name = "arrow"
@@ -837,3 +851,22 @@
 
 		src.loadArrow(I, user)
 
+// not obtainable through normal means
+/obj/item/gun/bow/crossbow
+	name = "crossbow"
+	desc = "Though old in make, it's remarkably well cared for."
+	icon = 'icons/obj/items/guns/energy.dmi'
+	icon_state = "crossbow"
+	inhand_image_icon = 'icons/mob/inhand/hand_guns.dmi'
+	item_state = "crossbow"
+	force = MELEE_DMG_PISTOL
+	can_dual_wield = TRUE // :getin:
+	two_handed = FALSE
+
+/obj/item/gun/bow/crossbow/update_icon(draw_fraction)
+	// do not call parent
+
+/obj/item/gun/bow/crossbow/wooden
+/obj/item/gun/bow/crossbow/wooden/New()
+	. = ..()
+	src.setMaterial(getMaterial("wood"))

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -3004,6 +3004,28 @@ ABSTRACT_TYPE(/datum/job/special/pod_wars)
 			return
 		M.bioHolder.AddEffect("accent_goodmin", magical=1)
 
+/datum/job/special/werewolf_hunter
+	name = "Werewolf Hunter"
+	access_string = "Staff Assistant"
+	limit = 0
+	change_name_on_spawn = TRUE
+	slot_head = list(/obj/item/clothing/head/witchfinder)
+	slot_ears = list(/obj/item/device/radio/headset/ghost_buster/werewolf_hunter)
+	slot_suit = list(/obj/item/clothing/suit/witchfinder)
+	slot_jump = list(/obj/item/clothing/under/gimmick/witchfinder)
+	slot_glov = list(/obj/item/clothing/shoes/black)
+	slot_foot = list(/obj/item/clothing/shoes/witchfinder)
+	slot_back = list(/obj/item/quiver/leather/stocked)
+	slot_belt = list(/obj/item/storage/belt/crossbow)
+	items_in_belt = list(
+		/obj/item/gun/bow/crossbow/wooden,
+		/obj/item/gun/bow/crossbow/wooden,
+		/obj/item/handcuffs/silver,
+		/obj/item/handcuffs/silver,
+		/obj/item/plant/herb/aconite,
+		/obj/item/plant/herb/aconite,
+	)
+
 /*---------------------------------------------------------------*/
 
 /datum/job/created

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -451,6 +451,27 @@
 	icon_override = "ghost_buster"
 	icon_tooltip = "Ghost Buster"
 
+/obj/item/device/radio/headset/ghost_buster/werewolf_hunter
+	name = "\improper Werewolf Hunter's headset"
+	desc = "To hear the cries of the downtrodden, those defenseless against The Beast."
+	icon_state = "multi headset"
+	secure_frequencies = list(
+		"g" = R_FREQ_SECURITY,
+		"e" = R_FREQ_ENGINEERING,
+		"r" = R_FREQ_RESEARCH,
+		"m" = R_FREQ_MEDICAL,
+		"c" = R_FREQ_CIVILIAN,
+		)
+	secure_classes = list(
+		"g" = RADIOCL_SECURITY,
+		"e" = RADIOCL_ENGINEERING,
+		"r" = RADIOCL_RESEARCH,
+		"m" = RADIOCL_MEDICAL,
+		"c" = RADIOCL_CIVILIAN,
+		)
+	icon_override = "ghost_buster"
+	icon_tooltip = "Werewolf Hunter"
+
 /obj/item/device/radio/headset/command/nt/commander
 	name = "\improper NT Commander's headset"
 	desc = "Issued to NanoTrasen Commanders, this radio headset can access several secure radio channels."

--- a/code/obj/item/handcuffs.dm
+++ b/code/obj/item/handcuffs.dm
@@ -184,3 +184,8 @@
 	icon_state = "buddycuff"
 	m_amt = 0
 	strength = 1
+
+/obj/item/handcuffs/silver
+/obj/item/handcuffs/silver/New()
+	. = ..()
+	src.setMaterial(getMaterial("silver"))

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -889,6 +889,17 @@
 	max_wclass = W_CLASS_NORMAL
 	item_function_flags = IMMUNE_TO_ACID
 
+/obj/item/storage/belt/crossbow
+	name = "old hunting belt"
+	desc = "Holds all the things you need for a proper werewolf hunt."
+	icon_state = "hunterbelt"
+	item_state = "hunter"
+	check_wclass = TRUE
+	can_hold = list(
+		/obj/item/gun/bow/crossbow,
+		/obj/item/plant/herb/aconite,
+	)
+
 /obj/item/storage/belt/security
 	name = "security toolbelt"
 	desc = "For the trend-setting officer on the go. Has a place on it to clip a baton and a holster for a small gun."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Special Job: Werewolf Hunter

Uses the witchfinder clothing set with black gloves

Adds some new supporting stuff:
Headset: `werewolf_hunter` that uses the ghost buster icon.
Back: Leather quiver pre-stocked with 20 silver-tipped arrows.
Belt: Custom belt that holds and comes with two wooden crossbows (see below), 2 silvered handcuffs, and 2 aconite.

New gun: Crossbow, a subtype of bows. Can be dual-wielded.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
kyle said it would be cool

## Screenshot
![image](https://github.com/user-attachments/assets/2e43e02f-5a0c-4abd-9bb5-f2f3ce877aa4)
