### PR TITLE
Mark quickhacks as level 2 contraband

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -2502,6 +2502,7 @@ proc/broadcast_to_all_gangs(var/message)
 	throwforce = 1
 	force = 1
 	w_class = W_CLASS_TINY
+	contraband = 2
 	var/max_charges = 5
 	var/charges = 5
 
@@ -2596,7 +2597,7 @@ proc/broadcast_to_all_gangs(var/message)
 	category = "Country Western"
 /datum/gang_item/space
 	category = "Space Gang"
-/datum/gang_item/space
+/datum/gang_item/weapon
 	category = "Weapon"
 /datum/gang_item/equipment
 	category = "Consumable"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Give quickhacks a level 2 contraband rating.
Also while we're here, fix a duplicate `/datum/gang_item` path definition for space gang vs. weapon items.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They're illegal, it says so right in the description. Security treats this as contraband anyway.. 

This rating is not enough to get secbots to attack you or trip a sec scanner if held in-hand. It does let sechuds see you walking around with it.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Quickhacks are now marked as contraband.
```
