### PR TITLE
Emag act for Pod targeting missile launcher

### DIFF
--- a/code/datums/components/smartgun_homing.dm
+++ b/code/datums/components/smartgun_homing.dm
@@ -108,3 +108,10 @@
 			farthest_target_from_cursor = A
 
 	return farthest_target_from_cursor
+
+
+/datum/component/holdertargeting/smartgun/homing/pod/emagged
+	type_to_target = /mob/living
+
+/datum/component/holdertargeting/smartgun/homing/pod/emagged/is_valid_target(mob/user, atom/A)
+	return (istype(A, /mob/living))

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -2549,6 +2549,15 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 			return
 		..()
 
+	emag_act(mob/user)
+		var/datum/component/holdertargeting/smartgun/homing/pod/targeting_comp = src.GetComponent(/datum/component/holdertargeting/smartgun/homing/pod)
+		if(istype(targeting_comp, /datum/component/holdertargeting/smartgun/homing/pod/emagged))
+			boutput(user, SPAN_ALERT("[src]'s targeting system is already malfunctioning!"))
+		else
+			qdel(targeting_comp)
+			AddComponent(/datum/component/holdertargeting/smartgun/homing/pod/emagged, 1)
+			boutput(user, SPAN_ALERT("You short circuit [src]'s targeting circuit!"))
+
 	proc/set_collapsed_state(var/collapsed)
 		if (src.setTwoHanded(!collapsed))
 			src.collapsed = collapsed

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -2554,7 +2554,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 		if(istype(targeting_comp, /datum/component/holdertargeting/smartgun/homing/pod/emagged))
 			boutput(user, SPAN_ALERT("[src]'s targeting system is already malfunctioning!"))
 		else
-			qdel(targeting_comp)
+			targeting_comp.RemoveComponent()
 			AddComponent(/datum/component/holdertargeting/smartgun/homing/pod/emagged, 1)
 			boutput(user, SPAN_ALERT("You short circuit [src]'s targeting circuit!"))
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an emag_act to the pod targeting missile launcher found in armory to instead make it target any mob/living (doesn't change projectile behaviour of only exploding on pods, just makes it only home in on any mob/living).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More wacky emag interactions is more good
![image](https://github.com/user-attachments/assets/213f42be-8b00-4b7d-9524-a7a4ab16a615)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)The pod targeting missile launcher can now be emagged.
```
