### PR TITLE
Cyborgs can now pick scream sound by using a verb

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2312,6 +2312,22 @@
 		update_bodypart(part = "head")
 		return 1
 
+	verb/cmd_pick_scream()
+		set category = "Robot Commands"
+		set name = "Change scream"
+
+		var/scream = tgui_input_list(usr, "Select a scream sound", "Scream settings", list("scream 1", "scream 2"))
+		if (!scream) return 0
+		var/mob/living/user = usr
+
+		switch (scream)
+			if ("scream 1")
+				user.sound_scream = 'sound/voice/screams/robot_scream.ogg'
+			if ("scream 2")
+				user.sound_scream = 'sound/voice/screams/Robot_Scream_2.ogg'
+		return 1
+
+
 	verb/access_internal_pda()
 		set category = "Robot Commands"
 		set name = "Cyborg PDA"

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2327,7 +2327,6 @@
 				user.sound_scream = 'sound/voice/screams/Robot_Scream_2.ogg'
 		return 1
 
-
 	verb/access_internal_pda()
 		set category = "Robot Commands"
 		set name = "Cyborg PDA"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[silicons][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cyborgs can now change their scream sound using a verb similar to `Change facial expression (screen head only)`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
One cyborg was getting repeatedly disassembled at round start to get the correct scream sound


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Valtsu0
(+)Cyborgs can now pick their scream sound by using the "Change scream" verb
```
