### PR TITLE
add blue light filter glasses

### DIFF
--- a/_std/color.dm
+++ b/_std/color.dm
@@ -118,6 +118,15 @@
 #define COLOR_MATRIX_INVERSE_LABEL "inverse"
 #define COLOR_MATRIX_INVERSE list(-1, 0, 0, 0, -1, 0, 0, 0, -1, 1, 1, 1)
 
+#define COLOR_MATRIX_BLUELIGHT_LABEL "bluelight"
+#define COLOR_MATRIX_BLUELIGHT\
+    list( \
+        1.00, 0.00, 0.00, 0.00, \
+        0.00, 0.80, 0.00, 0.00, \
+        0.00, 0.00, 0.60, 0.00, \
+        0.00, 0.00, 0.00, 1.00, \
+        0.00, 0.00, 0.00, 0.00 \
+    )
 /// Takes two 20-length lists, turns them into 5x4 matrices, multiplies them together, and returns a 20-length list
 /proc/mult_color_matrix(var/list/Mat1, var/list/Mat2) // always 5x4 please
 	if (length(Mat1) != 20 || length(Mat2) != 20)

--- a/_std/color.dm
+++ b/_std/color.dm
@@ -118,15 +118,6 @@
 #define COLOR_MATRIX_INVERSE_LABEL "inverse"
 #define COLOR_MATRIX_INVERSE list(-1, 0, 0, 0, -1, 0, 0, 0, -1, 1, 1, 1)
 
-#define COLOR_MATRIX_BLUELIGHT_LABEL "bluelight"
-#define COLOR_MATRIX_BLUELIGHT\
-    list( \
-        1.00, 0.00, 0.00, 0.00, \
-        0.00, 0.80, 0.00, 0.00, \
-        0.00, 0.00, 0.60, 0.00, \
-        0.00, 0.00, 0.00, 1.00, \
-        0.00, 0.00, 0.00, 0.00 \
-    )
 /// Takes two 20-length lists, turns them into 5x4 matrices, multiplies them together, and returns a 20-length list
 /proc/mult_color_matrix(var/list/Mat1, var/list/Mat2) // always 5x4 please
 	if (length(Mat1) != 20 || length(Mat2) != 20)

--- a/code/WorkInProgress/zamu_mail.dm
+++ b/code/WorkInProgress/zamu_mail.dm
@@ -489,6 +489,7 @@ var/global/mail_types_by_job = list(
 		// so you can keep looking at your screen,
 		// even in the brightness of nuclear hellfire o7
 		/obj/item/clothing/glasses/sunglasses/tanning = 10,
+		/obj/item/clothing/glasses/eyestrain = 10,
 		),
 
 

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -857,3 +857,27 @@ TYPEINFO(/obj/item/clothing/glasses/toggleable/atmos)
 			return
 		src.clear_overlays(M)
 		src.generate_overlays(M)
+
+/obj/item/clothing/glasses/eyestrain
+	name = "blue-light filtering glasses"
+	desc = "A pair of glasses that reduce eye-strain from staring a computer screen all shift."
+	icon_state = "oglasses"
+	// would be nice if these tinted TGUI
+
+	color_r = 1
+	color_g = 0.9
+	color_b = 0.8
+
+	equipped(mob/user, slot)
+		..()
+		var/mob/living/carbon/human/H = user
+		if(istype(H) && slot == SLOT_GLASSES)
+			if(H.client)
+				user.apply_color_matrix(COLOR_MATRIX_BLUELIGHT, COLOR_MATRIX_BLUELIGHT_LABEL)
+
+	unequipped(mob/user, slot)
+		..()
+		var/mob/living/carbon/human/H = user
+		if(istype(H))
+			if (H.client)
+				user.remove_color_matrix(COLOR_MATRIX_BLUELIGHT_LABEL)

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -868,16 +868,3 @@ TYPEINFO(/obj/item/clothing/glasses/toggleable/atmos)
 	color_g = 0.9
 	color_b = 0.8
 
-	equipped(mob/user, slot)
-		..()
-		var/mob/living/carbon/human/H = user
-		if(istype(H) && slot == SLOT_GLASSES)
-			if(H.client)
-				user.apply_color_matrix(COLOR_MATRIX_BLUELIGHT, COLOR_MATRIX_BLUELIGHT_LABEL)
-
-	unequipped(mob/user, slot)
-		..()
-		var/mob/living/carbon/human/H = user
-		if(istype(H))
-			if (H.client)
-				user.remove_color_matrix(COLOR_MATRIX_BLUELIGHT_LABEL)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Add a new color matrix `COLOR_MATRIX_BLUELIGHT` that reduces green and heavily reduces blue colors.
* Add new eyestrain glasses aka blue-light filtering glasses
* Add these new eyestrain glasses to the geneticist mail pool

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More variety for geneticist mail. Funny mail joke aimed towards people who sit at the console all shift :o)

## Screenshot
A geneticist in their natural habitat:
![image](https://github.com/user-attachments/assets/05c959f3-8dbb-4fa4-a68b-9648cac6f2b1)
