### PR TITLE
Include font awesome css in html interfaces header for 516

### DIFF
--- a/code/chui/window.dm
+++ b/code/chui/window.dm
@@ -142,6 +142,7 @@ chui/window
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	[who.byond_version >= 516 ? "<link rel='stylesheet' type='text/css' href='[resource("vendor/css/font-awesome.css")]'>" : ""]
 	<style type='text/css'>
 		body {
 			font-family: Tahoma, Arial, sans-serif;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Includes the font awesome css in the header for all simple html windows viewed with Browse


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Some of these windows relied on font awesome classes which is why they would force chui. With chui disabled these windows lost styling and in some cases functionality as well