### PR TITLE
Fix Instrument Chords

### DIFF
--- a/code/modules/items/instruments/instruments.dm
+++ b/code/modules/items/instruments/instruments.dm
@@ -81,11 +81,11 @@
 				src.note = src.notes[i]
 				src.sounds_instrument += (src.instrument_sound_directory + "[note].ogg")
 
-	proc/play_note(var/note, var/mob/user, var/pitch_override = null, var/volume_override = null)
+	proc/play_note(var/note, var/mob/user, var/pitch_override = null, var/volume_override = null, var/use_cooldown = TRUE)
 		if (note != clamp(note, 1, length(sounds_instrument)))
 			return FALSE
 		var/atom/player = user || src
-		if(ON_COOLDOWN(player, "instrument_play", src.note_time)) // on user or src because sometimes instruments play themselves
+		if(use_cooldown && ON_COOLDOWN(player, "instrument_play", src.note_time)) // on user or src because sometimes instruments play themselves
 			return FALSE
 
 		if (special_index && note >= special_index) // Add additional time if we just played a special note
@@ -193,7 +193,7 @@
 			if("play_note")
 				var/note_to_play = params["note"] + 1 // 0->1 (js->dm) array index change
 				var/volume = params["volume"]
-				src.play_note(note_to_play, ui.user, volume_override = volume)
+				src.play_note(note_to_play, ui.user, volume_override = volume, use_cooldown = FALSE)
 				. = TRUE
 			if("play_keyboard_on")
 				usr.client.apply_keybind("instrument_keyboard")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[GAME OBJECTS] [BUG] [MAJOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a `use_cooldown` parameter to the proc `play_note` and uses it next to the `ON_COOLDOWN` check.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

[PR #22557](https://github.com/goonstation/goonstation/pull/22557) changes the `play_note` `action` of `ui_act` to use the proc `play_note` instead of `playsound`.

This makes it use a cooldown while playing manually-played instruments, which it didn't have before. With the cooldown, chords can't be played unless multiple instruments are used.

This is presumed to be a bug, as [PR #22557](https://github.com/goonstation/goonstation/pull/22557) makes no mention of this change for manually-played instruments.

Fixes issues [#22562](https://github.com/goonstation/goonstation/issues/22562) and [#22563](https://github.com/goonstation/goonstation/issues/22563).

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Facsimile
(+)Fixes instrument chord bug introduced by PR #22557 (Cyborg instrument screams).
```
