### PR TITLE
Security lobby on Nadir is mislabeled

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -39436,9 +39436,7 @@
 	},
 /area/station/medical/medbay/surgery)
 "qyO" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Emergency Storage"
-	},
+/obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/mail/vertical,
 /obj/mapping_helper/firedoor_spawn,
 /obj/forcefield/energyshield/perma/doorlink,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove the name mapvar from the upper security foyer door, letting it use the area name instead.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #22575

