### PR TITLE
Fix folded paper items not showing their name on examine

### DIFF
--- a/code/modules/writing/paper.dm
+++ b/code/modules/writing/paper.dm
@@ -888,7 +888,7 @@
 
 /obj/item/paper/folded/examine()
 	if (src.sealed)
-		return list(desc)
+		return list("This is \an [src.name].", desc)
 	else
 		return ..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Folded paper overrides it parent paper examine to avoid calling ui interaction, but this causes the default behavior of the examine text to show the item name to fail.

To fix this, we re-add the examine item description to the folded paper examine in the code path where it does not call the parent examine proc. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22008