### PR TITLE
Prevent stowaways from being trapped in cog1 mining magnet control room

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -21644,7 +21644,7 @@
 /area/station/turret_protected/ai_upload_foyer)
 "bzQ" = (
 /obj/decal/cleanable/cobweb,
-/obj/storage/crate,
+/obj/machinery/sheet_extruder,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -60737,12 +60737,6 @@
 	icon_state = "L1"
 	},
 /area/station/crew_quarters/market)
-"uBA" = (
-/obj/machinery/sheet_extruder,
-/turf/simulated/floor/shuttlebay{
-	name = "reinforced plating"
-	},
-/area/station/mining/magnet)
 "uCf" = (
 /obj/storage/secure/closet/brig_automatic/minibrig,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -130403,7 +130397,7 @@ adC
 bWn
 bzQ
 bzR
-uBA
+bzR
 cbz
 cdX
 cdU


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Re-arrange the cog1 mining office so the two crates that spawn in are accessible from the general mining office.

You can still unscrew a window to make a break for it through space, but you're no longer required to do so and can ask the nice miners to please let you out instead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22597
