### PR TITLE
Allow for selecting "Male", "Female" and "Other" in old secure data computer

### DIFF
--- a/code/obj/machinery/computer/secure_data.dm
+++ b/code/obj/machinery/computer/secure_data.dm
@@ -477,10 +477,13 @@
 							src.active_record_general["fingerprint"] = t1
 					if ("sex")
 						if (istype(src.active_record_general, /datum/db_record))
-							if (src.active_record_general["sex"] == "Male")
-								src.active_record_general["sex"] = "Female"
-							else
-								src.active_record_general["sex"] = "Male"
+							switch(src.active_record_general["sex"])
+								if("Male")
+									src.active_record_general["sex"] = "Female"
+								if ("Female")
+									src.active_record_general["sex"] = "Other"
+								if ("Other")
+									src.active_record_general["sex"] = "Male"
 					if ("pronouns")
 						if (istype(src.active_record_general, /datum/db_record))
 							var/datum/pronouns/pronouns = choose_pronouns(usr, "Please select pronouns:", "Security Records", src.active_record_general["pronouns"])

--- a/code/obj/machinery/computer/secure_data.dm
+++ b/code/obj/machinery/computer/secure_data.dm
@@ -484,6 +484,8 @@
 									src.active_record_general["sex"] = "Other"
 								if ("Other")
 									src.active_record_general["sex"] = "Male"
+								else
+									src.active_record_general["sex"] = "Other"
 					if ("pronouns")
 						if (istype(src.active_record_general, /datum/db_record))
 							var/datum/pronouns/pronouns = choose_pronouns(usr, "Please select pronouns:", "Security Records", src.active_record_general["pronouns"])


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][ui]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace a binary male/female if with a switch that toggles through "Male", "Female", and "Other" for the old secure records UI still accessible via DetNet VR.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #12813