### PR TITLE
Tweak western maint areas on Kondaru

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -1569,16 +1569,16 @@
 	name = "Clowntainment"
 	})
 "agt" = (
-/obj/machinery/power/apc/autoname_west,
+/obj/machinery/power/apc/autoname_west{
+	areastring = "Clowntainment"
+	},
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/decal/cleanable/dirt,
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/clown{
-	name = "Clowntainment"
-	})
+/area/station/maintenance/northwest)
 "agw" = (
 /obj/decal/tile_edge/line/black{
 	dir = 4;
@@ -1807,9 +1807,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/clown{
-	name = "Clowntainment"
-	})
+/area/station/maintenance/northwest)
 "ahn" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -2167,15 +2165,14 @@
 	name = "W light switch";
 	pixel_x = -23;
 	pixel_y = -7;
-	dir = 8
+	dir = 8;
+	otherarea = "station/crew_quarters/clown"
 	},
 /obj/cable{
 	icon_state = "2-5"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/clown{
-	name = "Clowntainment"
-	})
+/area/station/maintenance/northwest)
 "ait" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/radio/news_office)
@@ -35276,11 +35273,6 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"gjB" = (
-/obj/decal/cleanable/dirt,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/science/lab)
 "gjD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -94355,7 +94347,7 @@ bSt
 bQU
 bQU
 bzR
-gjB
+bAP
 bYG
 ccV
 cbi


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Change the area of three tiles to north-west maints from clowntainment
  * Add area varedits to the APC and lightswitch to maintain functionality 
    * i don't like varedits but i dislike the areas not lining up more
* Change the area of a single tile to south-west maints from toxin lab

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Make what looks like maints areas immune to rad storms 