### PR TITLE
Pod wars commander jobs are "TEAM Pod Commander"

### DIFF
--- a/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
+++ b/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
@@ -381,33 +381,23 @@ ABSTRACT_TYPE(/obj/deployable_turret/pod_wars)
 		if (isliving(user))
 			var/obj/item/card/id/I = user.get_id()
 
+			if(!istype(I, /obj/item/card/id/pod_wars))
+				boutput(user, SPAN_ALERT("[ship]'s locking mechanism is incompatible with your ID!"))
+				return
+			var/obj/item/card/id/pod_wars/PW_ID = I
 			if (isnull(assigned_id))
 				if (istype(I))
 					boutput(user, SPAN_NOTICE("[ship]'s locking mechinism recognizes [I] as its key!"))
 					playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
 					assigned_id = I
-					team_num = get_team(I)
+					team_num = PW_ID.team
 					ship.locked = 0
 					return
 
 			if (istype(I))
-				if (I == assigned_id || get_team(I) == team_num)
+				if (I == assigned_id || PW_ID.team == team_num)
 					ship.locked = !ship.locked
 					boutput(user, SPAN_ALERT("[ship] is now [ship.locked ? "locked" : "unlocked"]!"))
-
-
-
-	proc/get_team(var/obj/item/card/id/I)
-		switch(I.assignment)
-			if("NanoTrasen Commander")
-				return TEAM_NANOTRASEN
-			if("NanoTrasen Pilot")
-				return TEAM_NANOTRASEN
-			if("Syndicate Commander")
-				return TEAM_SYNDICATE
-			if("Syndicate Pilot")
-				return TEAM_SYNDICATE
-		return -1
 
 ////////////////////PDAs and PDA Accessories/////////////////////
 /obj/item/device/pda2/pod_wars

--- a/code/datums/gamemodes/pod_wars/pw_team.dm
+++ b/code/datums/gamemodes/pod_wars/pw_team.dm
@@ -41,11 +41,11 @@
 		switch(team_num)
 			if (TEAM_NANOTRASEN)
 				name = "NanoTrasen"
-				commander_job_title = "NanoTrasen Commander"
+				commander_job_title = "NanoTrasen Pod Commander"
 				base_area = /area/pod_wars/team1 //area north, NT crew
 			if (TEAM_SYNDICATE)
 				name = "Syndicate"
-				commander_job_title = "Syndicate Commander"
+				commander_job_title = "Syndicate Pod Commander"
 				base_area = /area/pod_wars/team2 //area south, Syndicate crew
 
 		setup_voice_line_alt_amounts()
@@ -101,8 +101,8 @@
 			var/mob/new_player/M = mind.current
 			if (!istype(M)) continue
 			if(jobban_isbanned(M, "Captain")) continue //If you can't captain a Space Station, you probably can't command a starship either...
-			if(jobban_isbanned(M, "NanoTrasen Commander")) continue
-			if(jobban_isbanned(M, "Syndicate Commander")) continue
+			if(jobban_isbanned(M, "NanoTrasen Pod Commander")) continue
+			if(jobban_isbanned(M, "Syndicate Pod Commander")) continue
 
 			if ((M.ready) && !candidates.Find(M.mind))
 				switch(priority)
@@ -144,14 +144,14 @@
 			var/mob/new_player/N = M
 			if (team_num == TEAM_NANOTRASEN)
 				if (M.mind == commander)
-					H.mind.assigned_role = "NanoTrasen Commander"
+					H.mind.assigned_role = "NanoTrasen Pod Commander"
 				else
 					H.mind.assigned_role = "NanoTrasen Pod Pilot"
 				H.mind.special_role = "NanoTrasen"
 
 			else if (team_num == TEAM_SYNDICATE)
 				if (M.mind == commander)
-					H.mind.assigned_role = "Syndicate Commander"
+					H.mind.assigned_role = "Syndicate Pod Commander"
 				else
 					H.mind.assigned_role = "Syndicate Pod Pilot"
 				H.mind.special_role = "Syndicate"

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2885,7 +2885,7 @@ ABSTRACT_TYPE(/datum/job/special/pod_wars)
 		slot_poc2 = list(/obj/item/requisition_token/podwars/NT)
 
 		commander
-			name = "NanoTrasen Commander"
+			name = "NanoTrasen Pod Commander"
 #ifdef MAP_OVERRIDE_POD_WARS
 			limit = 1
 #else
@@ -2930,7 +2930,7 @@ ABSTRACT_TYPE(/datum/job/special/pod_wars)
 		slot_poc2 = list(/obj/item/requisition_token/podwars/SY)
 
 		commander
-			name = "Syndicate Commander"
+			name = "Syndicate Pod Commander"
 #ifdef MAP_OVERRIDE_POD_WARS
 			limit = 1
 #else

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -717,7 +717,7 @@ proc/filter_carrier_pets(var/type)
 		src.UpdateIcon()
 
 /mob/living/critter/small_animal/turtle/sylvester/Commander
-	beret_remove_job_needed = "NanoTrasen Commander"
+	beret_remove_job_needed = "NanoTrasen Pod Commander"
 
 	New()
 		..()

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -208,8 +208,8 @@ TYPEINFO(/obj/item/card/emag)
 		team = 1
 
 		commander
-			name = "NanoTrasen Commander"
-			assignment = "NanoTrasen Commander"
+			name = "NanoTrasen Pod Commander"
+			assignment = "NanoTrasen Pod Commander"
 			access = list(access_heads, access_captain)
 
 	syndicate
@@ -220,8 +220,8 @@ TYPEINFO(/obj/item/card/emag)
 		team = 2
 
 		commander
-			name = "Syndicate Commander"
-			assignment = "Syndicate Commander"
+			name = "Syndicate Pod Commander"
+			assignment = "Syndicate Pod Commander"
 			access = list(access_syndicate_shuttle, access_syndicate_commander)
 
 

--- a/code/obj/landmark.dm
+++ b/code/obj/landmark.dm
@@ -210,7 +210,7 @@ var/global/list/job_start_locations = list()
 	icon_state = "pod_nt"
 
 /obj/landmark/start/job/podwars/NT/commander
-	name = "NanoTrasen Commander"
+	name = "NanoTrasen Pod Commander"
 	icon_state = "pod_nt_commander"
 
 /obj/landmark/start/job/podwars/syndie
@@ -218,7 +218,7 @@ var/global/list/job_start_locations = list()
 	icon_state = "pod_syndie"
 
 /obj/landmark/start/job/podwars/syndie/commander
-	name = "Syndicate Commander"
+	name = "Syndicate Pod Commander"
 	icon_state = "pod_syndie_commander"
 
 /* ===== Antagonist Starts ===== */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes job title for pod wars commander jobs to "Nanotrasen pod commander" and "Syndicate pod commander" 
Makes pod wars ID team check just check if its a podwars ID then just use that team instead of checking assignment.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Make it clearer these roles are intended for podwars and have items (i.e. pw req tokens) that may not fit a normal round (also so I can add a proper NT commander job to the roster of NT jobs that has gear more geared towards a normal round)