### PR TITLE
fix get_effective_value returning the wrong stat on "harvests"

### DIFF
--- a/code/modules/hydroponics/plants.dm
+++ b/code/modules/hydroponics/plants.dm
@@ -330,7 +330,7 @@ ABSTRACT_TYPE(/datum/plant)
 			if("harvtime")
 				output_base = src.harvtime
 			if("harvests")
-				output_base = src.harvtime
+				output_base = src.harvests
 			if("cropsize")
 				output_base = src.cropsize
 			if("potency")


### PR DESCRIPTION
[hydroponics][bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This bug fixes get_effective_value returning the modified `.harvtime` value instead of the modified `.harvests` value

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This bug could make spliced plants have a ridicilous amount of harvests