### PR TITLE
Split changelog into TGUI wrapped for 516 and legacy CHUI for 515

### DIFF
--- a/browserassets/html/changelog.html
+++ b/browserassets/html/changelog.html
@@ -17,10 +17,10 @@
 
 	/* themeing for minor changes expandable dropdowns */
 	.log li.minor-changes {padding: 0px;}
-	.log li.minor-changes details {padding: 5px 5px; background: rgb(225, 225, 225); cursor: default;}
+	.log li.minor-changes details {padding: 5px 5px; background: rgb(225, 225, 225);}
 	.log li.minor-changes details[open], .log li.minor-changes details:hover {background: rgb(202, 215, 224);}
 	.log li.minor-changes details[open] div {background: rgb(243, 243, 243); max-height: none; margin: 5px 0 5px;}
-	.log li.minor-changes details summary {font-weight: bold; cursor: pointer; outline: none;}
+	.log li.minor-changes details summary {font-weight: bold; cursor: pointer;}
 
 	.log.ass {background: #ffe9de;}
 	.log.ass li.title {background: #fce5cb;}

--- a/browserassets/html/changelog.html
+++ b/browserassets/html/changelog.html
@@ -16,24 +16,21 @@
 	.log li.admin span {color: #2A76E7;}
 
 	/* themeing for minor changes expandable dropdowns */
-	.log li.minor-changes { padding: 0px; }
-	.log li.minor-changes details { padding: 5px 5px; background: rgb(225, 225, 225); cursor: default; }
-	.log li.minor-changes details[open], .log li.minor-changes details:hover { background: rgb(202, 215, 224);	}
-	.log li.minor-changes details[open] div { background: rgb(243, 243, 243); max-height: none; margin: 5px 0 5px;}
-	.log li.minor-changes details summary { font-weight: bold; cursor: pointer; outline: none; }
+	.log li.minor-changes {padding: 0px;}
+	.log li.minor-changes details {padding: 5px 5px; background: rgb(225, 225, 225); cursor: default;}
+	.log li.minor-changes details[open], .log li.minor-changes details:hover {background: rgb(202, 215, 224);}
+	.log li.minor-changes details[open] div {background: rgb(243, 243, 243); max-height: none; margin: 5px 0 5px;}
+	.log li.minor-changes details summary {font-weight: bold; cursor: pointer; outline: none;}
 
 	.log.ass {background: #ffe9de;}
 	.log.ass li.title {background: #fce5cb;}
 	.log.ass li.date {background: #fce5cb;}
-	.log.ass li.minor-changes details { background: #fce9d9 }
+	.log.ass li.minor-changes details {background: #fce9d9}
+	.log.ass li.minor-changes details[open], .log.ass li.minor-changes details:hover {background: #ffd4b0;}
 
 	h3 {padding: 0 10px; margin: 0; color: #58B4DC;}
 	.team, .lic {padding: 10px; margin: 0; line-height: 1.4;}
 	.lic {font-size: 0.9em;}
-
-	.log.ass li.minor-changes details[open], .log.ass li.minor-changes details:hover {
-		background: #ffd4b0;
-	}
 
 	a.pr_link {
 		float: right;

--- a/browserassets/html/legacy_changelog.html
+++ b/browserassets/html/legacy_changelog.html
@@ -14,24 +14,37 @@
 	.log li.testmerge {background: rgb(216, 230, 240) !important;}
 	.log li.admin {font-size: 1.2em; padding: 5px 5px 5px 10px;}
 	.log li.admin span {color: #2A76E7;}
-
-	/* themeing for minor changes expandable dropdowns */
-	.log li.minor-changes { padding: 0px; }
-	.log li.minor-changes details { padding: 5px 5px; background: rgb(225, 225, 225); cursor: default; }
-	.log li.minor-changes details[open], .log li.minor-changes details:hover { background: rgb(202, 215, 224);	}
-	.log li.minor-changes details[open] div { background: rgb(243, 243, 243); max-height: none; margin: 5px 0 5px;}
-	.log li.minor-changes details summary { font-weight: bold; cursor: pointer; outline: none; }
+	.log li.collapse-button { background: rgb(243, 243, 243); padding-left: 5px; cursor: pointer;}
+	.log .collapsible { max-height: 0; overflow: hidden; transition: max-height 0.2s ease-out;}
 
 	.log.ass {background: #ffe9de;}
 	.log.ass li.title {background: #fce5cb;}
 	.log.ass li.date {background: #fce5cb;}
-	.log.ass li.minor-changes details { background: #fce9d9 }
+	.log.ass li.collapse-button { background: #fce9d9; }
 
 	h3 {padding: 0 10px; margin: 0; color: #58B4DC;}
 	.team, .lic {padding: 10px; margin: 0; line-height: 1.4;}
 	.lic {font-size: 0.9em;}
 
-	.log.ass li.minor-changes details[open], .log.ass li.minor-changes details:hover {
+	.collapse-button:before {
+		content: '\02795'; /* Unicode character for "plus" sign (+) */
+		font-size: 13px;
+		margin-right: 5px;
+	}
+
+	.active:before {
+		content: "\2796"; /* Unicode character for "minus" sign (-) */
+	}
+
+	li.collapse-button.active, li.collapse-button:hover {
+		background: rgb(225, 225, 225);
+	}
+
+	li.collapse-button.active.testmerge, li.collapse-button:hover {
+		background: rgb(202, 215, 224) !important;
+	}
+
+	.log.ass li.collapse-button.active, .log.ass li.collapse-button:hover {
 		background: #ffd4b0;
 	}
 
@@ -78,5 +91,23 @@
 		visibility: visible;
 	}
 </style>
+
+<script>
+window.onload = function(e) {
+	var coll = document.getElementsByClassName("collapse-button");
+	var i;
+	for (i = 0; i < coll.length; i++) {
+		coll[i].addEventListener("click", function() {
+			this.classList.toggle("active");
+			var content = this.nextElementSibling;
+			if (content.style.maxHeight){
+				content.style.maxHeight = null;
+			} else {
+				content.style.maxHeight = content.scrollHeight + "px";
+			}
+		});
+	}
+}
+</script>
 <!-- CSS INJECT GOES HERE -->
 <!-- HTML GOES HERE -->

--- a/code/datums/admin_changelog.dm
+++ b/code/datums/admin_changelog.dm
@@ -5,7 +5,7 @@
 ATTENTION: The changelog has moved into its own file: strings/admin_changelog.txt
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
-/datum/admin_changelog/New()
+/datum/admin_changelog/New(use_modern_tags)
 	..()
 	//Note: deliberately using double quotes so that it won't be included in the RSC -SpyGuy
-	html = changelog_parse(file2text("strings/admin_changelog.txt"), "Admin Changelog")
+	html = changelog_parse(file2text("strings/admin_changelog.txt"), "Admin Changelog", use_modern_tags = use_modern_tags)

--- a/code/datums/changelog.dm
+++ b/code/datums/changelog.dm
@@ -58,7 +58,7 @@ so you'll want your single-digit days to have 0s in front
 	. += "(e)🧪|Testmerge"
 	. += splittext(changelog_regex.group[2], "\n") // actual changelog (*) changes
 
-/proc/changelog_parse(changes, title, testmerge_changes)
+/proc/changelog_parse(changes, title, testmerge_changes, use_modern_tags)
 	var/list/html = list()
 	var/text = changes
 	if (!text)
@@ -99,7 +99,10 @@ so you'll want your single-digit days to have 0s in front
 						html += "<li class='date testmerge'>Current Testmerged PRs</li>"
 						continue
 					if (length(collapsible_html)) // test -1 below because the prior changes would've eaten it
-						html += "<li class='collapse-button[tmerge_lines_left > -1 ? " testmerge" : ""]'>Minor Changes</li><div class='collapsible'>[collapsible_html.Join()]</div>"
+						if (use_modern_tags)
+							html += "<li class='minor-changes[tmerge_lines_left > -1 ? " testmerge" : ""]'><details><summary>Minor Changes</summary><div>[collapsible_html.Join()]</div></details></li>"
+						else
+							html += "<li class='collapse-button[tmerge_lines_left > -1 ? " testmerge" : ""]'>Minor Changes</li><div class='collapsible'>[collapsible_html.Join()]</div>"
 						collapsible_html.Cut()
 						author = null
 						added_collapsible_author = 0
@@ -229,11 +232,14 @@ so you'll want your single-digit days to have 0s in front
 					continue
 
 		if(collapsible_html.len)
-			html += "<li class='collapse-button[tmerge_lines_left > 0 ? " testmerge" : ""]'>Minor Changes</li><div class='collapsible'>[collapsible_html.Join()]</div>"
+			if (use_modern_tags)
+				html += "<li class='minor-changes[tmerge_lines_left > 0 ? " testmerge" : ""]'><details><summary>Minor Changes</summary></li><div>[collapsible_html.Join()]</div></details>"
+			else
+				html += "<li class='collapse-button[tmerge_lines_left > 0 ? " testmerge" : ""]'>Minor Changes</li><div class='collapsible'>[collapsible_html.Join()]</div>"
 		html += "</ul>"
 		return html.Join()
 
-/datum/changelog/New()
+/datum/changelog/New(use_modern_tags)
 	..()
 
 #ifdef TESTMERGE_PRS
@@ -253,7 +259,7 @@ so you'll want your single-digit days to have 0s in front
     <li>Official Forums<br><strong><a target="_blank" href="https://forum.ss13.co/" target="_blank">https://forum.ss13.co</a></strong></li>
 </ul>"}
 
-	html += changelog_parse(file2text("strings/changelog.txt"), "Changelog", src.testmerge_changes)
+	html += changelog_parse(file2text("strings/changelog.txt"), "Changelog", src.testmerge_changes, use_modern_tags)
 	html += {"
 <h3>GoonStation 13 Development Team</h3>
 <p class="team">

--- a/code/global.dm
+++ b/code/global.dm
@@ -389,7 +389,9 @@ var/global
 	datum/configuration/config = null
 	datum/sun/sun = null
 
+	datum/changelog/legacy_changelog = null
 	datum/changelog/changelog = null
+	datum/admin_changelog/legacy_admin_changelog = null
 	datum/admin_changelog/admin_changelog = null
 
 	list/datum/powernet/powernets = null

--- a/code/interface.dm
+++ b/code/interface.dm
@@ -8,12 +8,13 @@
 				src.Browse(null, "window=changes")
 			else
 				var/changelogHtml
+				var/data
 				if (byond_version >= 516)
-
 					changelogHtml = grabResource("html/changelog.html")
+					data = changelog.html
 				else
 					changelogHtml = grabResource("html/legacy_changelog.html")
-				var/data = changelog:html
+					data = legacy_changelog.html
 				var/fontcssdata = {"
 				<style type="text/css">
 				@font-face {

--- a/code/interface.dm
+++ b/code/interface.dm
@@ -7,7 +7,12 @@
 			if (winexists(src, "changes") && winget(src, "changes", "is-visible") == "true")
 				src.Browse(null, "window=changes")
 			else
-				var/changelogHtml = grabResource("html/changelog.html")
+				var/changelogHtml
+				if (byond_version >= 516)
+
+					changelogHtml = grabResource("html/changelog.html")
+				else
+					changelogHtml = grabResource("html/legacy_changelog.html")
 				var/data = changelog:html
 				var/fontcssdata = {"
 				<style type="text/css">
@@ -22,7 +27,10 @@
 				"}
 				changelogHtml = replacetext(changelogHtml, "<!-- CSS INJECT GOES HERE -->", fontcssdata)
 				changelogHtml = replacetext(changelogHtml, "<!-- HTML GOES HERE -->", "[data]")
-				src.Browse(changelogHtml, "window=changes;size=500x650;title=Changelog;", 1)
+				if (byond_version >= 516)
+					message_modal(src, changelogHtml, "Changelog", width = 500, height = 650, sanitize = FALSE)
+				else
+					src.Browse(changelogHtml, "window=changes;size=500x650;title=Changelog;", 1)
 				src.changes = 1
 
 		bugreport()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1724,8 +1724,14 @@ var/list/fun_images = list()
 	if (winexists(src, "adminchanges") && winget(src, "adminchanges", "is-visible") == "true")
 		src.Browse(null, "window=adminchanges")
 	else
-		var/changelogHtml = grabResource("html/changelog.html")
-		var/data = admin_changelog:html
+		var/changelogHtml
+		var/data
+		if (src.byond_version >= 516)
+			changelogHtml = grabResource("html/changelog.html")
+			data = admin_changelog.html
+		else
+			changelogHtml = grabResource("html/legacy_changelog.html")
+			data = legacy_admin_changelog.html
 		var/fontcssdata = {"
 				<style type="text/css">
 				@font-face {
@@ -1739,7 +1745,10 @@ var/list/fun_images = list()
 		"}
 		changelogHtml = replacetext(changelogHtml, "<!-- CSS INJECT GOES HERE -->", fontcssdata)
 		changelogHtml = replacetext(changelogHtml, "<!-- HTML GOES HERE -->", "[data]")
-		src.Browse(changelogHtml, "window=adminchanges;size=500x650;title=Admin+Changelog;", 1)
+		if (src.byond_version >= 516)
+			message_modal(src, changelogHtml, "Admin Changelog", width = 500, height = 650, sanitize = FALSE)
+		else
+			src.Browse(changelogHtml, "window=adminchanges;size=500x650;title=Admin+Changelog;", 1)
 
 /client/proc/removeSelf()
 	SET_ADMIN_CAT(ADMIN_CAT_SELF)

--- a/code/world/initialization/2_New.dm
+++ b/code/world/initialization/2_New.dm
@@ -31,8 +31,10 @@
 	makepowernets()
 
 	Z_LOG_DEBUG("World/New", "Setting up changelogs...")
-	changelog = new /datum/changelog()
-	admin_changelog = new /datum/admin_changelog()
+	legacy_changelog = new /datum/changelog()
+	changelog = new /datum/changelog(TRUE)
+	legacy_admin_changelog = new /datum/admin_changelog()
+	admin_changelog = new /datum/admin_changelog(TRUE)
 
 #ifdef DATALOGGER
 	game_stats = new


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Splits the changelog and admin changelog into a new modern TGUI wrapped version and a legacy CHUI version
* new version makes use of the `details` and `summary` tags to replace the old javascript code
* CSS has been updated to style the new TGUI wrapped version pretty closely to the original, with some minor improvements on the faming of minor changes
![image](https://github.com/user-attachments/assets/faa58341-b366-471c-8df8-ada4a189e605)
* Removes the animation when expanding minor changes (sorry, not supported by the details tag natively and we cant embed any scripts in the TGUI wrapper)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* CHUI deprecation
* 516 compatibilty
* Supports both 515 and 516 during our transition phase

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sovexe
(+)The changelog has been updated to support 516, a legacy version remains for 515
```