### PR TITLE
Fix broken APC sprite not showing properly

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -294,7 +294,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 // also add overlays for indicator lights
 /obj/machinery/power/apc/update_icon()
 	ClearAllOverlays(1)
-	if(opened)
+	if(src.status & BROKEN)
+		icon_state = "apc-b"
+	else if(opened)
 		icon_state = "apc1"
 
 		if (cell)
@@ -1451,9 +1453,6 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 /obj/machinery/power/apc/set_broken()
 	. = ..()
 	if(.) return
-	icon_state = "apc-b"
-	ClearAllOverlays() //no need to cache since nobody repairs these
-
 	operating = 0
 	update()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When calling `set_broken` on APCs, handle the broken icon state change in `update_icon` instead of directly modifying the icon state in `set_broken`. 

This stopped working when `set_broken` began calling `power_change`, which then calls `UpdateIcon`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22549
