### PR TITLE
fix keybind cloud data not updating properly

### DIFF
--- a/code/modules/interface/keybind_menu_chui.dm
+++ b/code/modules/interface/keybind_menu_chui.dm
@@ -54,7 +54,13 @@
 					var/datum/keymap/keydat = new(changed_keys_rev) //this should only have the changed entries, for optimal merge
 					current_keymap.overwrite_by_action(keydat)
 					current_keymap.on_update(owner)
-					owner.player.cloudSaves.putData("custom_keybind_data", json_encode(changed_keys_rev))
+					var/fetched_keylist = owner.player.cloudSaves.getData("custom_keybind_data")
+					var/new_keybind_data = list()
+					if (!isnull(fetched_keylist) && fetched_keylist != "") //The client has a list of custom keybinds.
+						new_keybind_data = json_decode(fetched_keylist)
+					for (var/i in changed_keys_rev)
+						new_keybind_data[i] = changed_keys_rev[i]
+					owner.player.cloudSaves.putData("custom_keybind_data", json_encode(new_keybind_data))
 					boutput(owner, SPAN_NOTICE("Your custom keybinding data has been saved."))
 					hasChanges = FALSE
 					. = TRUE


### PR DESCRIPTION
[BUGFIX][INTERNAL]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Merges newly entered custom keybinds with previous keybinds in player data, instead of overwriting the previous keybind list with the new one. Most likely a fix for #17789 and #8521, and maybe also possibly #21811 and #18415 and #12529. Granted, these are all describing the same issue, but hey! 5 bug reports squashed at once! 

Note: I am in very unfamiliar territory and would appreciate a little extra scrutiny to make sure I didn't bork anything with player data. The testing I did also wasn't mega rigorous but it does at least *seem* to work.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

i squash the Bug 🐛

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Nexusuxen
(*)Custom keybinds should properly save between rounds now.
```
