### PR TITLE
Refactor pod locking to better handle biometric locks

### DIFF
--- a/code/datums/hud/pod.dm
+++ b/code/datums/hud/pod.dm
@@ -41,7 +41,7 @@
 		weapon = create_screen("weapon", "Main Weapon", 'icons/mob/hud_pod.dmi', "weapon-off", "NORTH+1,WEST+7", tooltipTheme = "pod-alt", desc = "Turn the main weapon on or off, if the pod is equipped with one")
 		lights = create_screen("lights", "Toggle Lights", 'icons/mob/hud_pod.dmi', "lights-off", "NORTH+1, WEST+8", tooltipTheme = "pod", desc = "Turn the pod's external lights on or off")
 		secondary = create_screen("secondary", "Secondary System", 'icons/mob/hud_pod.dmi', "blank", "NORTH+1,WEST+9", tooltipTheme = "pod", desc = "Activate the secondary system installed in the pod, if there is one")
-		lock = create_screen("lock", "Lock", 'icons/mob/hud_pod.dmi', "lock-locked", "NORTH+1,WEST+10", tooltipTheme = "pod-alt", desc = "LOCK YOUR PODS YOU DOOFUSES")
+		lock = create_screen("lock", "Lock", 'icons/mob/hud_pod.dmi', "lock-locked", "NORTH+1,WEST+10", tooltipTheme = "pod-alt", desc = "Lock or unlock the pod.")
 		set_code = create_screen("set_code", "Set Lock code", 'icons/mob/hud_pod.dmi', "set-code", "NORTH+1,WEST+11", tooltipTheme = "pod", desc = "Set the code used to unlock the pod")
 		rts = create_screen("return_to_station", "Return To [capitalize(station_or_ship())]", 'icons/mob/hud_pod.dmi', "return-to-station", "NORTH+1,WEST+12", tooltipTheme = "pod", desc = "Using this will place you on the station Z-level the next time you fly off the edge of the current level")
 		leave = create_screen("leave", "Leave Pod", 'icons/mob/hud_pod.dmi', "leave", "SOUTH,EAST", tooltipTheme = "pod-alt", desc = "Get out of the pod")
@@ -153,7 +153,7 @@
 					sensors_use.overlays += missing
 
 		if (master.lock)
-			if (master.lock.code && master.locked)
+			if (master.lock.is_set() && master.locked)
 				lock.icon_state = "lock-locked"
 			else
 				lock.icon_state = "lock-unlocked"
@@ -325,13 +325,11 @@
 					master.sensors.opencomputer(user)
 			if ("lock")
 				if (master.lock)
-					if (!master.lock.code || master.lock.code == "")
+					if (!master.lock.is_set())
 						master.lock.configure_mode = 1
 						if (master)
 							master.locked = 0
 						master.lock.code = ""
-
-						boutput(user, SPAN_NOTICE("Code reset.  Please type new code and press enter."))
 						master.lock.show_lock_panel(user)
 					else if (!master.locked)
 						master.locked = 1
@@ -341,11 +339,15 @@
 						boutput(user, SPAN_ALERT("The ship mechanism clicks unlocked."))
 			if ("set_code")
 				if (master.lock)
+					if (master.lock.is_set())
+						if (!master.lock.can_reset)
+							boutput(user, SPAN_NOTICE("This lock cannot have its code reset."))
+							return
+						boutput(user, SPAN_NOTICE("Code reset. Please type new code and press enter."))
 					master.lock.configure_mode = 1
 					if (master)
 						master.locked = 0
 					master.lock.code = ""
-					boutput(user, SPAN_NOTICE("Code reset.  Please type new code and press enter."))
 					master.lock.show_lock_panel(user)
 			if ("return_to_station")
 				master.return_to_station()

--- a/code/modules/transport/pods/secondary_system.dm
+++ b/code/modules/transport/pods/secondary_system.dm
@@ -861,6 +861,7 @@ ABSTRACT_TYPE(/obj/item/shipcomponent/secondary_system/thrusters)
 	icon_state = "lock"
 	var/code = ""
 	var/configure_mode = 0 //If true, entering a valid code sets that as the code.
+	var/can_reset = TRUE //! Can you reset the code for this lock?
 
 	disposing()
 		if (ship)
@@ -1106,23 +1107,28 @@ ABSTRACT_TYPE(/obj/item/shipcomponent/secondary_system/thrusters)
 				boutput(usr, SPAN_ALERT("You must be inside the ship to do that!"))
 				return
 
+			if (src.is_set())
+				if(!src.can_reset)
+					boutput(usr, SPAN_ALERT("This lock cannot have its code reset."))
+					return
+				boutput(usr, SPAN_NOTICE("Code reset. Please type new code and press enter."))
+
 			src.configure_mode = 1
 			if (src.ship)
 				src.ship.locked = 0
 			src.code = ""
 
-			boutput(usr, "Code reset.  Please type new code and press enter.")
 			show_lock_panel(usr)
+		ship.myhud.update_states()
+
+	/// Has this lock been set
+	proc/is_set()
+		return !(code == "")
 
 /obj/item/shipcomponent/secondary_system/lock/bioscan
 	name = "Biometric Hatch Locking Unit"
 	desc = "A basic hatch locking mechanism with a biometric scan."
-	system = "Lock"
-	f_active = 1
-	power_used = 0
-	icon_state = "lock"
-	code = ""
-	configure_mode = 0 //If true, entering a valid code sets that as the code.
+	can_reset = FALSE
 	var/bdna = null
 
 	show_lock_panel(mob/living/user)
@@ -1154,6 +1160,12 @@ ABSTRACT_TYPE(/obj/item/shipcomponent/secondary_system/thrusters)
 						src.ship.visible_message("[user] holds [valid_dna_source] against the [src.ship] for a moment.")
 					ship.locked = !ship.locked
 					boutput(user, SPAN_ALERT("[ship] is now [ship.locked ? "locked" : "unlocked"]!"))
+				else
+					boutput(user, SPAN_ALERT("You are not recognized as the key for [ship]!"))
+			ship.myhud.update_states()
+
+	is_set()
+		return !isnull(bdna)
 
 /obj/item/shipcomponent/secondary_system/crash
 	name = "Syndicate Explosive Entry Device"

--- a/code/modules/transport/pods/secondary_system.dm
+++ b/code/modules/transport/pods/secondary_system.dm
@@ -1161,7 +1161,7 @@ ABSTRACT_TYPE(/obj/item/shipcomponent/secondary_system/thrusters)
 					ship.locked = !ship.locked
 					boutput(user, SPAN_ALERT("[ship] is now [ship.locked ? "locked" : "unlocked"]!"))
 				else
-					boutput(user, SPAN_ALERT("You are not recognized as the key for [ship]!"))
+					boutput(user, SPAN_ALERT("You are not recognized by the biometric lock for [ship]!"))
 			ship.myhud.update_states()
 
 	is_set()

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -1528,14 +1528,15 @@
 			dat += {"<BR><A href='?src=\ref[src];alights=1'>(Activate)</A>"}
 		dat+= {"([src.lights.power_used])"}
 	if(src.lock)
+		dat += "<HR><B>Lock</B>:<br>"
 		if(src.locked)
-			dat += "<HR><B>Lock</B>:<br><a href='?src=\ref[src.lock];unlock=1'>(Unlock)</a>"
+			dat += "<a href='?src=\ref[src.lock];unlock=1'>(Unlock)</a>"
 		else
-			dat += "<HR><B>Lock</B>:"
-			if (src.lock.code)
-				dat += "<br><a href='?src=\ref[src.lock];lock=1'>(Lock)</a>"
-
-			dat += " <a href='?src=\ref[src.lock];setcode=1;'>(Set Code)</a>"
+			if (src.lock.is_set())
+				dat += "<a href='?src=\ref[src.lock];lock=1'>(Lock)</a>"
+			// if the lock is not set OR it is set and can be reset, show the set code button
+			if (!src.lock.is_set() || (src.lock.is_set() && src.lock.can_reset))
+				dat += " <a href='?src=\ref[src.lock];setcode=1;'>(Set Code)</a>"
 	user.Browse(dat, "window=ship_main")
 	onclose(user, "ship_main")
 	return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Refactor the pod lock secondary system
  * Add variable `can_reset`, defaults to true, biometric pod lock is false
  * Add proc `is_set()`, that checks if the lock is set.
    * For combination locks, this checks if the `code` var is set
    * For biometric locks, check if the `bdna` var is set
* Update code to use `is_set() and `can_reset` where applicable
  * Only state that the code is reset when we can reset the lock code
  * Ensure the pod computer shows the Set Code link only when it is possible to set the code
* Remove some duplicatated var definitions from `lock/bioscan` that are same as parent
* Give some boutput feedback when you can't unlock the biometric pod lock
* Update the description of the lock/unlock HUD icon

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21954
