### PR TITLE
Regrowing lizard tails fixes associated clumsiness

### DIFF
--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -1422,6 +1422,7 @@
 				newtail.holder = src
 				organ_list["tail"] = newtail
 				src.donor.update_body()
+				src.donor.bioHolder.RemoveEffect(newtail.failure_ability)
 				success = 1
 
 		if (success)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When recieving a tail organ via `receieve_organ`, remove the tail's failure ability bioeffect from the donor.

This is called from the `regrow_tail` ability for lizards, fixing the associated issue.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21852