### PR TITLE
Implement 516 ByondUI wiggle fix

### DIFF
--- a/code/datums/character_preview.dm
+++ b/code/datums/character_preview.dm
@@ -51,7 +51,7 @@
 	src.handler = new
 	src.handler.plane = PLANE_BLACKNESS
 	src.handler.mouse_opacity = 0
-	src.handler.screen_loc = "[src.preview_id]:1,1"
+	src.handler.set_position(src.preview_id, 1, 1)
 	src.viewer?.screen += src.handler
 
 	if (custom_setup)

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -28,6 +28,15 @@
  */
 /atom/movable/screen/proc/set_position(x, y, px = 0, py = 0)
 	screen_loc = "[x]:[px],[y]:[py]"
+	fix_screen_loc(x, y, px, py)
+
+/// 516 hack fix for screen_loc issues with the TGUI ByondUI element
+/atom/movable/screen/proc/fix_screen_loc(x, y, px, py)
+    set waitfor = FALSE
+    sleep(0.1 SECONDS)
+    screen_loc = "[x]:100:0,100:0"
+    sleep(0.1 SECONDS)
+    screen_loc = "[x]:[px],[y]:[py]"
 
 /atom/movable/screen/hud
 	plane = PLANE_HUD

--- a/code/modules/minimap/minimap_objects/minimap_ui.dm
+++ b/code/modules/minimap/minimap_objects/minimap_ui.dm
@@ -31,7 +31,7 @@
 	src.handler = new
 	src.handler.plane = PLANE_BLACKNESS
 	src.handler.mouse_opacity = 0
-	src.handler.screen_loc = "[src.minimap_id]:1,1"
+	src.handler.set_position(src.minimap_id,1,1)
 
 	src.minimap = minimap
 	src.minimap.screen_loc = "[src.minimap_id]:1,1"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Implements https://github.com/tgstation/tgstation/pull/89933 with some minor tweaks


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* To work around the current issue of ByondUI map elements not properly scaling content to fit


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sovexe
(+)Character creator previews and minimaps now scale correctly in 516
```
