### PR TITLE
Add CSS to Mat Fabricators for 516 styling

### DIFF
--- a/browserassets/css/mat_fabricator.css
+++ b/browserassets/css/mat_fabricator.css
@@ -1,0 +1,87 @@
+body {
+	background: #121212;
+	color: #e0e0e0;
+	margin: 0;
+	padding: 10px;
+}
+
+a {
+	color: #e0e0e0;
+	text-decoration: none;
+	background: #1e1e1e;
+	border: 1px solid #333;
+	padding: 6px 12px;
+	margin: 2px;
+	display: inline-block;
+	border-radius: 4px;
+	transition: background 0.2s, color 0.2s, border-color 0.2s;
+	font-size: 10pt;
+}
+
+a:hover {
+	background: #58B4DC;
+	color: #000;
+	border-color: #58B4DC;
+}
+
+hr {
+	border: none;
+	border-top: 1px solid #333;
+	margin: 10px 0;
+}
+
+.icon-list,
+.icon-folder-open,
+.icon-cog,
+.icon-wrench,
+.icon-search,
+.icon-caret-right {
+	color: #b0bec5;
+	margin-right: 4px;
+}
+
+/* Scrollable content box styling */
+div[style*="overflow-y: auto"] {
+	background: #1e1e1e;
+	border: 1px solid #333;
+	border-radius: 4px;
+	padding: 10px;
+	max-height: 500px;
+	overflow-y: auto;
+}
+
+/* Item links inside scrollable area */
+div[style*="overflow-y: auto"] a {
+	background: transparent;
+	border: none;
+	color: #90caf9;
+	padding: 0;
+	display: inline;
+}
+
+div[style*="overflow-y: auto"] a:hover {
+	color: #58B4DC;
+}
+
+/* Add breathing room between item blocks */
+div[style*="overflow-y: auto"] br + br {
+	margin-bottom: 10px;
+	display: block;
+	content: "";
+}
+
+/* Optional: make "Category" links slightly more buttony */
+div:has(.icon-search) a {
+	background: #1e1e1e;
+	border: 1px solid #333;
+	padding: 4px 8px;
+	border-radius: 4px;
+	margin: 2px;
+	display: inline-block;
+}
+
+div:has(.icon-search) a:hover {
+	background: #58B4DC;
+	color: #000;
+	border-color: #58B4DC;
+}

--- a/code/modules/materials/Mat_Fabrication.dm
+++ b/code/modules/materials/Mat_Fabrication.dm
@@ -108,7 +108,7 @@
 		..()
 
 	attack_hand(mob/user)
-		user.Browse(buildHtml(), "window=nfab;size=550x650;title=Nano-fabricator;fade_in=0;can_resize=0", 1)
+		user.Browse(buildHtml(), "window=nfab;size=550x680;title=Nano-fabricator;fade_in=0;can_resize=0", 1)
 		return
 
 	mouse_drop(over_object, src_location, over_location)
@@ -177,6 +177,7 @@
 
 	proc/buildHtml()
 		var/html = list()
+		html += "<link rel='stylesheet' type='text/css' href='[resource("css/mat_fabricator.css")]' />"
 		html += "<a href='?src=\ref[src];tab=recipes'><i class='icon-list'></i> Blueprints</a>  "
 		html += "<a href='?src=\ref[src];tab=storage'><i class='icon-folder-open'></i> Storage</a>  "
 		html += "<a href='?src=\ref[src];tab=progress'><i class='icon-cog'></i> Progress</a>  "

--- a/code/modules/materials/Mat_Fabrication.dm
+++ b/code/modules/materials/Mat_Fabrication.dm
@@ -108,7 +108,12 @@
 		..()
 
 	attack_hand(mob/user)
-		user.Browse(buildHtml(), "window=nfab;size=550x680;title=Nano-fabricator;fade_in=0;can_resize=0", 1)
+		var/html = buildHtml()
+		if (user.client.byond_version >= 516)
+			html = "<link rel='stylesheet' type='text/css' href='[resource("css/mat_fabricator.css")]' />" + html
+			user.Browse(html, "window=nfab;size=550x680;title=Nano-fabricator;fade_in=0;can_resize=0")
+		else
+			user.Browse(html, "window=nfab;size=550x650;title=Nano-fabricator;fade_in=0;can_resize=0", 1)
 		return
 
 	mouse_drop(over_object, src_location, over_location)
@@ -177,7 +182,6 @@
 
 	proc/buildHtml()
 		var/html = list()
-		html += "<link rel='stylesheet' type='text/css' href='[resource("css/mat_fabricator.css")]' />"
 		html += "<a href='?src=\ref[src];tab=recipes'><i class='icon-list'></i> Blueprints</a>  "
 		html += "<a href='?src=\ref[src];tab=storage'><i class='icon-folder-open'></i> Storage</a>  "
 		html += "<a href='?src=\ref[src];tab=progress'><i class='icon-cog'></i> Progress</a>  "

--- a/code/modules/materials/Mat_Fabrication.dm
+++ b/code/modules/materials/Mat_Fabrication.dm
@@ -111,7 +111,7 @@
 		var/html = buildHtml()
 		if (user.client.byond_version >= 516)
 			html = "<link rel='stylesheet' type='text/css' href='[resource("css/mat_fabricator.css")]' />" + html
-			user.Browse(html, "window=nfab;size=550x680;title=Nano-fabricator;fade_in=0;can_resize=0")
+			user.Browse(html, "window=nfab;size=600x680;title=Nano-fabricator;fade_in=0;can_resize=0")
 		else
 			user.Browse(html, "window=nfab;size=550x650;title=Nano-fabricator;fade_in=0;can_resize=0", 1)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Styles the mat fabricator with some nice darkmode css, button like links, and blue hightlighting
![image](https://github.com/user-attachments/assets/5759adb7-9827-468f-91a5-12c68980afcc)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* This UI is trash, without CHUI it was extra trash, now it's passable


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sovexe
(+)Mat Fabricators have been given proper styling in BYOND 516
```
