### PR TITLE
Prevent cthulu staff summon from spamming maptext

### DIFF
--- a/code/modules/antagonists/wizard/abilities/summon_staff.dm
+++ b/code/modules/antagonists/wizard/abilities/summon_staff.dm
@@ -26,23 +26,24 @@
 			boutput(M, SPAN_ALERT("Not when you're incapacitated or restrained."))
 			return 1
 
-		if(!istype(get_area(M), /area/sim/gunsim)) // Avoid dead chat spam
-			M.say("KOHM HEIRE", FALSE, maptext_style, maptext_colors)
-		..()
-
 		var/list/staves = list()
-		var/we_hold_it = 0
+		var/we_hold_it = FALSE
 		for_by_tcl(S, /obj/item/staff/cthulhu)
 			if (M.mind && M.mind.key == S.wizard_key)
 				if (S == M.find_in_hand(S))
-					we_hold_it = 1
+					we_hold_it = TRUE
 					continue
 				if (!(S in staves))
 					staves["[S.name] #[staves.len + 1] [ismob(S.loc) ? "carried by [S.loc.name]" : "at [get_area(S)]"]"] += S
 
+		if (!we_hold_it)
+			if(!istype(get_area(M), /area/sim/gunsim)) // Avoid dead chat spam
+				M.say("KOHM HEIRE", FALSE, maptext_style, maptext_colors)
+			..()
+
 		switch (staves.len)
 			if (-INFINITY to 0)
-				if (we_hold_it != 0)
+				if (we_hold_it)
 					boutput(M, SPAN_ALERT("You're already holding your staff."))
 					return 1 // No cooldown.
 				else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Only do the cthulu summon staff maptext/voiceline if we aren't holding it
* Use TRUE/FALSE defines for `we_hold_it` variable to make flow clearer

Note: The same change is NOT applied to the thunder staff, as casting that will always have an effect (recharging the staff) and always put the ability on cooldown.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22638