### PR TITLE
Blindness from eye damage requires eye replacement

### DIFF
--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -478,18 +478,18 @@
 		if (src.organHolder)
 			var/datum/organHolder/O = src.organHolder
 			if (side == "right")
-				if (O.right_eye)
+				if (O.right_eye?.provides_sight)
 					O.right_eye.brute_dam = max(0, O.right_eye.brute_dam + amount)
 			else if (side == "left")
-				if (O.left_eye)
+				if (O.left_eye?.provides_sight)
 					O.left_eye.brute_dam = max(0, O.left_eye.brute_dam + amount)
 			else
-				if (O.right_eye && O.left_eye)
+				if (O.right_eye?.provides_sight && O.left_eye?.provides_sight)
 					O.right_eye.brute_dam = max(0, O.right_eye.brute_dam + (amount/2))
 					O.left_eye.brute_dam = max(0, O.left_eye.brute_dam + (amount/2))
-				else if (O.right_eye)
+				else if (O.right_eye?.provides_sight)
 					O.right_eye.brute_dam = max(0, O.right_eye.brute_dam + amount)
-				else if (O.left_eye)
+				else if (O.left_eye?.provides_sight)
 					O.left_eye.brute_dam = max(0, O.left_eye.brute_dam + amount)
 		else
 			src.eye_damage = max(0, src.eye_damage + amount)
@@ -528,7 +528,8 @@
 
 				if (prob(eye_dam - 25 + 1))
 					src.show_text("You go blind!", "red")
-					src.bioHolder.AddEffect("blind")
+					src.organHolder?.left_eye?.take_damage(100)
+					src.organHolder?.right_eye?.take_damage(100)
 				else
 					src.change_eye_blurry(rand(12,16))
 

--- a/code/obj/item/organs/eye.dm
+++ b/code/obj/item/organs/eye.dm
@@ -109,6 +109,15 @@
 
 		return 1
 
+	// dead eyes stop working
+	breakme()
+		. = ..()
+		src.provides_sight = FALSE
+
+	unbreakme()
+		. = ..()
+		src.provides_sight = TRUE
+
 /obj/item/organ/eye/left
 	name = "left eye"
 	body_side = L_ORGAN


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][medical]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Eyes generally take damage via the `take_eye_damage` proc, which applies some damage to the eye organs themselves as well as applies affects to the mob as a whole, such as eye bluriness and blindness. We check if the eye is actually providing sight before applying damage.

Instead of applying the blindness bioEffect, we instead damage the eyes directly by 100, causing the organ to fail.

Failing organs call `breakme()`, so we add a `breakme()` extension for eyes that sets `provides_sight` to `FALSE`.

This is already detected and handled in the blindness lifeprocess to remove sight.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Eyes that are damaged to blindness still only show as "Moderately" damaged on health scan instead of "Dead"
* Fixes #21869 - Replacing eyes does not fix eye damage related blindness
* The blindness caused by eye damage is not genetic, and should not be cured by mutadone
* Give roboticists more visitors to replace eyes.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Blindness from severely damaged eyes cannot be fixed with mutadone or oculine. Wear proper PPE!
```
