### PR TITLE
Shuffle some areas on donut3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -67639,10 +67639,10 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -407,7 +407,7 @@
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "acS" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle,
@@ -705,11 +705,6 @@
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
-"ahY" = (
-/turf/simulated/floor/arrival{
-	dir = 8
-	},
-/area/station/hangar/arrivals)
 "aib" = (
 /obj/disposalpipe/segment{
 	dir = 8
@@ -944,7 +939,7 @@
 /turf/simulated/floor/green/side{
 	dir = 9
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "alO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -1087,7 +1082,7 @@
 	name = "bot navigation beacon"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "anO" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 10;
@@ -1852,7 +1847,7 @@
 /turf/simulated/floor/green/corner{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "ayR" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/wood/two,
@@ -2425,7 +2420,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "aGD" = (
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
@@ -2829,7 +2824,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "aNi" = (
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass,
@@ -3256,7 +3251,7 @@
 /turf/simulated/floor/arrival{
 	dir = 1
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "aTU" = (
 /obj/decal/tile_edge/line/black{
 	dir = 1;
@@ -3402,7 +3397,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "aWa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -3444,7 +3439,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "aWA" = (
 /obj/railing/orange,
 /obj/decal/cleanable/dirt/jen,
@@ -3636,7 +3631,7 @@
 "aYV" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/stairs/wide,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "aZp" = (
 /obj/disposalpipe/segment/ejection,
 /obj/decal/tile_edge/line/black{
@@ -4274,7 +4269,7 @@
 /turf/simulated/floor{
 	icon_state = "L7"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "bjR" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -4333,7 +4328,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/stairs/wide/other,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "bkQ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -4526,7 +4521,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "bnj" = (
 /obj/table/wood/auto,
 /obj/item/robodefibrillator{
@@ -5002,17 +4997,21 @@
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "bvb" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "bvo" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/decal/stripe_delivery,
@@ -5596,7 +5595,7 @@
 /obj/mapping_helper/access,
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "bCY" = (
 /obj/machinery/networked/artifact_console,
 /obj/cable{
@@ -5938,7 +5937,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "bHV" = (
 /obj/cable/orange{
 	icon_state = "4-8"
@@ -6015,7 +6014,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "bJk" = (
 /obj/table/glass/auto,
 /obj/item/paper_bin{
@@ -6031,7 +6030,7 @@
 /turf/simulated/floor/arrival{
 	dir = 9
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "bJw" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
@@ -6103,7 +6102,7 @@
 "bKd" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/arrival,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "bKg" = (
 /obj/decal/tile_edge/check/red{
 	dir = 9;
@@ -6348,7 +6347,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "bOf" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -6357,7 +6356,7 @@
 /turf/simulated/floor/green/corner{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "bOm" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/mesh/catwalk/jen,
@@ -6640,7 +6639,7 @@
 /obj/stool/bench/auto,
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "bUC" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/mesh/catwalk/jen,
@@ -7330,7 +7329,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "ceJ" = (
 /obj/lattice{
 	dir = 9;
@@ -7572,7 +7571,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/green/corner,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "chM" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purple/side,
@@ -7651,6 +7650,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/gas)
+"ciR" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/northwest)
 "ciW" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -8784,7 +8789,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "cxe" = (
 /obj/fakeobject/sink{
 	dir = 4
@@ -8978,7 +8983,7 @@
 /area/station/hallway/primary/east)
 "czv" = (
 /turf/simulated/floor/arrival,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "czw" = (
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass{
@@ -9264,7 +9269,7 @@
 	},
 /obj/disposalpipe/junction/middle/west,
 /turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "cDj" = (
 /obj/indestructible/shuttle_corner{
 	dir = 0
@@ -10015,7 +10020,7 @@
 "cPY" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "cQb" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -10696,7 +10701,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "dcs" = (
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/wood/six,
@@ -11211,7 +11216,7 @@
 /turf/simulated/floor{
 	icon_state = "L8"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "djS" = (
 /obj/machinery/sim/vr_bed{
 	dir = 8;
@@ -11443,7 +11448,7 @@
 	})
 "dne" = (
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "dnh" = (
 /obj/table/auto,
 /obj/item/device/light/glowstick{
@@ -12169,7 +12174,7 @@
 /turf/simulated/floor/arrival/corner{
 	dir = 4
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "dzY" = (
 /obj/cable{
 	icon_state = "5-8"
@@ -12357,7 +12362,7 @@
 /turf/simulated/floor/arrival{
 	dir = 1
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "dDb" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -12432,7 +12437,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "dDW" = (
 /obj/machinery/fluid_canister,
 /obj/decal/cleanable/dirt/jen,
@@ -12471,7 +12476,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "dEt" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 1;
@@ -12589,7 +12594,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "dGG" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable{
@@ -12917,7 +12922,7 @@
 	mail_tag = "janitor"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "dLX" = (
 /obj/machinery/light/incandescent/netural,
 /obj/decoration/decorativeplant/plant6,
@@ -12928,7 +12933,7 @@
 /turf/simulated/floor/green/side{
 	dir = 6
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "dMi" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/light/small/sticky,
@@ -13012,7 +13017,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "dNz" = (
 /turf/simulated/floor/carpet/arcade,
 /area/station/medical/asylum/rec)
@@ -13293,7 +13298,7 @@
 /turf/simulated/floor{
 	icon_state = "L1"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "dRw" = (
 /obj/stool/chair{
 	dir = 8
@@ -13459,7 +13464,7 @@
 /turf/simulated/floor{
 	icon_state = "L5"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "dTB" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor/specialroom/arcade,
@@ -14437,6 +14442,9 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/omni,
 /area/station/medical/head)
+"ehJ" = (
+/turf/simulated/wall/auto/jen/blue,
+/area/station/hallway/primary/northwest)
 "ehN" = (
 /obj/table/wood/auto,
 /obj/item/camera{
@@ -15217,7 +15225,7 @@
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "evF" = (
 /obj/machinery/dispenser,
 /turf/simulated/floor/yellowblack{
@@ -15860,7 +15868,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "eHS" = (
 /obj/machinery/light_switch/south,
 /turf/simulated/floor/redwhite,
@@ -15987,7 +15995,7 @@
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "eJA" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -16327,7 +16335,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "eQa" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/right{
@@ -16814,7 +16822,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "eXq" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle{
@@ -17155,7 +17163,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "fbZ" = (
 /obj/stool/chair/comfy/yellow{
 	dir = 4
@@ -17648,7 +17656,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "fkA" = (
 /obj/mesh/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -17675,7 +17683,7 @@
 "fkJ" = (
 /obj/machinery/vending/air_vendor,
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "fkX" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable{
@@ -18754,7 +18762,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "fDe" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -18826,7 +18834,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/jen,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "fEc" = (
 /obj/rack,
 /obj/item/clothing/shoes/magnetic,
@@ -18943,7 +18951,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "fFG" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/black,
@@ -19844,7 +19852,7 @@
 "fSR" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "fSX" = (
 /obj/disposalpipe/segment/food{
 	dir = 4;
@@ -20031,7 +20039,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "fVV" = (
 /obj/item/storage/wall/fire{
 	dir = 4;
@@ -21630,7 +21638,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/jen,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "gwi" = (
 /obj/mesh/grille/steel,
 /obj/cable,
@@ -21867,7 +21875,7 @@
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "gzY" = (
 /obj/disposalpipe/segment/brig,
 /turf/simulated/wall/auto/jen/red,
@@ -22326,7 +22334,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "gHk" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/right{
@@ -22893,7 +22901,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "gQk" = (
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/maintenance/outer/se)
@@ -23285,7 +23293,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "gWS" = (
 /obj/machinery/light/small/floor/harsh,
 /obj/disposalpipe/segment/mail,
@@ -23312,7 +23320,7 @@
 /turf/simulated/floor/stairs/wide/middle{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "gXT" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -23575,7 +23583,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/jen,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "hbR" = (
 /obj/indestructible/shuttle_corner{
 	dir = 4
@@ -23725,7 +23733,7 @@
 /turf/simulated/floor/green/side{
 	dir = 6
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "heg" = (
 /obj/decal/stripe_caution,
 /obj/machinery/nanofab/refining,
@@ -24492,7 +24500,7 @@
 /turf/simulated/floor{
 	icon_state = "L13"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "hrm" = (
 /obj/table/wood/auto,
 /obj/item/plate{
@@ -24997,7 +25005,7 @@
 /turf/simulated/floor/arrival{
 	dir = 1
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "hwM" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -25085,7 +25093,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "hxO" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/escape/corner,
@@ -25281,7 +25289,7 @@
 /turf/simulated/floor/arrival{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "hAG" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -25562,7 +25570,7 @@
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "hFv" = (
 /obj/storage/crate/packing,
 /obj/random_item_spawner/dressup/some,
@@ -26115,7 +26123,7 @@
 "hOU" = (
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "hPB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -26335,7 +26343,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "hUZ" = (
 /obj/stool/bench/sauna{
 	dir = 4
@@ -26597,7 +26605,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "iag" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light/emergency{
@@ -26610,7 +26618,7 @@
 /turf/simulated/floor/arrival{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "iak" = (
 /obj/machinery/disposal/transport{
 	name = "Medbay/Science Transport"
@@ -27735,7 +27743,7 @@
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "itK" = (
 /obj/machinery/power/collector_array,
 /obj/cable/orange{
@@ -28179,7 +28187,7 @@
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "iAu" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light/emergency{
@@ -29513,7 +29521,7 @@
 /turf/simulated/floor/stairs/wide{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "iWe" = (
 /obj/table/auto,
 /obj/machinery/coffeemaker/command,
@@ -29673,7 +29681,7 @@
 "iYH" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "iYI" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -30433,7 +30441,7 @@
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "jjU" = (
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
@@ -30873,7 +30881,7 @@
 "jrD" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/stairs/wide,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "jrH" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -31364,7 +31372,7 @@
 "jyv" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "jyF" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 5;
@@ -31796,7 +31804,7 @@
 /turf/simulated/floor/stairs/wide/other{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "jFv" = (
 /obj/decal/tile_edge/check{
 	color = "#AB8CB0";
@@ -32799,7 +32807,7 @@
 "jUs" = (
 /obj/disposalpipe/segment/food,
 /turf/simulated/wall/auto/jen,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "jUv" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 4
@@ -32833,7 +32841,7 @@
 /area/station/maintenance/inner/nw)
 "jUI" = (
 /turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "jUK" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/reinforced/jen,
@@ -33465,6 +33473,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"kee" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/hallway/primary/northwest)
 "keh" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 2;
@@ -34057,7 +34072,7 @@
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "kns" = (
 /obj/stone,
 /turf/simulated/floor/grass/leafy,
@@ -34113,7 +34128,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "kon" = (
 /obj/machinery/conveyor/WE{
 	id = "qm_tohall"
@@ -34294,13 +34309,6 @@
 	},
 /turf/simulated/floor/carpet/green/standard/edge,
 /area/station/crew_quarters/quartersC)
-"kqV" = (
-/obj/disposalpipe/segment/transport,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hangar/arrivals)
 "kqZ" = (
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass/security{
@@ -34748,7 +34756,7 @@
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "kyu" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -34756,7 +34764,7 @@
 /turf/simulated/floor{
 	icon_state = "L10"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "kyv" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/carpet/arcade/half,
@@ -34882,7 +34890,7 @@
 /turf/simulated/floor/arrival{
 	dir = 1
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "kAe" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 6;
@@ -35663,7 +35671,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "kMN" = (
 /obj/mesh/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -36183,7 +36191,7 @@
 /turf/simulated/floor/arrival{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "kVR" = (
 /obj/storage/closet/wardrobe/blue,
 /turf/simulated/floor/sanitary,
@@ -36490,7 +36498,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "lag" = (
 /obj/landmark/start/job/medical_doctor,
 /obj/stool/chair/office,
@@ -36499,7 +36507,7 @@
 "las" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "lay" = (
 /obj/decal/stage_edge{
 	layer = 2.8
@@ -36706,7 +36714,7 @@
 /turf/simulated/floor/arrival{
 	dir = 5
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "leg" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/window_blinds/cog2/right,
@@ -38451,7 +38459,7 @@
 "lEh" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "lEi" = (
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating/jen,
@@ -38678,7 +38686,7 @@
 /turf/simulated/floor/arrival{
 	dir = 10
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "lGU" = (
 /obj/indestructible/shuttle_corner{
 	dir = 4
@@ -39022,6 +39030,10 @@
 /obj/storage/secure/closet/civilian/hydro,
 /turf/simulated/floor/wood/five,
 /area/station/hydroponics/bay)
+"lMe" = (
+/obj/mapping_helper/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/northwest)
 "lMh" = (
 /obj/submachine/seed_vendor,
 /turf/simulated/floor,
@@ -39266,7 +39278,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "lPS" = (
 /obj/disposalpipe/segment/brig,
 /turf/simulated/wall/auto/reinforced/jen/red,
@@ -39380,10 +39392,6 @@
 	dir = 4
 	},
 /area/station/hydroponics/bay)
-"lRi" = (
-/obj/mapping_helper/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/bar)
 "lRu" = (
 /obj/item/device/radio/intercom/engineering{
 	dir = 8
@@ -39461,7 +39469,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "lSz" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -39548,6 +39556,10 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/carpet/arcade/half,
 /area/station/crew_quarters/arcade/dungeon)
+"lTo" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/northwest)
 "lTs" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable{
@@ -40087,7 +40099,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "lZV" = (
 /obj/stool/chair/yellow{
 	dir = 8
@@ -40184,7 +40196,7 @@
 "mbH" = (
 /obj/machinery/door/airlock/pyro/reinforced/arrivals,
 /turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "mbM" = (
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/funeral_parlor)
@@ -40619,7 +40631,7 @@
 "mjW" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/jen,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "mjX" = (
 /obj/railing/orange{
 	dir = 1
@@ -40773,7 +40785,7 @@
 /turf/simulated/floor{
 	icon_state = "L3"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "mmR" = (
 /obj/machinery/disposal/mail/small/autoname/medbay/robotics/east,
 /obj/disposalpipe/trunk/mail,
@@ -41378,7 +41390,7 @@
 "mxy" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "mxC" = (
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass,
@@ -41763,7 +41775,7 @@
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "mDk" = (
 /obj/computer3frame,
 /obj/machinery/power/data_terminal,
@@ -42505,7 +42517,7 @@
 /turf/simulated/floor/green/side{
 	dir = 6
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "mRQ" = (
 /obj/mesh/catwalk/jen,
 /turf/simulated/floor/plating/jen,
@@ -42576,7 +42588,7 @@
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "mSs" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable{
@@ -43037,7 +43049,7 @@
 /turf/simulated/floor{
 	icon_state = "L6"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "mZl" = (
 /turf/simulated/floor/purple/side,
 /area/station/hallway/primary/south)
@@ -43074,7 +43086,7 @@
 /turf/simulated/floor{
 	icon_state = "L12"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "mZQ" = (
 /obj/machinery/light/incandescent/netural,
 /obj/machinery/camera{
@@ -43587,7 +43599,7 @@
 /turf/simulated/floor/stairs/wide/other{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "nhy" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -44370,7 +44382,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "nuJ" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -44424,7 +44436,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "nvN" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -44541,7 +44553,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "nxB" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 8
@@ -44874,7 +44886,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/jen,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "nCW" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -45047,7 +45059,7 @@
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "nGk" = (
 /obj/item/clothing/suit/bedsheet/pink,
 /obj/stool/bed,
@@ -45698,7 +45710,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "nOQ" = (
 /obj/storage/closet/coffin/wood,
 /obj/disposalpipe/segment/transport{
@@ -46018,7 +46030,7 @@
 /area/station/crew_quarters/market)
 "nTG" = (
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "nTJ" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/mesh/catwalk,
@@ -47191,7 +47203,7 @@
 "onB" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "onP" = (
 /obj/machinery/computer/solar_control/east{
 	dir = 8
@@ -47541,7 +47553,7 @@
 /turf/simulated/floor/green/side{
 	dir = 9
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "otz" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/decal/stripe_caution,
@@ -47821,7 +47833,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "oyh" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/mesh/catwalk/jen,
@@ -47885,7 +47897,7 @@
 /turf/simulated/floor{
 	icon_state = "L4"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "oyH" = (
 /obj/cable{
 	icon_state = "2-10"
@@ -48285,7 +48297,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "oFl" = (
 /turf/simulated/wall/auto/jen,
 /area/station/storage/tech)
@@ -48452,7 +48464,7 @@
 	pixel_x = -12
 	},
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "oHM" = (
 /obj/landmark/magnet_shield,
 /obj/securearea{
@@ -49423,7 +49435,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "oXq" = (
 /obj/stool/chair/purple{
 	dir = 1
@@ -49577,7 +49589,7 @@
 "oZG" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/jen/blue,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "oZH" = (
 /obj/machinery/vending/medical_public,
 /obj/machinery/light/emergency{
@@ -49776,7 +49788,7 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "pcB" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -49792,7 +49804,7 @@
 /turf/simulated/floor/arrival{
 	dir = 4
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "pdl" = (
 /obj/mesh/catwalk,
 /turf/simulated/floor/airless/plating/catwalk/auto,
@@ -50257,11 +50269,7 @@
 	},
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/bar)
-"pjX" = (
-/obj/disposalpipe/segment/transport,
-/turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/crew_quarters/cafeteria)
 "pka" = (
 /obj/machinery/info_map,
 /turf/simulated/floor/red/side,
@@ -50416,7 +50424,7 @@
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "pmj" = (
 /obj/table/glass/reinforced/auto,
 /obj/random_item_spawner/snacks/one_or_zero,
@@ -51208,7 +51216,7 @@
 /turf/simulated/floor/arrival{
 	dir = 1
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "pAu" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -51222,7 +51230,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "pAA" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -51378,7 +51386,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "pDb" = (
 /obj/item/ammo/bullets/tranq_darts{
 	pixel_x = 9;
@@ -51446,7 +51454,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "pDN" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -51636,7 +51644,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "pFp" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -52361,7 +52369,7 @@
 /turf/simulated/floor/arrival{
 	dir = 9
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "pRl" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin{
@@ -52434,7 +52442,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "pSq" = (
 /obj/railing/orange{
 	dir = 1
@@ -52626,6 +52634,11 @@
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
+"pVE" = (
+/turf/simulated/floor/stairs/wide{
+	dir = 1
+	},
+/area/station/hallway/primary/northwest)
 "pVO" = (
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -53781,7 +53794,7 @@
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "qpp" = (
 /obj/decal/tile_edge/line/white{
 	dir = 8;
@@ -53923,7 +53936,7 @@
 /turf/simulated/floor/arrival{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "qrH" = (
 /obj/item/storage/wall/emergency{
 	dir = 1;
@@ -53945,7 +53958,7 @@
 /turf/simulated/floor{
 	icon_state = "L16"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "qrO" = (
 /obj/table/wood/auto,
 /obj/machinery/computer3/generic/personal/personel_alt,
@@ -53956,7 +53969,7 @@
 "qrX" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/jen,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "qsj" = (
 /obj/machinery/sim/vr_bed{
 	dir = 8;
@@ -54366,7 +54379,7 @@
 /area/station/quartermaster/office)
 "qxT" = (
 /turf/simulated/floor/caution/north,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "qyi" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
@@ -54695,7 +54708,7 @@
 /turf/simulated/floor/green/side{
 	dir = 9
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "qEH" = (
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass{
@@ -55064,7 +55077,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "qKD" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/mesh/catwalk/jen,
@@ -55829,7 +55842,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "qWa" = (
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
@@ -56112,7 +56125,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "qZG" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -56149,11 +56162,11 @@
 /obj/landmark/pest,
 /obj/shrub,
 /turf/simulated/grass,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "qZZ" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/stairs/wide/other,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "rae" = (
 /obj/machinery/computer3/luggable,
 /obj/item/screwdriver{
@@ -57958,7 +57971,7 @@
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "rEC" = (
 /obj/disposalpipe/junction/right/west,
 /obj/machinery/light/emergency{
@@ -58554,7 +58567,7 @@
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "rNn" = (
 /obj/table/auto,
 /obj/machinery/power/data_terminal,
@@ -58693,7 +58706,7 @@
 /turf/simulated/floor{
 	icon_state = "L9"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "rOI" = (
 /obj/decal/tile_edge/check{
 	dir = 6;
@@ -59029,7 +59042,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "rUJ" = (
 /obj/table/auto,
 /obj/machinery/cashreg,
@@ -59250,7 +59263,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "rXd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -59599,6 +59612,9 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
+"sbT" = (
+/turf/simulated/floor,
+/area/station/hallway/primary/northwest)
 "sbW" = (
 /obj/table/glass/reinforced/auto,
 /obj/item/storage/box/gl_kit{
@@ -59782,7 +59798,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "seM" = (
 /obj/machinery/light/small/floor/warm,
 /obj/cable/orange{
@@ -59821,7 +59837,7 @@
 /turf/simulated/floor/arrival{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "sfw" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer3/generic/radio,
@@ -59846,7 +59862,7 @@
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "sge" = (
 /obj/table/auto,
 /obj/item/device/gps{
@@ -60146,7 +60162,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/arrival,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "smc" = (
 /obj/decal/tile_edge/line/black{
 	dir = 4;
@@ -60764,7 +60780,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "sup" = (
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -61369,7 +61385,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "sEm" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -61450,7 +61466,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "sFj" = (
 /obj/decal/tile_edge/line/black{
 	dir = 1;
@@ -61535,7 +61551,7 @@
 "sHa" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "sHf" = (
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
@@ -61736,7 +61752,7 @@
 /turf/simulated/floor{
 	icon_state = "L15"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "sKV" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -62890,7 +62906,7 @@
 /turf/simulated/floor/arrival/corner{
 	dir = 8
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "tcM" = (
 /obj/machinery/light/incandescent/cool,
 /obj/machinery/camera{
@@ -63058,7 +63074,7 @@
 /obj/mapping_helper/access,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "tfP" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
@@ -63268,9 +63284,6 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
-"thJ" = (
-/turf/simulated/wall/auto/jen,
-/area/station/hangar/arrivals)
 "thU" = (
 /obj/decal/tile_edge/line/red{
 	dir = 9;
@@ -63329,7 +63342,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "tiM" = (
 /obj/decal/tile_edge/line/green{
 	dir = 9;
@@ -63504,7 +63517,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "tlS" = (
 /obj/decal/stripe_caution,
 /obj/decal/cleanable/rust/jen,
@@ -63839,7 +63852,7 @@
 /area/station/science/lobby)
 "trf" = (
 /turf/simulated/wall/auto/reinforced/jen,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "trw" = (
 /turf/space,
 /area/supply/spawn_point)
@@ -64575,7 +64588,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "tDj" = (
 /obj/shrub{
 	dir = 1;
@@ -64674,7 +64687,7 @@
 /turf/simulated/floor/arrival{
 	dir = 1
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "tER" = (
 /obj/stool/chair/dining/wood,
 /turf/simulated/floor/carpet{
@@ -65090,7 +65103,7 @@
 /area/station/hallway/primary/east)
 "tJK" = (
 /turf/simulated/wall/auto/jen,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "tJP" = (
 /obj/cable/blue{
 	icon_state = "4-8"
@@ -65744,7 +65757,7 @@
 /turf/simulated/floor/arrival{
 	dir = 9
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "tTt" = (
 /obj/machinery/disposal/morgue,
 /obj/disposalpipe/trunk/morgue,
@@ -65859,7 +65872,7 @@
 /turf/simulated/floor/arrival{
 	dir = 10
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "tVB" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -66225,7 +66238,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/green/corner,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "ubq" = (
 /obj/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -66782,7 +66795,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "unp" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/wood/seven,
@@ -66846,6 +66859,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig/north_side)
+"uoz" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/northwest)
 "uoI" = (
 /obj/decal/tile_edge/line/black{
 	dir = 9;
@@ -67620,10 +67639,14 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "uAJ" = (
 /obj/decal/tile_edge/stripe/corner{
 	dir = 8
@@ -67848,7 +67871,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "uDm" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
@@ -68008,7 +68031,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/arrival,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "uFp" = (
 /obj/machinery/door/poddoor/blast/pyro{
 	dir = 4;
@@ -68370,7 +68393,7 @@
 /turf/simulated/floor/green/side{
 	dir = 5
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "uJP" = (
 /obj/decal/cleanable/rust/jen,
 /obj/decal/cleanable/blood,
@@ -68557,7 +68580,7 @@
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light/emergency,
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "uNl" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -68772,7 +68795,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/arrival,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "uRL" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 8
@@ -69531,7 +69554,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "vce" = (
 /turf/simulated/floor/plating/jen,
 /area/station/science/gen_storage)
@@ -69771,7 +69794,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "vfr" = (
 /obj/mesh/catwalk,
 /obj/cable/yellow{
@@ -70334,7 +70357,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "vnK" = (
 /obj/table/round/auto,
 /obj/random_item_spawner/desk_stuff/few,
@@ -70488,7 +70511,7 @@
 /turf/simulated/floor{
 	icon_state = "L2"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "vpx" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
@@ -70815,7 +70838,7 @@
 /turf/simulated/floor/green/corner{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "vtT" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/light/small/sticky{
@@ -70837,7 +70860,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "vuP" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/yellowblack{
@@ -71335,7 +71358,7 @@
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "vBR" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
@@ -71369,14 +71392,14 @@
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "vCr" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "vCx" = (
 /obj/cable,
 /obj/machinery/power/apc/autoname_east,
@@ -71718,7 +71741,7 @@
 /turf/simulated/floor/arrival/corner{
 	dir = 8
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "vIr" = (
 /obj/decal/tile_edge/line/green{
 	dir = 5;
@@ -71794,7 +71817,7 @@
 /turf/simulated/floor/arrival{
 	dir = 1
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "vKm" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -71804,7 +71827,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "vKR" = (
 /obj/railing/orange{
 	dir = 4
@@ -72289,7 +72312,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/arrival,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "vQA" = (
 /obj/submachine/poster_creator{
 	dir = 4
@@ -72540,7 +72563,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/arrival,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "vVc" = (
 /turf/space,
 /area/shuttle/merchant_shuttle/right_station/destiny)
@@ -72905,7 +72928,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "waE" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/carpet/arcade/half,
@@ -73625,7 +73648,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "wmI" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 8
@@ -73937,7 +73960,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "wql" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -74005,7 +74028,7 @@
 /turf/simulated/floor/arrival{
 	dir = 4
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "wrj" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -74079,7 +74102,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "wsa" = (
 /obj/machinery/firealarm/east,
 /obj/disposalpipe/segment/brig,
@@ -74183,7 +74206,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/jen,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "wue" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 9;
@@ -74433,7 +74456,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "wyb" = (
 /obj/machinery/conveyor/WE{
 	id = "qm_in"
@@ -75250,7 +75273,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/secondary/entry)
 "wJp" = (
 /obj/item/storage/firstaid/toxin{
 	pixel_x = 10;
@@ -75347,7 +75370,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "wKj" = (
 /obj/surgery_tray,
 /obj/item/circular_saw{
@@ -75422,7 +75445,7 @@
 	},
 /obj/disposalpipe/junction/middle/west,
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "wKT" = (
 /obj/table/reinforced/bar/auto,
 /obj/mapping_helper/firedoor_spawn,
@@ -76463,7 +76486,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "wZX" = (
 /obj/machinery/deep_fryer,
 /obj/landmark/bill_spawn,
@@ -76996,7 +77019,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "xhz" = (
 /obj/decal/cleanable/dirt,
 /obj/decal/cleanable/rust/jen,
@@ -77127,6 +77150,12 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/medical/asylum/computer)
+"xjj" = (
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/northwest)
 "xjr" = (
 /obj/table/auto,
 /obj/item/reagent_containers/glass/beaker/large/burn{
@@ -77183,7 +77212,7 @@
 "xjU" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/arrival,
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "xjX" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -77252,7 +77281,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "xkZ" = (
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -77415,7 +77444,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "xmF" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -77610,6 +77639,9 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/science/lab)
+"xpH" = (
+/turf/simulated/wall/auto/jen,
+/area/station/hallway/secondary/entry)
 "xpU" = (
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -77660,7 +77692,7 @@
 /turf/simulated/floor/arrival/corner{
 	dir = 1
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "xqr" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -78184,7 +78216,7 @@
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "xyc" = (
 /obj/railing/yellow,
 /obj/stool/chair/yellow{
@@ -78938,7 +78970,7 @@
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "xKm" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/jen,
@@ -79044,7 +79076,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/green/side,
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "xLT" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -79844,7 +79876,7 @@
 /turf/simulated/floor{
 	icon_state = "L11"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "xVT" = (
 /obj/disposalpipe/segment/brig{
 	dir = 2;
@@ -80045,7 +80077,7 @@
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "xYB" = (
 /obj/stool/chair/comfy/purple,
 /obj/decal/poster/wallsign/fire{
@@ -80642,7 +80674,7 @@
 /turf/simulated/floor/arrival/corner{
 	dir = 1
 	},
-/area/station/hangar/arrivals)
+/area/station/hallway/secondary/entry)
 "yif" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 9;
@@ -80858,7 +80890,7 @@
 /turf/simulated/floor{
 	icon_state = "L14"
 	},
-/area/station/hallway/primary/west)
+/area/station/hallway/primary/northwest)
 "yko" = (
 /turf/simulated/floor/darkblue/checker,
 /area/station/ai_monitored/storage/eva)
@@ -109471,7 +109503,7 @@ rdj
 rdj
 cPY
 bJk
-ahY
+qph
 yie
 kMG
 uRF
@@ -109773,8 +109805,8 @@ lPE
 lPE
 lEh
 kzM
-pjX
-kqV
+las
+wJe
 waC
 vUN
 sGu
@@ -109790,7 +109822,7 @@ sGu
 wua
 tJK
 nCS
-oBD
+lMe
 uCy
 uCy
 uCy
@@ -110086,7 +110118,7 @@ rEv
 eJy
 qph
 hFg
-tJK
+xpH
 oHE
 fkJ
 pCP
@@ -110380,7 +110412,7 @@ vnJ
 vKm
 dEr
 fbI
-pjX
+las
 tfm
 gQi
 las
@@ -110395,7 +110427,7 @@ wxW
 xhs
 fFx
 fkt
-enV
+pVE
 etR
 umn
 umn
@@ -110978,7 +111010,7 @@ kWF
 ybl
 kYy
 dRE
-thJ
+xpH
 waP
 kob
 cXT
@@ -112204,7 +112236,7 @@ lOJ
 lOJ
 lOJ
 nuH
-wQc
+xjj
 xLH
 vTk
 waV
@@ -112504,9 +112536,9 @@ cua
 rdj
 rdj
 rdj
-iHj
+lTo
 xYA
-wQc
+xjj
 xLH
 vTk
 ntB
@@ -112806,9 +112838,9 @@ uIw
 rdj
 rdj
 rdj
-iHj
+lTo
 xYA
-wQc
+xjj
 gzN
 vTk
 rJM
@@ -113108,9 +113140,9 @@ fhT
 rdj
 rdj
 rdj
-iHj
+lTo
 suj
-wQc
+xjj
 hxM
 fCP
 sww
@@ -113412,7 +113444,7 @@ rdj
 rdj
 trf
 ceI
-wQc
+xjj
 dGE
 jMF
 yjd
@@ -113714,7 +113746,7 @@ rdj
 rdj
 trf
 nOP
-wQc
+xjj
 dGE
 jMF
 jMF
@@ -114016,7 +114048,7 @@ rdj
 rdj
 trf
 oFj
-wQc
+xjj
 dGE
 jMF
 jMF
@@ -114318,9 +114350,9 @@ rdj
 trf
 trf
 suj
-wQc
+xjj
 dGE
-xJG
+ehJ
 dqP
 aIK
 wVG
@@ -114620,9 +114652,9 @@ pDN
 sHa
 qED
 vtS
-wQc
+xjj
 vCr
-xJG
+ehJ
 aIK
 iAF
 cZx
@@ -115224,7 +115256,7 @@ xDr
 wKB
 bvb
 wKH
-lJe
+kee
 pcu
 gkg
 vpt
@@ -115827,8 +115859,8 @@ gwb
 tJK
 tJK
 xmE
-umn
-umn
+sbT
+sbT
 vcd
 tJK
 izk
@@ -116130,7 +116162,7 @@ knc
 knc
 ayN
 anN
-umn
+sbT
 jyv
 tJK
 brk
@@ -116431,8 +116463,8 @@ iYH
 iYH
 dLW
 ePT
-umn
-umn
+sbT
+sbT
 nTG
 tJK
 brk
@@ -116722,7 +116754,7 @@ tJK
 tJK
 tJK
 dNx
-ovT
+ciR
 chz
 oXc
 sew
@@ -117024,7 +117056,7 @@ otv
 xxT
 iAs
 bOf
-ovT
+ciR
 qZD
 bqD
 bqD
@@ -117625,10 +117657,10 @@ xir
 thp
 uAO
 gHg
-wam
+uoz
 mmJ
 oyF
-ovT
+ciR
 wZW
 bqD
 lce
@@ -118229,7 +118261,7 @@ uVw
 vea
 mmH
 dDU
-umn
+sbT
 bjz
 djE
 dcb
@@ -119135,7 +119167,7 @@ vRz
 rNa
 mpU
 kom
-ovT
+ciR
 hqP
 ykn
 dcb
@@ -120041,7 +120073,7 @@ mpU
 mpU
 mpU
 pjW
-lRi
+qle
 pzj
 xjS
 qle


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Add a new north-west hall area which extends from the chapel to the junction by EVA storage. Add an APC and related wiring for this new area.
* Replace the arrival hangar area with the entry hall area, and extend the entry area down to the new north-west hall, matching the arrival checker trim on the map.
* Change two isolated bar tiles to cafeteria, making a contiguous region

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* The west hall area is huge, spanning from the chapel to the courtroom. This change brings it closer in size to the east hall, which is still rather large.
* There's a special monologue area check for the entry hall that currently can't get played on donut3
* Areas should be contiguous