### PR TITLE
Prevent meteors from outright destroying arrival shuttle windows

### DIFF
--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -259,7 +259,7 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 				src.damage_heat(rand(10, 25))
 
 	meteorhit(var/obj/M)
-		if (istype(M, /obj/newmeteor/massive))
+		if (istype(M, /obj/newmeteor/massive) && !(IS_ARRIVALS(get_area(src))))
 			smash()
 			return
 		src.damage_blunt(20)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
In the `meteorhit` proc for windows, add a check to see if the window is in an arrivals area. If so, do not smash the window but instead damage it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This strikes a balance between meteors doing nothing to arrivals or spacing arrivals on hit.

This will generally only affect the arrivals shuttle on Donut3 (and wrestlemap), as most windows on arrival shuttles are protected from the map edges by other structures.

Fix #22173
Fix #22174
