### PR TITLE
fix glove namecallining

### DIFF
--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -53,7 +53,7 @@
 			if (src.is_heat_resistant())
 				boutput(H, SPAN_NOTICE("Being fire resistant protects you from the flames!"))
 			else
-				boutput(H, SPAN_NOTICE("Your [G] protect you from the flames!"))
+				boutput(H, SPAN_NOTICE("Your [G.name] protect you from the flames!"))
 		else
 			M.update_burning(-1.2)
 			H.TakeDamage(prob(50) ? "l_arm" : "r_arm", 0, rand(1,2))


### PR DESCRIPTION
[BUG][TRIVIAL][CLOTHING]

## About the PR 
Chanhe how the words are for globes when touchinng peoples (on fire) - using of `.name` so thereis no "the"

testing on basic nonfirey glove tyep (black, slahsher, custom material fibrilith), works.

## Why's this needed? 
Fixes #22506

No changinglog, I think