### PR TITLE
Align capsule overlay on fallen figure machines

### DIFF
--- a/code/modules/items/gimmick/figurine.dm
+++ b/code/modules/items/gimmick/figurine.dm
@@ -1153,6 +1153,9 @@ ABSTRACT_TYPE(/datum/figure_info/patreon)
 
 	fall()
 		..()
+		src.capsule_image.pixel_x = src.pixel_x - 4
+		src.capsule_image.pixel_y = src.pixel_y - 8
+		src.UpdateOverlays(src.capsule_image, "capsules")
 		if (src.status & BROKEN)
 			src.icon_state = "[src.base_icon_state]-fallen-broken"
 		else
@@ -1160,6 +1163,9 @@ ABSTRACT_TYPE(/datum/figure_info/patreon)
 
 	right()
 		..()
+		src.capsule_image.pixel_x = src.pixel_x
+		src.capsule_image.pixel_y = src.pixel_y
+		src.UpdateOverlays(src.capsule_image, "capsules")
 		src.icon_state = src.base_icon_state
 
 	powered()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Use pixel offsets to properly align the image representing the number of capsules in the capsule figure machine when falling, and reset them on righting.

It still looks a little jank because the now-visible side isn't filled in, but it at least preserves the illusion that it's falling over as one unit from the front angle.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #9757
