### PR TITLE
When in an object, you can't interact with things outside

### DIFF
--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -119,8 +119,16 @@ var/stink_remedy = list("some deodorant","a shower","a bath","a spraydown with a
 		var/mob/target = source
 		if (target.next_move > world.time && IN_RANGE(target.prev_loc, user, 1))
 			return TRUE
+	var/has_telekinesis = FALSE
+	var/is_carbon = FALSE
+	if (iscarbon(user))
+		is_carbon = TRUE
+		var/mob/living/carbon/C = user
+		if (C.bioHolder?.HasEffect("telekinesis"))
+			has_telekinesis = TRUE
+
 	if(BOUNDS_DIST(source, user) == 0 || (IN_RANGE(source, user, 1))) // IN_RANGE is for general stuff, bounds_dist is for large sprites, presumably
-		if(mobuser && !istype(mobuser.loc, /turf)) // if we're not on a turf, we can only interact with stuff inside the same object or in ourselves
+		if(!has_telekinesis && mobuser && !istype(mobuser.loc, /turf)) // if we're not on a turf, we can only interact with stuff inside the same object or in ourselves
 			if(!((source == mobuser.loc) || (source in mobuser.loc) || (source in mobuser)))
 				return FALSE
 		return TRUE
@@ -132,36 +140,32 @@ var/stink_remedy = list("some deodorant","a shower","a bath","a spraydown with a
 		for_by_tcl(TR, /obj/item/terminus_drive)
 			if(IN_RANGE(user,TR,1))
 				return TRUE
-	else
-		if (iscarbon(user))
-			var/mob/living/carbon/C = user
-			if (C.bioHolder?.HasEffect("telekinesis") && GET_DIST(source, user) <= 7) //You can only reach stuff within your screen.
-				var/X = source:x
-				var/Y = source:y
-				var/Z = source:z
-				if (isrestrictedz(Z) || isrestrictedz(user:z))
-					boutput(user, SPAN_ALERT("Your telekinetic powers don't seem to work here."))
-					return FALSE
-				SPAWN(0)
-					//I really shouldnt put this here but i dont have a better idea
-					var/obj/overlay/O = new /obj/overlay ( locate(X,Y,Z) )
-					O.name = "sparkles"
-					O.anchored = ANCHORED
-					O.set_density(0)
-					O.layer = FLY_LAYER
-					O.set_dir(pick(cardinal))
-					O.icon = 'icons/effects/effects.dmi'
-					O.icon_state = "nothing"
-					flick("empdisable",O)
-					sleep(0.5 SECONDS)
-					qdel(O)
+	else if (has_telekinesis && GET_DIST(source, user) <= 7) //You can only reach stuff within your screen.
+		var/X = source:x
+		var/Y = source:y
+		var/Z = source:z
+		if (isrestrictedz(Z) || isrestrictedz(user:z))
+			boutput(user, SPAN_ALERT("Your telekinetic powers don't seem to work here."))
+			return FALSE
+		SPAWN(0)
+			//I really shouldnt put this here but i dont have a better idea
+			var/obj/overlay/O = new /obj/overlay ( locate(X,Y,Z) )
+			O.name = "sparkles"
+			O.anchored = ANCHORED
+			O.set_density(0)
+			O.layer = FLY_LAYER
+			O.set_dir(pick(cardinal))
+			O.icon = 'icons/effects/effects.dmi'
+			O.icon_state = "nothing"
+			flick("empdisable",O)
+			sleep(0.5 SECONDS)
+			qdel(O)
 
-				return TRUE
-
-		else if (isobj(source))
-			var/obj/SO = source
-			if(SO.can_access_remotely(user))
-				return TRUE
+		return TRUE
+	else if (!is_carbon && isobj(source))
+		var/obj/SO = source
+		if(SO.can_access_remotely(user))
+			return TRUE
 
 	if (mirrored_physical_zone_created) //checking for vistargets if true
 		var/turf/T = get_turf(source)

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -115,6 +115,9 @@ var/stink_remedy = list("some deodorant","a shower","a bath","a spraydown with a
 	ENSURE_TYPE(mobuser)
 	if(mobuser?.client?.holder?.ghost_interaction)
 		return TRUE
+	if(!istype(mobuser.loc, /turf)) // if we're not on a turf, we can only interact with stuff inside the same object or in ourselves
+		if(!((source in mobuser.loc) || (source in mobuser)))
+			return FALSE
 	if(istype(source, /mob))
 		var/mob/target = source
 		if (target.next_move > world.time && IN_RANGE(target.prev_loc, user, 1))

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -120,7 +120,7 @@ var/stink_remedy = list("some deodorant","a shower","a bath","a spraydown with a
 		if (target.next_move > world.time && IN_RANGE(target.prev_loc, user, 1))
 			return TRUE
 	if(BOUNDS_DIST(source, user) == 0 || (IN_RANGE(source, user, 1))) // IN_RANGE is for general stuff, bounds_dist is for large sprites, presumably
-		if(!istype(mobuser.loc, /turf)) // if we're not on a turf, we can only interact with stuff inside the same object or in ourselves
+		if(mobuser && !istype(mobuser.loc, /turf)) // if we're not on a turf, we can only interact with stuff inside the same object or in ourselves
 			if(!((source == mobuser.loc) || (source in mobuser.loc) || (source in mobuser)))
 				return FALSE
 		return TRUE

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -115,14 +115,14 @@ var/stink_remedy = list("some deodorant","a shower","a bath","a spraydown with a
 	ENSURE_TYPE(mobuser)
 	if(mobuser?.client?.holder?.ghost_interaction)
 		return TRUE
-	if(!istype(mobuser.loc, /turf)) // if we're not on a turf, we can only interact with stuff inside the same object or in ourselves
-		if(!((source == mobuser.loc) || (source in mobuser.loc) || (source in mobuser)))
-			return FALSE
 	if(istype(source, /mob))
 		var/mob/target = source
 		if (target.next_move > world.time && IN_RANGE(target.prev_loc, user, 1))
 			return TRUE
 	if(BOUNDS_DIST(source, user) == 0 || (IN_RANGE(source, user, 1))) // IN_RANGE is for general stuff, bounds_dist is for large sprites, presumably
+		if(!istype(mobuser.loc, /turf)) // if we're not on a turf, we can only interact with stuff inside the same object or in ourselves
+			if(!((source == mobuser.loc) || (source in mobuser.loc) || (source in mobuser)))
+				return FALSE
 		return TRUE
 	else if (source in bible_contents)
 		for_by_tcl(B, /obj/item/bible) // o coder past, quieten your rage
@@ -141,7 +141,7 @@ var/stink_remedy = list("some deodorant","a shower","a bath","a spraydown with a
 				var/Z = source:z
 				if (isrestrictedz(Z) || isrestrictedz(user:z))
 					boutput(user, SPAN_ALERT("Your telekinetic powers don't seem to work here."))
-					return 0
+					return FALSE
 				SPAWN(0)
 					//I really shouldnt put this here but i dont have a better idea
 					var/obj/overlay/O = new /obj/overlay ( locate(X,Y,Z) )

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -116,7 +116,7 @@ var/stink_remedy = list("some deodorant","a shower","a bath","a spraydown with a
 	if(mobuser?.client?.holder?.ghost_interaction)
 		return TRUE
 	if(!istype(mobuser.loc, /turf)) // if we're not on a turf, we can only interact with stuff inside the same object or in ourselves
-		if(!((source in mobuser.loc) || (source in mobuser)))
+		if(!((source == mobuser.loc) || (source in mobuser.loc) || (source in mobuser)))
 			return FALSE
 	if(istype(source, /mob))
 		var/mob/target = source


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Change interaction range so that when you're inside an object or mob, you can only interact with items that are:
* The object you're clicking on (i.e. opening a locker with a hand while inside)
* Something else inside the same object
* Something on your person (i.e. a held item)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes operating computers from within a neighboring locker/dimensional shift/etc
Fixes #19385
Fixes #22107

Does NOT prevent cyborgs from click-dragging items inside stations while inside.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)When inside an object or mob, you cannot interact with things outside it.
```