### PR TITLE
Rework how plasmalungs trait is applied to mobs and antags

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -885,7 +885,7 @@
 		newbody.traitHolder.owner = newbody
 		if (src.spell_soulguard)
 			newbody.equip_sensory_items()
-			newbody.equip_body_traits(is_antagonist=(src.spell_soulguard==SOULGUARD_SPELL))
+			newbody.equip_body_traits(extended_tank=(src.spell_soulguard==SOULGUARD_SPELL))
 
 	// Prone to causing runtimes, don't enable.
 /*	if (src.mutantrace && !src.spell_soulguard)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -885,6 +885,7 @@
 		newbody.traitHolder.owner = newbody
 		if (src.spell_soulguard)
 			newbody.equip_sensory_items()
+			newbody.equip_body_traits(is_antagonist=(src.spell_soulguard==SOULGUARD_SPELL))
 
 	// Prone to causing runtimes, don't enable.
 /*	if (src.mutantrace && !src.spell_soulguard)
@@ -1949,6 +1950,23 @@
 				else
 					return 0
 
+/**
+Attempts to put an item in the hand of a mob, if not possible then stow it, then by default delete the item.
+
+ * @param I The item to put in the hand.
+
+ * @param hand The hand to put the item in.
+
+ * @param delete_item If TRUE, the item will be deleted if it cannot be put in hand or stowed. If FALSE, the item is dropped at the current location.
+
+ * @return TRUE if the item was successfully put in hand or stowed, FALSE otherwise.
+**/
+/mob/living/carbon/human/proc/put_in_hand_or_stow(obj/item/I, hand, delete_item = TRUE)
+	if (!src.put_in_hand(I, hand))
+		if(!src.stow_in_available(I, delete_item))
+			return FALSE
+	return TRUE
+
 /mob/living/carbon/human/proc/get_slot(slot)
 	switch(slot)
 		if (SLOT_BACK)
@@ -2295,24 +2313,34 @@
 			src.drop_from_slot(current, get_turf(current))
 	src.force_equip(I, slot)
 	return TRUE
-///Tries to put an item in an available backpack, pocket, or hand slot, default specified to delete the item if unsuccessful
+
+/**
+Tries to put an item in an available backpack, belt storage, pocket, or hand slot. Will delete items that cannot be placed by default.
+
+ * @param I The item to stow.
+
+ * @param delete_item If TRUE, the item will be deleted if it cannot be stowed. If FALSE, the item is dropped at the current location.
+
+ * @return TRUE if the item was stowed, FALSE if it was not.
+**/
 /mob/living/carbon/human/proc/stow_in_available(obj/item/I, delete_item = TRUE)
 	if (src.autoequip_slot(I, SLOT_IN_BACKPACK))
-		return
+		return TRUE
 	if (src.autoequip_slot(I, SLOT_IN_BELT))
-		return
+		return TRUE
 	if (src.autoequip_slot(I, SLOT_L_STORE))
-		return
+		return TRUE
 	if (src.autoequip_slot(I, SLOT_R_STORE))
-		return
+		return TRUE
 	if (src.autoequip_slot(I, SLOT_L_HAND))
-		return
+		return TRUE
 	if (src.autoequip_slot(I, SLOT_R_HAND))
-		return
+		return TRUE
 	if (delete_item)
 		qdel(I)
 	else
 		I.set_loc(get_turf(src))
+	return FALSE
 
 /mob/living/carbon/human/swap_hand(var/specify=-1)
 	if(src.hand == specify)

--- a/code/modules/antagonists/basketball/basketball_wizard.dm
+++ b/code/modules/antagonists/basketball/basketball_wizard.dm
@@ -12,18 +12,13 @@
 		H.equip_new_if_possible(pick(concrete_typesof(/obj/item/clothing/under/jersey)), SLOT_W_UNIFORM)
 		H.equip_new_if_possible(/obj/item/clothing/shoes/white, SLOT_SHOES)
 		H.equip_new_if_possible(pick(concrete_typesof(/obj/item/clothing/head/wizard)), SLOT_HEAD)
-		H.equip_if_possible(new /obj/item/device/radio/headset/wizard(H), SLOT_EARS)
+		H.equip_new_if_possible(/obj/item/device/radio/headset/wizard, SLOT_EARS)
+		H.equip_new_if_possible(/obj/item/tank/emergency_oxygen/extended, SLOT_L_STORE)
 		H.equip_new_if_possible(/obj/item/bball_uplink, SLOT_R_STORE)
 		H.equip_new_if_possible(/obj/item/storage/backpack, SLOT_BACK)
 		H.equip_new_if_possible(/obj/item/basketball, SLOT_R_HAND)
 		SPAWN(0)
 			H.choose_name(what_you_are="Basketball Wizard")
 
-		if("plasmalungs" in H.client?.preferences.traitPreferences.traits_selected)
-			H.equip_if_possible(new /obj/item/clothing/mask/breath(H), SLOT_WEAR_MASK)
-			H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended/plasma(H), SLOT_L_STORE)
-		else
-			H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended(H), SLOT_L_STORE)
-
 		H.equip_sensory_items()
-
+		H.equip_body_traits(is_antagonist=TRUE)

--- a/code/modules/antagonists/basketball/basketball_wizard.dm
+++ b/code/modules/antagonists/basketball/basketball_wizard.dm
@@ -21,4 +21,4 @@
 			H.choose_name(what_you_are="Basketball Wizard")
 
 		H.equip_sensory_items()
-		H.equip_body_traits(is_antagonist=TRUE)
+		H.equip_body_traits(extended_tank=TRUE)

--- a/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
+++ b/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
@@ -45,11 +45,7 @@
 		H.equip_if_possible(new /obj/item/clothing/mask/gas/swat/syndicate(H), SLOT_WEAR_MASK)
 		H.equip_if_possible(new /obj/item/clothing/glasses/sunglasses(H), SLOT_GLASSES)
 		H.equip_if_possible(new /obj/item/requisition_token/syndicate(H), SLOT_R_STORE)
-
-		if("plasmalungs" in src.owner.current.client?.preferences.traitPreferences.traits_selected) //sigh
-			H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended/plasma(H), SLOT_L_STORE)
-		else
-			H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended(H), SLOT_L_STORE)
+		H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended(H), SLOT_L_STORE)
 
 		if(src.id == ROLE_NUKEOP_COMMANDER)
 			H.equip_if_possible(new /obj/item/clothing/head/helmet/space/syndicate/commissar_cap(H), SLOT_HEAD)
@@ -62,6 +58,7 @@
 			H.equip_if_possible(new /obj/item/device/radio/headset/syndicate(H), SLOT_EARS)
 
 		H.equip_sensory_items()
+		H.equip_body_traits(is_antagonist=TRUE)
 
 		var/obj/item/card/id/syndicate/ID
 		if(src.id == ROLE_NUKEOP_COMMANDER)

--- a/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
+++ b/code/modules/antagonists/nuclear_operative/nuclear_operative.dm
@@ -58,7 +58,7 @@
 			H.equip_if_possible(new /obj/item/device/radio/headset/syndicate(H), SLOT_EARS)
 
 		H.equip_sensory_items()
-		H.equip_body_traits(is_antagonist=TRUE)
+		H.equip_body_traits(extended_tank=TRUE)
 
 		var/obj/item/card/id/syndicate/ID
 		if(src.id == ROLE_NUKEOP_COMMANDER)

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -62,7 +62,7 @@
 		H.equip_if_possible(new /obj/item/pirate_hand_tele(H), SLOT_R_HAND)
 
 		H.equip_sensory_items()
-		H.equip_body_traits(is_antagonist=TRUE)
+		H.equip_body_traits(extended_tank=TRUE)
 
 		H.traitHolder.addTrait("training_drinker")
 		H.addBioEffect("accent_pirate")

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -62,6 +62,7 @@
 		H.equip_if_possible(new /obj/item/pirate_hand_tele(H), SLOT_R_HAND)
 
 		H.equip_sensory_items()
+		H.equip_body_traits(is_antagonist=TRUE)
 
 		H.traitHolder.addTrait("training_drinker")
 		H.addBioEffect("accent_pirate")

--- a/code/modules/antagonists/salvager/salvager.dm
+++ b/code/modules/antagonists/salvager/salvager.dm
@@ -25,15 +25,6 @@
 		H.equip_if_possible(new /obj/item/clothing/suit/space/salvager(H), SLOT_WEAR_SUIT)
 		H.equip_if_possible(new /obj/item/clothing/glasses/salvager(H), SLOT_GLASSES)
 
-		var/obj/item/clothing/glasses/G = H.glasses
-		if(istype(G))
-			if (H.traitHolder.hasTrait("shortsighted"))
-				G.correct_bad_vision = TRUE
-			if (H.traitHolder.hasTrait("blind"))
-				G.allow_blind_sight = TRUE
-
-		H.equip_sensory_items()
-
 		var/obj/item/device/radio/headset/headset = H.ears
 		if(!headset)
 			headset = new /obj/item/device/radio/headset/salvager
@@ -64,6 +55,7 @@
 		H.equip_new_if_possible(/obj/item/tool/omnitool, SLOT_IN_BACKPACK)
 		H.equip_new_if_possible(/obj/item/weldingtool, SLOT_IN_BACKPACK)
 
+		// we don't need to add body or sensory trait items as we have removed all traits above
 		H.traitHolder.addTrait("training_engineer")
 
 	add_to_image_groups()

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -62,7 +62,7 @@
 		H.equip_if_possible(SB, SLOT_BELT)
 
 		H.equip_sensory_items()
-		H.equip_body_traits(is_antagonist=TRUE)
+		H.equip_body_traits(extended_tank=TRUE)
 
 		H.assign_gimmick_skull()
 

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -50,11 +50,7 @@
 		H.equip_if_possible(new /obj/item/clothing/suit/wizrobe(H), SLOT_WEAR_SUIT)
 		H.equip_if_possible(new /obj/item/clothing/head/wizard(H), SLOT_HEAD)
 		H.equip_if_possible(new /obj/item/clothing/shoes/sandal/magic/wizard(H), SLOT_SHOES)
-		if("plasmalungs" in H.client?.preferences.traitPreferences.traits_selected)
-			H.equip_if_possible(new /obj/item/clothing/mask/breath(H), SLOT_WEAR_MASK)
-			H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended/plasma(H), SLOT_L_STORE)
-		else
-			H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended(H), SLOT_L_STORE)
+		H.equip_if_possible(new /obj/item/tank/emergency_oxygen/extended(H), SLOT_L_STORE)
 		H.equip_if_possible(new /obj/item/paper/Wizardry101(H), SLOT_R_STORE)
 		H.equip_if_possible(new /obj/item/staff(H), SLOT_R_HAND)
 
@@ -66,6 +62,7 @@
 		H.equip_if_possible(SB, SLOT_BELT)
 
 		H.equip_sensory_items()
+		H.equip_body_traits(is_antagonist=TRUE)
 
 		H.assign_gimmick_skull()
 

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -530,17 +530,30 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 			src.stow_in_available(src.ears)
 		src.equip_if_possible(new /obj/item/device/radio/headset/deaf(src), SLOT_EARS)
 
+/**
+Equip items from body traits.
+
+ * @param is_antagonist - If TRUE, the mob is an antagonist and will spawn with a pocket extended tank instead of a mini tank.
+
+**/
 /// Equip items from body traits
-/mob/living/carbon/human/proc/equip_body_traits()
+/mob/living/carbon/human/proc/equip_body_traits(is_antagonist=FALSE)
 	if (src.traitHolder && src.traitHolder.hasTrait("plasmalungs"))
 		if (src.wear_mask && !(src.wear_mask.c_flags & MASKINTERNALS)) //drop non-internals masks
 			src.stow_in_available(src.wear_mask)
 
 		if(!src.wear_mask)
 			src.equip_if_possible(new /obj/item/clothing/mask/breath(src), SLOT_WEAR_MASK)
-
-		var/obj/item/tank/good_air = new /obj/item/tank/mini_plasma(src)
-		src.put_in_hand_or_drop(good_air)
+		var/obj/item/tank/good_air
+		if (is_antagonist)
+			good_air = new /obj/item/tank/emergency_oxygen/extended/plasma(src)
+			// TODO: antagonists spawn tanks in the left pocket by practice, not pattern
+			if (istype(src.l_store, /obj/item/tank/emergency_oxygen/extended))
+				qdel(src.l_store)
+			src.equip_if_possible(good_air, SLOT_L_STORE)
+		else
+			good_air = new /obj/item/tank/mini_plasma(src)
+			src.put_in_hand_or_stow(good_air, delete_item=FALSE)
 		if (!good_air.using_internal())//set tank ON
 			good_air.toggle_valve()
 
@@ -694,9 +707,9 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 
 	// Special mutantrace items
 	if (src.traitHolder && src.traitHolder.hasTrait("pug"))
-		src.put_in_hand_or_drop(new /obj/item/reagent_containers/food/snacks/cookie/dog)
+		src.put_in_hand_or_stow(new /obj/item/reagent_containers/food/snacks/cookie/dog, delete_item = FALSE)
 	else if (src.traitHolder && src.traitHolder.hasTrait("skeleton"))
-		src.put_in_hand_or_drop(new /obj/item/joint_wax)
+		src.put_in_hand_or_stow(new /obj/item/joint_wax, delete_item = FALSE)
 
 	src.equip_sensory_items()
 

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -536,7 +536,6 @@ Equip items from body traits.
  * @param is_antagonist - If TRUE, the mob is an antagonist and will spawn with a pocket extended tank instead of a mini tank.
 
 **/
-/// Equip items from body traits
 /mob/living/carbon/human/proc/equip_body_traits(is_antagonist=FALSE)
 	if (src.traitHolder && src.traitHolder.hasTrait("plasmalungs"))
 		if (src.wear_mask && !(src.wear_mask.c_flags & MASKINTERNALS)) //drop non-internals masks
@@ -547,7 +546,7 @@ Equip items from body traits.
 		var/obj/item/tank/good_air
 		if (is_antagonist)
 			good_air = new /obj/item/tank/emergency_oxygen/extended/plasma(src)
-			// TODO: antagonists spawn tanks in the left pocket by practice, not pattern
+			// TODO: antagonists spawn tanks in the left pocket by practice(copy/paste), not pattern
 			if (istype(src.l_store, /obj/item/tank/emergency_oxygen/extended))
 				qdel(src.l_store)
 			src.equip_if_possible(good_air, SLOT_L_STORE)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -533,10 +533,10 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 /**
 Equip items from body traits.
 
- * @param is_antagonist - If TRUE, the mob is an antagonist and will spawn with a pocket extended tank instead of a mini tank.
+ * @param extended_tank - If TRUE, the mob will spawn with a pocket extended tank instead of a mini tank.
 
 **/
-/mob/living/carbon/human/proc/equip_body_traits(is_antagonist=FALSE)
+/mob/living/carbon/human/proc/equip_body_traits(extended_tank=FALSE)
 	if (src.traitHolder && src.traitHolder.hasTrait("plasmalungs"))
 		if (src.wear_mask && !(src.wear_mask.c_flags & MASKINTERNALS)) //drop non-internals masks
 			src.stow_in_available(src.wear_mask)
@@ -544,7 +544,7 @@ Equip items from body traits.
 		if(!src.wear_mask)
 			src.equip_if_possible(new /obj/item/clothing/mask/breath(src), SLOT_WEAR_MASK)
 		var/obj/item/tank/good_air
-		if (is_antagonist)
+		if (extended_tank)
 			good_air = new /obj/item/tank/emergency_oxygen/extended/plasma(src)
 			// TODO: antagonists spawn tanks in the left pocket by practice(copy/paste), not pattern
 			if (istype(src.l_store, /obj/item/tank/emergency_oxygen/extended))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][traits]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reworks how the plasmalungs trait is applied to mobs on spawn:
* New helper proc: `put_in_hand_or_stow`
  * Attempts to place an item in-hand, and if that fails, in storage, and then either delete or place the item on the ground based on a var.
  * Call this in job setup wherever items are put in hand or dropped.
* Changes to `equip_body_traits`
  * Now accepts an `extended_tank` var, which will handle replacement of the extended oxygen tanks normally given to antagonists
  * Uses `put_in_hand_or_stow` for the mini plasma tank
* Antagonists
  * Antagonists that spawn with sensory items now also call `equip_body_traits` with `extended_tank` set to `TRUE`
  * Salvagers have all traits removed, so remove trait handling and leave a comment explaining why we don't call `equip_sensory_items` / `equip_body_traits` instead

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #22112
Reduces code duplication/special handling for plasmalungs trait in antagonist code  