### PR TITLE
Fix turboflash deconstruction

### DIFF
--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -400,12 +400,11 @@ TYPEINFO(/obj/item/device/flash/turbo)
 			return
 		if (iswrenchingtool(W) && !(src.secure))
 			boutput(user, "You disassemble [src]!")
-			src.cell.set_loc(get_turf(src))
-			var/obj/item/device/flash/F = new /obj/item/device/flash(get_turf(src.cell)) // is src.cell's turf because src's turf causes #22144 somehow
+			var/obj/item/device/flash/F = new /obj/item/device/flash(get_turf(src))
 			if(!src.status)
 				F.status = 0
 				F.set_icon_state("flash3")
-			qdel(src)
+			src.cell.set_loc(get_turf(src)) //Do this last as removing the cell deletes the turboflash
 		else if (isscrewingtool(W))
 			boutput(user, SPAN_NOTICE("You [src.secure ? "unscrew" : "secure"] the access panel."))
 			secure = !secure

--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -401,7 +401,7 @@ TYPEINFO(/obj/item/device/flash/turbo)
 		if (iswrenchingtool(W) && !(src.secure))
 			boutput(user, "You disassemble [src]!")
 			src.cell.set_loc(get_turf(src))
-			var/obj/item/device/flash/F = new /obj/item/device/flash(get_turf(src.cell)) // is src.cell's turf src's turf causes #22144 somehow
+			var/obj/item/device/flash/F = new /obj/item/device/flash(get_turf(src.cell)) // is src.cell's turf because src's turf causes #22144 somehow
 			if(!src.status)
 				F.status = 0
 				F.set_icon_state("flash3")

--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -401,7 +401,7 @@ TYPEINFO(/obj/item/device/flash/turbo)
 		if (iswrenchingtool(W) && !(src.secure))
 			boutput(user, "You disassemble [src]!")
 			src.cell.set_loc(get_turf(src))
-			var/obj/item/device/flash/F = new /obj/item/device/flash( get_turf(src) )
+			var/obj/item/device/flash/F = new /obj/item/device/flash(get_turf(src.cell)) // is src.cell's turf src's turf causes #22144 somehow
 			if(!src.status)
 				F.status = 0
 				F.set_icon_state("flash3")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes flash-cell assemblies not dropping a flash when deconstructed

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #22144
