### PR TITLE
Colour coded command chairs

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -4438,14 +4438,13 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "azs" = (
-/obj/stool/chair/office/red{
-	dir = 4;
-	tag = "icon-office_chair_red (EAST)"
-	},
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/stool/chair/comfy/blue{
+	dir = 4
 	},
 /turf/simulated/floor/wood/two,
 /area/station/bridge/united_command)
@@ -4464,14 +4463,13 @@
 /turf/simulated/floor/wood/two,
 /area/station/bridge/united_command)
 "azv" = (
-/obj/stool/chair/office/purple{
-	dir = 8;
-	tag = "icon-office_chair_purple (WEST)"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
+/obj/stool/chair/comfy/green{
+	dir = 8
+	},
 /turf/simulated/floor/wood/two,
 /area/station/bridge/united_command)
 "azx" = (
@@ -4620,13 +4618,12 @@
 /turf/simulated/floor/stairs/medical,
 /area/station/medical/medbay/cloner)
 "aAg" = (
-/obj/stool/chair/office/red{
-	dir = 4;
-	tag = "icon-office_chair_red (EAST)"
-	},
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
 	icon_state = "0-4"
+	},
+/obj/stool/chair/comfy/purple{
+	dir = 4
 	},
 /turf/simulated/floor/wood/two,
 /area/station/bridge/united_command)
@@ -4805,12 +4802,11 @@
 /turf/simulated/floor/wood/two,
 /area/station/bridge/united_command)
 "aAX" = (
-/obj/stool/chair/office/yellow{
-	dir = 1;
-	tag = "icon-office_chair_yellow (NORTH)"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/stool/chair/comfy/ergonomic{
+	dir = 1
 	},
 /turf/simulated/floor/wood/two,
 /area/station/bridge/united_command)
@@ -7964,11 +7960,11 @@
 	},
 /area/station/medical/medbay)
 "aSW" = (
-/obj/stool/chair/office/blue,
 /obj/machinery/light_switch/auto,
 /obj/machinery/alarm{
 	pixel_y = 25
 	},
+/obj/stool/chair/office/blue,
 /turf/simulated/floor/wood/two,
 /area/station/bridge/united_command)
 "aSY" = (
@@ -8515,7 +8511,6 @@
 	},
 /area/station/medical/medbay)
 "aWz" = (
-/obj/stool/chair/office/blue,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -8523,6 +8518,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/stool/chair/office/blue,
 /turf/simulated/floor/wood/two,
 /area/station/bridge/united_command)
 "aWA" = (
@@ -17183,6 +17179,15 @@
 /obj/machinery/power/apc/autoname_north/hardened,
 /turf/simulated/floor/black,
 /area/listeningpost/power)
+"mLT" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/stool/chair/comfy/red{
+	dir = 1
+	},
+/turf/simulated/floor/wood/two,
+/area/station/bridge/united_command)
 "mMP" = (
 /obj/table/reinforced/auto,
 /obj/item/clothing/head/helmet/welding{
@@ -24413,13 +24418,12 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "xBH" = (
-/obj/stool/chair/office/purple{
-	dir = 8;
-	tag = "icon-office_chair_purple (WEST)"
-	},
 /obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/stool/chair/comfy/yellow{
+	dir = 8
 	},
 /turf/simulated/floor/wood/two,
 /area/station/bridge/united_command)
@@ -82072,7 +82076,7 @@ azf
 aSW
 azu
 aAi
-aAX
+mLT
 azf
 wrZ
 ayi

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -14231,15 +14231,15 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "dJD" = (
-/obj/stool/chair/comfy/blue{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/stool/chair/office/blue{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -33167,7 +33167,7 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen/freezer)
 "rEV" = (
-/obj/stool/chair/comfy/blue{
+/obj/stool/chair/comfy/yellow{
 	dir = 8
 	},
 /obj/cable{
@@ -39400,7 +39400,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/stool/chair/comfy/blue{
+/obj/stool/chair/comfy/ergonomic{
 	dir = 1
 	},
 /obj/landmark/start/job/captain,
@@ -40021,7 +40021,7 @@
 /turf/simulated/floor/carpet/blue/fancy,
 /area/station/hallway/primary/south)
 "wvu" = (
-/obj/stool/chair/comfy/blue{
+/obj/stool/chair/comfy/purple{
 	dir = 8
 	},
 /obj/cable{
@@ -40108,7 +40108,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/stool/chair/comfy/blue{
+/obj/stool/chair/comfy/green{
 	dir = 8
 	},
 /obj/landmark/start/job/head_of_personnel,
@@ -41917,7 +41917,7 @@
 /turf/simulated/floor/greenblack,
 /area/station/hallway/primary/east)
 "xTZ" = (
-/obj/stool/chair/comfy/blue{
+/obj/stool/chair/comfy/red{
 	dir = 4
 	},
 /obj/cable{

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -13062,10 +13062,10 @@
 	},
 /area/station/bridge)
 "aTW" = (
-/obj/stool/chair/comfy,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/stool/chair/comfy/purple,
 /turf/simulated/floor/carpet{
 	icon_state = "blue1"
 	},
@@ -13476,6 +13476,9 @@
 	},
 /area/station/bridge)
 "aVj" = (
+/obj/stool/chair/comfy{
+	dir = 4
+	},
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fblue2"
@@ -14533,11 +14536,11 @@
 	},
 /area/station/bridge)
 "aXW" = (
-/obj/stool/chair/comfy{
-	dir = 1
-	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/stool/chair/comfy/green{
+	dir = 1
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "blue1"
@@ -45660,6 +45663,15 @@
 /obj/machinery/door/airlock/pyro,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
+"joX" = (
+/obj/stool/chair/comfy/red{
+	dir = 4
+	},
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fblue2"
+	},
+/area/station/bridge)
 "jpj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -52546,6 +52558,17 @@
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
+"oCc" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/stool/chair/comfy/yellow{
+	dir = 1
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "blue1"
+	},
+/area/station/bridge)
 "oCo" = (
 /obj/storage/secure/closet/civilian/janitor,
 /obj/item/reagent_containers/glass/bottle/cleaner,
@@ -58074,6 +58097,15 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/engine/coldloop)
+"sHp" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/stool/chair/comfy/blue,
+/turf/simulated/floor/carpet{
+	icon_state = "blue1"
+	},
+/area/station/bridge)
 "sHJ" = (
 /obj/machinery/computer/solar_control/east{
 	dir = 4
@@ -90172,7 +90204,7 @@ aQL
 aQN
 aQN
 aTU
-aVj
+joX
 aVj
 aXU
 aQN
@@ -91077,10 +91109,10 @@ aPN
 aQN
 aQN
 aSO
-aTW
+sHp
 aVm
 aOH
-aXW
+oCc
 aYZ
 aQN
 baS

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -28519,7 +28519,7 @@
 /turf/simulated/floor/circuit/off,
 /area/station/bridge)
 "bHF" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/comfy/yellow{
 	dir = 4
 	},
 /turf/simulated/floor/carpet{
@@ -28537,7 +28537,7 @@
 	},
 /area/station/bridge)
 "bHI" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/comfy/green{
 	dir = 8
 	},
 /turf/simulated/floor/carpet{
@@ -29313,9 +29313,6 @@
 /turf/simulated/floor/circuit/off,
 /area/station/bridge)
 "bJC" = (
-/obj/stool/chair/comfy{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -29323,6 +29320,9 @@
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/stool/chair/comfy/purple{
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -30056,11 +30056,11 @@
 	},
 /area/station/bridge)
 "bLm" = (
-/obj/stool/chair/comfy{
-	dir = 8
-	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/stool/chair/comfy/red{
+	dir = 8
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "blue1"
@@ -68045,6 +68045,15 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/blue/side,
 /area/station/medical/medbay/surgery/storage)
+"pYa" = (
+/obj/stool/chair/comfy/blue{
+	dir = 4
+	},
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fblue2"
+	},
+/area/station/bridge)
 "pYd" = (
 /obj/machinery/atmospherics/unary/vent{
 	dir = 4
@@ -143539,7 +143548,7 @@ hJe
 bBN
 bDK
 bFG
-bHF
+pYa
 bJC
 bHF
 bMU

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -28581,7 +28581,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/stool/chair/comfy/blue{
+/obj/stool/chair/comfy/yellow{
 	dir = 4
 	},
 /obj/landmark/start/job/chief_engineer,
@@ -33759,7 +33759,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/stool/chair/comfy/blue{
+/obj/stool/chair/comfy/red{
 	dir = 8
 	},
 /obj/landmark/start/job/head_of_security,
@@ -45955,7 +45955,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/stool/chair/comfy/blue{
+/obj/stool/chair/comfy/purple{
 	dir = 4
 	},
 /obj/landmark/start/job/research_director,
@@ -49353,7 +49353,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/stool/chair/comfy/blue{
+/obj/stool/chair/comfy/ergonomic{
 	dir = 8
 	},
 /obj/landmark/start/job/captain,
@@ -52363,7 +52363,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "xza" = (
-/obj/stool/chair/comfy/blue{
+/obj/stool/chair/comfy/green{
 	dir = 8
 	},
 /obj/landmark/start/job/head_of_personnel,

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -1246,7 +1246,7 @@
 	},
 /area/station/engine/monitoring)
 "apH" = (
-/obj/stool/chair/comfy,
+/obj/stool/chair/comfy/blue,
 /obj/landmark/start/job/medical_director,
 /turf/simulated/floor/blueblack,
 /area/station/bridge)
@@ -4172,7 +4172,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "biw" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/comfy/red{
 	dir = 1
 	},
 /obj/landmark/start/job/head_of_security,
@@ -10803,7 +10803,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/security/beepsky)
 "ddA" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/comfy/green{
 	dir = 8
 	},
 /obj/landmark/start/job/head_of_personnel,
@@ -23512,7 +23512,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "haF" = (
-/obj/stool/chair/comfy,
+/obj/stool/chair/comfy/purple,
 /obj/landmark/start/job/research_director,
 /obj/disposalpipe/segment/mail{
 	dir = 8;
@@ -62723,7 +62723,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/south)
 "tac" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/comfy/yellow{
 	dir = 1
 	},
 /obj/landmark/start/job/chief_engineer,

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -35182,7 +35182,7 @@
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
 "gfS" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/comfy/red{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
@@ -39058,7 +39058,7 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/north,
 /area/station/crew_quarters/quarters_east)
 "iQo" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/comfy/green{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
@@ -39135,7 +39135,7 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "iSr" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/comfy/blue{
 	dir = 8
 	},
 /obj/cable{
@@ -46548,7 +46548,7 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
 "okq" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/comfy/purple{
 	dir = 8
 	},
 /obj/cable{
@@ -55992,7 +55992,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "uTa" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/comfy/yellow{
 	dir = 8
 	},
 /obj/cable{

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -4131,6 +4131,12 @@
 	dir = 6
 	},
 /area/station/crew_quarters/market)
+"bPW" = (
+/obj/stool/chair/comfy/blue{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/station/bridge)
 "bQb" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -7261,6 +7267,15 @@
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
+"dnE" = (
+/obj/stool/chair/comfy/red{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/west,
+/area/station/bridge)
 "dnH" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -8923,7 +8938,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quarters_east)
 "dYQ" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/comfy/yellow{
 	dir = 1
 	},
 /obj/disposalpipe/segment/mail/horizontal,
@@ -26249,7 +26264,7 @@
 /turf/simulated/floor/blueblack,
 /area/station/medical/medbay/pharmacy)
 "kVX" = (
-/obj/stool/chair/comfy,
+/obj/stool/chair/office/blue,
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/bridge)
@@ -40614,7 +40629,7 @@
 	},
 /area/station/medical/medbay)
 "rhk" = (
-/obj/stool/chair/comfy,
+/obj/stool/chair/office/blue,
 /obj/item/device/radio/intercom/bridge{
 	broadcasting = 0
 	},
@@ -41946,6 +41961,13 @@
 "rNu" = (
 /turf/simulated/floor/engine/caution/corner,
 /area/shuttle/sea_elevator/upper)
+"rNP" = (
+/obj/stool/chair/comfy/green{
+	dir = 1
+	},
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
+/area/station/bridge)
 "rOp" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
@@ -52632,7 +52654,7 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "wwq" = (
-/obj/stool/chair/comfy{
+/obj/stool/chair/comfy/purple{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
@@ -99256,7 +99278,7 @@ azs
 bRH
 iPe
 nKK
-tvE
+dnE
 tvE
 lsG
 ldw
@@ -99560,7 +99582,7 @@ iPe
 kVX
 tbq
 sQw
-dYQ
+rNP
 cdL
 ihW
 lHV
@@ -100162,7 +100184,7 @@ wOo
 gMN
 iPe
 xvD
-wwq
+bPW
 wwq
 qzz
 kyo

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -38101,7 +38101,7 @@
 /turf/simulated/floor/black,
 /area/station/science/artifact)
 "leR" = (
-/obj/stool/chair/comfy/green{
+/obj/stool/chair/comfy/ergonomic{
 	dir = 4
 	},
 /obj/cable{
@@ -38328,7 +38328,7 @@
 	},
 /area/station/bridge/hos)
 "lvP" = (
-/obj/stool/chair/dining/wood{
+/obj/stool/chair/comfy/yellow{
 	dir = 4
 	},
 /obj/landmark/start/job/chief_engineer,
@@ -38774,7 +38774,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/maintenance/inner/central)
 "lZJ" = (
-/obj/stool/chair/dining/wood{
+/obj/stool/chair/comfy/purple{
 	dir = 8
 	},
 /obj/cable{
@@ -43170,7 +43170,7 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "rHv" = (
-/obj/stool/chair/dining/wood{
+/obj/stool/chair/comfy/blue{
 	dir = 8
 	},
 /obj/cable{
@@ -44084,7 +44084,7 @@
 /turf/simulated/floor/grass,
 /area/spacehabitat/owlery)
 "tbN" = (
-/obj/stool/chair/dining/wood{
+/obj/stool/chair/comfy/red{
 	dir = 8
 	},
 /obj/cable{
@@ -44288,7 +44288,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "toV" = (
-/obj/stool/chair/dining/wood{
+/obj/stool/chair/comfy/green{
 	dir = 4
 	},
 /obj/landmark/start/job/head_of_personnel,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the bridges of all maps on rotation to have colour coded command chairs.
![bridge](https://github.com/user-attachments/assets/d2fe2b5e-a907-4690-85db-ccb62df61eab)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Neat little detail.
