### PR TITLE
Fix DNR borgings

### DIFF
--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -1207,7 +1207,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/leg/right)
 				borg.death()
 				qdel(src)
 				return
-			if ( brain.owner  &&  (jobban_isbanned(brain.owner.current,"Cyborg") || (brain.owner.get_player().dnr && !src.syndicate)) ) //If the borg-to-be is jobbanned or has DNR set and the frame isn't syndie
+			if ( brain.owner  &&  (jobban_isbanned(brain.owner.current,"Cyborg") || brain.owner.get_player().dnr) ) //If the borg-to-be is jobbanned or has DNR set
 				src.visible_message(SPAN_ALERT("The brain inside [src] disintegrates!"))
 				borg.part_head.brain = null
 				qdel(brain)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the Jobban/DNR check for cyborgs to when the construction is completed and the mob is made, rather than when the brain is put in the head.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If someone gets borgbanned or sets DNR between brain being put in the head and the head being used to build a borg then they would still be borged. 

Fixes #18055
