### PR TITLE
Fix latejoin silicon missile warp

### DIFF
--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -486,6 +486,17 @@ var/global/list/persistent_bank_purchaseables =	list(\
 			var/mob/living/carbon/human/H = M
 			if(istype(H))
 				H.equip_new_if_possible(/obj/item/clothing/mask/breath, SLOT_WEAR_MASK)
+			var/mob/living/silicon/sillycon = M
+			if(istype(sillycon))
+				var/obj/item/organ/brain/latejoin/latejoin_brain = null
+				if (istype(sillycon,/mob/living/silicon/ai))
+					var/mob/living/silicon/ai/AI = sillycon
+					latejoin_brain = AI.brain
+				if (istype(sillycon,/mob/living/silicon/robot))
+					var/mob/living/silicon/robot/R = sillycon
+					latejoin_brain = R.part_head?.brain
+				if(istype(latejoin_brain))
+					return FALSE //Don't missile launch latejoin silicons that already exist
 			SPAWN(0)
 				if(istype(M.loc, /obj/storage))
 					launch_with_missile(M.loc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stops latejoin silicons from purchasing missile arrival


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
AIs and Borgs would teleport to their missile from wherever they were.
Fixes #17908

