### PR TITLE
Fix unable to cryo borgs

### DIFF
--- a/code/obj/cryotron.dm
+++ b/code/obj/cryotron.dm
@@ -367,9 +367,6 @@
 
 	/// Handling dragging players in to cryo, mainly for silicon players.
 	MouseDrop_T(atom/target, mob/user as mob)
-		if (!ishuman(target) && !isrobot(user))
-			return
-
 		if (BOUNDS_DIST(src, user) != 0)
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stops the human target robot user check on cryotron mousedrop, valid mob check is already handled in can_mob_enter_cryo proc that gets called in the insert prompt

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #18764