### PR TITLE
Add MouseDrop to the Aquatic Research Terminal

### DIFF
--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -427,32 +427,10 @@ TYPEINFO(/obj/item/fish_portal)
 			W.set_loc(src)
 			W.dropped(user)
 
-	MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
-		if (!isliving(user))
-			boutput(user, SPAN_ALERT("You can't do that while dead, this isn't Davy Jones' Locker!"))
-			return
-		if (BOUNDS_DIST(user, src) > 0)
-			boutput(user, SPAN_ALERT("You need to move closer to the [src] to do that."))
-			return
-		if (BOUNDS_DIST(O, user) > 0)
-			boutput(user, SPAN_ALERT("[O] is too far away to load into the [src]!"))
-			return
-		if (src.working)
-			boutput(user, SPAN_ALERT("The [src] is busy!"))
-			return
-
-		if (istype(O, /obj/item/reagent_containers/food/fish/))
-			user.visible_message(SPAN_NOTICE("[user] begins quickly stuffing [O] into the [src]!"))
-			var/itemtype = O.type
-			var/staystill = user.loc
-			for(var/obj/item/P in view(1,user))
-				if (user.loc != staystill) break
-				if (P.type != itemtype) continue
-				P.set_loc(src)
-				playsound(src.loc, 'sound/effects/bubbles_short.ogg', 85, 1)
-				sleep(0.3 SECONDS)
-			boutput(user, SPAN_NOTICE("You finish stuffing [O] into the [src]!"))
-			return
+	New()
+		..()
+		AddComponent(/datum/component/transfer_input/quickloading, allowed)
+		AddComponent(/datum/component/transfer_output)
 
 /obj/submachine/fishing_upload_terminal/portable
 	anchored = 0

--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -342,6 +342,10 @@ TYPEINFO(/obj/item/fish_portal)
 	var/working = FALSE
 	var/allowed = list(/obj/item/reagent_containers/food/fish)
 
+	New()
+		..()
+		AddComponent(/datum/component/transfer_input/quickloading, allowed)
+
 	attack_hand(var/mob/user)
 		if (!length(src.contents))
 			boutput(user, SPAN_ALERT("There is nothing in the upload terminal!"))
@@ -426,11 +430,6 @@ TYPEINFO(/obj/item/fish_portal)
 			user.u_equip(W)
 			W.set_loc(src)
 			W.dropped(user)
-
-	New()
-		..()
-		AddComponent(/datum/component/transfer_input/quickloading, allowed)
-		AddComponent(/datum/component/transfer_output)
 
 /obj/submachine/fishing_upload_terminal/portable
 	anchored = 0

--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -427,6 +427,33 @@ TYPEINFO(/obj/item/fish_portal)
 			W.set_loc(src)
 			W.dropped(user)
 
+	MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+		if (!isliving(user))
+			boutput(user, SPAN_ALERT("You can't do that while dead, this isn't Davy Jones' Locker!"))
+			return
+		if (BOUNDS_DIST(user, src) > 0)
+			boutput(user, SPAN_ALERT("You need to move closer to the [src] to do that."))
+			return
+		if (BOUNDS_DIST(O, user) > 0)
+			boutput(user, SPAN_ALERT("[O] is too far away to load into the [src]!"))
+			return
+		if (src.working)
+			boutput(user, SPAN_ALERT("The [src] is busy!"))
+			return
+
+		if (istype(O, /obj/item/reagent_containers/food/fish/))
+			user.visible_message(SPAN_NOTICE("[user] begins quickly stuffing [O] into the [src]!"))
+			var/itemtype = O.type
+			var/staystill = user.loc
+			for(var/obj/item/P in view(1,user))
+				if (user.loc != staystill) break
+				if (P.type != itemtype) continue
+				P.set_loc(src)
+				playsound(src.loc, 'sound/effects/bubbles_short.ogg', 85, 1)
+				sleep(0.3 SECONDS)
+			boutput(user, SPAN_NOTICE("You finish stuffing [O] into the [src]!"))
+			return
+
 /obj/submachine/fishing_upload_terminal/portable
 	anchored = 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Adds drag-and-drop functionality for depositing fish to the Aquatic Research Terminal.
- User can click a fish and drag it to the terminal in order to quickly deposit every fish of that type (bass, salmon, goldfish, etc.).
- A quiet bubbling noise will accompany each fish being deposited.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, depositing fish into the Aquatic Research Terminal is click-intensive and time consuming, as the user has to manually pick up each fish and use it on the terminal individually. This also leads to the occasional problem of double-clicking the terminal and causing it to begin uploading the data (which takes a few seconds), causing unnecessary delays. Adding MouseDrop to the terminal is a quality of life change that alleviates both of these issues.

[qol]