### PR TITLE
Bambini is consistently named on sea maps

### DIFF
--- a/assets/maps/prefabs/underwater/nadir/prefab_water_nadirelevator.dmm
+++ b/assets/maps/prefabs/underwater/nadir/prefab_water_nadirelevator.dmm
@@ -1422,8 +1422,8 @@
 	name = "The Recluse"
 	})
 "TP" = (
-/obj/npc/trader/bee{
-	name = "Bambini"
+/obj/npc/trader/bee/sea{
+	dir = 4
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor2"

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_beetrader.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_beetrader.dmm
@@ -165,7 +165,7 @@
 /turf/simulated/floor/white,
 /area/bee_trader)
 "u" = (
-/obj/npc/trader/bee{
+/obj/npc/trader/bee/sea{
 	dir = 4
 	},
 /turf/simulated/floor{

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -1218,6 +1218,9 @@ ABSTRACT_TYPE(/obj/npc/trader/robot/robuddy)
 
 
 
+/obj/npc/trader/bee/sea
+	name = "Bambini"
+
 // Hon- I mean, hello sir.
 
 /obj/npc/trader/exclown


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a `/sea` variant of the bee trader Bombini, with the only change being the name `Bambini`, and use it on water maps. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #11622
