### PR TITLE
Allow butts to be attached to TTVs again

### DIFF
--- a/code/obj/item/device/transfer_valve.dm
+++ b/code/obj/item/device/transfer_valve.dm
@@ -118,34 +118,44 @@ TYPEINFO(/obj/item/device/transfer_valve)
 
 		return
 
-	/// Attach the tank the mob is currently holding
+	/**
+	Attach the tank (or butt) the mob is currently holding to the transfer valve.
+
+	* @param `mob/user` The mob holding the tank to attach.
+
+	* @param `tank_preference` The tank slot to attach the tank to. If null, the tank will be attached to the first available slot.
+	**/
 	proc/attach_tank(mob/user, tank_preference=null)
 		if (!user) return
 		var/obj/item/I = user.equipped()
-		if (!istype(I, /obj/item/tank) || istype(I, /obj/item/clothing/head/butt)) return
-		var/obj/item/tank/myTank = I
-		if (!myTank.compatible_with_TTV) return
+		if (istype(I, /obj/item/tank))
+			var/obj/item/tank/myTank = I
+			if (!myTank.compatible_with_TTV) return
+		else if (istype(I, /obj/item/clothing/head/butt))
+			; // butts allowed without additional checks
+		else
+			return
 		// Handle UI tank attachment
 		if (tank_preference == 1)
 			// This check should always pass
 			if (!src.tank_one)
-				src.tank_one = myTank
+				src.tank_one = I
 		else if (tank_preference == 2)
 			// As should this one
 			if (!src.tank_two)
-				src.tank_two = myTank
+				src.tank_two = I
 		// Handle attackby tank attachment (wherever fits)
 		else if (!tank_preference && !src.tank_one)
-			src.tank_one = myTank
+			src.tank_one = I
 		else if (!tank_preference && !src.tank_two)
-			src.tank_two = myTank
+			src.tank_two = I
 		else
 			// it did not fit, clearly. dummy.
-			boutput(user, SPAN_NOTICE("\the [myTank] cannot fit on the [src]!"))
+			boutput(user, SPAN_NOTICE("\the [I] cannot fit on the [src]!"))
 			return
 		user.drop_item()
-		myTank.set_loc(src)
-		boutput(user, SPAN_NOTICE("You attach \the [myTank] to the transfer valve"))
+		I.set_loc(src)
+		boutput(user, SPAN_NOTICE("You attach \the [I] to the transfer valve"))
 		if(src.tank_one && src.tank_two)
 			var/turf/T = get_turf(src)
 			var/butt = istype(tank_one, /obj/item/clothing/head/butt) || istype(tank_two, /obj/item/clothing/head/butt)
@@ -215,10 +225,16 @@ TYPEINFO(/obj/item/device/transfer_valve)
 		src.AttackSelf(usr)
 		src.add_fingerprint(usr)
 
-	proc/remove_tank(var/T)
-		if (!istype(T, /obj/item/tank)) return
-		var/obj/item/tank/removed = T
-		boutput(usr, SPAN_NOTICE("You remove the [removed] from [src]."))
+	/**
+	Remove a tank (or butt) from the transfer valve.
+
+	 * @param `tank_or_butt` The tank or butt to remove.
+
+	**/
+	proc/remove_tank(tank_or_butt)
+		var/obj/item/removed = tank_or_butt
+		if (!istype(removed)) return // huh, must have been the wind
+		boutput(usr, SPAN_NOTICE("You remove \the [removed] from [src]."))
 		removed.set_loc(get_turf(src))
 		removed = null
 		UpdateIcon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* In `attach_tank`, fix the type check to allow for tanks and butts
  * Make the `compatible_with_TTV` check only apply for tanks
* In `remove_tank`, remove the explicit tank `istype` check
* Flesh out doc-comments

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22667