### PR TITLE
Terrainifying to ground prevents space-only events

### DIFF
--- a/code/modules/admin/terrainify.dm
+++ b/code/modules/admin/terrainify.dm
@@ -2,6 +2,8 @@
 #define TERRAINIFY_VEHICLE_CARS (1 << 1)
 #define TERRAINIFY_ALLOW_VEHCILES (1 << 2)
 
+var/global/is_map_on_ground_terrain = FALSE
+
 /client/proc/cmd_terrainify_station()
 	SET_ADMIN_CAT(ADMIN_CAT_FUN)
 	set name = "Terrainify"
@@ -242,6 +244,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 	var/syndi_camo_color = null
 	var/ambient_color
 	var/startTime
+	var/generates_solid_ground = TRUE
 
 	New()
 		..()
@@ -330,6 +333,9 @@ ABSTRACT_TYPE(/datum/terrainify)
 		if(params["Parallax"])
 			var/datum/parallax_render_source_group/render_group = new parallax_render_source_group()
 			ADD_PARALLAX_RENDER_SOURCES_FROM_GROUP(Z_LEVEL_STATION, render_group, 5 SECONDS)
+
+		if (src.generates_solid_ground)
+			global.is_map_on_ground_terrain = TRUE
 
 		log_terrainify(user, "has turned space and the station into [src.name].")
 
@@ -602,6 +608,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 	additional_options = list()
 	additional_toggles = list()
 	ambient_color = "#222222"
+	generates_solid_ground = FALSE
 
 	New()
 		..()
@@ -658,6 +665,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 	name = "Void Station"
 	desc = "Turn space into the unknowable void? Space if filled with the void, inhibited by those departed, and chunks of scaffolding."
 	additional_toggles = list("Void Bubbles"=FALSE, "Void Worley"=FALSE)
+	generates_solid_ground = FALSE
 
 	New()
 		syndi_camo_color = list(nuke_op_color_matrix[1], "#a223d2", nuke_op_color_matrix[3])
@@ -1240,6 +1248,7 @@ ABSTRACT_TYPE(/datum/terrainify)
 /datum/terrainify/plasma
 	name = "Plasma Station"
 	desc = "Fill space with plasma gas? Warning: this is as bad as it sounds."
+	generates_solid_ground = FALSE
 
 	convert_turfs(list/turfs)
 		for (var/turf/T in turfs)
@@ -1460,6 +1469,7 @@ client/proc/unterrainify()
 		station_repair.preconvert_turfs = preconvert_turfs
 
 		RESTORE_PARALLAX_RENDER_SOURCE_GROUP_TO_DEFAULT(Z_LEVEL_STATION)
+		global.is_map_on_ground_terrain = FALSE
 
 		message_admins("Finished returning the station to space!")
 

--- a/code/modules/events/meteor_shower.dm
+++ b/code/modules/events/meteor_shower.dm
@@ -34,6 +34,8 @@ var/global/meteor_shower_active = 0
 		if(.)
 			if ( map_setting == "NADIR" ) // Nadir can have a counterpart to this event with acid hailstones, but it will need to function differently
 				. = FALSE
+			if (global.is_map_on_ground_terrain)
+				. = FALSE
 
 	event_effect(source, amount, direction, delay, warning_time, speed, datum/material/transmute_material_instead="random")
 		..()

--- a/code/modules/events/pretty_space.dm
+++ b/code/modules/events/pretty_space.dm
@@ -4,6 +4,12 @@
 	customization_available = 1
 	required_elapsed_round_time = 0 MINUTES
 
+	is_event_available(ignore_time_lock)
+		. = ..()
+		if(.)
+			if (global.is_map_on_ground_terrain)
+				. = FALSE
+
 	admin_call(var/source)
 		if (..())
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][events]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a new variable to track if the terrainify datum generates solid ground (not all do)

If the variable is true, then during terrainify set a new global `is_map_on_ground_terrain` to `TRUE`. During unterrainify, set the variable to `FALSE`.

In the event code for meteor showers and pretty space, check the `is_map_on_ground_terrain` variable during `is_event_available` and return `FALSE` if we're on the ground, preventing them from automatically occuring.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22723
