### PR TITLE
Prevents the burgle from appearing in chef objectives

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -501,6 +501,8 @@ var/global
 
 	list/allowed_favorite_ingredients = concrete_typesof(/obj/item/reagent_containers/food/snacks) - concrete_typesof(/obj/item/reagent_containers/food/snacks/ingredient/egg/critter) - list(
 		/obj/item/reagent_containers/food/snacks/burger/humanburger,
+		/obj/item/reagent_containers/food/snacks/burger/plague,
+		/obj/item/reagent_containers/food/snacks/burger/burgle,
 		/obj/item/reagent_containers/food/snacks/donut/custom/robust,
 		/obj/item/reagent_containers/food/snacks/ingredient/meat/humanmeat,
 		/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget/flock,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [COOKING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR prevents the Burgle (diseased) and burgle (crime) from appearing in the chef "make a food item with this ingredient" objectives, as well as in favorite foods for the Picky Eater trait.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The Burgle (diseased) only appears in the afterlife bar and at Centcomm, and the burgle (crime) requires a secret chem to cook. These seem prohibitively difficult to obtain for something as simple as a crew objective.

Fixes #13095, Fixes #15639, Fixes #21021

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)The burgle can no longer appear in chef objectives, or as the favorite food of picky eaters
```
