### PR TITLE
Armory auth access cleanup

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -3869,6 +3869,18 @@ ABSTRACT_TYPE(/area/station/ai_monitored/storage/)
 
 	Entered(atom/movable/A, atom/oldloc)
 		. = ..()
+		if (current_state == GAME_STATE_PLAYING) //Don't worry about this in setup.
+			var/obj/O = A
+			if (istype(O))
+				if(access_armory in O.req_access) // Auto update access for armory stuff when it enters armory if it mismatches current auth status
+					if(src.armory_auth && !O.has_access(access_security))
+						O.req_access += access_security
+						O.visible_message(SPAN_NOTICE("[O]'s access is automatically updated!"))
+						playsound(O, 'sound/machines/chime.ogg', 50)
+					else if (!src.armory_auth && O.has_access(access_security))
+						O.req_access = list(access_armory)
+						O.visible_message(SPAN_NOTICE("[O]'s access is automatically reset!"))
+						playsound(O, 'sound/machines/chime.ogg', 50)
 		if (current_state < GAME_STATE_FINISHED)
 			if(istype(A, /mob/living) && !istype(A, /mob/living/intangible))
 				var/mob/living/M = A
@@ -3883,7 +3895,6 @@ ABSTRACT_TYPE(/area/station/ai_monitored/storage/)
 				SPAWN(120 SECONDS)
 					entered_ckeys -= ckey
 				logTheThing(LOG_STATION, M, "entered the Armory [log_loc(M)].[armory_auth ? "" : " - Armory unauthorized."]")
-
 // // // // // //
 
 /// Turret protected areas, will activate AI turrets to pop up when entered, and vice-versa when exited.

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -29,11 +29,6 @@
 
 		src.net_id = generate_net_id(src)
 		MAKE_DEFAULT_RADIO_PACKET_COMPONENT(src.net_id, null, control_frequency)
-
-		/*for (var/obj/machinery/door/airlock/D in armory_area)
-			if (D.has_access(access_armory))
-				D.no_access = 1
-		*/
 		..()
 
 	disposing()
@@ -137,26 +132,18 @@
 		src.icon_state = "drawbr-alert"
 		src.UpdateIcon()
 
-		ON_COOLDOWN(src, "unauth", 5 MINUTES)
+		ON_COOLDOWN(src, "unauth", 5 SECONDS)
 
 		src.authorized = null
 		src.authorized_registered = null
 
 		SEND_GLOBAL_SIGNAL(COMSIG_GLOBAL_ARMORY_AUTH)
 
-		for (var/obj/machinery/door/airlock/D in armory_area)
-			if (D.has_access(access_armory))
-				D.req_access = list(access_security)
-				//D.no_access = 0
-			LAGCHECK(LAG_REALTIME)
-
 		if (armory_area)
 			for(var/obj/O in armory_area)
-				if (istype(O,/obj/storage/secure/crate))
-					O.req_access = list(access_security)
-				else if (istype(O,/obj/machinery/vending))
-					O.req_access = list(access_security)
-
+				if(!(access_armory in O.req_access)) //Did it have armory access in the first place?
+					continue
+				O.req_access += access_security
 				LAGCHECK(LAG_REALTIME)
 
 		SPAWN(0.5 SECONDS)
@@ -165,32 +152,26 @@
 			playsound(src, 'sound/vox/authorized.ogg', 50, vary=FALSE, extrarange=10)
 
 	proc/unauthorize()
-		if(src.authed)
+		if(!src.authed)
+			return
 
-			logTheThing(LOG_STATION, usr, "unauthorized armory access")
-			command_announcement("<br><b>[SPAN_ALERT("Armory weapons access has been revoked from all security personnel. All crew are advised to hand in riot gear to the Head of Security.")]</b>", "Security Level Decreased", "sound/misc/announcement_1.ogg")
-			authed = 0
-			src.ClearSpecificOverlays("screen_image")
-			icon_state = "drawbr"
-			src.UpdateIcon()
+		logTheThing(LOG_STATION, usr, "unauthorized armory access")
+		command_announcement("<br><b>[SPAN_ALERT("Armory weapons access has been revoked from all security personnel. All crew are advised to hand in riot gear to the Head of Security.")]</b>", "Security Level Decreased", "sound/misc/announcement_1.ogg")
+		authed = 0
+		src.ClearSpecificOverlays("screen_image")
+		icon_state = "drawbr"
+		src.UpdateIcon()
 
-			src.authorized = null
-			src.authorized_registered = null
+		src.authorized = null
+		src.authorized_registered = null
 
-			SEND_GLOBAL_SIGNAL(COMSIG_GLOBAL_ARMORY_UNAUTH)
+		SEND_GLOBAL_SIGNAL(COMSIG_GLOBAL_ARMORY_UNAUTH)
 
-			for (var/obj/machinery/door/airlock/D in armory_area)
-				if (D.has_access(access_security))
-					D.req_access = list(access_armory)
-				LAGCHECK(LAG_REALTIME)
-
-			if (armory_area)
-				for(var/obj/O in armory_area)
-					if (istype(O,/obj/storage/secure/crate))
-						O.req_access = list(access_armory)
-					else if (istype(O,/obj/machinery/vending))
-						O.req_access = list(access_armory)
-
+		if (armory_area)
+			for(var/obj/O in armory_area)
+				if(!(access_armory in O.req_access)) //Did it have armory access in the first place?
+					continue
+				O.req_access = list(access_armory)
 				LAGCHECK(LAG_REALTIME)
 
 	proc/print_auth_needed(var/mob/author)

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -132,7 +132,7 @@
 		src.icon_state = "drawbr-alert"
 		src.UpdateIcon()
 
-		ON_COOLDOWN(src, "unauth", 5 SECONDS)
+		ON_COOLDOWN(src, "unauth", 5 MINUTES)
 
 		src.authorized = null
 		src.authorized_registered = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cleans up armory access changing a bunch to fix strange behaviours
- Armory access is now never removed from an object on auth, and is always checked before editing an objects access
- All objects inside the armory with armory access are now (de)authed, this only affects turret controls, but would also apply to say, a turret if it had armory access (they are sec access not armory access).
- An armory access object entering armory will now update its access relative to auth status (e.g. bringing a macrophaser crate from cargo into an already authed armory will add sec access, or bringing an authed shotgun crate to a deauthed armory will set it back to just armory access)
- Change having the whole of unauthorise() in an if(src.authed) to a return early if not authed

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Armory access changes presently have a lot of strange edge cases, for example you can (de)auth any vending machine (e.g. portananomed) to give it armory/sec access.
Bringing an armory crate back to an authed armory would require de and then reauthing armory to unlock it.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Armory will now only authorise objects that have armory access.
(+)Bringing an armory access object to armory will update its access to match auth status.
```
