### PR TITLE
Space Phoenixes don't get warmed by space or airless turfs

### DIFF
--- a/code/mob/living/critter/space_phoenix.dm
+++ b/code/mob/living/critter/space_phoenix.dm
@@ -66,8 +66,6 @@
 
 	Life()
 		. = ..()
-		var/area/A = get_area(src)
-
 		if (istype(get_turf(src), /turf/space))
 			src.delStatus("burning")
 
@@ -76,7 +74,7 @@
 				src.HealDamage("All", (2 + src.extra_life_regen) * mult, (2 + src.extra_life_regen) * mult)
 				src.HealBleeding(0.1)
 
-		if (src.check_area_dangerous(A) && !A.permafrosted)
+		if (src.in_dangerous_place())
 			src.changeStatus("phoenix_vulnerable", 5 SECONDS)
 
 			if (!src.hasStatus("phoenix_warmth_counter"))
@@ -200,8 +198,8 @@
 		..()
 		if (istype(NewLoc, /turf/space))
 			EndSpacePush(src)
-		var/area/A = get_area(src)
-		if (src.check_area_dangerous(A) && !A.permafrosted)
+
+		if (src.in_dangerous_place())
 			src.changeStatus("phoenix_vulnerable", 5 SECONDS)
 
 			if (!src.hasStatus("phoenix_warmth_counter"))
@@ -280,9 +278,15 @@
 				floor.icon_state = icon_s
 				floor.set_dir(direct)
 
-	proc/check_area_dangerous(area/A)
-		return A && !A.permafrosted && istype(A, /area/station) && !istype(A, /area/station/solar) && !istype(A, /area/station/shield_zone) && \
-			!istype(A, /area/station/turret_protected) && !istype(A, /area/station/com_dish)
+	///Check our current location to see if we're in a dangerous(ly warm) place
+	proc/in_dangerous_place()
+		. = TRUE
+		var/area/A = get_area(src)
+		if (A.permafrosted || !istype(A, /area/station))
+			return FALSE
+		var/turf/T = get_turf(src)
+		if (istype(T, /turf/space) || istype(T, /turf/simulated/floor/airless))
+			return FALSE
 
 /image/phoenix_temperature_indicator
 	plane = PLANE_HUD

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -3588,11 +3588,13 @@
 
 	onUpdate(timePassed)
 		..()
-		var/area/A = get_area(src.owner)
-		if (istype(A, /area/station) && !A.permafrosted)
+		var/mob/living/critter/space_phoenix/phoenix = src.owner
+		if (!istype(phoenix))
+			return // ???
+
+		if (phoenix.in_dangerous_place())
 			src.time_passed = min(src.time_passed + timePassed, 30 SECONDS)
 			if (src.time_passed >= 30 SECONDS)
-				var/mob/living/critter/space_phoenix/phoenix = src.owner
 				if (!ON_COOLDOWN(phoenix, "warmth_damage", 1 SECOND))
 					var/mult = max(LIFE_PROCESS_TICK_SPACING, timePassed) / LIFE_PROCESS_TICK_SPACING
 					phoenix.TakeDamage("All", burn = 4 * mult)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace the space phoenix chained area check with a combined area/turf check. Use this check in space phoenix move/life, as well as the warmth counter status effect


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Feels more natural to check for space/airless tile turfs instead of a large chained area exception list. Fixes an issue where AI Upload, AI Core, and Computer Core were not considered dangerous places.

Noted Balance Effects:
* Allows phoenixes to advance further into the station via hull-breached areas
* Makes phoenixes much more dangerous to miners as they'll no longer be protected by the magnet catwalks