### PR TITLE
Refactor Job Antagonist blacklists

### DIFF
--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -85,15 +85,7 @@ var/datum/job_controller/job_controls
 			return
 		// antag job exemptions
 		if(player.mind?.is_antagonist())
-			if ((!job.allow_traitors && player.mind.special_role))
-				return
-			else if (!job.allow_spy_theft && (player.mind.special_role == ROLE_SPY_THIEF))
-				return
-			else if (istype(ticker?.mode, /datum/game_mode/revolution) && job.cant_spawn_as_rev)
-				return
-			else if ((istype(ticker?.mode, /datum/game_mode/conspiracy)) && job.cant_spawn_as_con)
-				return
-			else if ((!job.can_join_gangs) && (player.mind.special_role in list(ROLE_GANG_MEMBER,ROLE_GANG_LEADER)))
+			if (!job.can_be_antag(player.mind.special_role))
 				return
 		// job ban check
 		if (!job.no_jobban_from_this_job && jobban_isbanned(player, job.name))
@@ -159,13 +151,8 @@ var/datum/job_controller/job_controls
 			var/datum/job/job = find_job_in_controller_by_string(player_preferences.job_favorite)
 			if (job)
 				// antag fall through flag set check
-				if ((!job.allow_traitors && player.mind.special_role))
+				if (!job.can_be_antag(player.mind.special_role))
 					player.antag_fallthrough = TRUE
-				else if (!job.allow_spy_theft && (player.mind.special_role == ROLE_SPY_THIEF))
-					player.antag_fallthrough = TRUE
-				else if ((!job.can_join_gangs) && (player.mind.special_role in list(ROLE_GANG_MEMBER,ROLE_GANG_LEADER)))
-					player.antag_fallthrough = TRUE
-
 				// try to assign fav job
 				if (check_job_eligibility(player, job, STAPLE_JOBS))
 					player.mind.assigned_role = job.name

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -123,7 +123,7 @@
 
 /proc/can_join_gangs(mob/M) //stupid frickin 515 call syntax making me make this a global grumble grumble
 	var/datum/job/job = find_job_in_controller_by_string(M.mind.assigned_role)
-	. = !job || job.can_join_gangs
+	. = (!job || !job.can_be_antag(ROLE_GANG_LEADER) || !job.can_be_antag(ROLE_GANG_LEADER))
 
 /datum/game_mode/gang/send_intercept()
 	..(src.traitors)
@@ -2378,7 +2378,7 @@ proc/broadcast_to_all_gangs(var/message)
 			return
 
 		var/datum/job/job = find_job_in_controller_by_string(target.mind.assigned_role)
-		if(job && !job.can_join_gangs)
+		if(job && (!job.can_be_antag(ROLE_GANG_MEMBER) || !job.can_be_antag(ROLE_GANG_LEADER)))
 			boutput(target, SPAN_ALERT("You are too responsible to join a gang!"))
 			return
 

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -183,9 +183,7 @@ ABSTRACT_TYPE(/datum/game_mode)
 				continue
 			var/datum/job/job = find_job_in_controller_by_string(C.mob.job)
 			if (job)
-				if(!job.allow_traitors)
-					continue
-				if (!job.can_join_gangs && (type == ROLE_GANG_LEADER || type == ROLE_GANG_MEMBER))
+				if(!job.can_be_antag(type))
 					continue
 		else
 			continue

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -302,7 +302,7 @@ var/global/datum/mutex/limited/latespawning = new(5 SECONDS)
 		global.latespawning.lock()
 
 		if (JOB && (force || job_controls.check_job_eligibility(src, JOB, STAPLE_JOBS | SPECIAL_JOBS)))
-			var/mob/character = create_character(JOB, JOB.allow_traitors)
+			var/mob/character = create_character(JOB, JOB.can_roll_antag)
 			if (isnull(character))
 				global.latespawning.unlock()
 				return
@@ -826,7 +826,7 @@ a.latejoin-card:hover {
 					// Check if they have this antag type enabled. If not, too bad!
 					// get_preference_for_role can't handle antag types under 'misc' like wrestler or wolf, so we need to special case those
 					var/antag_enabled = new_character.client?.preferences.vars[get_preference_for_role(bad_type) || get_preference_for_role(ROLE_MISC)]
-					if (antag_enabled)
+					if (antag_enabled && job.can_be_antag(bad_type))
 						if ((!livingtraitor && prob(40)) || (livingtraitor && !ticker.mode.latejoin_only_if_all_antags_dead && prob(4)))
 							makebad(new_character, bad_type)
 							new_character.mind.late_special_role = TRUE

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -826,7 +826,7 @@ a.latejoin-card:hover {
 					// Check if they have this antag type enabled. If not, too bad!
 					// get_preference_for_role can't handle antag types under 'misc' like wrestler or wolf, so we need to special case those
 					var/antag_enabled = new_character.client?.preferences.vars[get_preference_for_role(bad_type) || get_preference_for_role(ROLE_MISC)]
-					if (antag_enabled && job.can_be_antag(bad_type))
+					if (antag_enabled && J.can_be_antag(bad_type))
 						if ((!livingtraitor && prob(40)) || (livingtraitor && !ticker.mode.latejoin_only_if_all_antags_dead && prob(4)))
 							makebad(new_character, bad_type)
 							new_character.mind.late_special_role = TRUE

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -135,7 +135,7 @@
 					boutput(H, SPAN_NOTICE("A peculiar noise intrudes upon the radio frequency of your [Hs.name]."))
 					if (H.client && !H.mind?.is_antagonist() && !isVRghost(H) && (H.client.preferences.be_traitor || src.override_player_pref) && isalive(H))
 						var/datum/job/J = find_job_in_controller_by_string(H?.mind.assigned_role)
-						if (J?.allow_traitors)
+						if (J.can_be_antag(ROLE_SLEEPER_AGENT))
 							src.candidates.Add(H)
 				break
 		for (var/mob/living/silicon/robot/R in mobs)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactors job antagonist prevention to two variables:
- can_roll_antag <Blanket no making this job antag variable
- invalid_antagonist_roles < List of role defines that this job cannot be

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having a variable per antag thats either "can be this role" or "cant be this role" interchangably is poor code quality, this allows more dynamic job prevention (e.g. you could say that specifically miners cannot specifically be vampire), though there are no intended player facing changes in what antags can be rolled (except Head of Mining updated to the same list as the rest of command)

TESTMERGE FIRST TO MAKE SURE NO HEADS OF SECURITY ROLL GANG LEADER

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Job-based antagonist preventions have been refactored internally, report any oddities.
```
