### PR TITLE
Heads can be placed on cabinets like hats

### DIFF
--- a/code/datums/components/hattable.dm
+++ b/code/datums/components/hattable.dm
@@ -40,7 +40,7 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 	var/offsetBy_x = 0
 
 
-	if (istype(item, /obj/item/clothing/head/))
+	if (istype(item, /obj/item/clothing/head/) | istype(item, /obj/item/organ/head))
 		src.hat = item
 		ADD_FLAG(src.hat.appearance_flags, KEEP_TOGETHER) // Flags needed for wigs!
 		ADD_FLAG(src.hat.vis_flags, VIS_INHERIT_DIR)

--- a/code/datums/components/hattable.dm
+++ b/code/datums/components/hattable.dm
@@ -40,7 +40,7 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 	var/offsetBy_x = 0
 
 
-	if (istype(item, /obj/item/clothing/head/) | istype(item, /obj/item/organ/head))
+	if (istype(item, /obj/item/clothing/head/) || istype(item, /obj/item/organ/head))
 		src.hat = item
 		ADD_FLAG(src.hat.appearance_flags, KEEP_TOGETHER) // Flags needed for wigs!
 		ADD_FLAG(src.hat.vis_flags, VIS_INHERIT_DIR)

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -19,8 +19,6 @@
 	tooltip_flags = REBUILD_ALWAYS //TODO: handle better??
 	max_damage = INFINITY
 	throw_speed = 1
-	var/default_hat_y = 0
-	var/default_hat_x = 0
 
 	var/obj/item/organ/brain/brain = null
 	var/obj/item/skull/skull = null

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -19,6 +19,8 @@
 	tooltip_flags = REBUILD_ALWAYS //TODO: handle better??
 	max_damage = INFINITY
 	throw_speed = 1
+	var/default_hat_y = 0
+	var/default_hat_x = 0
 
 	var/obj/item/organ/brain/brain = null
 	var/obj/item/skull/skull = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Game-Objects] [C-Feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Simple change lets you put heads on cabinets like hats. Skeletons can become the camera helmet!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Crawling heads would be funny. Skeletons get actual use out of this but not much more than they would if they just got a camera helmet.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CalliopeSoups
(+)You can now put heads ontop of mechcomp cabinets like hats.
```
