### PR TITLE
Fix arrivals atmos

### DIFF
--- a/code/modules/events/minor/artifact.dm
+++ b/code/modules/events/minor/artifact.dm
@@ -1,3 +1,4 @@
+
 /datum/random_event/minor/artifact
 	name = "Artifact Spawn"
 

--- a/code/modules/events/minor/artifact.dm
+++ b/code/modules/events/minor/artifact.dm
@@ -1,4 +1,3 @@
-
 /datum/random_event/minor/artifact
 	name = "Artifact Spawn"
 

--- a/code/obj/item/handheld_dispenser/dispenser.dm
+++ b/code/obj/item/handheld_dispenser/dispenser.dm
@@ -95,7 +95,7 @@
 			 null, null, null, INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ATTACKED)
 
 	else
-		if(issimulatedturf(target))
+		if(!issimulatedturf(target))
 			return
 		var/directs = selection.get_directions(direction)
 		for(var/obj/machinery/atmospherics/device in target)

--- a/code/obj/item/handheld_dispenser/dispenser.dm
+++ b/code/obj/item/handheld_dispenser/dispenser.dm
@@ -96,7 +96,7 @@
 
 	else
 		if(istype(target, /turf/simulated))
-			retur
+			return
 		var/directs = selection.get_directions(direction)
 		for(var/obj/machinery/atmospherics/device in target)
 			if((device.initialize_directions & directs))

--- a/code/obj/item/handheld_dispenser/dispenser.dm
+++ b/code/obj/item/handheld_dispenser/dispenser.dm
@@ -95,8 +95,8 @@
 			 null, null, null, INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ATTACKED)
 
 	else
-		if(!isturf(target))
-			return
+		if(istype(target, /turf/simulated))
+			retur
 		var/directs = selection.get_directions(direction)
 		for(var/obj/machinery/atmospherics/device in target)
 			if((device.initialize_directions & directs))

--- a/code/obj/item/handheld_dispenser/dispenser.dm
+++ b/code/obj/item/handheld_dispenser/dispenser.dm
@@ -95,7 +95,7 @@
 			 null, null, null, INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ATTACKED)
 
 	else
-		if(istype(target, /turf/simulated))
+		if(issimulatedturf(target))
 			return
 		var/directs = selection.get_directions(direction)
 		for(var/obj/machinery/atmospherics/device in target)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Atmospherics]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This stops the HPD from building atmos objects on unsimulated turf, by changing the isturf to istype. Ensures people cant build in arrivals



## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #22739