### PR TITLE
don't automatically activate pod engines when replacing the fuel tank

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -452,7 +452,6 @@
 					src.fueltank = W
 					src.updateDialog()
 					src.myhud?.update_fuel()
-					src.engine?.activate()
 				else
 					boutput(usr, SPAN_ALERT("That doesn't fit there."))
 					return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][vehicles]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove a line automatically turning the pod engine on when replacing the fuel tank.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Right now if you want to prep a pod for later use, you have to fuel the tank, then hop in and turn the engine off.
Fix #22743
