### PR TITLE
Replace Oshan Computer Core turret with non-construction type

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -5495,7 +5495,7 @@
 /area/station/turret_protected/Zeta)
 "asM" = (
 /obj/machinery/light/incandescent/greenish,
-/obj/machinery/turret/construction,
+/obj/machinery/turret,
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
 "asN" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace the oshan computer core turret with a regular version, instead of the `/construction` subtype.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's not area-focused like other turrets; it will happily shoot into the clown hole if someone is in there and the wall is broken by e.g. a hotspot.

Map consistency; this is the only construction turret in all maps.