### PR TITLE
Let people hit cyborgs with tools

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1090,7 +1090,7 @@
 	attackby(obj/item/W, mob/user)
 		if (istype(W, /obj/item/card/emag))
 			return
-		if (user.a_intent != INTENT_HELP)
+		if (user.a_intent == INTENT_HARM)
 			..()
 			return
 		if (istype(W,/obj/item/device/borg_linker) && !isghostdrone(user))

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1087,10 +1087,10 @@
 					src.cell = null
 					src.part_chest?.cell = null
 
-	attackby(obj/item/W, mob/user)
+	attackby(obj/item/W, mob/user, params, is_special = 0, silent = FALSE)
 		if (istype(W, /obj/item/card/emag))
 			return
-		if (user.a_intent == INTENT_HARM)
+		if (user.a_intent == INTENT_HARM || is_special)
 			..()
 			return
 		if (istype(W,/obj/item/device/borg_linker) && !isghostdrone(user))

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1235,7 +1235,6 @@
 				else
 					boutput(user, SPAN_ALERT("Access denied."))
 
-
 		else if (istype(W, /obj/item/instrument) && opened)
 			user.drop_item(W)
 			W.set_loc(src)

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1088,6 +1088,11 @@
 					src.part_chest?.cell = null
 
 	attackby(obj/item/W, mob/user)
+		if (istype(W, /obj/item/card/emag))
+			return
+		if (user.a_intent != INTENT_HELP)
+			..()
+			return
 		if (istype(W,/obj/item/device/borg_linker) && !isghostdrone(user))
 			var/obj/item/device/borg_linker/linker = W
 			if(!opened)
@@ -1230,8 +1235,7 @@
 				else
 					boutput(user, SPAN_ALERT("Access denied."))
 
-		else if (istype(W, /obj/item/card/emag))
-			return
+
 		else if (istype(W, /obj/item/instrument) && opened)
 			user.drop_item(W)
 			W.set_loc(src)


### PR DESCRIPTION
[Silicon] [Bug]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a check to the cyborg attackby for intent, so you can hit cyborgs with tools. Also moves the emag check to the top so the emag interaction stays hidden even on harm intent.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

You should probably be able to hit cyborgs with crowbars and screwdrivers to kill them, and should also probably be on help intent to repair and modify cyborgs.
fixes #22327
