### PR TITLE
Change name of rock material to stone

### DIFF
--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -548,7 +548,7 @@ ABSTRACT_TYPE(/datum/material/metal)
 
 /datum/material/metal/rock
 	mat_id = "rock"
-	name = "rock"
+	name = "stone"
 	desc = "Near useless asteroid rock with some traces of random metals."
 	color = "#ACACAC"
 	texture = "rock"
@@ -1742,21 +1742,6 @@ ABSTRACT_TYPE(/datum/material/fabric)
 		setProperty("hard", 4)
 		setProperty("thermal", 9)
 		setProperty("electrical", 7)
-
-/datum/material/metal/censorium
-	mat_id = "censorium"
-	name = "censorium"
-	desc = "A charred rock. Doesn't do much."
-	color = "#948686"
-
-	New()
-		..()
-		setProperty("electrical", 4)
-		setProperty("thermal", 4)
-		setProperty("hard", 2)
-		setProperty("density", 2)
-		setProperty("flammable", 3)
-		setProperty("chemical", 4)
 
 /datum/material/fabric/hauntium
 	mat_id = "hauntium"

--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -402,11 +402,6 @@ ABSTRACT_TYPE(/obj/item/material_piece/rubber)
 	icon_state = "bar"
 	default_material = "soulsteel"
 
-/obj/item/material_piece/metal/censorium
-	desc = "A bar of censorium. Nice try."
-	icon_state = "bar"
-	default_material = "censorium"
-
 /obj/item/material_piece/bone
 	name = "bits of bone"
 	desc = "some bits and pieces of bones."

--- a/code/modules/materials/Mat_Recipes.dm
+++ b/code/modules/materials/Mat_Recipes.dm
@@ -80,25 +80,6 @@
 		if(one && two) return 1
 		else return 0
 
-/datum/material_recipe/censorium
-	name = "censorium"
-	result_id = "censorium"
-	result_item = /obj/item/material_piece/metal/censorium
-
-	validate(var/datum/material/M)
-		var/hasChar = 0
-		var/hasRock = 0
-
-		for(var/datum/material/CM in M.getParentMaterials())
-			if(CM.getID() == "char") hasChar = 1
-			if(CM.getID() == "rock") hasRock = 1
-
-		if(M.getID() == "char") hasChar = 1
-		if(M.getID() == "rock") hasRock = 1
-
-		if(hasChar && hasRock) return 1
-		else return 0
-
 /datum/material_recipe/copper // this doesn't REALLY make sense how steel recipe does but I don't care. Need a way to make copper for coroisum
 	name = "copper"
 	result_id = "copper"

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -210,13 +210,13 @@
 			..()
 
 /obj/item/raw_material/rock
-	name = "rock"
+	name = "stone"
 	desc = "It's plain old space rock. Pretty worthless!"
 	icon_state = "rock1"
 	force = 8
 	throwforce = 10
 	scoopable = 0
-	material_name = "Rock"
+	material_name = "Stone"
 	default_material = "rock"
 
 	setup_material()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[matsci][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Change name of rock material and material piece to stone
* Remove censorium material

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
material combinations stuff ending with "ock" are too ripe for breaking rule 4. I am hoping "one" is less troublesome.