### PR TITLE
Pyro Airlock access cleanup

### DIFF
--- a/code/obj/machinery/door/airlock_pyro.dm
+++ b/code/obj/machinery/door/airlock_pyro.dm
@@ -4,6 +4,7 @@
 	name = "airlock"
 	icon = 'icons/obj/doors/SL_doors.dmi'
 	flags = IS_PERSPECTIVE_FLUID | FLUID_DENSE
+	req_access = null
 
 /obj/machinery/door/airlock/pyro/safe
 	can_shock = FALSE
@@ -29,7 +30,6 @@
 	name = "command airlock"
 	icon_state = "com_closed"
 	icon_base = "com"
-	req_access = null
 	health = 800
 	health_max = 800
 
@@ -37,7 +37,7 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/command/centcom)
 	mats = 0
 
 /obj/machinery/door/airlock/pyro/command/centcom
-	req_access_txt = "57"
+	req_access = list(access_centcom)
 	cant_emag = TRUE
 	cyborgBumpAccess = FALSE
 	hardened = TRUE
@@ -49,7 +49,6 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/command/centcom)
 	icon_base = "com2"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 TYPEINFO(/obj/machinery/door/airlock/pyro/command/syndicate)
 	mats = 0
@@ -64,13 +63,11 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/command/syndicate)
 	icon_base = "manta"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 	hardened = TRUE
 	aiControlDisabled = TRUE
 	cyborgBumpAccess = FALSE
 
 /obj/machinery/door/airlock/pyro/weapons/noemag
-	req_access = null
 	cant_emag = TRUE
 	cyborgBumpAccess = FALSE
 
@@ -88,14 +85,12 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/command/syndicate)
 	name = "security airlock"
 	icon_state = "sec_closed"
 	icon_base = "sec"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/security/alt
 	icon_state = "sec2_closed"
 	icon_base = "sec2"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 // -------- engineering
 
@@ -103,14 +98,12 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/command/syndicate)
 	name = "engineering airlock"
 	icon_state = "eng_closed"
 	icon_base = "eng"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/engineering/alt
 	icon_state = "eng2_closed"
 	icon_base = "eng2"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/mining
 	name = "mining airlock"
@@ -118,7 +111,6 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/command/syndicate)
 	icon_base = "mining"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 // -------- medsci
 
@@ -126,28 +118,24 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/command/syndicate)
 	name = "medical airlock"
 	icon_state = "research_closed"
 	icon_base = "research"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/medical/alt
 	icon_state = "research2_closed"
 	icon_base = "research2"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/medical/alt2
 	icon_state = "med_closed"
 	icon_base = "med"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/medical/morgue
 	icon_state = "morgue_closed"
 	icon_base = "morgue"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/sci_alt
 	name = "research airlock"
@@ -155,7 +143,6 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/command/syndicate)
 	icon_base = "sci"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/toxins_alt
 	name = "toxins airlock"
@@ -163,7 +150,6 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/command/syndicate)
 	icon_base = "toxins2"
 	panel_icon_state = "2_panel_open"
 	welded_icon_state = "2_welded"
-	req_access = null
 
 // -------- maintenance
 
@@ -171,7 +157,6 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/command/syndicate)
 	name = "maintenance airlock"
 	icon_state = "maint_closed"
 	icon_base = "maint"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/maintenance/alt
 	icon_state = "maint2_closed"
@@ -216,12 +201,12 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/reinforced)
 	return
 
 /obj/machinery/door/airlock/pyro/reinforced/syndicate
-	req_access_txt = "52"
+	req_access = list(access_syndicate_shuttle)
 	explosion_resistance = 999999
 	anchored = ANCHORED_ALWAYS //haha fuk u
 
 	listeningpost
-		req_access_txt = "-1"
+		req_access = list(access_impossible)
 
 /obj/machinery/door/airlock/pyro/reinforced/arrivals
 	icon_state = "arrivals_closed"
@@ -258,62 +243,50 @@ TYPEINFO(/obj/machinery/door/airlock/pyro/glass/reinforced)
 /obj/machinery/door/airlock/pyro/glass/reinforced/blob_act(power)
 	return
 
-/obj/machinery/door/airlock/pyro/glass/brig
-	req_access_txt = "2"
-
 /obj/machinery/door/airlock/pyro/glass/command
 	name = "command airlock"
 	icon_state = "com_glass_closed"
 	icon_base = "com_glass"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/engineering
 	name = "engineering airlock"
 	icon_state = "eng_glass_closed"
 	icon_base = "eng_glass"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/security //Shitty Azungar recolor, no need to thank me.
 	name = "security airlock"
 	icon_state = "sec_glass_closed"
 	icon_base = "sec_glass"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/security/alt
 	name = "security airlock"
 	icon_state = "sec_glassalt_closed"
 	icon_base = "sec_glassalt"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/med
 	name = "medical airlock"
 	icon_state = "med_glass_closed"
 	icon_base = "med_glass"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/sci
 	name = "research airlock"
 	icon_state = "sci_glass_closed"
 	icon_base = "sci_glass"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/toxins
 	name = "toxins airlock"
 	icon_state = "toxins_glass_closed"
 	icon_base = "toxins_glass"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/mining
 	name = "mining airlock"
 	icon_state = "mining_glass_closed"
 	icon_base = "mining_glass"
-	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/botany
 	name = "botany airlock"
 	icon_state = "botany_glass_closed"
 	icon_base = "botany_glass"
-	req_access = null
 
 // -------- windoors
 

--- a/maps/cogwip/ships.dmm
+++ b/maps/cogwip/ships.dmm
@@ -246,10 +246,10 @@
 	},
 /area/space)
 "aK" = (
-/obj/machinery/door/airlock/pyro/glass/brig{
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
-	icon_state = "glass_closed"
 	},
+/obj/mapping_helper/access/brig,
 /turf/simulated/floor/circuit/red,
 /area/space)
 "aL" = (
@@ -10003,7 +10003,7 @@
 "zQ" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 2;
-	
+
 	},
 /turf/simulated/floor/caution/north,
 /area/space)
@@ -10387,7 +10387,7 @@
 "AT" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
-	
+
 	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4;

--- a/maps/unused/crash_gimmick.dmm
+++ b/maps/unused/crash_gimmick.dmm
@@ -14970,7 +14970,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/brig,
-/obj/machinery/door/airlock/pyro/glass/brig{
+/obj/machinery/door/airlock/pyro/glass{
 	name = "Brig"
 	},
 /obj/mapping_helper/access/brig,
@@ -33470,7 +33470,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe{
 	dir = 4
 	},
-/obj/machinery/door/airlock/pyro/glass/brig{
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Solitary"
 	},
@@ -65556,7 +65556,7 @@
 	},
 /area/station/hallway/secondary/exit)
 "sfw" = (
-/obj/machinery/door/airlock/pyro/glass/brig{
+/obj/machinery/door/airlock/pyro/glass{
 	name = "microbrig"
 	},
 /obj/mapping_helper/access/brig,
@@ -70225,7 +70225,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe{
 	dir = 4
 	},
-/obj/machinery/door/airlock/pyro/glass/brig{
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Solitary"
 	},

--- a/maps/z3_water.dmm
+++ b/maps/z3_water.dmm
@@ -461,9 +461,8 @@
 /turf/unsimulated/floor/damaged3,
 /area/wrecknsspolaris)
 "ct" = (
-/obj/machinery/door/airlock/pyro/glass/brig{
-	dir = 4;
-	req_access_txt = null
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon = 'icons/turf/floors.dmi';
@@ -471,9 +470,8 @@
 	},
 /area/wrecknsspolaris)
 "cu" = (
-/obj/machinery/door/airlock/pyro/glass/brig{
-	dir = 4;
-	req_access_txt = null
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/wrecknsspolaris)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Define req_access = null on the parent pyro airlock rather than every single airlock (it already had req_access as null this is just for readability)
Stop using req_access_txt these use magic numbers, use req_access = list(access) instead
Kill /airlock/pyro/glass/brig as the only difference was its access, which in the 4 places it was used was either mappinghelpered or overridden to null anyway.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
req_access_txt is evil, so is defining accesses on airlocks themselves