### PR TITLE
Remove req_access_txt from non-map stuff

### DIFF
--- a/code/modules/robotics/bot/evilbot.dm
+++ b/code/modules/robotics/bot/evilbot.dm
@@ -19,7 +19,7 @@
 	setup_default_startup_task = /datum/computer/file/guardbot_task/security/crazy
 	setup_default_tool_path = /obj/item/device/guardbot_tool/taser
 	no_camera = 1
-	req_access_txt = "8088"
+	req_access = list(access_impossible)
 	object_flags = 0
 
 	speak(var/message)

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1585,7 +1585,7 @@ TYPEINFO(/obj/machinery/vending/medical)
 	icon_state = "sec"
 	icon_panel = "standard-panel"
 	icon_deny = "sec-deny"
-	req_access_txt = 0
+	req_access = null
 	acceptcard = 0
 
 	light_r =0.8

--- a/code/obj/machinery/computer/door_control.dm
+++ b/code/obj/machinery/computer/door_control.dm
@@ -2,7 +2,7 @@
 	name = "Door Control"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "sec_computer"
-	req_access_txt = "2"
+	req_access = list(access_brig)
 //	var/authenticated = 0.0		if anyone wants to make it so you need to log in in future go ahead.
 	id = 1
 

--- a/code/obj/machinery/door/airlock_other.dm
+++ b/code/obj/machinery/door/airlock_other.dm
@@ -46,7 +46,7 @@ TYPEINFO(/obj/machinery/door/airlock/syndicate)
 	name = "reinforced external airlock"
 	desc = "Looks pretty tough. I wouldn't take this door on in a fight."
 	icon = 'icons/obj/doors/Doorext.dmi'
-	req_access_txt = "52"
+	req_access = list(access_syndicate_shuttle)
 	cant_emag = TRUE
 	hardened = TRUE
 	aiControlDisabled = TRUE
@@ -65,7 +65,7 @@ TYPEINFO(/obj/machinery/door/airlock/centcom)
 
 /obj/machinery/door/airlock/centcom
 	icon = 'icons/obj/doors/Doorcom.dmi'
-	req_access_txt = "57"
+	req_access = list(access_centcom)
 	cant_emag = TRUE
 	cyborgBumpAccess = FALSE
 	hardened = TRUE

--- a/code/obj/machinery/door/window.dm
+++ b/code/obj/machinery/door/window.dm
@@ -264,7 +264,7 @@
 	icon_state = "leftsecure"
 	base_state = "leftsecure"
 	var/id = 1
-	req_access_txt = "2"
+	req_access = list(access_brig)
 	autoclose = FALSE //brig doors close only when the cell timer starts
 
 /obj/machinery/door/window/brigdoor/New()

--- a/code/obj/storage/secure_crates.dm
+++ b/code/obj/storage/secure_crates.dm
@@ -36,7 +36,7 @@
 	confiscated_items
 		name = "confiscated items crate"
 		desc = "Secure storage for confiscated contraband."
-		req_access_txt = "2"
+		req_access = list(access_brig)
 
 	armory
 		name = "secure weapons crate"
@@ -90,7 +90,7 @@
 
 /obj/storage/secure/crate/gear/saxitoxin_grenades
 	name = "nerve agent crate (DANGER)"
-	req_access_txt = "52"
+	req_access = list(access_syndicate_shuttle)
 	spawn_contents = list(/obj/item/reagent_containers/syringe/atropine = 3,\
 	/obj/item/chem_grenade/saxitoxin = 3)
 

--- a/code/z_adventurezones/luna.dm
+++ b/code/z_adventurezones/luna.dm
@@ -840,7 +840,7 @@ Contents:
 	name = "security door"
 	desc = "A security door used to separate museum compartments."
 	autoclose = FALSE
-	req_access_txt = ""
+	req_access = null
 	object_flags = BOTS_DIRBLOCK
 
 /obj/machinery/door/poddoor/blast/lunar/tour
@@ -918,7 +918,7 @@ Contents:
 	opacity = 1
 	autoclose = FALSE
 	cant_emag = TRUE
-	req_access_txt = "999"
+	req_access = list(access_impossible)
 
 	var/broken = 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes req_access_txt from all non-map instances of the variable (with the exception of pyro airlocks, thats in #22769)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
req_access uses the defines and is much cleaner, req_access_txt must die, custom accesses should be set with access spawners(but they dont presently affect secure storages)