### PR TITLE
Miranda's Rights fixes

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -141,8 +141,6 @@
 		if (src.receives_miranda)
 			M.verbs += /mob/proc/recite_miranda
 			M.verbs += /mob/proc/add_miranda
-			if (!isnull(M.mind))
-				M.mind.miranda = DEFAULT_MIRANDA
 		LAZYLISTADDUNIQUE(M.faction, src.faction)
 		for (var/T in src.trait_list)
 			M.traitHolder.addTrait(T)
@@ -201,6 +199,10 @@
 	/// Is this job highlighted for priority latejoining
 	proc/is_highlighted()
 		return global.priority_job == src
+
+	/// The default miranda's rights for this job
+	proc/get_default_miranda()
+		return DEFAULT_MIRANDA
 
 	///Check if a string matches this job's name or alias with varying case sensitivity
 	proc/match_to_string(string, case_sensitive)
@@ -1488,7 +1490,7 @@ ABSTRACT_TYPE(/datum/job/special/random)
 	items_in_backpack = list(/obj/item/device/flash)
 	wiki_link = "https://wiki.ss13.co/Inspector"
 
-	proc/inspector_miranda()
+	get_default_miranda()
 		return "You have been found to be in breach of Nanotrasen corporate regulation [rand(1,100)][pick(uppercase_letters)]. You are allowed a grace period of 5 minutes to correct this infringement before you may be subjected to disciplinary action including but not limited to: strongly worded tickets, reduction in pay, and being buried in paperwork for the next [rand(10,20)] standard shifts."
 
 	special_setup(var/mob/living/carbon/human/M)
@@ -1502,7 +1504,6 @@ ABSTRACT_TYPE(/datum/job/special/random)
 			var/obj/item/clipboard/with_pen/inspector/clipboard = new /obj/item/clipboard/with_pen/inspector(B)
 			B.storage.add_contents(clipboard)
 			clipboard.set_owner(M)
-		M.mind?.set_miranda(list(PROC_REF(inspector_miranda)))
 		return
 
 /datum/job/special/random/diplomat
@@ -2141,7 +2142,9 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 		var/datum/bioEffect/power/be = M.bioHolder.AddEffect("adrenaline", do_stability=0)
 		be.safety = 1
 		be.altered = 1
-		M?.mind?.miranda = "Evildoer! You have been apprehended by a hero of space justice!"
+
+	get_default_miranda()
+		return "Evildoer! You have been apprehended by a hero of space justice!"
 
 /datum/job/special/halloween/pickle
 	name = "Pickle"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -12,7 +12,7 @@ datum/mind
 	var/list/datum/dynamic_player_memory/dynamic_memories = list()
 	var/remembered_pin = null
 	var/last_memory_time = 0 //Give a small delay when adding memories to prevent spam. It could happen!
-	var/miranda // sec's miranda rights thingy.
+	var/miranda = null // sec's miranda rights thingy.
 
 	var/violated_hippocratic_oath = 0
 	var/soul = 100 // how much soul we have left
@@ -221,8 +221,9 @@ datum/mind
 		miranda = new_text
 
 	proc/get_miranda()
-		if (islist(src.miranda)) //isproc machine broke, so uh just wrap your procs in a list when you pass them here to distinguish them from strings :)
-			return call(src.miranda[1])()
+		if (isnull(src.miranda)) //isproc machine broke, so uh just wrap your procs in a list when you pass them here to distinguish them from strings :)
+			var/datum/job/job = find_job_in_controller_by_string(src.assigned_role)
+			return job.get_default_miranda()
 		return src.miranda
 
 	proc/show_miranda(mob/recipient)

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1484,18 +1484,25 @@
 	if (src.mind.last_memory_time + 10 <= world.time) // leaving it using this var cause vOv
 		src.mind.last_memory_time = world.time // why not?
 
-		var/new_rights = input(usr, "Change what you will say with the Say Miranda Rights verb.", "Set Miranda Rights", src.mind.get_miranda() || DEFAULT_MIRANDA) as null|text
-		if (!new_rights || new_rights == src.mind.miranda)
-			src.show_text("Miranda rights not changed.", "red")
-			return
+		var/choice = tgui_alert(usr, "Edit Miranda's rights?", "Miranda Rights", list("Edit", "Reset", "Cancel"))
+		switch(choice)
+			if("Edit")
+				var/new_rights = tgui_input_text(usr, "Change what you will say with the Say Miranda Rights verb.", "Set Miranda Rights", src.mind.get_miranda() || DEFAULT_MIRANDA)
+				if (!new_rights || new_rights == src.mind.miranda)
+					src.show_text("Miranda rights not changed.", "red")
+					return
 
-		new_rights = copytext(new_rights, 1, MAX_MESSAGE_LEN)
-		new_rights = sanitize(strip_html(new_rights))
+				new_rights = copytext(new_rights, 1, MAX_MESSAGE_LEN)
+				new_rights = sanitize(strip_html(new_rights))
 
-		src.mind.set_miranda(new_rights)
+				src.mind.set_miranda(new_rights)
 
-		logTheThing(LOG_TELEPATHY, src, "has set their miranda rights quote to: [src.mind.miranda]")
-		src.show_text("Miranda rights set to \"[src.mind.miranda]\"", "blue")
+				logTheThing(LOG_TELEPATHY, src, "has set their miranda rights quote to: [src.mind.miranda]")
+				src.show_text("Miranda rights set to \"[src.mind.miranda]\"", "blue")
+			if("Reset")
+				src.mind.set_miranda(null)
+				logTheThing(LOG_TELEPATHY, src, "has reset their miranda rights.")
+				src.show_text("Miranda rights reset.", "blue")
 
 /mob/verb/abandon_mob()
 	set name = "Respawn"

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -2167,7 +2167,8 @@
 
 			if ("miranda")
 				if (src.emote_check(voluntary, 50))
-					if (src.mind && (src.mind.assigned_role in list("Captain", "Head of Personnel", "Head of Security", "Security Officer", "Security Assistant", "Detective", "Vice Officer", "Inspector")))
+					var/datum/job/job = find_job_in_controller_by_string(src.mind.assigned_role)
+					if (src.mind && job.receives_miranda)
 						src.recite_miranda()
 
 			if ("dab") //I'm honestly not sure how I'm ever going to code anything lower than this - Readster 23/04/19


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Miranda's rights are now by default null on mind and when trying to state null rights call assigned_role's proc that returns default rights.
Trying to manually state miranda's rights now checks if your job gets miranda's rights rather than using a magic list of job names.
You can now reset your miranda's rights back to null (and the miranda setting menu uses TGUI inputs)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #22687
PROC_REFs scare me, wrapping them in lists is even worse.