### PR TITLE
Allow roundstart chaplain vampires

### DIFF
--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -227,12 +227,6 @@ ABSTRACT_TYPE(/datum/game_mode)
 /// Set up an antag with default equipment, objectives etc as they would be in mixed
 /// Should only be used for roundstart setup
 /datum/game_mode/proc/equip_antag(datum/mind/antag)
-	if (antag.assigned_role == "Chaplain" && antag.special_role == ROLE_VAMPIRE)
-		// vamp will burn in the chapel before he can react
-		if (prob(50))
-			antag.special_role = ROLE_TRAITOR
-		else
-			antag.special_role = ROLE_CHANGELING
 
 	antag.add_antagonist(antag.special_role, source = ANTAGONIST_SOURCE_ROUND_START)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove the bit of code replacing vampire chaplains with 50/50 ling or traitor

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This exists so vampire chaplains don't burn up in chapel before they even fade in, however since then chaplains have been made immune to burning in the chapel.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Chaplains can roll roundstart vampire again (They are immune to burning in the chapel).
```
