### PR TITLE
Add new miner job objective: Tamed Rockworms

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -638,6 +638,24 @@ ABSTRACT_TYPE(/datum/objective/crew/miner)
 			check_result = length(materials) >= 10
 		return check_result
 
+#ifndef UNDERWATER_MAP // not a lot of rockworms under the sea
+/datum/objective/crew/miner/rockworm
+	explanation_text = "Have two tamed rock worms at the end of the round."
+	var/static/check_result
+	check_completion()
+		. = ..()
+		if (isnull(check_result))
+			check_result = FALSE
+			var/tame_worm_count = 0
+			for_by_tcl(worm, /mob/living/critter/rockworm)
+				if (worm.tamed)
+					tame_worm_count++
+					if (tame_worm_count >= 2)
+						check_result = TRUE
+						break
+		return check_result
+#endif
+
 ABSTRACT_TYPE(/datum/objective/crew/researchdirector)
 /datum/objective/crew/researchdirector/heisenbee
 	explanation_text = "Ensure that Heisenbee escapes on the shuttle."

--- a/code/mob/living/critter/mining_critter.dm
+++ b/code/mob/living/critter/mining_critter.dm
@@ -386,6 +386,11 @@
 		..()
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_RADPROT_INT, src, 80) // They live in asteroids so they should be resistant
 		AddComponent(/datum/component/consume/can_eat_raw_materials, FALSE)
+		START_TRACKING
+
+	disposing()
+		. = ..()
+		STOP_TRACKING
 
 	is_spacefaring()
 		return TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Add a new objective for miners: Have two tamed rockworms by end of round.
* Track rockworms so we can `for_by_tcl` them at end-of-round.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Encourage miners to try taming rockworms, and give them more variety in objectives.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Miners may be tasked with taming rockworms as a crew objective.
```
