### PR TITLE
fixes incandescent lights autopositioning onto false walls

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -255,7 +255,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/light, proc/broken, proc/admin_toggle, proc/
 					directions = cardinal
 				for (var/dir in directions)
 					T = get_step(src,dir)
-					if(istype(T,/turf/simulated/false_wall))
+					if(istype(T, /turf/simulated/wall/false_wall))
 						continue
 					if (istype(T,/turf/simulated/wall) || istype(T,/turf/unsimulated/wall) || (locate(/obj/mapping_helper/wingrille_spawn) in T) || (locate(/obj/window) in T))
 						var/is_jen_wall = 0 // jen walls' ceilings are narrower, so let's move the lights a bit further inward!

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -255,6 +255,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/light, proc/broken, proc/admin_toggle, proc/
 					directions = cardinal
 				for (var/dir in directions)
 					T = get_step(src,dir)
+					if(istype(T,/turf/simulated/false_wall))
+						continue
 					if (istype(T,/turf/simulated/wall) || istype(T,/turf/unsimulated/wall) || (locate(/obj/mapping_helper/wingrille_spawn) in T) || (locate(/obj/window) in T))
 						var/is_jen_wall = 0 // jen walls' ceilings are narrower, so let's move the lights a bit further inward!
 						if (istype(T, /turf/simulated/wall/auto/jen) || istype(T, /turf/simulated/wall/auto/reinforced/jen))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Lights will no longer  autoposition onto false walls.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #15392