### PR TITLE
Makes ammo cook off at high temperatures

### DIFF
--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -297,6 +297,16 @@
 	get_desc()
 		return . += "There [src.amount_left == 1 ? "is" : "are"] [src.amount_left][ammo_type.material && istype(ammo_type.material, /datum/material/metal/silver) ? " silver " : " "]bullet\s left!"
 
+	temperature_expose(datum/gas_mixture/air, temperature, volume)
+		. = ..()
+		if (temperature > (T0C + 400) && prob(60) && src.use(1)) //google told me this is roughly when ammo starts cooking off
+			SPAWN(rand(0,5)) //randomize a bit so piles of ammo don't shoot in waves
+				//shoot in a truly random direction
+				shoot_projectile_relay_pixel_spread(src, src.ammo_type, src, rand(-32, 32), rand(-32, 32), 360)
+				if (prob(30) && src.use(1)) //small chance to do two per tick
+					sleep(0.3 SECONDS)
+					shoot_projectile_DIR(src, src.ammo_type, pick(alldirs))
+
 //no caliber:
 /obj/item/ammo/bullets/vbullet
 	sname = "VR bullets"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ammo "cooks off" when exposed to > 400C, firing 1-2 random shots every time it does.
It will NOT fire when in your inventory or in your gun, just exposed ammo lying on the ground.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ammo fires are cool, lets you make a nasty makeshift bomb by hiding ammo under a welding tank and blowing it up.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Ammo will cook off when exposed to high temperatures. Ammo in your inventory or in a gun is unaffected.
```
