### PR TITLE
Characters with a missing eye get an eyepatch on spawn

### DIFF
--- a/code/datums/part_customization.dm
+++ b/code/datums/part_customization.dm
@@ -6,6 +6,8 @@ ABSTRACT_TYPE(/datum/part_customization)
 	///Can be a type or a list of types to randomly pick from
 	var/part_type = null
 	var/base_64_cache = null
+	/// Associated trait ID, if one is needed
+	var/associated_trait_id = null
 	var/trait_cost = 0 //idk let's keep using trait points for now
 	///Cannot be added alongside these part IDs
 	var/incompatible_parts = list()
@@ -15,6 +17,8 @@ ABSTRACT_TYPE(/datum/part_customization)
 
 	///Check if we can, then apply the part
 	proc/try_apply(mob/M, list/custom_parts = null)
+		if (src.associated_trait_id && M.traitHolder)
+			M.traitHolder.addTrait(associated_trait_id)
 		if (src.can_apply(M, custom_parts))
 			src.apply_to(M)
 			return TRUE
@@ -252,6 +256,7 @@ ABSTRACT_TYPE(/datum/part_customization/human/missing)
 		eye_left
 			id = "eye_missing_left"
 			slot = "left_eye"
+			associated_trait_id = "eye_missing_left"
 			trait_cost = 1
 
 			get_name()
@@ -260,6 +265,7 @@ ABSTRACT_TYPE(/datum/part_customization/human/missing)
 		eye_right
 			id = "eye_missing_right"
 			slot = "right_eye"
+			associated_trait_id = "eye_missing_right"
 			trait_cost = 1
 
 			get_name()

--- a/code/datums/part_customization.dm
+++ b/code/datums/part_customization.dm
@@ -17,8 +17,6 @@ ABSTRACT_TYPE(/datum/part_customization)
 
 	///Check if we can, then apply the part
 	proc/try_apply(mob/M, list/custom_parts = null)
-		if (src.associated_trait_id && M.traitHolder)
-			M.traitHolder.addTrait(associated_trait_id)
 		if (src.can_apply(M, custom_parts))
 			src.apply_to(M)
 			return TRUE
@@ -27,6 +25,9 @@ ABSTRACT_TYPE(/datum/part_customization)
 	///Actually add the part
 	proc/apply_to(mob/M)
 		PROTECTED_PROC(TRUE)
+		SHOULD_CALL_PARENT(TRUE)
+		if (src.associated_trait_id && M.traitHolder)
+			M.traitHolder.addTrait(associated_trait_id)
 		return
 
 	///Can we add the part, `custom_parts` is an associative list of slot IDs to part IDs
@@ -56,6 +57,7 @@ ABSTRACT_TYPE(/datum/part_customization/human)
 /datum/part_customization/human
 
 	apply_to(mob/living/carbon/human/human)
+		. = ..()
 		var/chosen_part_type = pick(src.part_type)
 		if (istype(src, /datum/part_customization/human/arm) || istype(src, /datum/part_customization/human/leg))
 			if(human.limbs.get_limb(slot)?.type != chosen_part_type)
@@ -75,6 +77,7 @@ ABSTRACT_TYPE(/datum/part_customization/human)
 			part_type = /obj/item/parts/human_parts/arm/left
 
 			apply_to(mob/living/carbon/human/human)
+				. = ..()
 				var/limb_type = human.mutantrace.l_limb_arm_type_mutantrace
 				if (human.gender == FEMALE) //gendered limbs???
 					limb_type = human.mutantrace.l_limb_arm_type_mutantrace_f || limb_type
@@ -89,6 +92,7 @@ ABSTRACT_TYPE(/datum/part_customization/human)
 			part_type = /obj/item/parts/human_parts/arm/right
 
 			apply_to(mob/living/carbon/human/human)
+				. = ..()
 				var/limb_type = human.mutantrace.r_limb_arm_type_mutantrace
 				if (human.gender == FEMALE) //gendered limbs???
 					limb_type = human.mutantrace.r_limb_arm_type_mutantrace_f || limb_type
@@ -140,6 +144,7 @@ ABSTRACT_TYPE(/datum/part_customization/human)
 			part_type = /obj/item/parts/human_parts/leg/left
 
 			apply_to(mob/living/carbon/human/human)
+				. = ..()
 				var/limb_type = human.mutantrace.l_limb_leg_type_mutantrace
 				if (human.gender == FEMALE)
 					limb_type = human.mutantrace.l_limb_leg_type_mutantrace_f || limb_type
@@ -154,6 +159,7 @@ ABSTRACT_TYPE(/datum/part_customization/human)
 			part_type = /obj/item/parts/human_parts/leg/right
 
 			apply_to(mob/living/carbon/human/human)
+				. = ..()
 				var/limb_type = human.mutantrace.r_limb_leg_type_mutantrace
 				if (human.gender == FEMALE)
 					limb_type = human.mutantrace.r_limb_leg_type_mutantrace_f || limb_type
@@ -211,6 +217,7 @@ ABSTRACT_TYPE(/datum/part_customization/human/missing)
 	custom_icon_state = "missing"
 
 	apply_to(mob/living/carbon/human/human)
+		. = ..()
 		if (istype(src, /datum/part_customization/human/missing/organ))
 			var/obj/item/organ/old_organ = human.organHolder?.get_organ(src.slot)
 			if(old_organ)

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1484,7 +1484,9 @@ TYPEINFO(/datum/trait/partyanimal)
 /datum/trait/missing_left_eye
 	name = "Missing Left Eye"
 	id = "eye_missing_left"
+	unselectable = TRUE
 
 /datum/trait/missing_right_eye
 	name = "Missing Right Eye"
 	id = "eye_missing_right"
+	unselectable = TRUE

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1478,3 +1478,13 @@ TYPEINFO(/datum/trait/partyanimal)
 		if(ishuman(owner) && prob(10))
 			var/mob/living/carbon/human/H = owner
 			randomize_mob_limbs(H)
+
+// organ removal handled in part customization, tracked here for equipping sensory item
+
+/datum/trait/missing_left_eye
+	name = "Missing Left Eye"
+	id = "eye_missing_left"
+
+/datum/trait/missing_right_eye
+	name = "Missing Right Eye"
+	id = "eye_missing_right"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1479,8 +1479,8 @@ TYPEINFO(/datum/trait/partyanimal)
 			var/mob/living/carbon/human/H = owner
 			randomize_mob_limbs(H)
 
-// organ removal handled in part customization, tracked here for equipping sensory item
-
+// organ removal associated traits
+// removal is handled in part customization, tracked here for equipping sensory item
 /datum/trait/missing_left_eye
 	name = "Missing Left Eye"
 	id = "eye_missing_left"

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -521,6 +521,21 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 		if (src.glasses)
 			src.stow_in_available(src.glasses)
 		src.equip_if_possible(new /obj/item/clothing/glasses/visor(src), SLOT_GLASSES)
+	else // if you're blind and have missing eyes, you don't get a cool patch sorry
+		var/missing_left = src.traitHolder.hasTrait("eye_missing_left")
+		var/missing_right =  src.traitHolder.hasTrait("eye_missing_right")
+		if (src.glasses && (missing_left || missing_right))
+			src.stow_in_available(src.glasses)
+		if (missing_left && missing_right)
+			src.equip_if_possible(new /obj/item/clothing/glasses/blindfold(src), SLOT_GLASSES)
+		else if (missing_left)
+			var/obj/item/clothing/glasses/eyepatch/eyepatch = new(src)
+			eyepatch.icon_state = "eyepatch-L"
+			eyepatch.block_eye = "L"
+			src.equip_if_possible(eyepatch, SLOT_GLASSES)
+		else if (missing_right)
+			src.equip_if_possible(new /obj/item/clothing/glasses/eyepatch(src), SLOT_GLASSES)
+
 	if (src.traitHolder.hasTrait("shortsighted"))
 		if (src.glasses)
 			src.stow_in_available(src.glasses)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][traits]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a feature to part customization to optionally apply a trait to characters.
Add unselectable traits for left and right missing eyes.
Add check for the new traits when equipping sensory items that will add an eyepatch of the correct side, or a blindfold if both of your eyes are missing. If you are blind, you do not get a cool eyepatch or blindfold, you need your VISOR instead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Seems fitting for characters that are missing eyes to have them covered in some way. Players don't have to keep them, of course, but spawning with them lets them make that choice instead of raiding medbay's fabricator.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Characters with a missing eye get an eyepatch on spawn.
```
