### PR TITLE
Reduce mimic/martian counts in gauntlet

### DIFF
--- a/code/datums/gauntlet/crittergauntlet.dm
+++ b/code/datums/gauntlet/crittergauntlet.dm
@@ -1053,7 +1053,7 @@ var/global/datum/arena/gauntletController/gauntlet_controller = new()
 	mimic
 		name = "Mimic"
 		point_cost = 1
-		count = 6
+		count = 3
 		types = list(/mob/living/critter/mimic/virtual)
 
 	meaty
@@ -1065,19 +1065,19 @@ var/global/datum/arena/gauntletController/gauntlet_controller = new()
 	martian
 		name = "Martian"
 		point_cost = 1
-		count = 6
+		count = 3
 		types = list(/mob/living/critter/martian)
 
 	soldier
 		name = "Martian Soldier"
 		point_cost = 3
-		count = 4
+		count = 2
 		types = list(/mob/living/critter/martian/soldier)
 
 	warrior
 		name = "Martian Warrior"
 		point_cost = 3
-		count = 2
+		count = 1
 		types = list(/mob/living/critter/martian/warrior)
 
 	mutant
@@ -1089,7 +1089,7 @@ var/global/datum/arena/gauntletController/gauntlet_controller = new()
 	martian_assorted
 		name = "Martian Assortment"
 		point_cost = 6
-		count = 12
+		count = 6
 		types = list(/mob/living/critter/martian/soldier, /mob/living/critter/martian/soldier, /mob/living/critter/martian/soldier, /mob/living/critter/martian/warrior)
 
 	bear


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduce the count of mimics and martians spawned per wave in the critter gauntlet


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These critters were buffed to have a lot more HP, so the resulting gauntlet is a slog.