### PR TITLE
Add artifact talismans and chairs as rewards in the gauntlet

### DIFF
--- a/code/datums/gauntlet/crittergauntlet.dm
+++ b/code/datums/gauntlet/crittergauntlet.dm
@@ -623,6 +623,10 @@ var/global/datum/arena/gauntletController/gauntlet_controller = new()
 			minimum_level = 15
 			supplies = list(/obj/item/artifact/melee_weapon)
 
+		talisman
+			minimum_level = 35
+			supplies = list(/obj/item/artifact/talisman)
+
 	inactive_artifact
 		name = "An Artifact"
 		minimum_level = 20
@@ -782,6 +786,12 @@ var/global/datum/arena/gauntletController/gauntlet_controller = new()
 		point_cost = -2
 		minimum_level = 15
 		supplies = list(/obj/item/storage/firstaid/vr/toxin, /obj/item/storage/firstaid/vr/oxygen, /obj/item/storage/firstaid/vr/brain, /obj/item/reagent_containers/emergency_injector/vr/calomel)
+
+	chair
+		name = "Chair"
+		point_cost = -1
+		minimum_level = 20
+		supplies = list(/obj/item/chair/folded)
 
 /datum/gauntletEvent
 	var/name = "Event"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds talismans and chairs as rewards in the guantlet.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Talisman buffs fit well with the combat-oriented nature of the gauntlet.

Chairs are strong tools with a wide sweeping attack and enabling chair-dives. I think it's worthwhile to let people get used to their mechanics in the gauntlet.