### PR TITLE
Adapt briefing screens for Carnigorm and HTR Team minimaps

### DIFF
--- a/assets/maps/allocated/htr_team_ship.dmm
+++ b/assets/maps/allocated/htr_team_ship.dmm
@@ -329,6 +329,7 @@
 /area/space)
 "LB" = (
 /obj/machinery/light/small/floor/warm,
+/obj/hearing_connector/target/nanotrasen,
 /turf/unsimulated/floor/blue,
 /area/space)
 "NA" = (

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -62,6 +62,9 @@ var/list/admin_verbs = list(
 		/client/proc/change_admin_prefs,
 		//client/proc/cmd_boot,
 
+		/client/proc/toggle_carnigorm_briefing,
+		/client/proc/toggle_HTR_briefing,
+
 		/client/proc/enableDrunkMode,
 		/client/proc/forceDrunkMode,
 

--- a/code/modules/hearing_connector/hearing_connector.dm
+++ b/code/modules/hearing_connector/hearing_connector.dm
@@ -1,0 +1,162 @@
+// Replaces a map computer screen with video and audio from a set
+
+/// Is the map broadcast for this faction enabled
+var/global/list/map_broadcast_enabled = list(
+	FACTION_NANOTRASEN = FALSE,
+	FACTION_SYNDICATE = FALSE,
+)
+
+/obj/hearing_connector
+	name = "Hearing Connector"
+	icon = 'icons/mob/screen1.dmi'
+	invisibility = INVIS_ALWAYS
+	anchored = ANCHORED_ALWAYS
+	var/id = "default"
+
+/obj/hearing_connector/target
+	icon_state = "down"
+
+/obj/hearing_connector/target/New()
+	. = ..()
+	START_TRACKING
+
+/obj/hearing_connector/target/disposing()
+	STOP_TRACKING
+	. = ..()
+
+// TODO: Need to add to the HTR spawn ship (currently in secret?)
+/obj/hearing_connector/target/nanotrasen
+	id = FACTION_NANOTRASEN
+
+/obj/hearing_connector/target/syndicate
+	id = FACTION_SYNDICATE
+
+/obj/hearing_connector/origin
+	icon_state = "up"
+
+/obj/hearing_connector/origin/New()
+	. = ..()
+	START_TRACKING
+
+	if ((global.map_broadcast_enabled[src.id]))
+		src.enable()
+
+/obj/hearing_connector/origin/disposing()
+	STOP_TRACKING
+	. = ..()
+
+/obj/hearing_connector/origin/proc/enable()
+	var/turf/origin = get_turf(src)
+	origin.listening_turfs ||= list()
+
+	for_by_tcl(connector, /obj/hearing_connector/target)
+		if (src == connector)
+			continue
+		if (connector.id != src.id)
+			continue
+		var/turf/target = get_turf(connector)
+		origin.listening_turfs += target
+
+/obj/hearing_connector/origin/proc/disable()
+	var/turf/origin = get_turf(src)
+	origin.listening_turfs ||= list()
+
+	for_by_tcl(connector, /obj/hearing_connector/target)
+		if (src == connector)
+			continue
+		if (connector.id != src.id)
+			continue
+		var/turf/target = get_turf(connector)
+		origin.listening_turfs -= target
+
+/obj/hearing_connector/origin/nanotrasen
+	id = FACTION_NANOTRASEN
+/obj/hearing_connector/origin/syndicate
+	id = FACTION_SYNDICATE
+
+/area/high_command
+	icon_state = "green"
+	var/id = null
+
+/area/high_command/nanotrasen
+	name = "Nanotrasen High Command"
+/area/high_command/nanotrasen/office_set
+	name = "Nanotrasen Commander's Office"
+	icon_state = "blue"
+	id = FACTION_NANOTRASEN
+
+/area/high_command/syndicate
+	name = "Syndicate High Command"
+/area/high_command/syndicate/office_set
+	name = "Syndicate Commander's Office"
+	icon_state = "red"
+	id = FACTION_SYNDICATE
+
+/client/proc/toggle_carnigorm_briefing()
+	set name = "Toggle Cairngorm Briefing Screen"
+	set desc = "Change the minimap screen on the Carnigorm to show an office set instead of the minimap."
+	SET_ADMIN_CAT(ADMIN_CAT_FUN)
+	ADMIN_ONLY
+
+	var/state = tgui_alert(usr, "Cairngorm Briefing Screen:", "Confirmation", list("On", "Off"))
+	var/toggle = FALSE
+	if (state == "On")
+		toggle = TRUE
+
+	if (global.map_broadcast_enabled[FACTION_SYNDICATE] == toggle)
+		return
+
+	global.map_broadcast_enabled[FACTION_SYNDICATE] = toggle
+
+	if (toggle)
+		for_by_tcl(connector, /obj/hearing_connector/origin)
+			if (connector.id == FACTION_SYNDICATE)
+				connector.enable()
+		for_by_tcl(map, /datum/minimap/area_map/broadcast)
+			if (map.id == FACTION_SYNDICATE)
+				map.enable_broadcast()
+	else
+		for_by_tcl(connector, /obj/hearing_connector/origin)
+			if (connector.id == FACTION_SYNDICATE)
+				connector.disable()
+		for_by_tcl(map, /datum/minimap/area_map/broadcast)
+			if (map.id == FACTION_SYNDICATE)
+				map.disable_broadcast()
+
+	message_admins(SPAN_INTERNAL("[key_name(src)] has toggled the Cairngorm Briefing Screen [state]."))
+	logTheThing(LOG_ADMIN, src, "toggled the Cairngorm Briefing Screen [state].")
+
+/client/proc/toggle_HTR_briefing()
+	set name = "Toggle HTR Briefing Screen"
+	set desc = "Change the minimap screen on the HTR Team ship to show an office set instead of the minimap."
+	SET_ADMIN_CAT(ADMIN_CAT_FUN)
+	ADMIN_ONLY
+
+	var/state = tgui_alert(usr, "HTR Briefing Screen:", "Confirmation", list("On", "Off"))
+	var/toggle = FALSE
+	if (state == "On")
+		toggle = TRUE
+
+	if (global.map_broadcast_enabled[FACTION_NANOTRASEN] == toggle)
+		return
+
+	global.map_broadcast_enabled[FACTION_NANOTRASEN] = toggle
+
+	if (toggle)
+		for_by_tcl(connector, /obj/hearing_connector/origin)
+			if (connector.id == FACTION_NANOTRASEN)
+				connector.enable()
+		for_by_tcl(map, /datum/minimap/area_map/broadcast)
+			if (map.id == FACTION_NANOTRASEN)
+				map.enable_broadcast()
+
+	else
+		for_by_tcl(connector, /obj/hearing_connector/origin)
+			if (connector.id == FACTION_NANOTRASEN)
+				connector.disable()
+		for_by_tcl(map, /datum/minimap/area_map/broadcast)
+			if (map.id == FACTION_NANOTRASEN)
+				map.disable_broadcast()
+
+	message_admins(SPAN_INTERNAL("[key_name(src)] has toggled the HTR Briefing Screen [state]."))
+	logTheThing(LOG_ADMIN, src, "toggled the HTR Briefing Screen [state].")

--- a/code/modules/minimap/minimap_objects/objects/map_computer.dm
+++ b/code/modules/minimap/minimap_objects/objects/map_computer.dm
@@ -67,6 +67,7 @@
 	name = "Atrium Station Map"
 	desc = "A cutting-edge cathode ray tube monitor, actively rendering many dozens of kilobytes of stolen structural data."
 	map_type = MAP_SYNDICATE
+	map_path = /datum/minimap/area_map/broadcast/carnigorm
 
 	light_r = 1
 	light_g = 0.3
@@ -132,6 +133,7 @@
 	name = "Station Map"
 	desc = "A cutting-edge cathode ray tube monitor, actively rendering a visualization of the target station."
 	map_type = MAP_HTR_TEAM
+	map_path = /datum/minimap/area_map/broadcast/htr
 
 	light_r = 0.3
 	light_g = 0.3

--- a/code/modules/minimap/minimaps/_area_minimap.dm
+++ b/code/modules/minimap/minimaps/_area_minimap.dm
@@ -147,3 +147,46 @@
 		var/icon/icon = new(src.map.icon)
 		icon.SwapColor(rgb(0, 0, 0), rgb(0, 0, 0, 0))
 		src.map.icon = icon
+
+/datum/minimap/area_map/broadcast
+	var/atom/movable/minimap_render_object/vis_contents_display
+	var/id = null
+	var/area/broadcast_set_area = null
+	var/list/turf/broadcast_set_turfs = null
+	var/turfs_cached
+
+/datum/minimap/area_map/broadcast/New()
+	. = ..()
+	START_TRACKING
+
+/datum/minimap/area_map/broadcast/disposing()
+	STOP_TRACKING
+	. = ..()
+
+/datum/minimap/area_map/broadcast/initialise_minimap_render()
+	. = ..()
+	src.vis_contents_display = new()
+	src.vis_contents_display.vis_flags |= VIS_INHERIT_ID
+	src.vis_contents_display.mouse_opacity = 0
+	src.vis_contents_display.pixel_x -= 5
+	src.vis_contents_display.pixel_y -= 4
+
+/datum/minimap/area_map/broadcast/proc/enable_broadcast()
+	if (length(src.vis_contents_display.vis_contents) == 0)
+		for (var/turf/T as anything in get_area_turfs(src.broadcast_set_area))
+			T.appearance_flags |= KEEP_TOGETHER
+			src.vis_contents_display.vis_contents += T
+	src.minimap_holder.vis_contents -= src.minimap_render
+	src.minimap_holder.vis_contents += src.vis_contents_display
+
+/datum/minimap/area_map/broadcast/proc/disable_broadcast()
+	src.minimap_holder.vis_contents += src.minimap_render
+	src.minimap_holder.vis_contents -= src.vis_contents_display
+
+/datum/minimap/area_map/broadcast/carnigorm
+	id = FACTION_SYNDICATE
+	broadcast_set_area = /area/high_command/syndicate/office_set
+
+/datum/minimap/area_map/broadcast/htr
+	id = FACTION_NANOTRASEN
+	broadcast_set_area = /area/high_command/nanotrasen/office_set

--- a/code/modules/minimap/minimaps/_area_minimap.dm
+++ b/code/modules/minimap/minimaps/_area_minimap.dm
@@ -152,8 +152,6 @@
 	var/atom/movable/minimap_render_object/vis_contents_display
 	var/id = null
 	var/area/broadcast_set_area = null
-	var/list/turf/broadcast_set_turfs = null
-	var/turfs_cached
 
 /datum/minimap/area_map/broadcast/New()
 	. = ..()

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1423,6 +1423,7 @@
 #include "code\modules\goonhub\event_recording\types\StationName.dm"
 #include "code\modules\goonhub\event_recording\types\Ticket.dm"
 #include "code\modules\gps\gps.dm"
+#include "code\modules\hearing_connector\hearing_connector.dm"
 #include "code\modules\holiday\halloween.dm"
 #include "code\modules\holiday\spacemas.dm"
 #include "code\modules\hydroponics\gene_strains.dm"

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -7824,6 +7824,12 @@
 	},
 /turf/unsimulated/floor/grass/leafy,
 /area/crater/biodome/north)
+"aMi" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate)
 "aMk" = (
 /obj/decal/stalagmite,
 /turf/unsimulated/floor/cave,
@@ -16793,6 +16799,14 @@
 "boH" = (
 /turf/unsimulated/wall/auto/adventure/iomoon,
 /area/iomoon)
+"boK" = (
+/obj/stool/chair/red{
+	dir = 4
+	},
+/obj/hearing_connector/origin/syndicate,
+/obj/machinery/light/small/floor/warm,
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate/office_set)
 "boM" = (
 /turf/unsimulated/floor/red/side{
 	dir = 8
@@ -18097,6 +18111,18 @@
 	},
 /turf/unsimulated/iomoon/floor,
 /area/iomoon)
+"btl" = (
+/obj/machinery/light/lamp/black{
+	pixel_x = 13
+	},
+/obj/table/nanotrasen/auto,
+/obj/machinery/phone/unlisted{
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/obj/hearing_connector/origin/nanotrasen,
+/turf/unsimulated/floor/carpet/green/fancy/edge/nw,
+/area/high_command/nanotrasen/office_set)
 "btp" = (
 /obj/item/sea_ladder,
 /obj/item/sea_ladder,
@@ -36509,6 +36535,11 @@
 "cHS" = (
 /turf/unsimulated/floor/wizard/carpet,
 /area/owlery/office)
+"cHT" = (
+/obj/table/nanotrasen/auto,
+/obj/hearing_connector/origin/nanotrasen,
+/turf/unsimulated/floor/carpet/green/fancy/edge/south,
+/area/high_command/nanotrasen/office_set)
 "cHU" = (
 /obj/table/reinforced/bar/auto,
 /obj/fakeobject{
@@ -56092,6 +56123,12 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/unsimulated/floor/black,
 /area/owlery/lab)
+"eUn" = (
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 9
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate)
 "eUA" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -56333,6 +56370,15 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/iomoon/base/underground)
+"ffO" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/unsimulated/wall/auto/supernorn,
+/area/high_command/nanotrasen)
 "ffY" = (
 /obj/stool/chair/dining/wood{
 	dir = 4
@@ -57847,6 +57893,12 @@
 	},
 /turf/unsimulated/floor/plating/damaged2,
 /area/owlery/Owlmait2)
+"gqZ" = (
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 9
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/nanotrasen)
 "gsH" = (
 /mob/living/critter/small_animal/crab/lava/deep,
 /turf/unsimulated/iomoon/floor{
@@ -58405,6 +58457,12 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/retentioncenter)
+"gLq" = (
+/obj/table/syndicate/auto,
+/obj/item/device/audio_log/radioship/large,
+/obj/hearing_connector/origin/syndicate,
+/turf/unsimulated/floor/carpet/red/fancy/edge/sw,
+/area/high_command/syndicate/office_set)
 "gLr" = (
 /obj/map/light/dimreddish,
 /obj/fakeobject/cultiststatue,
@@ -59079,6 +59137,16 @@
 /obj/item/clothing/mask/anime,
 /turf/unsimulated/floor/grass/leafy,
 /area/dojo)
+"hsV" = (
+/obj/table/syndicate/auto,
+/obj/machinery/phone/unlisted{
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/obj/item/megaphone/syndicate,
+/obj/hearing_connector/origin/syndicate,
+/turf/unsimulated/floor/carpet/red/fancy/edge/ne,
+/area/high_command/syndicate/office_set)
 "htI" = (
 /obj/disposalpipe/segment{
 	desc = "An underfloor transport pipe.";
@@ -59142,6 +59210,12 @@
 	dir = 8
 	},
 /area/owlery/gangzone)
+"huq" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate)
 "huB" = (
 /obj/mesh/grille/steel,
 /obj/fakeobject{
@@ -59663,6 +59737,12 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/sim/gunsim/lobby)
+"hQR" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/nanotrasen)
 "hRy" = (
 /obj/table/auto,
 /obj/item/stimpack,
@@ -59784,6 +59864,10 @@
 	dir = 10
 	},
 /area/owlery/staffhall)
+"hWX" = (
+/obj/decal/poster/wallsign/security,
+/turf/unsimulated/wall/auto/adventure/shuttle/dark,
+/area/high_command/syndicate/office_set)
 "hXz" = (
 /obj/mesh/catwalk,
 /obj/cable/green{
@@ -60477,6 +60561,10 @@
 	dir = 8
 	},
 /area/centcom/offices/cogwerks)
+"izz" = (
+/obj/decoration/clock,
+/turf/unsimulated/wall/auto/supernorn,
+/area/high_command/nanotrasen/office_set)
 "izT" = (
 /turf/unsimulated/wall/auto/lead/gray,
 /area/iomoon/base)
@@ -60504,6 +60592,10 @@
 	},
 /turf/unsimulated/floor/martian,
 /area/crunch)
+"iBJ" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/unsimulated/floor/black,
+/area/high_command/nanotrasen)
 "iBN" = (
 /obj/fakeobject/dreambeach/seashells,
 /obj/fakeobject/dreambeach/palm_leaf,
@@ -61296,6 +61388,15 @@
 	},
 /turf/unsimulated/floor/black,
 /area/owlery/Owlmait2)
+"jdX" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate)
 "jej" = (
 /obj/storage/crate/bin{
 	pixel_x = 5
@@ -61766,6 +61867,9 @@
 /obj/decal/stripe_delivery,
 /turf/unsimulated/floor/plating,
 /area/marsoutpost)
+"juV" = (
+/turf/unsimulated/wall/auto/adventure/shuttle/dark,
+/area/high_command/syndicate/office_set)
 "jvd" = (
 /obj/mesh/catwalk,
 /obj/cable/yellow{
@@ -61810,6 +61914,15 @@
 	},
 /turf/unsimulated/floor/sanitary,
 /area/crypt/sigma/morgue)
+"jvx" = (
+/turf/unsimulated/wall/auto/supernorn,
+/area/high_command/nanotrasen/office_set)
+"jvD" = (
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 5
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate)
 "jvG" = (
 /obj/fakeobject/cargopad,
 /obj/machinery/light,
@@ -62096,6 +62209,14 @@
 	dir = 10
 	},
 /area/centcom/gallery)
+"jHx" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/hearing_connector/origin/syndicate,
+/obj/machinery/light/small/floor/warm,
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate/office_set)
 "jHy" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/fakeobject/microscope,
@@ -63642,6 +63763,11 @@
 	dir = 4
 	},
 /area/dojo/sakura)
+"kTd" = (
+/obj/table/nanotrasen/auto,
+/obj/hearing_connector/origin/nanotrasen,
+/turf/unsimulated/floor/carpet/green/fancy/edge/se,
+/area/high_command/nanotrasen/office_set)
 "kTs" = (
 /turf/unsimulated/wall/generic{
 	desc = "It's sealed shut.";
@@ -63722,6 +63848,9 @@
 	icon_state = "floor3"
 	},
 /area/hospital/samostrel)
+"kWx" = (
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate)
 "kWN" = (
 /obj/table/auto/desk,
 /obj/item/pen/fancy{
@@ -64613,6 +64742,13 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/unsimulated/floor/wood/six,
 /area/afterlife/bar/sanctuary)
+"lJB" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/hearing_connector/origin/syndicate,
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate/office_set)
 "lJF" = (
 /turf/unsimulated/floor/wood/eight,
 /area/centcom/offices/bilo)
@@ -65079,6 +65215,13 @@
 "mef" = (
 /turf/unsimulated/floor,
 /area/watchful_eye_sensor)
+"meL" = (
+/obj/decal/poster{
+	icon = 'icons/obj/decals/posters.dmi';
+	icon_state = "pack_smart"
+	},
+/turf/unsimulated/wall/auto/adventure/shuttle/dark,
+/area/high_command/syndicate/office_set)
 "mfw" = (
 /obj/machinery/vending/meat/prefab_grill,
 /turf/unsimulated/floor/setpieces/bloodfloor{
@@ -65131,6 +65274,12 @@
 	},
 /turf/unsimulated/floor/airless/plating/catwalk/auto/iomoon,
 /area/iomoon)
+"mhQ" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate)
 "mie" = (
 /obj/stool/chair/dining/regal{
 	anchored = 1;
@@ -65486,6 +65635,10 @@
 /area/centcom/offices{
 	icon_state = "blue"
 	})
+"mxX" = (
+/obj/decal/poster,
+/turf/unsimulated/wall/auto/supernorn,
+/area/high_command/nanotrasen/office_set)
 "myh" = (
 /turf/unsimulated/floor/plating,
 /area/meat_derelict/main)
@@ -66953,6 +67106,15 @@
 	opacity = 0
 	},
 /area/centcom/lobby)
+"nKo" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/unsimulated/wall/auto/supernorn,
+/area/high_command/nanotrasen)
 "nKN" = (
 /obj/fakeobject/pipe{
 	color = "b4b4b4";
@@ -67990,6 +68152,13 @@
 	temperature = 313.15
 	},
 /area/iomoon/caves)
+"oye" = (
+/obj/stool/chair/red{
+	dir = 4
+	},
+/obj/hearing_connector/origin/syndicate,
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate/office_set)
 "oyo" = (
 /obj/stool/chair/office/red{
 	dir = 8
@@ -68103,6 +68272,12 @@
 /obj/mesh/catwalk,
 /turf/space,
 /area/watchful_eye_sensor)
+"oEt" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/nanotrasen)
 "oEX" = (
 /obj/table/auto,
 /obj/item/paper/businesscard/lawyers,
@@ -68155,6 +68330,12 @@
 	},
 /turf/unsimulated/wall/auto/lead/blue,
 /area/upper_arctic/comms)
+"oHw" = (
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 10
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate)
 "oHI" = (
 /obj/machinery/vending/medical,
 /obj/machinery/light{
@@ -68244,6 +68425,12 @@
 	name = "strange surface"
 	},
 /area/crater/cave/lower)
+"oJo" = (
+/obj/fakeobject/barbuddy_dispenser{
+	pixel_y = -9
+	},
+/turf/unsimulated/wall/auto/supernorn,
+/area/high_command/nanotrasen/office_set)
 "oJy" = (
 /obj/stool/chair/dining/wood{
 	dir = 4
@@ -69821,6 +70008,20 @@
 	},
 /turf/unsimulated/dirt,
 /area/crypt/graveyard/swamp)
+"pSI" = (
+/obj/table/nanotrasen/auto,
+/obj/hearing_connector/origin/nanotrasen,
+/turf/unsimulated/floor/carpet/green/fancy/edge/sw,
+/area/high_command/nanotrasen/office_set)
+"pSL" = (
+/obj/fakeobject{
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "bonsai";
+	pixel_y = 11
+	},
+/obj/hearing_connector/origin/nanotrasen,
+/turf/unsimulated/floor/marble/black,
+/area/high_command/nanotrasen/office_set)
 "pSW" = (
 /obj/map/light/graveyard,
 /obj/tree{
@@ -70167,6 +70368,9 @@
 /obj/machinery/portable_reclaimer,
 /turf/unsimulated/floor/plating,
 /area/hospital/underground)
+"qfA" = (
+/turf/unsimulated/floor/black,
+/area/high_command/nanotrasen)
 "qfG" = (
 /obj/shrub{
 	dir = 10;
@@ -70220,6 +70424,10 @@
 	opacity = 0
 	},
 /area/titlescreen)
+"qgW" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate)
 "qhR" = (
 /obj/table/reinforced/auto,
 /turf/unsimulated/floor/shuttle{
@@ -70835,6 +71043,10 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/moon/museum)
+"qGy" = (
+/obj/decoration/clock,
+/turf/unsimulated/wall/auto/adventure/shuttle/dark,
+/area/high_command/syndicate/office_set)
 "qGG" = (
 /obj/machinery/vehicle/pod_smooth/syndicate,
 /obj/decal/tile_edge/stripe{
@@ -71076,6 +71288,10 @@
 /area/sim/tdome/tdomea{
 	name = "Thunderdome Lounge"
 	})
+"qOz" = (
+/obj/hearing_connector/origin/syndicate,
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate/office_set)
 "qOB" = (
 /obj/map/light/brighterwhite,
 /turf/unsimulated/floor/carpet{
@@ -72131,6 +72347,10 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/moon/museum)
+"rEn" = (
+/obj/hearing_connector/origin/nanotrasen,
+/turf/unsimulated/floor/marble/black,
+/area/high_command/nanotrasen/office_set)
 "rEI" = (
 /turf/unsimulated/floor/plating,
 /area/meat_derelict/guts)
@@ -72260,6 +72480,12 @@
 	icon_state = "floor2"
 	},
 /area/shuttle/merchant_shuttle/left_centcom/destiny)
+"rHU" = (
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 5
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/nanotrasen)
 "rIo" = (
 /obj/overlay{
 	density = 1;
@@ -72888,6 +73114,11 @@
 	},
 /turf/unsimulated/outdoors/grass,
 /area/shuttle/merchant_shuttle/diner_centcom)
+"shq" = (
+/obj/machinery/light/small/floor/cool,
+/obj/hearing_connector/origin/nanotrasen,
+/turf/unsimulated/floor/marble/black,
+/area/high_command/nanotrasen/office_set)
 "shs" = (
 /obj/item/clothing/suit/bedsheet/pink,
 /obj/stool/bed,
@@ -72943,6 +73174,12 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/centcom/lobby)
+"siR" = (
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 6
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/syndicate)
 "sjB" = (
 /obj/lattice{
 	dir = 1;
@@ -73133,6 +73370,15 @@
 	dir = 1
 	},
 /area/iomoon/base/underground)
+"sps" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/unsimulated/wall/auto/adventure/shuttle/dark,
+/area/high_command/syndicate)
 "spy" = (
 /turf/unsimulated/floor/stairs/wide/other{
 	dir = 8
@@ -74112,6 +74358,16 @@
 	},
 /turf/unsimulated/floor/shuttlebay,
 /area/diner/tug)
+"tqz" = (
+/obj/table/syndicate/auto,
+/obj/item/cash_briefcase/syndicate/loaded,
+/obj/hearing_connector/origin/syndicate,
+/obj/item/paper/businesscard/mabinogi{
+	pixel_y = 7;
+	pixel_x = 4
+	},
+/turf/unsimulated/floor/carpet/red/fancy/edge/se,
+/area/high_command/syndicate/office_set)
 "tqB" = (
 /turf/unsimulated/floor/marble,
 /area/centcom/gallery)
@@ -74293,6 +74549,10 @@
 	dir = 1
 	},
 /area/iomoon/base)
+"txp" = (
+/obj/hearing_connector/origin/syndicate,
+/turf/unsimulated/floor/redblack,
+/area/high_command/syndicate/office_set)
 "txy" = (
 /turf/unsimulated/wall/auto/lead/gray,
 /area/iomoon/caves)
@@ -74378,6 +74638,15 @@
 "tFG" = (
 /turf/unsimulated/floor/carpet/regalcarpet/border,
 /area/centcom/gallery)
+"tFW" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/nanotrasen)
 "tGw" = (
 /obj/item/cigbutt{
 	pixel_x = 6
@@ -74524,6 +74793,11 @@
 "tMB" = (
 /turf/unsimulated/wall/auto/adventure/fake_window,
 /area/sim/racing_entry)
+"tMT" = (
+/obj/hearing_connector/origin/syndicate,
+/obj/stool/chair/office/syndie,
+/turf/unsimulated/floor/redblack,
+/area/high_command/syndicate/office_set)
 "tMW" = (
 /obj/fakeobject/pipe{
 	density = 1;
@@ -74990,6 +75264,15 @@
 /obj/mapping_helper/access/owlmaint,
 /turf/unsimulated/floor/plating,
 /area/owlery/owllock)
+"ufo" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/unsimulated/wall/auto/adventure/shuttle/dark,
+/area/high_command/syndicate)
 "ufy" = (
 /obj/geode/crystal/uqill,
 /turf/unsimulated/floor/cave,
@@ -75277,6 +75560,12 @@
 /obj/machinery/light/small/floor,
 /turf/unsimulated/floor/circuit/white,
 /area/centcom/offices/bilo)
+"uuV" = (
+/obj/table/nanotrasen/auto,
+/obj/item/device/audio_log,
+/obj/hearing_connector/origin/nanotrasen,
+/turf/unsimulated/floor/carpet/green/fancy/edge/ne,
+/area/high_command/nanotrasen/office_set)
 "uvs" = (
 /turf/unsimulated/floor/carpet/red/decal,
 /area/centcom/offices/grifflez)
@@ -75460,6 +75749,11 @@
 /mob/living/critter/zombie/scientist,
 /turf/unsimulated/floor/white/grime,
 /area/crypt/sigma/lab)
+"uCb" = (
+/obj/stool/chair/comfy/blue,
+/obj/hearing_connector/origin/nanotrasen,
+/turf/unsimulated/floor/marble/black,
+/area/high_command/nanotrasen/office_set)
 "uCm" = (
 /turf/unsimulated/wall/setpieces/leadwindow/white{
 	dir = 8
@@ -75891,6 +76185,16 @@
 	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
+"uRG" = (
+/obj/table/nanotrasen/auto,
+/obj/item/paper,
+/obj/item/pen/fancy{
+	pixel_x = -9;
+	pixel_y = 11
+	},
+/obj/hearing_connector/origin/nanotrasen,
+/turf/unsimulated/floor/carpet/green/fancy/edge/north,
+/area/high_command/nanotrasen/office_set)
 "uRP" = (
 /obj/map/light/graveyard,
 /mob/living/critter/zombie,
@@ -77432,6 +77736,12 @@
 	},
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/bubs)
+"wac" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/nanotrasen)
 "wao" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/unsimulated/floor/white,
@@ -77629,6 +77939,11 @@
 /obj/item/ammo/ammobox/shootingrange,
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/firing_range)
+"wjO" = (
+/obj/table/syndicate/auto,
+/obj/hearing_connector/origin/syndicate,
+/turf/unsimulated/floor/carpet/red/fancy/edge/south,
+/area/high_command/syndicate/office_set)
 "wjW" = (
 /obj/indestructible/shuttle_corner{
 	icon = 'icons/turf/walls/silicate.dmi';
@@ -78813,6 +79128,12 @@
 /obj/geode/crystal/uqill,
 /turf/unsimulated/floor/cave,
 /area/crater/cave/lower)
+"xdd" = (
+/obj/table/syndicate/auto,
+/obj/machinery/light/lamp/black,
+/obj/hearing_connector/origin/syndicate,
+/turf/unsimulated/floor/carpet/red/fancy/edge/nw,
+/area/high_command/syndicate/office_set)
 "xdm" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/meat_derelict/main)
@@ -78931,6 +79252,12 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/iomoon/base)
+"xiJ" = (
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 6
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/nanotrasen)
 "xiM" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/decal/stripe_delivery,
@@ -80025,6 +80352,11 @@
 /obj/mapping_helper/access/owlcommand,
 /turf/unsimulated/floor/black,
 /area/owlery/staffhall)
+"xUv" = (
+/obj/table/podium_wood/syndicate,
+/obj/hearing_connector/origin/syndicate,
+/turf/unsimulated/floor/carpet/red/fancy/edge/north,
+/area/high_command/syndicate/office_set)
 "xUA" = (
 /obj/decal/glow{
 	anchored = 1;
@@ -80332,6 +80664,12 @@
 "ybJ" = (
 /turf/unsimulated/floor/dojo/stone,
 /area/titlescreen)
+"ybM" = (
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 10
+	},
+/turf/unsimulated/floor/black,
+/area/high_command/nanotrasen)
 "ybN" = (
 /obj/mapping_helper/turf/floor/darkener{
 	dir = 5
@@ -80374,6 +80712,7 @@
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/katzen)
 "yea" = (
+/obj/hearing_connector/target/syndicate,
 /turf/unsimulated/floor/black{
 	icon_state = "cairngorm11"
 	},
@@ -115319,16 +115658,16 @@ bVT
 bVT
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+kWx
+kWx
+kWx
+kWx
+kWx
+kWx
+kWx
+kWx
+kWx
+aaa
 cnw
 cnw
 cnw
@@ -115621,16 +115960,16 @@ bVU
 bVU
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+kWx
+siR
+sps
+huq
+huq
+huq
+huq
+jvD
+kWx
+aaa
 cnw
 cnw
 cnw
@@ -115923,16 +116262,16 @@ bVU
 bVU
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+kWx
+qgW
+juV
+txp
+boK
+oye
+qOz
+jdX
+kWx
+aaa
 cnw
 cnw
 cnw
@@ -116225,16 +116564,16 @@ pZn
 bVU
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+kWx
+qgW
+meL
+txp
+xdd
+gLq
+qOz
+aMi
+kWx
+aaa
 cnw
 cnw
 cnw
@@ -116527,16 +116866,16 @@ slS
 bVU
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+kWx
+qgW
+juV
+tMT
+xUv
+wjO
+qOz
+aMi
+kWx
+aaa
 cnw
 cnw
 cnw
@@ -116829,16 +117168,16 @@ hzi
 bVU
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+kWx
+qgW
+qGy
+txp
+hsV
+tqz
+qOz
+aMi
+kWx
+aaa
 cnw
 cnw
 cnw
@@ -117131,16 +117470,16 @@ rKO
 bVU
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+kWx
+qgW
+hWX
+txp
+jHx
+lJB
+qOz
+aMi
+kWx
+aaa
 cnw
 cnw
 cnw
@@ -117433,16 +117772,16 @@ rRv
 bVU
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+kWx
+oHw
+ufo
+mhQ
+mhQ
+mhQ
+mhQ
+eUn
+kWx
+aaa
 cnw
 cnw
 cnw
@@ -117735,16 +118074,16 @@ oKc
 bVU
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+kWx
+kWx
+kWx
+kWx
+kWx
+kWx
+kWx
+kWx
+kWx
+aaa
 cnw
 cnw
 cnw
@@ -118037,16 +118376,16 @@ lvP
 bVU
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 cnw
 cnw
 cnw
@@ -118339,16 +118678,16 @@ tmM
 bVU
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+qfA
+qfA
+qfA
+qfA
+qfA
+qfA
+qfA
+qfA
+qfA
+aaa
 cnw
 cnw
 cnw
@@ -118641,16 +118980,16 @@ bVU
 bVU
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+qfA
+xiJ
+ffO
+hQR
+hQR
+hQR
+hQR
+rHU
+qfA
+aaa
 cnw
 cnw
 cnw
@@ -118943,16 +119282,16 @@ bVU
 bVU
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+qfA
+iBJ
+jvx
+pSL
+rEn
+shq
+rEn
+tFW
+qfA
+aaa
 cnw
 cnw
 cnw
@@ -119245,16 +119584,16 @@ bVT
 bVT
 bVT
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+qfA
+iBJ
+mxX
+rEn
+btl
+pSI
+rEn
+oEt
+qfA
+aaa
 cnw
 cnw
 cnw
@@ -119547,16 +119886,16 @@ aaa
 aaa
 aaa
 aaa
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+qfA
+iBJ
+jvx
+uCb
+uRG
+cHT
+rEn
+oEt
+qfA
+aaa
 cnw
 cnw
 cnw
@@ -119848,17 +120187,17 @@ cnw
 cnw
 cnw
 cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+aaa
+qfA
+iBJ
+izz
+rEn
+uuV
+kTd
+rEn
+oEt
+qfA
+aaa
 cnw
 cnw
 cnw
@@ -120150,17 +120489,17 @@ cnw
 cnw
 cnw
 cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+aaa
+qfA
+iBJ
+oJo
+rEn
+rEn
+shq
+rEn
+oEt
+qfA
+aaa
 cnw
 cnw
 cnw
@@ -120452,17 +120791,17 @@ cnw
 cnw
 cnw
 cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+aaa
+qfA
+ybM
+nKo
+wac
+wac
+wac
+wac
+gqZ
+qfA
+aaa
 cnw
 cnw
 cnw
@@ -120754,17 +121093,17 @@ cnw
 cnw
 cnw
 cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+aaa
+qfA
+qfA
+qfA
+qfA
+qfA
+qfA
+qfA
+qfA
+qfA
+aaa
 cnw
 cnw
 cnw
@@ -121056,17 +121395,17 @@ cnw
 cnw
 cnw
 cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 cnw
 cnw
 cnw


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][gamemodes]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows admins to change the display of the atrium minimaps on the Carnigorm and HTR Team ship to instead show an office set. Everything said by mobs in the office set will be heard by the players on the Carnigorm/HTR Ship.

* Add two "offices" for the Syndicate and Nanotrasen to z2.
* Add hearing connector targets to the Carnigorm and HTR Team ship.
* Add unique "broadcast" map datums that connect and toggle viscontents
* Add admin verbs for toggling the broadcast on/off.

This is an adaptation of the briefing system used for 35 Below. Original code by Mr. Moriarty and Bartimeus, licensed CC BY-NC-SA 3.0 here: https://github.com/Herbstation/35below/blob/main/herb_modular/code/area/soviet_high_command.dm
https://github.com/Herbstation/35below/blob/main/herb_modular/code/modules/minimap/minimaps/soviet_map.dm

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Enable admins to act out in-character briefings with these teams.

This feature could also be used in podwars, but would require adding the offices to the pod wars map itself as it doesn't include z2.

## Demo
(to be uploaded)