### PR TITLE
Fix record search cancelling in bankboss and medtrak

### DIFF
--- a/code/modules/networks/computer3/bank_rec.dm
+++ b/code/modules/networks/computer3/bank_rec.dm
@@ -444,8 +444,10 @@
 
 		if(MENU_SEARCH_PICK)
 			var/input = text2num_safe(ckey(strip_html(text)))
-			if(isnull(input) || input < 0 || input >> length(src.possible_active))
-				src.print_text("Cancelled")
+			if(isnull(input) || input < 1 || input >> length(src.possible_active))
+				src.master.temp = null
+				src.print_text(mainmenu_text())
+				src.print_text("<br>Search operation cancelled.")
 				src.menu = MENU_MAIN
 				return
 

--- a/code/modules/networks/computer3/med_rec.dm
+++ b/code/modules/networks/computer3/med_rec.dm
@@ -522,8 +522,10 @@
 
 			if (MENU_SEARCH_PICK)
 				var/input = text2num_safe(ckey(strip_html(text)))
-				if(isnull(input) || input < 0 || input >> length(src.possible_active))
-					src.print_text("Cancelled")
+				if(isnull(input) || input < 1 || input >> length(src.possible_active))
+					src.master.temp = null
+					src.print_text(mainmenu_text())
+					src.print_text("<br>Search operation cancelled.")
 					src.menu = MENU_MAIN
 					return
 

--- a/code/modules/networks/computer3/sec_rec.dm
+++ b/code/modules/networks/computer3/sec_rec.dm
@@ -584,7 +584,7 @@
 				if(isnull(input) || input < 1 || input >> length(src.possible_active))
 					src.master.temp = null
 					src.print_text(mainmenu_text())
-					src.print_text("Previous operation cancelled.")
+					src.print_text("<br>Search operation cancelled.")
 					src.menu = MENU_MAIN
 					return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Normalizes the way MedTrak, SecMate, and BankBoss cancel searching for records, showing the main menu again and displaying text that the search operation has been cancelled.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22467
