### PR TITLE
Stop the radio station intercom from being mechscanned

### DIFF
--- a/code/modules/telescience/radiostation.dm
+++ b/code/modules/telescience/radiostation.dm
@@ -1172,7 +1172,8 @@ ABSTRACT_TYPE(/obj/item/record/random/notaquario)
 	fields = strings("radioship/radioship_records.txt","log_2")
 
 
-
+TYPEINFO(/obj/item/device/radio/intercom/radiostation)
+	mats = 0
 /obj/item/device/radio/intercom/radiostation
 	name = "broadcast radio"
 	desc = "A powerful radio transmitter. Enable the microphone to begin broadcasting your radio show."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[removal][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Zero out the mats for the special radio station intercom type

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The special radio station intercom should stay unique to the radio station. None of the other radio station equipment can be scanned.