### PR TITLE
Remove extra robotics apc on mushroom

### DIFF
--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -36099,10 +36099,6 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"ugY" = (
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/robotics)
 "uhh" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/main)
@@ -97035,7 +97031,7 @@ beu
 ben
 aVD
 ben
-ugY
+ben
 ben
 jYD
 koJ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the second apc in robotics on mushroom

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #22775