### PR TITLE
Tweak solar flare interaction with interdictors

### DIFF
--- a/code/modules/events/solar_flare.dm
+++ b/code/modules/events/solar_flare.dm
@@ -4,24 +4,29 @@
 
 	event_effect(var/source)
 		..()
-		var/signal_loss_current = rand(66,100)
-		var/headline_estimate = min(signal_loss_current + rand(-10,10),100)
-		var/flare_start_time = rand(50,100)
+		var/signal_loss_initial = rand(66,100)
+		var/signal_loss_current = signal_loss_initial
+		var/flare_start_time = rand(100,200)
 		//spatial interdictor: mitigate signal loss
 		//consumes 2,000 units of charge (1 million joules) as the effect is zone-wide and requires significant energetic investment
 		for_by_tcl(IX, /obj/machinery/interdictor)
 			if(IX.z == 1 && IX.expend_interdict(2000))
 				var/itdr_strength = IX.interdict_range
 				signal_loss_current = max(0,signal_loss_current - rand(itdr_strength,itdr_strength*2))
-				SPAWN(flare_start_time)
+				SPAWN(flare_start_time/4)
 					if(IX && IX.canInterdict) //just in case
 						playsound(IX,'sound/machines/firealarm.ogg',50,FALSE,5,0.6)
-						var/adjusted_est = max(signal_loss_current + rand(-5,5),0)
-						IX.visible_message(SPAN_ALERT("<b>[IX]</b> detects a radio-frequency disturbance. Estimated strength post-interdiction: [adjusted_est]%."))
+						IX.visible_message(SPAN_ALERT("<b>[IX]</b> detects a mass radio-frequency disturbance. Applying wide-spectrum interdiction."))
 						//break omitted, multiple interdictors can stack
 
 		if (random_events.announce_events)
-			command_alert("A solar flare has been detected near the [station_or_ship()]. We estimate a signal interference rate of [headline_estimate]% lasting anywhere between three to five minutes.", "Solar Flare", alert_origin = ALERT_WEATHER)
+			SPAWN(flare_start_time/2)
+				var/headline_estimate = min(signal_loss_current + rand(-10,10),100)
+				var/headline = "A solar flare has been detected near the [station_or_ship()]. We estimate a signal interference rate of [headline_estimate]% lasting anywhere between three to five minutes."
+				if (signal_loss_initial != signal_loss_current)
+					headline += "<br>Local spatial interdiction reduced interference by an estimated [min(signal_loss_initial, signal_loss_initial - signal_loss_current + rand(-5, 5))]%."
+				command_alert(headline, "Solar Flare", alert_origin = ALERT_WEATHER)
+
 		SPAWN(flare_start_time)
 			signal_loss += signal_loss_current
 			global.solar_gen_rate *= signal_loss_current

--- a/code/modules/events/solar_flare.dm
+++ b/code/modules/events/solar_flare.dm
@@ -24,7 +24,7 @@
 				var/headline_estimate = min(signal_loss_current + rand(-10,10),100)
 				var/headline = "A solar flare has been detected near the [station_or_ship()]. We estimate a signal interference rate of [headline_estimate]% lasting anywhere between three to five minutes."
 				if (signal_loss_initial != signal_loss_current)
-					headline += "<br>Local spatial interdiction reduced interference by an estimated [min(signal_loss_initial, signal_loss_initial - signal_loss_current + rand(-5, 5))]%."
+					headline += "<br>Local spatial interdiction reduced interference by an estimated [min(headline_estimate, signal_loss_initial - signal_loss_current + rand(-5, 5))]%."
 				command_alert(headline, "Solar Flare", alert_origin = ALERT_WEATHER)
 
 		SPAWN(flare_start_time)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game objects][events]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Tweaks a few things about how interdictors interact with the solar flare event:
* Solar flares are given a larger "wind-up" time (to 100-200 from 50-100).
* Interdictors now act as a slight early warning system for solar flares.
* Interdictors no longer individually announce an estimated signal loss reduction; this was misleading as each interdictor slowly reduced the number.
* If event announcements are enabled and interdictors have reduced the signal loss, add a message indicating an estimated reduction to the event announcement.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Better feedback on interdictors actually doing something when solar flares happen.
Fix #12436

Did you know:
* In a best-case scenario, it takes 7 lambda interdictors to nullify the signal loss event?
* In a worst-case scenario, it could take as many as 20 lambda interdictors!