### PR TITLE
Add a floor-only wandering AI and apply to small animals

### DIFF
--- a/code/mob/living/critter/ai/bunny.dm
+++ b/code/mob/living/critter/ai/bunny.dm
@@ -6,6 +6,6 @@
 /datum/aiTask/prioritizer/critter/bunny/New()
 	..()
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/flight_range, list(holder, src))
-	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/floor_only, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/eat, list(holder, src))
 

--- a/code/mob/living/critter/ai/cat.dm
+++ b/code/mob/living/critter/ai/cat.dm
@@ -5,5 +5,5 @@
 
 /datum/aiTask/prioritizer/critter/cat/New()
 	..()
-	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/floor_only, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/attack, list(holder, src))

--- a/code/mob/living/critter/ai/dog.dm
+++ b/code/mob/living/critter/ai/dog.dm
@@ -5,7 +5,7 @@
 
 /datum/aiTask/prioritizer/critter/dog/New()
 	..()
-	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/floor_only, list(holder, src))
 
 // Go fetch!
 /datum/aiTask/sequence/goalbased/critter/dog/fetch

--- a/code/mob/living/critter/ai/generic_aiholders.dm
+++ b/code/mob/living/critter/ai/generic_aiholders.dm
@@ -20,6 +20,16 @@ if there is otherwise unique behaviour which you add to another mob consider mov
 	..()
 	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander, list(src.holder, src))
 
+/// Floor-only Wanderer
+/datum/aiHolder/wanderer/floor_only
+	New()
+		..()
+		default_task = get_instance(/datum/aiTask/prioritizer/critter/wanderer/floor_only, list(src))
+
+/datum/aiTask/prioritizer/critter/wanderer/floor_only/New()
+	..()
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/floor_only, list(src.holder, src))
+
 /// Aggressive Wanderer
 /datum/aiHolder/aggressive
 	New()

--- a/code/mob/living/critter/ai/mouse.dm
+++ b/code/mob/living/critter/ai/mouse.dm
@@ -5,7 +5,7 @@
 
 /datum/aiTask/prioritizer/critter/mouse/New()
 	..()
-	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/floor_only, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/eat, list(holder, src))
 
 /datum/aiHolder/mouse/mad
@@ -22,4 +22,4 @@
 /datum/aiHolder/mouse_remy
 	New()
 		..()
-		default_task = get_instance(/datum/aiTask/timed/wander, list(src))
+		default_task = get_instance(/datum/aiTask/timed/wander/floor_only, list(src))

--- a/code/mob/living/critter/ai/roach.dm
+++ b/code/mob/living/critter/ai/roach.dm
@@ -5,5 +5,5 @@
 
 /datum/aiTask/prioritizer/critter/roach/New()
 	..()
-	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/floor_only, list(holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/eat, list(holder, src))

--- a/code/mob/living/critter/ai/shared.dm
+++ b/code/mob/living/critter/ai/shared.dm
@@ -86,6 +86,19 @@
 	minimum_task_ticks = 1
 	maximum_task_ticks = 3
 
+/datum/aiTask/timed/wander/floor_only
+/datum/aiTask/timed/wander/floor_only/on_tick()
+	var/list/valid_dirs = list()
+	for (var/dir in alldirs)
+		if (isfloor(get_step(holder.owner, dir)))
+			valid_dirs += dir
+	if (length(valid_dirs) == 0)
+		valid_dirs = alldirs // we're stranded!
+	holder.owner.move_dir = pick(valid_dirs)
+	holder.owner.process_move()
+	holder?.stop_move() // Just in case they yeet themselves out of existance
+	holder?.owner.move_dir = null // clear out direction so it doesn't get latched when client is attached
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TARGETED TASK
 // a timed task that also relates to a target and the acquisition of said target

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -68,7 +68,7 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 	health_burn_vuln = 1
 	void_mindswappable = TRUE
 	is_npc = TRUE
-	ai_type = /datum/aiHolder/wanderer
+	ai_type = /datum/aiHolder/wanderer/floor_only
 	ai_retaliates = TRUE
 	ai_retaliate_patience = 2
 	ai_retaliate_persistence = RETALIATE_ONCE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][ai]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a timed wander aiTask subtype: floor only. This checks all directions for floors before picking a direction to move. In the case where there are no valid floors, just wander aimlessly, maybe they'll get back to land.
Add a wanderer aiHolder subtype: floor only, that uses the above task
Modify several small animal aiHolders to use the new floor_only aiTask.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Small animals can have little a survival instinct, as a treat. They'll try to stay on land, not wander into the cold void of space.

Fixes a very common issue on Donut3 where the pool critters almost always drift south into the armory turrets at some point.