### PR TITLE
Change the Donut3 brig visitation to solid windows

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -1384,6 +1384,12 @@
 /obj/mesh/catwalk/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
+"arY" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig/south_side)
 "asj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -4597,14 +4603,16 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload)
 "bpJ" = (
+/obj/submachine/ATM/atm_alt{
+	pixel_y = 32
+	},
 /obj/decal/tile_edge/line/black{
-	dir = 1;
+	dir = 4;
 	icon_state = "tile1"
 	},
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_x = 5;
-	pixel_y = 18
+/obj/decal/tile_edge/line/black{
+	dir = 9;
+	icon_state = "tile1"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig/south_side)
@@ -7283,11 +7291,11 @@
 	},
 /area/station/engine/monitoring)
 "cep" = (
-/obj/random_item_spawner/junk/one_or_zero,
 /obj/disposalpipe/segment/transport{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
 "cev" = (
@@ -7917,6 +7925,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
+"clT" = (
+/obj/table/reinforced/auto,
+/obj/machinery/phone,
+/turf/simulated/floor/black/grime,
+/area/station/security/visitation)
 "clX" = (
 /obj/mesh/grille/steel,
 /turf/simulated/floor/plating/jen,
@@ -18209,12 +18222,8 @@
 /turf/simulated/wall/auto/jen/yellow,
 /area/station/maintenance/outer/east)
 "fuC" = (
-/obj/stool/bench/red,
-/obj/decal/tile_edge/line/black{
-	dir = 4;
-	icon_state = "tile1"
-	},
-/turf/simulated/floor/grime,
+/obj/table/reinforced/auto,
+/turf/simulated/floor/black/grime,
 /area/station/security/brig/south_side)
 "fuE" = (
 /obj/cable{
@@ -19539,7 +19548,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
-/area/station/security/brig/north_side)
+/area/station/security/brig/solitary2)
 "fOw" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -23032,7 +23041,8 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/decoration/clock{
-	pixel_y = 32
+	pixel_y = 32;
+	pixel_x = 6
 	},
 /obj/cable{
 	icon_state = "2-8"
@@ -23043,6 +23053,12 @@
 	name = "autoname - SS13";
 	pixel_x = 10;
 	tag = ""
+	},
+/obj/machinery/door_control{
+	id = "visitorlockdown";
+	name = "Brig Visitor Lockdown Control";
+	pixel_x = -7;
+	pixel_y = 26
 	},
 /turf/simulated/floor/red/checker,
 /area/station/security/checkpoint/sec_foyer)
@@ -23548,6 +23564,11 @@
 	},
 /turf/simulated/wall/auto/jen/blue,
 /area/station/hallway/primary/southeast)
+"hbf" = (
+/obj/table/reinforced/auto,
+/obj/machinery/phone,
+/turf/simulated/floor/black/grime,
+/area/station/security/brig/south_side)
 "hbt" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -26016,10 +26037,6 @@
 /obj/decal/tile_edge/line/black{
 	dir = 9;
 	icon_state = "tile1"
-	},
-/obj/item/storage/pill_bottle/cyberpunk{
-	pixel_x = -1;
-	pixel_y = 1
 	},
 /obj/item/storage/toilet/random{
 	dir = 8
@@ -31699,6 +31716,17 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/kitchen)
+"jDY" = (
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "tile1"
+	},
+/obj/stool/bench/red,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig/south_side)
 "jEm" = (
 /obj/stool/bench/blue/auto,
 /obj/machinery/light/emergency,
@@ -33294,6 +33322,14 @@
 	},
 /turf/simulated/floor/airless/plating/jen,
 /area/station/turret_protected/AIbaseoutside)
+"kaN" = (
+/obj/decal/tile_edge/line/black{
+	dir = 4;
+	icon_state = "tile1"
+	},
+/obj/stool/bench/red,
+/turf/simulated/floor/grime,
+/area/station/security/brig/south_side)
 "kbg" = (
 /obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 8
@@ -35532,7 +35568,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
-/area/station/security/brig/south_side)
+/area/station/maintenance/outer/west)
 "kLw" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 1
@@ -38241,6 +38277,25 @@
 /area/station/wreckage{
 	name = "Restricted Area"
 	})
+"lCb" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "visitorlockdown";
+	layer = 6;
+	name = "Brig Visitor Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig/south_side)
 "lCe" = (
 /obj/stool/chair{
 	dir = 8
@@ -41656,12 +41711,15 @@
 	},
 /area/station/storage/emergency)
 "mBr" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /obj/decal/tile_edge/line/black{
 	dir = 5;
 	icon_state = "tile1"
-	},
-/obj/cable{
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig/south_side)
@@ -43816,15 +43874,15 @@
 	dir = 1;
 	icon_state = "tile1"
 	},
-/obj/decal/tile_edge/line/black{
-	dir = 6;
-	icon_state = "tile1"
-	},
 /obj/stool/bed,
 /obj/item/clothing/glasses/vr/arcade,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-2"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 6;
+	icon_state = "tile1"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig/south_side)
@@ -46082,6 +46140,23 @@
 	name = "reinforced plating"
 	},
 /area/station/science/chemistry)
+"nUC" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "visitorlockdown";
+	layer = 6;
+	name = "Brig Visitor Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig/south_side)
 "nUD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -55768,11 +55843,7 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/armory_outside)
 "qUL" = (
-/obj/mapping_helper/firedoor_spawn,
 /obj/table/reinforced/auto,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 4
-	},
 /turf/simulated/floor/black/grime,
 /area/station/security/visitation)
 "qUS" = (
@@ -55848,24 +55919,6 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction)
-"qWs" = (
-/obj/decal/tile_edge/line/black{
-	dir = 4;
-	icon_state = "tile1"
-	},
-/obj/decal/tile_edge/line/black{
-	dir = 9;
-	icon_state = "tile1"
-	},
-/obj/submachine/ATM/atm_alt{
-	pixel_y = 32
-	},
-/obj/machinery/phone/wall{
-	pixel_x = 24;
-	pixel_y = 12
-	},
-/turf/simulated/floor/grime,
-/area/station/security/brig/south_side)
 "qWE" = (
 /obj/storage/secure/closet/security/forensics,
 /obj/item/camera,
@@ -56564,12 +56617,18 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
 "rfY" = (
-/obj/mapping_helper/firedoor_spawn,
-/obj/table/reinforced/auto,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
+/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
+/obj/cable,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "visitorlockdown";
+	layer = 6;
+	name = "Brig Visitor Lockdown";
+	opacity = 0
 	},
-/turf/simulated/floor/black/grime,
+/turf/simulated/floor/plating,
 /area/station/security/brig/south_side)
 "rgr" = (
 /obj/mesh/grille/steel,
@@ -64983,6 +65042,9 @@
 /obj/decal/tile_edge/stripe/big,
 /turf/simulated/floor/black,
 /area/station/engine/inner)
+"tIF" = (
+/turf/simulated/wall/auto/reinforced/supernorn/blackred,
+/area/station/maintenance/outer/west)
 "tIG" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/light/small/sticky{
@@ -69248,6 +69310,18 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/engine/engineering)
+"uXp" = (
+/obj/table/reinforced/auto,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/incandescent/netural{
+	dir = 1;
+	pixel_x = 5;
+	pixel_y = 18
+	},
+/turf/simulated/floor/black/grime,
+/area/station/security/brig/south_side)
 "uXw" = (
 /obj/railing/orange,
 /obj/decal/cleanable/dirt/jen,
@@ -72332,11 +72406,6 @@
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
-"vRf" = (
-/turf/simulated/wall/auto/reinforced/supernorn/blackred{
-	icon_state = "R9"
-	},
-/area/station/security/visitation)
 "vRt" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -107394,7 +107463,7 @@ kgc
 fiB
 nll
 mBr
-afi
+arY
 afi
 qcu
 eeu
@@ -107696,9 +107765,9 @@ ctq
 fiB
 cQi
 bpJ
-afi
-afi
-afi
+jDY
+kaN
+kaN
 cQi
 pka
 wql
@@ -107997,9 +108066,9 @@ xuC
 lJb
 kgc
 cQi
-qWs
-fuC
-fuC
+cQi
+uXp
+hbf
 fuC
 cQi
 sup
@@ -108298,10 +108367,10 @@ xQr
 lFK
 xuC
 kLp
+tIF
 cQi
-cQi
-rfY
-rfY
+lCb
+nUC
 rfY
 cQi
 nKY
@@ -108603,7 +108672,7 @@ fVX
 cep
 tnN
 qUL
-qUL
+clT
 qUL
 tnN
 tnN
@@ -109814,7 +109883,7 @@ tnN
 lXa
 xKc
 xKc
-vRf
+tnN
 ggy
 ovT
 gjH

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -27940,6 +27940,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
+"ixa" = (
+/obj/disposalpipe/segment/food{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn/blackred,
+/area/station/security/brig/south_side)
 "ixb" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -35568,7 +35575,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
-/area/station/maintenance/outer/west)
+/area/station/security/brig/south_side)
 "kLw" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 1
@@ -65042,9 +65049,6 @@
 /obj/decal/tile_edge/stripe/big,
 /turf/simulated/floor/black,
 /area/station/engine/inner)
-"tIF" = (
-/turf/simulated/wall/auto/reinforced/supernorn/blackred,
-/area/station/maintenance/outer/west)
 "tIG" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/light/small/sticky{
@@ -107762,7 +107766,7 @@ fiB
 kuM
 xQr
 ctq
-fiB
+cQi
 cQi
 bpJ
 jDY
@@ -108064,7 +108068,7 @@ uwe
 uwe
 xuC
 lJb
-kgc
+ixa
 cQi
 cQi
 uXp
@@ -108367,7 +108371,7 @@ xQr
 lFK
 xuC
 kLp
-tIF
+cQi
 cQi
 lCb
 nUC


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Stretch the donut3 visitation area to include a row of plasmaglass wingrilles
* Wire up the wingrilles ala most brig windows
* Add phones to the brig/visitation tables
* Remove a Pill Bottle (???) under the brig toilet while we're here, so StirStir stops getting at it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Roaches and monkeys (including StirStir) can trivially break into/escape from the brig's south side.
