### PR TITLE
Add a multitool to the sequestered cloner prefab

### DIFF
--- a/assets/maps/prefabs/space/prefab_sequestered_cloner.dmm
+++ b/assets/maps/prefabs/space/prefab_sequestered_cloner.dmm
@@ -114,6 +114,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/prefab/sequestered_cloner)
+"kz" = (
+/obj/item/device/multitool/orange,
+/turf/simulated/floor/plating,
+/area/prefab/sequestered_cloner)
 "mm" = (
 /obj/storage/closet/emergency{
 	pixel_x = -8
@@ -1255,7 +1259,7 @@ rk
 pT
 RZ
 WS
-tJ
+kz
 tI
 "}
 (12,1,1) = {"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a multitool to the sequestered cloner prefab.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Right now the puzzle is unbeatable unless you bring an existing multitool in.

Players can get a multitool after this room from the belt in the CE locker anyway.