### PR TITLE
Split donut2 brig cells into separate areas

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -10962,7 +10962,7 @@
 	},
 /obj/machinery/floorflusher/solitary,
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary2)
 "bfX" = (
 /obj/machinery/vending/medical_public,
 /obj/disposalpipe/switch_junction{
@@ -11350,7 +11350,7 @@
 	pixel_y = 60
 	},
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "big" = (
 /obj/stool/chair{
 	dir = 4
@@ -11467,7 +11467,7 @@
 /obj/machinery/floorflusher/solitary2,
 /obj/disposalpipe/trunk/ejection,
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "biN" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/mining,
@@ -11595,7 +11595,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "bjO" = (
 /obj/disposalpipe/segment,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -12417,6 +12417,9 @@
 "boo" = (
 /obj/table/auto,
 /obj/machinery/recharger,
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
 /area/station/security/processing)
 "bop" = (
@@ -12429,6 +12432,9 @@
 /obj/landmark/start/job/security_assistant,
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
 /area/station/security/processing)
@@ -12560,6 +12566,11 @@
 /turf/simulated/floor/plating,
 /area/station/science/lab)
 "bpa" = (
+/obj/machinery/power/apc{
+	areastring = "Solitary Confinement";
+	pixel_y = -24
+	},
+/obj/cable,
 /turf/simulated/floor/redblack,
 /area/station/security/processing)
 "bpb" = (
@@ -17506,7 +17517,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary2)
 "cUI" = (
 /obj/decal/cleanable/dirt/dirt3,
 /obj/decal/cleanable/cobweb,
@@ -21023,12 +21034,11 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/machinery/phone/wall{
-	name = "Brig Cell #1";
 	pixel_x = 24;
 	pixel_y = 4
 	},
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary2)
 "fan" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/cable{
@@ -23306,7 +23316,7 @@
 	},
 /obj/item/clothing/suit/bedsheet/orange,
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "gws" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -26083,7 +26093,7 @@
 /obj/machinery/light/incandescent,
 /obj/stool,
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "ifo" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -26652,6 +26662,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria)
+"iwG" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/brig/solitary)
 "iwQ" = (
 /obj/storage/closet/welding_supply,
 /obj/machinery/camera{
@@ -27551,7 +27564,7 @@
 "iYR" = (
 /obj/storage/secure/closet/brig_automatic/solitary,
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary2)
 "iZe" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/cable{
@@ -30909,7 +30922,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "laX" = (
 /obj/machinery/crusher/slow,
 /obj/machinery/conveyor/NS{
@@ -31219,6 +31232,13 @@
 	icon_state = "fred1"
 	},
 /area/station/bridge)
+"llD" = (
+/obj/item/storage/toilet/random{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig/solitary)
 "llV" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/carpet,
@@ -31313,6 +31333,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/space)
+"lrh" = (
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 8
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig/solitary)
 "lrM" = (
 /obj/strip_door{
 	layer = 3
@@ -31470,12 +31496,11 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/phone/wall{
-	name = "Brig Cell #2";
 	pixel_x = -24;
 	pixel_y = 6
 	},
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "lwg" = (
 /turf/simulated/floor/yellow/side,
 /area/station/engine/inner)
@@ -32528,7 +32553,7 @@
 	},
 /obj/machinery/drainage,
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary2)
 "lUo" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Storage"
@@ -32627,7 +32652,7 @@
 	},
 /obj/item/clothing/suit/bedsheet/orange,
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary2)
 "lZU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -33450,6 +33475,9 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"mzw" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/brig/solitary2)
 "mzG" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -34706,7 +34734,7 @@
 	pixel_x = -8
 	},
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary2)
 "niO" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -36454,6 +36482,12 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
+/obj/cable,
+/obj/machinery/power/apc{
+	areastring = "Brig";
+	name = "Brig APC";
+	pixel_y = -24
+	},
 /turf/simulated/floor/redblack{
 	dir = 6
 	},
@@ -36917,7 +36951,6 @@
 "owl" = (
 /obj/stool,
 /obj/machinery/phone/wall{
-	name = "Brig Genpop Cell";
 	pixel_y = -24
 	},
 /turf/simulated/floor/grime,
@@ -38388,7 +38421,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "poj" = (
 /obj/disposalpipe/segment/food{
 	dir = 4;
@@ -39556,6 +39589,13 @@
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
+"pVG" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig/solitary2)
 "pVL" = (
 /obj/submachine/seed_vendor,
 /obj/machinery/light/incandescent,
@@ -41243,7 +41283,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/brig/solitary2)
 "qSd" = (
 /obj/machinery/door/poddoor/blast/single{
 	dir = 4;
@@ -41322,7 +41362,7 @@
 	pixel_y = -56
 	},
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary2)
 "qUk" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -44057,7 +44097,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/brig/solitary2)
 "sBZ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -45839,9 +45879,11 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/phone/wall{
-	name = "Brig Main Phone";
 	pixel_x = 24;
 	pixel_y = 4
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -46818,6 +46860,11 @@
 /obj/machinery/ore_cloud_storage_container,
 /turf/simulated/floor/grime,
 /area/station/mining/magnet)
+"uiI" = (
+/obj/stool,
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/grime,
+/area/station/security/brig/solitary2)
 "uiK" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -48045,8 +48092,7 @@
 "uWC" = (
 /obj/cable,
 /obj/machinery/power/apc{
-	areastring = "Brig";
-	name = "Brig APC";
+	areastring = "Solitary Confinement #2";
 	pixel_y = -24
 	},
 /turf/simulated/floor/redblack,
@@ -53194,7 +53240,7 @@
 "yda" = (
 /obj/storage/secure/closet/brig_automatic/solitary2,
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "yde" = (
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
@@ -53325,7 +53371,7 @@
 	},
 /obj/machinery/drainage,
 /turf/simulated/floor/grime,
-/area/station/security/brig)
+/area/station/security/brig/solitary)
 "yfi" = (
 /obj/machinery/door/airlock/pyro/sci_alt{
 	dir = 4
@@ -95082,11 +95128,11 @@ beO
 bfn
 qZS
 beT
-bgL
-bgL
-bgL
-bgL
-bgL
+iwG
+iwG
+iwG
+iwG
+iwG
 sLU
 bkG
 uji
@@ -95384,7 +95430,7 @@ beP
 bfj
 beM
 bgp
-bgL
+iwG
 gwo
 ifh
 lwb
@@ -95686,8 +95732,8 @@ pIx
 beM
 beM
 bgq
-bgL
-jJL
+iwG
+lrh
 bie
 biL
 poh
@@ -95988,9 +96034,9 @@ beA
 beM
 beM
 bgq
-bgL
+iwG
 yff
-bzG
+llD
 yda
 laR
 bkI
@@ -96600,11 +96646,11 @@ dKs
 wiZ
 blR
 qpk
-bgL
-bgL
-bgL
-bgL
-bgL
+mzw
+mzw
+mzw
+mzw
+mzw
 bns
 bns
 bns
@@ -96902,11 +96948,11 @@ bjO
 kvu
 blT
 hvw
-bmJ
+pVG
 iYR
 niJ
 lUk
-bgL
+mzw
 jDL
 bsq
 jDL
@@ -97208,7 +97254,7 @@ sBi
 bfU
 qTR
 cUs
-bgL
+mzw
 bns
 ukA
 bns
@@ -97508,9 +97554,9 @@ oHh
 tsG
 qRI
 fal
-bpF
+uiI
 lZM
-bgL
+mzw
 bgL
 qLw
 qLw
@@ -97808,11 +97854,11 @@ bgN
 kjG
 blT
 vfe
-bgL
-bgL
-bgL
-bgL
-bgL
+mzw
+mzw
+mzw
+mzw
+mzw
 bgL
 jJL
 sAG


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Split the single brig area on Donut2 into three areas: Solitary 1, Solitary 2, and Brig.
Add wiring and out-of-area APCs to support this change.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Areas should be contiguous. Most maps use a separate, single area for the holding cells, but in donut2's case each holding cell is on opposite sides of the processing hall.