### PR TITLE
Stop Nadir power alert from erroneously shaming engineering

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -298,6 +298,9 @@ var/global/current_state = GAME_STATE_INVALID
 	SPAWN(10 MINUTES) // standard engine warning
 		for_by_tcl(E, /obj/machinery/computer/power_monitor/smes)
 			LAGCHECK(LAG_LOW)
+			var/area/A = get_area(E) // only check the main (engine) pnet
+			if (!istype(A, /area/station) || istype(A, /area/station/engine/substation) || istype(A, /area/station/solar) || istype(A, /area/station/maintenance/solar))
+				continue
 			var/datum/powernet/PN = E.get_direct_powernet()
 			if(PN?.avail <= 0)
 				command_alert("Reports indicate that the engine on-board [station_name()] has not yet been started. Setting up the engine is strongly recommended, or else stationwide power failures may occur.", "Power Grid Warning", alert_origin = ALERT_STATION)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[station systems][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
In the check for posting the engine setup warning, check several areas to see if the SMES power monitor computer we're checking is in a relevant area; i.e. on station, but not in a solar or substation area.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The engine not setup alert on Nadir always fires off, regardless of engineer aptitude. Those poor engineers :(