### PR TITLE
Stop the pipes under windows in Clarion toxins from breaking

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -8420,7 +8420,7 @@
 	name = "chamber inlet pump";
 	target_pressure = 1000
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/blue,
 /area/station/science/lab)
 "bnd" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -14040,17 +14040,17 @@
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/crew_quarters/barber_shop)
 "dBQ" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /obj/machinery/door/poddoor/blast/single{
 	density = 0;
 	icon_state = "bdoorsingle0";
 	id = "tox_hs_one";
 	layer = 4;
-	name = "Chamber One Heat Shield";
+	name = "Heat Shield";
 	opacity = 0
-	},
-/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/obj/cable{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
@@ -16698,7 +16698,7 @@
 	name = "Chamber Ignition Switch";
 	pixel_x = 24
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/red,
 /area/station/science/lab)
 "fCY" = (
 /obj/machinery/alarm{
@@ -22187,19 +22187,6 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
-"jvN" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/obj/machinery/door/poddoor/blast/single{
-	density = 0;
-	icon_state = "bdoorsingle0";
-	id = "tox_hs_one";
-	layer = 4;
-	name = "Chamber One Heat Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/science/lab)
 "jvR" = (
 /obj/machinery/computer3/terminal/zeta{
 	dir = 4;
@@ -38571,16 +38558,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "vhL" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold,
-/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
+/obj/machinery/atmospherics/pipe/simple/overfloor,
 /obj/machinery/door/poddoor/blast/single{
 	density = 0;
 	icon_state = "bdoorsingle0";
 	id = "tox_hs_one";
 	layer = 4;
-	name = "Chamber One Heat Shield";
+	name = "Heat Shield";
 	opacity = 0
 	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "vhP" = (
@@ -93987,7 +93974,7 @@ bju
 cMs
 iPP
 fCF
-jvN
+vhL
 bpA
 bqC
 brP


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace the two burn chamber pipes underneath windows in Clarion toxins with an overfloor version that can't rupture. Add some blue/red floor tiling under the entire pipelines while we're here.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pipes you can't get to without compromising the burn chamber shouldn't be rupturable.