### PR TITLE
Fix the velvet railings in the fish exhibit random room

### DIFF
--- a/assets/maps/random_rooms/5x3/fishexhibit.dmm
+++ b/assets/maps/random_rooms/5x3/fishexhibit.dmm
@@ -35,7 +35,8 @@
 /obj/railing/velvet{
 	pixel_y = 17;
 	density = 0;
-	layer = 4
+	layer = 4;
+	dir = 1
 	},
 /turf/simulated/floor/marble/border_bw,
 /area/dmm_suite/clear_area)
@@ -48,7 +49,8 @@
 /obj/railing/velvet{
 	pixel_y = 17;
 	density = 0;
-	layer = 4
+	layer = 4;
+	dir = 1
 	},
 /turf/simulated/floor/marble/border_bw,
 /area/dmm_suite/clear_area)
@@ -59,7 +61,8 @@
 /obj/railing/velvet{
 	pixel_y = 17;
 	density = 0;
-	layer = 4
+	layer = 4;
+	dir = 1
 	},
 /obj/decal/poster/wallsign/dead_exec_portrait{
 	pixel_y = 32;
@@ -106,13 +109,14 @@
 	default_material = "steel";
 	rand_pos = 1
 	},
+/obj/map/light/cyan{
+	brightness = 5
+	},
 /obj/railing/velvet{
 	pixel_y = 17;
 	density = 0;
-	layer = 4
-	},
-/obj/map/light/cyan{
-	brightness = 5
+	layer = 4;
+	dir = 1
 	},
 /turf/simulated/floor/marble/border_bw,
 /area/dmm_suite/clear_area)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Set the dir of the velvet rope fences to visually match their northward appearance.
The velvet rope fences don't have multidir sprites, so we still need to modify the pixel_y to keep them against the north wall.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You get stuck behind an invisible fence wall when in this prefab
Fixes #22772