### PR TITLE
Use tryCast for Arcfiend ability checks

### DIFF
--- a/code/modules/antagonists/arcfiend/abilities/arc_flash.dm
+++ b/code/modules/antagonists/arcfiend/abilities/arc_flash.dm
@@ -15,10 +15,19 @@
 	/// Max number of additional mobs to chain to.
 	var/chain_count = 2
 
+	tryCast(atom/target, params)
+		if (target == src.holder.owner)
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
+		if (!ismob(target))
+			boutput(src.holder.owner, SPAN_ALERT("You can only cast this on mobs!"))
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
+		if (!IN_RANGE(src.holder.owner, target, (WIDE_TILE_WIDTH / 2)))
+			boutput(src.holder.owner, SPAN_ALERT("That is too far away!"))
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
+		return ..()
+
 	cast(atom/target)
 		. = ..()
-		if (!ismob(target) || target == src.holder.owner || !IN_RANGE(src.holder.owner, target, (WIDE_TILE_WIDTH / 2)))
-			return TRUE
 		arcFlash(src.holder.owner, target, src.wattage)
 
 		var/list/exempt_targets = list(src.holder.owner, target)

--- a/code/modules/antagonists/arcfiend/abilities/discharge.dm
+++ b/code/modules/antagonists/arcfiend/abilities/discharge.dm
@@ -54,4 +54,3 @@
 		S.set_up(2, FALSE, target)
 		S.start()
 		src.holder.owner.set_dir(get_dir(src.holder.owner, target))
-		return CAST_ATTEMPT_SUCCESS

--- a/code/modules/antagonists/arcfiend/abilities/discharge.dm
+++ b/code/modules/antagonists/arcfiend/abilities/discharge.dm
@@ -16,12 +16,16 @@
 	/// how much direct burn damage this attack deals, on top of any damage from the shock itself
 	var/direct_burn_damage = 15
 
+	tryCast(atom/target, params)
+		if (target == src.holder.owner)
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
+		if (!(BOUNDS_DIST(src.holder.owner, target) == 0))
+			boutput(src.holder.owner, SPAN_ALERT("That is too far away!"))
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
+		return ..()
+
 	cast(atom/target)
 		. = ..()
-		if (target == src.holder.owner)
-			return TRUE
-		if (!(BOUNDS_DIST(src.holder.owner, target) == 0))
-			return TRUE
 		if (ismob(target))
 			var/mob/M = target
 			M.shock(src.holder.owner, src.wattage, ignore_gloves = TRUE)
@@ -39,14 +43,15 @@
 			var/obj/machinery/door/airlock/airlock = target
 			if (airlock.hardened)
 				boutput(src.holder.owner, SPAN_ALERT("[target] is hardened against your electrical attacks, your [name] skill has no effect!"))
-				return TRUE
+				return CAST_ATTEMPT_FAIL_NO_COOLDOWN
 			airlock.loseMainPower()
 			target.add_fingerprint(src.holder.owner)
 			playsound(src.holder.owner, 'sound/effects/electric_shock.ogg', 50, TRUE)
 			boutput(src.holder.owner, SPAN_ALERT("You run a powerful current into [target], temporarily cutting its power!"))
 		else
-			return TRUE
+			return CAST_ATTEMPT_FAIL_NO_COOLDOWN
 		var/datum/effects/system/spark_spread/S = new /datum/effects/system/spark_spread
 		S.set_up(2, FALSE, target)
 		S.start()
 		src.holder.owner.set_dir(get_dir(src.holder.owner, target))
+		return CAST_ATTEMPT_SUCCESS

--- a/code/modules/antagonists/arcfiend/abilities/flash.dm
+++ b/code/modules/antagonists/arcfiend/abilities/flash.dm
@@ -10,7 +10,6 @@
 		. = ..()
 		playsound(holder.owner, 'sound/effects/power_charge.ogg', 100)
 		actions.start(new/datum/action/bar/private/flash(), src.holder.owner)
-		return CAST_ATTEMPT_SUCCESS
 
 
 

--- a/code/modules/antagonists/arcfiend/abilities/flash.dm
+++ b/code/modules/antagonists/arcfiend/abilities/flash.dm
@@ -10,6 +10,7 @@
 		. = ..()
 		playsound(holder.owner, 'sound/effects/power_charge.ogg', 100)
 		actions.start(new/datum/action/bar/private/flash(), src.holder.owner)
+		return CAST_ATTEMPT_SUCCESS
 
 
 

--- a/code/modules/antagonists/arcfiend/abilities/jolt.dm
+++ b/code/modules/antagonists/arcfiend/abilities/jolt.dm
@@ -17,17 +17,21 @@
 	/// Each individual shock will use this much wattage.
 	var/wattage = 2.6 KILO WATTS
 
+	tryCast(atom/target, params)
+		if (!(BOUNDS_DIST(src.holder.owner, target) == 0))
+			boutput(src.holder.owner, SPAN_ALERT("That is too far away!"))
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
+		if (!ishuman(target))
+			boutput(src.holder.owner, SPAN_ALERT("You can only use this on humans!"))
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
+		return ..()
+
 	cast(atom/target)
 		. = ..()
-		if (!(BOUNDS_DIST(src.holder.owner, target) == 0))
-			return TRUE
-		if (ishuman(target))
-			if (target == src.holder.owner)
-				self_cast(target)
-				return
-			actions.start(new/datum/action/bar/private/icon/jolt(src.holder.owner, target, src.holder, src.wattage), src.holder.owner)
-		else
-			return TRUE
+		if (target == src.holder.owner)
+			self_cast(target)
+			return CAST_ATTEMPT_SUCCESS
+		actions.start(new/datum/action/bar/private/icon/jolt(src.holder.owner, target, src.holder, src.wattage), src.holder.owner)
 
 	proc/self_cast(mob/living/carbon/human/H)
 		boutput(H, SPAN_ALERT("You send a massive electrical surge through yourself!"))

--- a/code/modules/antagonists/arcfiend/abilities/ride_the_lightning.dm
+++ b/code/modules/antagonists/arcfiend/abilities/ride_the_lightning.dm
@@ -37,9 +37,7 @@
 			src.cable_images[i] = cimg
 
 	tryCast(atom/target, params)
-		if (src.active)
-			return CAST_ATTEMPT_SUCCESS
-		else
+		if (!src.active)
 			var/turf/T = get_turf(src.holder.owner)
 			if (!T.z || isrestrictedz(T.z))
 				boutput(src.holder.owner, SPAN_ALERT("You are forbidden from using that here!"))

--- a/code/modules/antagonists/arcfiend/abilities/ride_the_lightning.dm
+++ b/code/modules/antagonists/arcfiend/abilities/ride_the_lightning.dm
@@ -36,22 +36,27 @@
 			cimg.plane = PLANE_ABOVE_BLACKNESS
 			src.cable_images[i] = cimg
 
-	cast(atom/target)
-		. = ..()
+	tryCast(atom/target, params)
 		if (src.active)
-			src.deactivate()
-			return TRUE
+			return CAST_ATTEMPT_SUCCESS
 		else
 			var/turf/T = get_turf(src.holder.owner)
 			if (!T.z || isrestrictedz(T.z))
 				boutput(src.holder.owner, SPAN_ALERT("You are forbidden from using that here!"))
-				return TRUE
+				return CAST_ATTEMPT_FAIL_CAST_FAILURE
 			if (T != src.holder.owner.loc) // See: no escaping port-a-brig
 				boutput(src.holder.owner, SPAN_ALERT("You cannot use this ability while inside [src.holder.owner.loc]!"))
-				return TRUE
+				return CAST_ATTEMPT_FAIL_CAST_FAILURE
 			if (!(locate(/obj/cable) in T))
 				boutput(src.holder.owner, SPAN_ALERT("You must use this ability on top of a cable!"))
-				return TRUE
+				return CAST_ATTEMPT_FAIL_CAST_FAILURE
+		return ..()
+
+	cast(atom/target)
+		. = ..()
+		if (src.active)
+			src.deactivate()
+		else
 			playsound(src.holder.owner, 'sound/machines/ArtifactBee2.ogg', 30, TRUE, -2)
 			actions.start(new/datum/action/bar/private/voltron(src), src.holder.owner)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][qol][gamemodes][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Move various target checks in arcfiend abilities from `cast` into `tryCast`, and ensure there is some feedback on why in more cases.

Adds a check for sap power that denies using the ability if sapping the targeted machine will not result in any power gain (e.g. attempting to sap hydroponics trays).

Use ability defines in code for code clarity. Adds some doccomments to the sap power defines for future devs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Don't punish Arcfiends with cooldowns for casts that won't do anything. Abort ability casts earlier when we know they won't work.

Better separates the ability effect in `cast` from the attempt to cast in `tryCast`.

Marked balance as this will stop some cooldowns from occurring when they otherwise would, but I think this is more QOL.