### PR TITLE
Stop ghostdrones/critters from using chem grenades

### DIFF
--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -104,6 +104,8 @@ ADMIN_INTERACT_PROCS(/obj/item/chem_grenade, proc/arm, proc/explode)
 	var/area/A = get_area(src)
 	if(A.sanctuary)
 		return
+	if (isghostdrone(user) || isghostcritter(user))
+		return
 	// Custom grenades only. Metal foam etc grenades cannot be modified (Convair880).
 	var/log_reagents = null
 	if (src.name == "grenade")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a check for ghostdrones/ghostcritters when arming a grenade and return early if the mob arming it is one of those.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
ghost things shouldn't be able to use e.g. crowd dispersal grenades