### PR TITLE
Colorable Hard Candy Wrappers

### DIFF
--- a/code/modules/food_and_drink/candy.dm
+++ b/code/modules/food_and_drink/candy.dm
@@ -620,6 +620,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy/wrapped_candy/taffy
 	real_name = "hard candy"
 	icon_state = "hardcandy"
 	var/flavor_name
+	var/wrapper_color
 
 	on_reagent_change()
 		..()
@@ -633,12 +634,31 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy/wrapped_candy/taffy
 
 	unwrap_candy(mob/user)
 		..()
+		if (src.wrapper_color)
+			var/image/image_wrapper = image(src.icon, "hardcandy-unwrapped")
+			image_wrapper.color = src.wrapper_color
+			src.UpdateOverlays(image_wrapper, "hardcandy-wrapper")
 		var/datum/color/average = src.reagents.get_average_color()
 		var/image/image_candy = image(src.icon, "hardcandy-nowrap")
 		image_candy.color = average.to_rgb()
 		image_candy.alpha = round(average.a / 1.2)
 		src.UpdateOverlays(image_candy, "hardcandy-nowrap")
 		src.update_name()
+
+	attackby(obj/item/W, mob/user)
+		if (istype(W, /obj/item/pen))
+			if (src.unwrapped == 0)
+				var/obj/item/pen/P = W
+				if (P.font_color)
+					boutput(user, SPAN_NOTICE("You color in the candy wrapper."))
+					var/image/image_wrapper = image(src.icon, "hardcandy")
+					image_wrapper.color = P.font_color
+					src.wrapper_color = P.font_color
+					src.UpdateOverlays(image_wrapper, "hardcandy-wrapper")
+			else
+				boutput(user, SPAN_ALERT("The candy's already been unwrapped!"))
+				return
+
 
 /obj/item/reagent_containers/food/snacks/candy/rock_candy
 	name = "rock candy"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

adds the ability to color hard candy wrappers with a pen/pencil/marker/crayon/etc

![dreamseeker_egJ333t9QX](https://github.com/user-attachments/assets/3bb369bb-ce47-469a-bff4-ceffd405685e)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

makes candy more colorful instead of a basic white wrapper! this is something we wanted to do originally in #17553 but forgot about

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lyy
(*)You can now color homemade hard candy wrappers with markers or crayons!
```
