### PR TITLE
Remove Securitrons from the Robotics fabricator

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1818,16 +1818,6 @@ ABSTRACT_TYPE(/datum/manufacture/aiModule)
 	time = 3 SECONDS
 	category = "Tool"
 
-/datum/manufacture/secbot
-	name = "Security Drone"
-	item_requirements = list("metal_dense" = 30,
-							 "conductive_high" = 20,
-							 "energy" = 20)
-	item_outputs = list(/obj/machinery/bot/secbot)
-	create = 1
-	time = 120 SECONDS
-	category = "Machinery"
-
 /datum/manufacture/floorbot
 	name = "Construction Drone"
 	item_requirements = list("metal" = 15,

--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -143,7 +143,6 @@
 		/datum/manufacture/stapler,
 		/datum/manufacture/surgical_spoon,
 		/datum/manufacture/implanter,
-		/datum/manufacture/secbot,
 		/datum/manufacture/medbot,
 		/datum/manufacture/firebot,
 		/datum/manufacture/floorbot,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Exactly what it says on the can: you can't just print them using mats. If you want to make a new securitron, you need to assemble them by hand using a security helmet and other items, as already listed on the wiki: https://wiki.ss13.co/Robots#Securitron


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Securitrons are powerful and don't need to be so cheap. Sec helmets require either stealing or cooperation from Security, which feels better balanced to me.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Jan.antilles
(+)Securitrons can no longer be printed from the robotics fabricator, and have to be assembled by hand.
```
