### PR TITLE
Refactor human body part customization

### DIFF
--- a/code/datums/part_customization.dm
+++ b/code/datums/part_customization.dm
@@ -55,18 +55,6 @@ ABSTRACT_TYPE(/datum/part_customization)
 
 ABSTRACT_TYPE(/datum/part_customization/human)
 /datum/part_customization/human
-
-	apply_to(mob/living/carbon/human/human)
-		. = ..()
-		var/chosen_part_type = pick(src.part_type)
-		if (istype(src, /datum/part_customization/human/arm) || istype(src, /datum/part_customization/human/leg))
-			if(human.limbs.get_limb(slot)?.type != chosen_part_type)
-				human.limbs.replace_with(src.slot, chosen_part_type, null, FALSE, TRUE) //pick can totally handle single values apparently
-		else
-			var/obj/item/organ/new_organ = new chosen_part_type()
-			if(!istype(human.organHolder?.get_organ(src.slot), chosen_part_type))
-				human.organHolder.receive_organ(new_organ, src.slot, force = TRUE)
-
 	can_apply(mob/M)
 		return ..() && ishuman(M)
 
@@ -100,42 +88,49 @@ ABSTRACT_TYPE(/datum/part_customization/human)
 					limb_type = src.part_type
 				if(!human.limbs.r_arm?.type == limb_type)
 					human.limbs.replace_with(src.slot, limb_type, null, FALSE, TRUE)
+		modded
 
-		robo_left
-			id = "arm_robo_left"
-			slot = "l_arm"
-			part_type = /obj/item/parts/robot_parts/arm/left/light
+			apply_to(mob/living/carbon/human/human)
+				. = ..()
+				var/chosen_part_type = pick(src.part_type)
+				if(human.limbs.get_limb(slot)?.type != chosen_part_type)
+					human.limbs.replace_with(src.slot, chosen_part_type, null, FALSE, TRUE)
 
-		robo_right
-			id = "arm_robo_right"
-			slot = "r_arm"
-			part_type = /obj/item/parts/robot_parts/arm/right/light
+			robo_left
+				id = "arm_robo_left"
+				slot = "l_arm"
+				part_type = /obj/item/parts/robot_parts/arm/left/light
 
-		robo_standard_left
-			id = "arm_robo_standard_left"
-			slot = "l_arm"
-			part_type = /obj/item/parts/robot_parts/arm/left/standard
-			trait_cost = 1
-			incompatible_parts = list("arm_robo_standard_right")
+			robo_right
+				id = "arm_robo_right"
+				slot = "r_arm"
+				part_type = /obj/item/parts/robot_parts/arm/right/light
 
-		robo_standard_right
-			id = "arm_robo_standard_right"
-			slot = "r_arm"
-			part_type = /obj/item/parts/robot_parts/arm/right/standard
-			trait_cost = 1
-			incompatible_parts = list("arm_robo_standard_left")
+			robo_standard_left
+				id = "arm_robo_standard_left"
+				slot = "l_arm"
+				part_type = /obj/item/parts/robot_parts/arm/left/standard
+				trait_cost = 1
+				incompatible_parts = list("arm_robo_standard_right")
 
-		plant_left
-			id = "arm_plant_left"
-			slot = "l_arm"
-			trait_cost = 1
-			part_type = list(/obj/item/parts/human_parts/arm/left/synth/bloom, /obj/item/parts/human_parts/arm/left/synth)
+			robo_standard_right
+				id = "arm_robo_standard_right"
+				slot = "r_arm"
+				part_type = /obj/item/parts/robot_parts/arm/right/standard
+				trait_cost = 1
+				incompatible_parts = list("arm_robo_standard_left")
 
-		plant_right
-			id = "arm_plant_right"
-			slot = "r_arm"
-			trait_cost = 1
-			part_type = list(/obj/item/parts/human_parts/arm/right/synth/bloom, /obj/item/parts/human_parts/arm/right/synth)
+			plant_left
+				id = "arm_plant_left"
+				slot = "l_arm"
+				trait_cost = 1
+				part_type = list(/obj/item/parts/human_parts/arm/left/synth/bloom, /obj/item/parts/human_parts/arm/left/synth)
+
+			plant_right
+				id = "arm_plant_right"
+				slot = "r_arm"
+				trait_cost = 1
+				part_type = list(/obj/item/parts/human_parts/arm/right/synth/bloom, /obj/item/parts/human_parts/arm/right/synth)
 
 	leg
 		default_left
@@ -168,19 +163,34 @@ ABSTRACT_TYPE(/datum/part_customization/human)
 				if(human.limbs.r_leg?.type != limb_type)
 					human.limbs.replace_with(src.slot, limb_type, null, FALSE, TRUE)
 
-		plant_left
-			id = "leg_plant_left"
-			slot = "l_leg"
-			trait_cost = 1
-			part_type = list(/obj/item/parts/human_parts/leg/left/synth/bloom, /obj/item/parts/human_parts/leg/left/synth)
+		modded
 
-		plant_right
-			id = "leg_plant_right"
-			slot = "r_leg"
-			trait_cost = 1
-			part_type = list(/obj/item/parts/human_parts/leg/right/synth/bloom, /obj/item/parts/human_parts/leg/right/synth)
+			apply_to(mob/living/carbon/human/human)
+				. = ..()
+				var/chosen_part_type = pick(src.part_type)
+				if(human.limbs.get_limb(slot)?.type != chosen_part_type)
+					human.limbs.replace_with(src.slot, chosen_part_type, null, FALSE, TRUE)
+
+			plant_left
+				id = "leg_plant_left"
+				slot = "l_leg"
+				trait_cost = 1
+				part_type = list(/obj/item/parts/human_parts/leg/left/synth/bloom, /obj/item/parts/human_parts/leg/left/synth)
+
+			plant_right
+				id = "leg_plant_right"
+				slot = "r_leg"
+				trait_cost = 1
+				part_type = list(/obj/item/parts/human_parts/leg/right/synth/bloom, /obj/item/parts/human_parts/leg/right/synth)
 
 	organ
+		apply_to(mob/living/carbon/human/human)
+			. = ..()
+			var/chosen_part_type = pick(src.part_type)
+			var/obj/item/organ/new_organ = new chosen_part_type()
+			if(!istype(human.organHolder?.get_organ(src.slot), chosen_part_type))
+				human.organHolder.receive_organ(new_organ, src.slot, force = TRUE)
+
 		eye_default_left
 			id = "eye_default_left"
 			slot = "left_eye"

--- a/code/datums/part_customization.dm
+++ b/code/datums/part_customization.dm
@@ -58,43 +58,81 @@ ABSTRACT_TYPE(/datum/part_customization/human)
 	can_apply(mob/M)
 		return ..() && ishuman(M)
 
-	arm
-		default_left
-			id = "arm_default_left"
-			slot = "l_arm"
-			part_type = /obj/item/parts/human_parts/arm/left
+ABSTRACT_TYPE(/datum/part_customization/human/limb)
+/datum/part_customization/human/limb
 
-			apply_to(mob/living/carbon/human/human)
-				. = ..()
-				var/limb_type = human.mutantrace.l_limb_arm_type_mutantrace
-				if (human.gender == FEMALE) //gendered limbs???
-					limb_type = human.mutantrace.l_limb_arm_type_mutantrace_f || limb_type
-				if (!limb_type)
-					limb_type = src.part_type
-				if(human.limbs.l_arm?.type != limb_type)
-					human.limbs.replace_with(src.slot, limb_type, null, FALSE, TRUE)
+	default
+		arm
+			left
+				id = "arm_default_left"
+				slot = "l_arm"
+				part_type = /obj/item/parts/human_parts/arm/left
 
-		default_right
-			id = "arm_default_right"
-			slot = "r_arm"
-			part_type = /obj/item/parts/human_parts/arm/right
+				apply_to(mob/living/carbon/human/human)
+					. = ..()
+					var/limb_type = human.mutantrace.l_limb_arm_type_mutantrace
+					if (human.gender == FEMALE) //gendered limbs???
+						limb_type = human.mutantrace.l_limb_arm_type_mutantrace_f || limb_type
+					if (!limb_type)
+						limb_type = src.part_type
+					if(human.limbs.l_arm?.type != limb_type)
+						human.limbs.replace_with(src.slot, limb_type, null, FALSE, TRUE)
 
-			apply_to(mob/living/carbon/human/human)
-				. = ..()
-				var/limb_type = human.mutantrace.r_limb_arm_type_mutantrace
-				if (human.gender == FEMALE) //gendered limbs???
-					limb_type = human.mutantrace.r_limb_arm_type_mutantrace_f || limb_type
-				if (!limb_type)
-					limb_type = src.part_type
-				if(!human.limbs.r_arm?.type == limb_type)
-					human.limbs.replace_with(src.slot, limb_type, null, FALSE, TRUE)
-		modded
+			right
+				id = "arm_default_right"
+				slot = "r_arm"
+				part_type = /obj/item/parts/human_parts/arm/right
 
-			apply_to(mob/living/carbon/human/human)
-				. = ..()
-				var/chosen_part_type = pick(src.part_type)
-				if(human.limbs.get_limb(slot)?.type != chosen_part_type)
-					human.limbs.replace_with(src.slot, chosen_part_type, null, FALSE, TRUE)
+				apply_to(mob/living/carbon/human/human)
+					. = ..()
+					var/limb_type = human.mutantrace.r_limb_arm_type_mutantrace
+					if (human.gender == FEMALE) //gendered limbs???
+						limb_type = human.mutantrace.r_limb_arm_type_mutantrace_f || limb_type
+					if (!limb_type)
+						limb_type = src.part_type
+					if(!human.limbs.r_arm?.type == limb_type)
+						human.limbs.replace_with(src.slot, limb_type, null, FALSE, TRUE)
+
+		leg
+			left
+				id = "leg_default_left"
+				slot = "l_leg"
+				part_type = /obj/item/parts/human_parts/leg/left
+
+				apply_to(mob/living/carbon/human/human)
+					. = ..()
+					var/limb_type = human.mutantrace.l_limb_leg_type_mutantrace
+					if (human.gender == FEMALE)
+						limb_type = human.mutantrace.l_limb_leg_type_mutantrace_f || limb_type
+					if (!limb_type)
+						limb_type = src.part_type
+					if(human.limbs.l_leg?.type != limb_type)
+						human.limbs.replace_with(src.slot, limb_type, null, FALSE, TRUE)
+
+			right
+				id = "leg_default_right"
+				slot = "r_leg"
+				part_type = /obj/item/parts/human_parts/leg/right
+
+				apply_to(mob/living/carbon/human/human)
+					. = ..()
+					var/limb_type = human.mutantrace.r_limb_leg_type_mutantrace
+					if (human.gender == FEMALE)
+						limb_type = human.mutantrace.r_limb_leg_type_mutantrace_f || limb_type
+					if (!limb_type)
+						limb_type = src.part_type
+					if(human.limbs.r_leg?.type != limb_type)
+						human.limbs.replace_with(src.slot, limb_type, null, FALSE, TRUE)
+
+	replacement
+
+		apply_to(mob/living/carbon/human/human)
+			. = ..()
+			var/chosen_part_type = pick(src.part_type)
+			if(human.limbs.get_limb(slot)?.type != chosen_part_type)
+				human.limbs.replace_with(src.slot, chosen_part_type, null, FALSE, TRUE)
+
+		arm
 
 			robo_left
 				id = "arm_robo_left"
@@ -132,45 +170,7 @@ ABSTRACT_TYPE(/datum/part_customization/human)
 				trait_cost = 1
 				part_type = list(/obj/item/parts/human_parts/arm/right/synth/bloom, /obj/item/parts/human_parts/arm/right/synth)
 
-	leg
-		default_left
-			id = "leg_default_left"
-			slot = "l_leg"
-			part_type = /obj/item/parts/human_parts/leg/left
-
-			apply_to(mob/living/carbon/human/human)
-				. = ..()
-				var/limb_type = human.mutantrace.l_limb_leg_type_mutantrace
-				if (human.gender == FEMALE)
-					limb_type = human.mutantrace.l_limb_leg_type_mutantrace_f || limb_type
-				if (!limb_type)
-					limb_type = src.part_type
-				if(human.limbs.l_leg?.type != limb_type)
-					human.limbs.replace_with(src.slot, limb_type, null, FALSE, TRUE)
-
-		default_right
-			id = "leg_default_right"
-			slot = "r_leg"
-			part_type = /obj/item/parts/human_parts/leg/right
-
-			apply_to(mob/living/carbon/human/human)
-				. = ..()
-				var/limb_type = human.mutantrace.r_limb_leg_type_mutantrace
-				if (human.gender == FEMALE)
-					limb_type = human.mutantrace.r_limb_leg_type_mutantrace_f || limb_type
-				if (!limb_type)
-					limb_type = src.part_type
-				if(human.limbs.r_leg?.type != limb_type)
-					human.limbs.replace_with(src.slot, limb_type, null, FALSE, TRUE)
-
-		modded
-
-			apply_to(mob/living/carbon/human/human)
-				. = ..()
-				var/chosen_part_type = pick(src.part_type)
-				if(human.limbs.get_limb(slot)?.type != chosen_part_type)
-					human.limbs.replace_with(src.slot, chosen_part_type, null, FALSE, TRUE)
-
+		leg
 			plant_left
 				id = "leg_plant_left"
 				slot = "l_leg"
@@ -183,23 +183,80 @@ ABSTRACT_TYPE(/datum/part_customization/human)
 				trait_cost = 1
 				part_type = list(/obj/item/parts/human_parts/leg/right/synth/bloom, /obj/item/parts/human_parts/leg/right/synth)
 
-	organ
+	missing
+		custom_icon = 'icons/ui/character_editor.dmi'
+		custom_icon_state = "missing"
+
 		apply_to(mob/living/carbon/human/human)
 			. = ..()
-			var/chosen_part_type = pick(src.part_type)
-			var/obj/item/organ/new_organ = new chosen_part_type()
+			var/obj/item/parts/limb = human.limbs.get_limb(src.slot)
+			limb?.remove(show_message=FALSE)
+			qdel(limb)
+
+		arm
+			left
+				id = "arm_missing_left"
+				slot = "l_arm"
+				incompatible_parts = list("arm_missing_right")
+
+				get_name()
+					return "missing left arm"
+
+			right
+				id = "arm_missing_right"
+				slot = "r_arm"
+				incompatible_parts = list("arm_missing_left")
+
+				get_name()
+					return "missing right arm"
+		leg
+
+			left
+				id = "leg_missing_left"
+				slot = "l_leg"
+
+				get_name()
+					return "missing left leg"
+
+			right
+				id = "leg_missing_right"
+				slot = "r_leg"
+
+				get_name()
+					return "missing right leg"
+
+
+ABSTRACT_TYPE(/datum/part_customization/human/organ)
+/datum/part_customization/human/organ
+
+	default
+
+		apply_to(mob/living/carbon/human/human)
+			. = ..()
+			var/obj/item/organ/chosen_part_type = human.mutantrace.mutant_organs[src.slot]
+			if (!chosen_part_type) // fall back to default organs if we don't get any special ones
+				chosen_part_type = pick(src.part_type)
 			if(!istype(human.organHolder?.get_organ(src.slot), chosen_part_type))
+				var/obj/item/organ/new_organ = new chosen_part_type()
 				human.organHolder.receive_organ(new_organ, src.slot, force = TRUE)
 
-		eye_default_left
+		eye_left
 			id = "eye_default_left"
 			slot = "left_eye"
 			part_type = /obj/item/organ/eye/left
 
-		eye_default_right
+		eye_right
 			id = "eye_default_right"
 			slot = "right_eye"
 			part_type = /obj/item/organ/eye/right
+
+	replacement
+		apply_to(mob/living/carbon/human/human)
+			. = ..()
+			var/chosen_part_type = pick(src.part_type)
+			if(!istype(human.organHolder?.get_organ(src.slot), chosen_part_type))
+				var/obj/item/organ/new_organ = new chosen_part_type()
+				human.organHolder.receive_organ(new_organ, src.slot, force = TRUE)
 
 		eye_plant_left
 			id = "eye_plant_left"
@@ -221,55 +278,18 @@ ABSTRACT_TYPE(/datum/part_customization/human)
 			slot = "right_eye"
 			part_type = /obj/item/organ/eye/cyber/configurable
 
-ABSTRACT_TYPE(/datum/part_customization/human/missing)
-/datum/part_customization/human/missing
-	custom_icon = 'icons/ui/character_editor.dmi'
-	custom_icon_state = "missing"
+	missing
+		custom_icon = 'icons/ui/character_editor.dmi'
+		custom_icon_state = "missing"
 
-	apply_to(mob/living/carbon/human/human)
-		. = ..()
-		if (istype(src, /datum/part_customization/human/missing/organ))
+
+		apply_to(mob/living/carbon/human/human)
+			. = ..()
 			var/obj/item/organ/old_organ = human.organHolder?.get_organ(src.slot)
 			if(old_organ)
 				human.organHolder.drop_organ(src.slot)
 				qdel(old_organ)
-		else
-			var/obj/item/parts/limb = human.limbs.get_limb(src.slot)
-			limb?.remove(0)
-			qdel(limb)
-	arm
-		left
-			id = "arm_missing_left"
-			slot = "l_arm"
-			incompatible_parts = list("arm_missing_right")
 
-			get_name()
-				return "missing left arm"
-
-		right
-			id = "arm_missing_right"
-			slot = "r_arm"
-			incompatible_parts = list("arm_missing_left")
-
-			get_name()
-				return "missing right arm"
-
-	leg
-		left
-			id = "leg_missing_left"
-			slot = "l_leg"
-
-			get_name()
-				return "missing left leg"
-
-		right
-			id = "leg_missing_right"
-			slot = "r_leg"
-
-			get_name()
-				return "missing right leg"
-
-	organ
 		eye_left
 			id = "eye_missing_left"
 			slot = "left_eye"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][traits]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Restructure human body part customization `/datum/part_customization/human` to better match `apply_to` overrides.

The two top-level children are abstract: `/datum/part_customization/human/limb` and `/datum/part_customization/human/organ`. These two parent types better mirror how different the storage, detection, and replacement of their parts work. Underneath each of these two abstract types are three further subtypes: `default`, `replacement`, and `missing`. Each of these subtypes uses a different `apply_to` methodology.

The `default` subtype `apply_to` checks the mutantrace datum to see if the limb/organ should be a mutantrace version, before falling back to the default human body part.

The `replacement` subtype `apply_to` is a more straightforward typecheck and replacement of the target body part.

The `missing` subtype `apply_to` removes the limb/organ cleanly.

This replaces the datum type-checking needed in the existing `apply_to`, trading typepath complexity for it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22852
Fixes non-humans spawning with human eyes