### PR TITLE
Don't runtime on admins adding invalid bioEffect IDs

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1393,6 +1393,9 @@ var/global/noir = 0
 					var/string_version
 					for(pick in picklist)
 						M.onProcCalled("addBioEffect", list("idToAdd" = pick, "magical" = 1))
+						if(!bioEffectList[pick])
+							boutput(usr, SPAN_ALERT("Invalid bioEffect ID [pick]"))
+							continue
 						if(M.bioHolder.AddEffect(pick, magical = 1))
 							successes++
 

--- a/code/modules/admin/bioeffectmanager.dm
+++ b/code/modules/admin/bioeffectmanager.dm
@@ -41,7 +41,9 @@
 	switch(action)
 		if ("addBioEffect")
 			var/input = tgui_input_text(ui.user, "Enter a /datum/bioEffect path or partial name.", "Add a Bioeffect", null, allowEmpty = TRUE)
-			var/datum/bioEffect/type_to_add = get_one_match(input, /datum/bioEffect, cmp_proc=/proc/cmp_text_asc)
+			var/datum/bioEffect/type_to_add = get_one_match(input, /datum/bioEffect, use_concrete_types=TRUE, cmp_proc=/proc/cmp_text_asc)
+			if (!type_to_add)
+				return
 			target_mob.bioHolder.AddEffect(initial(type_to_add.id))
 			target_mob.onProcCalled("addBioEffect", list(initial(type_to_add.id)))
 			logTheThing(LOG_ADMIN, ui.user, "Added bioeffect [initial(type_to_add.id)] to [constructName(target_mob)]")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[admin][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
if we can't match an input bioeffect via the add bioeffect or manage panel, return instead of pushing through and causing a runtime in AddEffect

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
runtimes should be for code issues, not admin misinputs