### PR TITLE
Department ID computer board

### DIFF
--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -62,9 +62,33 @@ TYPEINFO(/obj/item/circuitboard)
 /obj/item/circuitboard/communications
 	name = "circuit board (communications)"
 	computertype = /obj/machinery/computer/communications
+
+// ID Card computers
 /obj/item/circuitboard/card
 	name = "circuit board (ID computer)"
 	computertype = /obj/machinery/computer/card
+
+/obj/item/circuitboard/card/engineering
+	name = "circuit board (engineering ID computer)"
+	computertype = /obj/machinery/computer/card/department/engineering
+	icon_state = "circuit_engineering"
+
+/obj/item/circuitboard/card/medical
+	name = "circuit board (medical ID computer)"
+	computertype = /obj/machinery/computer/card/department/medical
+	icon_state = "circuit_medical"
+
+/obj/item/circuitboard/card/research
+	name = "circuit board (research ID computer)"
+	computertype = /obj/machinery/computer/card/department/research
+	icon_state = "circuit_research"
+
+/obj/item/circuitboard/card/security
+	name = "circuit board (security ID computer)"
+	computertype = /obj/machinery/computer/card/department/security
+	icon_state = "circuit_security"
+
+
 /obj/item/circuitboard/teleporter
 	name = "circuit board (teleporter)"
 	computertype = /obj/machinery/computer/teleporter

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -594,6 +594,7 @@
 	color = "#ffffcc" // look there's a lot of icons to edit just to add a single stripe of color to these computers
 	department = 1
 	req_access = list(access_engineering_chief)
+	circuit_type = /obj/item/circuitboard/card/engineering
 
 	civilian_access_list = list(access_maint_tunnels, access_tech_storage)
 	// stock engineering_access_list
@@ -607,6 +608,7 @@
 	color = "#99ccff"
 	department = 2
 	req_access = list(access_medical_director)
+	circuit_type = /obj/item/circuitboard/card/medical
 
 	civilian_access_list = list(access_morgue, access_maint_tunnels, access_tech_storage)
 	engineering_access_list = null
@@ -621,6 +623,7 @@
 	color = "#cc99ff"
 	department = 3
 	req_access = list(access_research_director)
+	circuit_type = /obj/item/circuitboard/card/research
 
 	civilian_access_list = list(access_maint_tunnels, access_tech_storage)
 	engineering_access_list = null
@@ -635,6 +638,7 @@
 	color = "#ff9999"
 	department = 4
 	req_access = list(access_maxsec)
+	circuit_type = /obj/item/circuitboard/card/security
 
 	civilian_access_list = list(access_morgue, access_maint_tunnels, access_tech_storage, access_bar, access_crematorium, access_kitchen, access_hydro)
 	engineering_access_list = list(access_engineering, access_engineering_control)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Give departmental ID computers special circuit boards


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These presently cannot be repaired if deconstructed to the board, instead building to the standard ID computer that the department heads can't use.
