### PR TITLE
Unit Test: Terrainify sanity check to try to limit simulated turfs

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -51,6 +51,7 @@
 #include "job_name_uniqueness.dm"
 #include "mutation_combo_valid_ids.dm"
 #include "od_compile_bot.dm"
+#include "terrainify.dm"
 
 #undef TEST_ASSERT
 #undef TEST_ASSERT_EQUAL

--- a/code/modules/unit_tests/terrainify.dm
+++ b/code/modules/unit_tests/terrainify.dm
@@ -1,0 +1,33 @@
+
+/datum/unit_test/terrainify
+
+/datum/unit_test/terrainify/proc/is_turf_path_safe(turf_path)
+	if(ispath(turf_path, /turf/unsimulated))
+		. = TRUE
+	else if(ispath(turf_path, /turf/simulated/wall/auto/asteroid))
+		var/turf/simulated/wall/auto/asteroid/a_type = turf_path
+		if(ispath(a_type::replace_type, /turf/unsimulated))
+			. = TRUE
+	else if(isnull(turf_path))
+		. = TRUE
+
+	if(!.)
+		. = .
+
+/datum/unit_test/terrainify/Run()
+	// Iterate through map generators and ensure none of them generate simulated turf
+	for(var/map_gen_type in childrentypesof(/datum/map_generator))
+		var/datum/map_generator/gen_under_test = new map_gen_type()
+		if("possible_biomes" in gen_under_test.vars)
+			for(var/i in gen_under_test.vars["possible_biomes"])
+				for(var/j in gen_under_test.vars["possible_biomes"][i])
+					var/datum/biome/gen_biome = gen_under_test.vars["possible_biomes"][i][j]
+					TEST_ASSERT(is_turf_path_safe(gen_biome::turf_type),"[map_gen_type]'s [i][j] biome [gen_biome] has sim element")
+
+		TEST_ASSERT(is_turf_path_safe(gen_under_test.wall_turf_type), "[map_gen_type]'s wall_turf_type has sim element")
+		TEST_ASSERT(is_turf_path_safe(gen_under_test.floor_turf_type), "[map_gen_type]'s floor_turf_type has sim element")
+
+	// This is mostly redundant but Azrun can't be trusted
+	for(var/biome_path in childrentypesof(/datum/biome))
+		var/datum/biome/biome = biome_path
+		TEST_ASSERT(is_turf_path_safe(biome::turf_type), "[biome]'s turf_type has sim element")

--- a/code/modules/unit_tests/terrainify.dm
+++ b/code/modules/unit_tests/terrainify.dm
@@ -27,6 +27,7 @@
 		TEST_ASSERT(is_turf_path_safe(gen_under_test.wall_turf_type), "[map_gen_type]'s wall_turf_type has sim element")
 		TEST_ASSERT(is_turf_path_safe(gen_under_test.floor_turf_type), "[map_gen_type]'s floor_turf_type has sim element")
 
+	// Iterate through /datum/biome and ensure none of them generate simulated turf
 	// This is mostly redundant but Azrun can't be trusted
 	for(var/biome_path in childrentypesof(/datum/biome))
 		var/datum/biome/biome = biome_path

--- a/code/modules/worldgen/mapgen/StorehouseGenerator.dm
+++ b/code/modules/worldgen/mapgen/StorehouseGenerator.dm
@@ -309,10 +309,6 @@
 
 	New()
 		..()
-		if(!meatier)
-			meatier = rustg_dbp_generate("[rand(1,420)]", "5", "15", "[world.maxx]", "0.001", "0.9")
-		if(!stomach)
-			stomach = rustg_worley_generate("17", "10", "30", "[world.maxx]", "5", "10")
 
 	assign_turf(turf/T, flags)
 		var/generate_stuff = !(flags & (MAPGEN_IGNORE_FLORA|MAPGEN_IGNORE_FAUNA))
@@ -320,6 +316,12 @@
 		var/meaty = FALSE
 		var/stomach_goop = FALSE
 		var/index = T.x * world.maxx + T.y
+
+		if(!meatier)
+			meatier = rustg_dbp_generate("[rand(1,420)]", "5", "15", "[world.maxx]", "0.001", "0.9")
+		if(!stomach)
+			stomach = rustg_worley_generate("17", "10", "30", "[world.maxx]", "5", "10")
+
 		if(index <= length(meatier))
 			meaty = text2num(meatier[T.x * world.maxx + T.y])
 		if(index <= length(stomach))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add basic checks to ensure `/datum/biome` and `/datum/map_generator` generate non-simulated turfs or turfs that will be destroyed into non-simulated turfs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stop @Azrun for indirectly making rounds bad.


