### PR TITLE
Add additional labelling for Artifact Lab's Mass Drivers on Donut2.

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -8351,6 +8351,10 @@
 	dir = 1
 	},
 /area/station/crew_quarters/stockex)
+"aSj" = (
+/obj/decal/stripe_caution,
+/turf/simulated/floor,
+/area/station/science/artifact)
 "aSm" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -16907,7 +16911,11 @@
 	pixel_y = 24
 	},
 /obj/decal/tile_edge/stripe/corner/extra_big2{
-	dir = 9
+	dir = 10
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	tag = "icon-xtra_bigstripe-edge (WEST)"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 8
@@ -17737,16 +17745,8 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/decal/tile_edge/stripe/corner/extra_big2{
-	dir = 9
-	},
 /obj/machinery/light/incandescent,
-/obj/decal/tile_edge/stripe/corner/extra_big2{
-	dir = 5
-	},
-/turf/simulated/floor/white/checker2{
-	dir = 8
-	},
+/turf/simulated/floor,
 /area/station/science/artifact)
 "dcu" = (
 /obj/decal/poster/wallsign/medbay_left{
@@ -22246,8 +22246,8 @@
 	name = "Emergency Ejection Button";
 	pixel_y = 24
 	},
-/obj/decal/tile_edge/stripe/corner/extra_big2{
-	dir = 5
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 4
@@ -29663,6 +29663,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/ptl)
+"krh" = (
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 9
+	},
+/turf/simulated/floor/white/checker2{
+	dir = 8
+	},
+/area/station/science/artifact)
 "krO" = (
 /obj/submachine/chef_sink/chem_sink{
 	pixel_y = 8
@@ -35048,6 +35056,9 @@
 /obj/stool/chair/office{
 	dir = 1
 	},
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 5
+	},
 /turf/simulated/floor/white/checker2{
 	dir = 8
 	},
@@ -37897,11 +37908,9 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/decal/tile_edge/stripe/extra_big{
+/obj/decal/stripe_caution,
+/turf/simulated/floor/yellow/side{
 	dir = 1
-	},
-/turf/simulated/floor/white/checker2{
-	dir = 8
 	},
 /area/station/science/artifact)
 "oUa" = (
@@ -45781,6 +45790,17 @@
 /obj/machinery/light/small/sticky/frostedred,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
+"tAw" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor/white/checker2{
+	dir = 8
+	},
+/area/station/science/artifact)
 "tAx" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4;
@@ -129455,8 +129475,8 @@ aaa
 cOu
 wef
 dXX
+aSj
 uoo
-tma
 xnK
 fkY
 viQ
@@ -129758,7 +129778,7 @@ aiU
 aiU
 aiU
 dcj
-tma
+uoo
 nAS
 tma
 fYd
@@ -130060,7 +130080,7 @@ yhM
 fed
 dXX
 oTZ
-fkY
+tAw
 cFC
 oUV
 nIf
@@ -130362,7 +130382,7 @@ aiU
 aiU
 aiU
 cEi
-tma
+krh
 hOU
 sEx
 ybe

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -37909,9 +37909,13 @@
 	icon_state = "2-8"
 	},
 /obj/decal/stripe_caution,
-/turf/simulated/floor/yellow/side{
+/obj/decal/tile_edge/floorguide/qm{
 	dir = 1
 	},
+/obj/decal/tile_edge/floorguide/arrow_n{
+	dir = 8
+	},
+/turf/simulated/floor/orange,
 /area/station/science/artifact)
 "oUa" = (
 /turf/simulated/floor/yellow/side{

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -37915,7 +37915,9 @@
 /obj/decal/tile_edge/floorguide/arrow_n{
 	dir = 8
 	},
-/turf/simulated/floor/orange,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
 /area/station/science/artifact)
 "oUa" = (
 /turf/simulated/floor/yellow/side{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Minor change adding simple floor markings to denote and accentuate the Artlab Mass Drivers.
Clearly marking which of the two is supposed to be used for shipment of Artifacts or otherwise,
to QM.

## Why's this needed? <!-- -->
A lack of floor-based visual delineation, in regard to the function of the two Mass Drivers.
Such a deficiency may lead to potentially ruinous outcomes should the incorrect Mass Driver
be used for the ejection of Artifacts that pose an immediate threat.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Atra_xite
(+)Floor Markings to denote Mass Driver intended use in Donut2 Artlab.
```
