### PR TITLE
Show Space Phoenix humans/critters collected as abilityHolder stats

### DIFF
--- a/code/mob/living/critter/space_phoenix.dm
+++ b/code/mob/living/critter/space_phoenix.dm
@@ -51,6 +51,8 @@
 
 		QDEL_NULL(src.organHolder)
 
+		src.setStatus("phoenix_empowered_feather", INFINITE_STATUS)
+
 	Life()
 		. = ..()
 		if (istype(get_turf(src), /turf/space))
@@ -451,7 +453,7 @@
 		..()
 
 /area/phoenix_nest
-	name = "Space Phoenix Nest"
+	name = "ice nest"
 	skip_sims = TRUE
 	var/mob/living/critter/space_phoenix/owning_phoenix = null
 	var/list/humans_for_revive = list()

--- a/code/mob/living/critter/space_phoenix.dm
+++ b/code/mob/living/critter/space_phoenix.dm
@@ -51,7 +51,7 @@
 
 		QDEL_NULL(src.organHolder)
 
-			Life()
+	Life()
 		. = ..()
 		if (istype(get_turf(src), /turf/space))
 			src.delStatus("burning")
@@ -473,7 +473,7 @@
 	proc/atom_entered(atom/movable/AM)
 		if (!src.owning_phoenix)
 			return
-var/datum/abilityHolder/space_phoenix/ability_holder = src.owning_phoenix.get_ability_holder(/datum/abilityHolder/space_phoenix)
+		var/datum/abilityHolder/space_phoenix/ability_holder = src.owning_phoenix.get_ability_holder(/datum/abilityHolder/space_phoenix)
 		if (istype(AM, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = AM
 			if (!isdead(H))
@@ -499,12 +499,12 @@ var/datum/abilityHolder/space_phoenix/ability_holder = src.owning_phoenix.get_ab
 				src.owning_phoenix.extra_life_regen += 0.3
 				src.owning_phoenix.collected_critters |= "[C.real_name]-\ref[C]"
 				C.setStatus("cold_snap", INFINITE_STATUS)
-ability_holder.updateText(FALSE)
+		ability_holder.updateText(FALSE)
 
 	proc/atom_exited(atom/movable/AM)
 		if (!src.owning_phoenix)
 			return
-var/datum/abilityHolder/space_phoenix/ability_holder = src.owning_phoenix.get_ability_holder(/datum/abilityHolder/space_phoenix)
+		var/datum/abilityHolder/space_phoenix/ability_holder = src.owning_phoenix.get_ability_holder(/datum/abilityHolder/space_phoenix)
 		if (istype(AM, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = AM
 			if (!isdead(H))

--- a/code/mob/living/critter/space_phoenix.dm
+++ b/code/mob/living/critter/space_phoenix.dm
@@ -51,20 +51,7 @@
 
 		QDEL_NULL(src.organHolder)
 
-		src.abilityHolder.addAbility(/datum/targetable/critter/space_phoenix/sail)
-		src.abilityHolder.addAbility(/datum/targetable/critter/space_phoenix/thermal_shock)
-		src.abilityHolder.addAbility(/datum/targetable/critter/space_phoenix/ice_barrier)
-		src.abilityHolder.addAbility(/datum/targetable/critter/space_phoenix/glacier)
-		src.abilityHolder.addAbility(/datum/targetable/critter/space_phoenix/wind_chill)
-		src.abilityHolder.addAbility(/datum/targetable/critter/space_phoenix/touch_of_death)
-		src.abilityHolder.addAbility(/datum/targetable/critter/space_phoenix/permafrost)
-
-		src.setStatus("phoenix_empowered_feather", INFINITE_STATUS)
-		src.setStatus("phoenix_mobs_collected", INFINITE_STATUS)
-
-		get_image_group(CLIENT_IMAGE_GROUP_TEMPERATURE_OVERLAYS).add_mob(src)
-
-	Life()
+			Life()
 		. = ..()
 		if (istype(get_turf(src), /turf/space))
 			src.delStatus("burning")
@@ -464,7 +451,7 @@
 		..()
 
 /area/phoenix_nest
-	name = "ice nest"
+	name = "Space Phoenix Nest"
 	skip_sims = TRUE
 	var/mob/living/critter/space_phoenix/owning_phoenix = null
 	var/list/humans_for_revive = list()
@@ -486,6 +473,7 @@
 	proc/atom_entered(atom/movable/AM)
 		if (!src.owning_phoenix)
 			return
+var/datum/abilityHolder/space_phoenix/ability_holder = src.owning_phoenix.get_ability_holder(/datum/abilityHolder/space_phoenix)
 		if (istype(AM, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = AM
 			if (!isdead(H))
@@ -497,9 +485,7 @@
 						src.owning_phoenix.setStatus("phoenix_revive_ready", INFINITE_STATUS)
 				if (!(H in src.entered_humans))
 					src.entered_humans += H
-					var/datum/statusEffect/phoenix_nest_counter/counter = src.owning_phoenix.hasStatus("phoenix_mobs_collected")
-					counter.humans_collected++
-					counter.onUpdate()
+					ability_holder.stored_human_count++
 					src.owning_phoenix.extra_life_regen += 0.3
 				src.owning_phoenix.collected_humans |= "[H.real_name]-\ref[H]"
 				H.setStatus("cold_snap", INFINITE_STATUS)
@@ -509,16 +495,16 @@
 				C.setStatus("in_phoenix_nest", INFINITE_STATUS)
 			else if (!(C in src.entered_critters) && !C.last_ckey)
 				src.entered_critters += C
-				var/datum/statusEffect/phoenix_nest_counter/counter = src.owning_phoenix.hasStatus("phoenix_mobs_collected")
-				counter.critters_collected++
-				counter.onUpdate()
+				ability_holder.stored_critter_count++
 				src.owning_phoenix.extra_life_regen += 0.3
 				src.owning_phoenix.collected_critters |= "[C.real_name]-\ref[C]"
 				C.setStatus("cold_snap", INFINITE_STATUS)
+ability_holder.updateText(FALSE)
 
 	proc/atom_exited(atom/movable/AM)
 		if (!src.owning_phoenix)
 			return
+var/datum/abilityHolder/space_phoenix/ability_holder = src.owning_phoenix.get_ability_holder(/datum/abilityHolder/space_phoenix)
 		if (istype(AM, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = AM
 			if (!isdead(H))
@@ -526,9 +512,7 @@
 			if (H in src.entered_humans)
 				src.owning_phoenix.extra_life_regen -= 0.3
 				src.entered_humans -= H
-				var/datum/statusEffect/phoenix_nest_counter/counter = src.owning_phoenix.hasStatus("phoenix_mobs_collected")
-				counter.humans_collected--
-				counter.onUpdate()
+				ability_holder.stored_human_count--
 				H.delStatus("cold_snap")
 		else if (istype(AM, /mob/living/critter))
 			var/mob/living/critter/C = AM
@@ -537,7 +521,7 @@
 			if (C in src.entered_critters)
 				src.owning_phoenix.extra_life_regen -= 0.3
 				src.entered_critters -= C
-				var/datum/statusEffect/phoenix_nest_counter/counter = src.owning_phoenix.hasStatus("phoenix_mobs_collected")
-				counter.critters_collected--
-				counter.onUpdate()
+				ability_holder.stored_critter_count--
 				C.delStatus("cold_snap")
+
+		ability_holder.updateText(FALSE)

--- a/code/modules/antagonists/space_phoenix/_phoenix_ability_holder.dm
+++ b/code/modules/antagonists/space_phoenix/_phoenix_ability_holder.dm
@@ -1,0 +1,12 @@
+/datum/abilityHolder/space_phoenix
+	usesPoints = FALSE
+	regenRate = FALSE
+
+	var/stored_critter_count = 0
+	var/stored_human_count = 0
+
+	onAbilityStat()
+		. = ..()
+		. = list()
+		.["Critters:"] = src.stored_critter_count
+		.["Humans:"] = src.stored_human_count

--- a/code/modules/antagonists/space_phoenix/space_phoenix.dm
+++ b/code/modules/antagonists/space_phoenix/space_phoenix.dm
@@ -13,11 +13,8 @@
 
 	give_equipment()
 		. = ..()
-		var/datum/abilityHolder/space_phoenix/A = src.owner.current.get_ability_holder(/datum/abilityHolder/space_phoenix)
-		if (!A)
-			src.ability_holder = src.owner.current.add_ability_holder(/datum/abilityHolder/space_phoenix)
-		else
-			src.ability_holder = A
+		var/datum/abilityHolder/space_phoenix/abil_holder = src.owner.current.get_ability_holder(/datum/abilityHolder/space_phoenix)
+		src.ability_holder = abil_holder || src.owner.current.add_ability_holder(/datum/abilityHolder/space_phoenix)
 
 		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/sail)
 		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/thermal_shock)
@@ -27,7 +24,6 @@
 		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/touch_of_death)
 		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/permafrost)
 
-		src.owner.current.setStatus("phoenix_empowered_feather", INFINITE_STATUS)
 		src.owner.current.setStatus("phoenix_mobs_collected", INFINITE_STATUS)
 
 		get_image_group(CLIENT_IMAGE_GROUP_TEMPERATURE_OVERLAYS).add_mob(src.owner.current)
@@ -41,7 +37,6 @@
 		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/touch_of_death)
 		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/permafrost)
 
-		src.owner.current.delStatus("phoenix_empowered_feather")
 		src.owner.current.delStatus("phoenix_mobs_collected")
 
 		get_image_group(CLIENT_IMAGE_GROUP_TEMPERATURE_OVERLAYS).remove_mob(src.owner.current)

--- a/code/modules/antagonists/space_phoenix/space_phoenix.dm
+++ b/code/modules/antagonists/space_phoenix/space_phoenix.dm
@@ -6,7 +6,45 @@
 	assigned_by = ANTAGONIST_SOURCE_RANDOM_EVENT
 	objectives = list(/datum/objective/specialist/phoenix_collect_humans, /datum/objective/specialist/phoenix_collect_critters, /datum/objective/specialist/phoenix_permafrost_areas)
 	success_medal = "Territorial Defender"
+	/// How far from the map edge does our nest need to be
 	var/map_edge_margin = 35
+	/// The ability holder of this space phoenix
+	var/datum/abilityHolder/space_phoenix/ability_holder
+
+	give_equipment()
+		. = ..()
+		var/datum/abilityHolder/space_phoenix/A = src.owner.current.get_ability_holder(/datum/abilityHolder/space_phoenix)
+		if (!A)
+			src.ability_holder = src.owner.current.add_ability_holder(/datum/abilityHolder/space_phoenix)
+		else
+			src.ability_holder = A
+
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/sail)
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/thermal_shock)
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/ice_barrier)
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/glacier)
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/wind_chill)
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/touch_of_death)
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/permafrost)
+
+		src.owner.current.setStatus("phoenix_empowered_feather", INFINITE_STATUS)
+		src.owner.current.setStatus("phoenix_mobs_collected", INFINITE_STATUS)
+
+		get_image_group(CLIENT_IMAGE_GROUP_TEMPERATURE_OVERLAYS).add_mob(src.owner.current)
+
+	remove_equipment()
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/sail)
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/thermal_shock)
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/ice_barrier)
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/glacier)
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/wind_chill)
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/touch_of_death)
+		src.ability_holder.addAbility(/datum/targetable/critter/space_phoenix/permafrost)
+
+		src.owner.current.delStatus("phoenix_empowered_feather")
+		src.owner.current.delStatus("phoenix_mobs_collected")
+
+		get_image_group(CLIENT_IMAGE_GROUP_TEMPERATURE_OVERLAYS).remove_mob(src.owner.current)
 
 	relocate()
 		..()

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -3667,12 +3667,13 @@
 	name = "Extra Health Regneration"
 	icon_state = "phoenix_health_regen"
 	effect_quality = STATUS_QUALITY_POSITIVE
-	var/critters_collected = 0
-	var/humans_collected = 0
 
 	getTooltip()
 		var/mob/living/critter/space_phoenix/phoenix = src.owner
-		return "You have [src.critters_collected]/5 critters and [src.humans_collected]/5 humans collected in your nest, giving you an extra [phoenix.extra_life_regen] points of out of combat health regeneration."
+		var/datum/abilityHolder/space_phoenix/ability_holder = phoenix.get_ability_holder(/datum/abilityHolder/space_phoenix)
+		if (!ability_holder)
+			return "Cannot connect to ability holder, please file a bug!"
+		return "Extra [phoenix.extra_life_regen] out of combat health regeneration from [min(ability_holder.stored_critter_count,5)]/5 critters and [min(ability_holder.stored_human_count,5)]/5 humans collected in your nest."
 
 /datum/statusEffect/phoenix_revive_ready
 	id = "phoenix_revive_ready"

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -3672,8 +3672,8 @@
 		var/mob/living/critter/space_phoenix/phoenix = src.owner
 		var/datum/abilityHolder/space_phoenix/ability_holder = phoenix.get_ability_holder(/datum/abilityHolder/space_phoenix)
 		if (!ability_holder)
-			return "Cannot connect to ability holder, please file a bug!"
-		return "Extra [phoenix.extra_life_regen] out of combat health regeneration from [min(ability_holder.stored_critter_count,5)]/5 critters and [min(ability_holder.stored_human_count,5)]/5 humans collected in your nest."
+			return "Cannot connect to ability holder, please file a bug report!"
+		return "Extra [phoenix.extra_life_regen] out of combat health regeneration from [min(ability_holder.stored_critter_count, 5)] / 5 critters and [min(ability_holder.stored_human_count, 5)] / 5 humans collected in your nest."
 
 /datum/statusEffect/phoenix_revive_ready
 	id = "phoenix_revive_ready"

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -859,6 +859,7 @@
 #include "code\modules\antagonists\slasher\abilities\stagger.dm"
 #include "code\modules\antagonists\slasher\abilities\summon_machete.dm"
 #include "code\modules\antagonists\slasher\abilities\take_control.dm"
+#include "code\modules\antagonists\space_phoenix\_phoenix_ability_holder.dm"
 #include "code\modules\antagonists\space_phoenix\space_phoenix.dm"
 #include "code\modules\antagonists\spy_thief\spy_thief.dm"
 #include "code\modules\antagonists\syndicate_cyborg\emagged_cyborg.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][gamemodes]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds a new phoenix ability holder that keeps track of the stored critters and humans
* Change space phoenix antagonist datum to use new ability holder via give/remove equipment
* Status effects are now also given/removed with the ability holder
* Changes the space phoenix health regen status effect description to use the ability holder
* The Extra Health Regneration tooltip starts with your regen bonus value


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Much easier to see your collected humans/critters, in line with other similar antagonists.
Seeing the regen value first in the description is more important now that there's direct feedback about how many humans/critters you've captured.

## Screenshots
![Screenshot 2025-04-05 014855](https://github.com/user-attachments/assets/d8d17b04-5626-4fc4-b0db-f70bdef9f0ac)
![Screenshot 2025-04-05 014902](https://github.com/user-attachments/assets/a8316d8f-88a3-47af-96d5-fb8ee09cf176)
