### PR TITLE
Lawbringer antagonist flavour text

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1393,6 +1393,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 	rechargeable = 0
 	can_swap_cell = 0
 	muzzle_flash = "muzzle_flash_elec"
+	tooltip_flags = REBUILD_USER
 	var/emagged = FALSE
 
 	New(var/mob/M)
@@ -1417,6 +1418,10 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 	disposing()
 		indicator_display = null
 		..()
+
+	get_desc(dist, mob/user)
+		if (user.mind.is_antagonist())
+			. += SPAN_ALERT("<b>It doesn't seem to like you...</b>")
 
 	attack_hand(mob/user)
 		if (!owner_prints)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If the person reading the lawbringer's description is an antagonist, add "It doesn't seem to like you..."
![image](https://github.com/user-attachments/assets/03d4c516-19e2-4955-bf7f-5dea9905556c)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More items should have fun flavour text depending on who is looking at it, it's a fun feature.
