### PR TITLE
Yoink the HoP's default sec accesses

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -204,8 +204,7 @@
 		if("Captain")
 			return get_all_accesses()
 		if("Head of Personnel")
-			return list(access_security, access_carrypermit, access_contrabandpermit, access_forensics_lockers, access_ticket,
-						access_tox, access_tox_storage, access_chemistry, access_medical, access_medlab,
+			return list(access_ticket, access_tox, access_tox_storage, access_chemistry, access_medical, access_medlab,
 						access_change_ids, access_eva, access_heads, access_head_of_personnel, access_medical_lockers,
 						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
 						access_kitchen, access_robotics, access_cargo, access_supply_console,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[add to wiki][balance][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the HoP's default security/carry/contra/foreniscs access.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They don't have security comms access and hold no real direct authority over the rest of security (until they're made acting captain). They keep ticketing access.

HoP's can still, of course, modify their ID to have these permissions at round start.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)The Head of Personnel does not have security access by default.
```
