### PR TITLE
Clean up HoP/customs areas between maps.

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -2413,27 +2413,18 @@ ABSTRACT_TYPE(/area/station/mining)
 	icon_state = "CAPN"
 	station_map_colour = MAPC_COMMAND
 
-/area/station/hos
-	name = "Head of Personnel's Office"
-	icon_state = "HOP"
-	station_map_colour = MAPC_COMMAND
-
-/area/station/hos/quarter
-	name = "Head of Personnel's Personal Quarter"
-	icon_state = "HOP"
-
 /area/station/bridge/captain
 	name = "Captain's Office"
 	icon_state = "CAPN"
 	spy_secure_area = TRUE
 
-/area/station/bridge/hos
-	name = "Head of Personnel's Office"
-	icon_state = "HOP"
-
 /area/station/bridge/customs
 	name = "Customs"
 	icon_state = "yellow"
+
+/area/station/bridge/reception
+	name = "Bridge Reception"
+	icon_state = "blue"
 
 ABSTRACT_TYPE(/area/station/crew_quarters)
 /area/station/crew_quarters
@@ -2580,7 +2571,7 @@ ABSTRACT_TYPE(/area/station/crew_quarters/radio)
 
 /area/station/crew_quarters/hop
 	name = "Head of Personnel's Quarters"
-	icon_state = "green"
+	icon_state = "HOP"
 	sound_environment = 4
 	station_map_colour = MAPC_COMMAND
 
@@ -2650,9 +2641,9 @@ ABSTRACT_TYPE(/area/station/crew_quarters/radio)
 	sound_environment = 2
 	station_map_colour = MAPC_BAR
 
-/area/station/crew_quarters/heads
-	name = "Head of Personnel's Office"
-	icon_state = "HOP"
+/area/station/crew_quarters/diplomat
+	name = "Diplomatic Quarters"
+	icon_state = "blue"
 	sound_environment = 4
 	station_map_colour = MAPC_COMMAND
 

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -4949,7 +4949,7 @@
 /area/station/crew_quarters/lounge)
 "aBK" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aBN" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -5194,7 +5194,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aCV" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating/random,
@@ -7575,7 +7575,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aQy" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -7639,7 +7639,7 @@
 	dir = 10;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aRf" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -7777,7 +7777,7 @@
 	dir = 5;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aRM" = (
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor,
@@ -7852,7 +7852,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aSl" = (
 /obj/storage/secure/closet/command/captain,
 /obj/machinery/phone/wall{
@@ -7895,7 +7895,7 @@
 /area/station/chapel/office)
 "aSA" = (
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aSB" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -7979,7 +7979,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aTb" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -7988,7 +7988,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aTc" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -8337,7 +8337,7 @@
 	dir = 6;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aVr" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon12,
 /turf/simulated/floor/orangeblack,
@@ -8478,7 +8478,7 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aWr" = (
 /obj/machinery/vending/pizza/fallen{
 	color = "#b0a060";
@@ -8781,7 +8781,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aYo" = (
 /obj/shrub{
 	dir = 1
@@ -8838,7 +8838,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aYK" = (
 /obj/machinery/computer3/terminal/zeta{
 	setup_os_string = "ZETA_MAINFRAME";
@@ -8960,7 +8960,7 @@
 	},
 /mob/living/critter/small_animal/dog/george/orwell,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aZH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -14600,7 +14600,7 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "jgk" = (
 /turf/simulated/wall/auto/reinforced/supernorn/the_tuff_stuff,
 /area/station/science/testchamber/bombchamber{
@@ -19027,7 +19027,7 @@
 	},
 /obj/item/pen/crayon/golden,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "pri" = (
 /obj/table/reinforced/bar/auto,
 /obj/decal/tile_edge/line/black{
@@ -23244,7 +23244,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vMX" = (
 /obj/cable/blue{
 	icon_state = "1-2"
@@ -23686,7 +23686,7 @@
 	dir = 9;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wux" = (
 /obj/cable{
 	icon_state = "4-8"

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -13452,15 +13452,10 @@
 /obj/item/clothing/head/powdered_wig,
 /obj/item/device/radio/headset/civilian,
 /obj/item/device/radio/headset/civilian,
-/obj/machinery/power/apc{
-	areastring = "Head of Personnel's Office";
-	dir = 4;
-	name = "HoP's Office APC";
-	pixel_x = 24
-	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -33684,15 +33679,11 @@
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/item/pen/crayon/golden,
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/hop)
 "saG" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -25,9 +25,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "aag" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -692,9 +690,7 @@
 /area/station/hallway/primary/north)
 "acV" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "adD" = (
 /obj/landmark/pest,
 /turf/simulated/floor/plating,
@@ -987,9 +983,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "ahb" = (
 /turf/space,
 /area/shuttle/merchant_shuttle/right_station/destiny)
@@ -1026,9 +1020,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "ahu" = (
 /obj/machinery/light{
 	dir = 8;
@@ -1126,9 +1118,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "ajM" = (
 /obj/machinery/light{
 	dir = 4;
@@ -6295,18 +6285,14 @@
 /area/station/bridge)
 "aWQ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "aWS" = (
 /obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "aWT" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge/captain)
@@ -6491,9 +6477,7 @@
 	},
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary/blue,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "aYn" = (
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -6787,9 +6771,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "baq" = (
 /obj/stool/chair/red{
 	dir = 8
@@ -7425,9 +7407,7 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/sanitary/blue,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "bfd" = (
 /obj/strip_door,
 /obj/cable{
@@ -15309,9 +15289,7 @@
 /obj/item/material_piece/foolsfoolsgold,
 /obj/item/device/gps,
 /turf/simulated/floor/carpet/green/fancy/edge/west,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "eAX" = (
 /obj/mesh/catwalk,
 /obj/landmark/magnet_shield,
@@ -18319,9 +18297,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "gIX" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 4;
@@ -18849,9 +18825,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "hhd" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -23071,9 +23045,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "keH" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -23104,9 +23076,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/green/fancy/innercorner/omni,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "kgx" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -24446,9 +24416,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "leh" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1;
@@ -24643,9 +24611,7 @@
 /obj/machinery/firealarm/east,
 /obj/machinery/light,
 /turf/simulated/floor/sanitary/blue,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "lkL" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -25072,9 +25038,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "lBa" = (
 /obj/mesh/catwalk,
 /obj/cable/yellow{
@@ -27975,9 +27939,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "nMc" = (
 /obj/cable/yellow{
 	icon_state = "4-8"
@@ -28595,9 +28557,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "ohk" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -29728,9 +29688,7 @@
 	pixel_y = 11
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "oWh" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -31804,9 +31762,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "qAX" = (
 /obj/stool/chair/moveable{
 	dir = 1
@@ -33738,9 +33694,7 @@
 	},
 /obj/item/pen/crayon/golden,
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "saG" = (
 /obj/machinery/firealarm/south,
 /obj/storage/cart/medcart/crash,
@@ -36060,9 +36014,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "tCV" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -40567,9 +40519,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "wON" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -40659,9 +40609,7 @@
 /area/station/maintenance/southwest)
 "wUi" = (
 /turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "wUD" = (
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/tools,
@@ -41989,9 +41937,7 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "xVW" = (
 /obj/disposaloutlet/south,
 /obj/disposalpipe/trunk/east,
@@ -42347,9 +42293,7 @@
 	},
 /mob/living/critter/small_animal/dog/blair,
 /turf/simulated/floor/carpet/green/fancy/edge/east,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "yid" = (
 /obj/machinery/disposal/mail/autoname/medbay,
 /obj/disposalpipe/trunk/mail{

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -5516,7 +5516,7 @@
 /area/station/bridge)
 "aRl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aRm" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/storage/eva)
@@ -5701,7 +5701,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aSI" = (
 /obj/submachine/chef_sink/chem_sink{
 	desc = "A water-filled unit intended for hand-washing purposes.";
@@ -6101,7 +6101,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aVC" = (
 /obj/machinery/disposal/small,
 /obj/disposalpipe/trunk{
@@ -6110,13 +6110,13 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aVD" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aVE" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -6125,13 +6125,13 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aVF" = (
 /obj/machinery/light,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aVI" = (
 /obj/machinery/light/emergency,
 /obj/table/reinforced/auto,
@@ -11728,7 +11728,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "bMI" = (
 /obj/table/auto,
 /obj/item/sheet/glass/reinforced/fullstack,
@@ -13484,7 +13484,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "ddX" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -13686,7 +13686,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "dmf" = (
 /obj/shrub{
 	icon = 'icons/obj/stationobjs.dmi';
@@ -15719,7 +15719,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "eQI" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -17389,7 +17389,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "gba" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -17419,7 +17419,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "gbX" = (
 /obj/machinery/computer/card/department/research,
 /obj/item/device/radio/intercom/medical,
@@ -25519,7 +25519,7 @@
 /area/station/crew_quarters/cafeteria)
 "lPb" = (
 /turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "lQz" = (
 /obj/landmark/start/job/chef,
 /turf/simulated/floor/specialroom/cafeteria,
@@ -27097,7 +27097,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "naT" = (
 /obj/stool/chair/dining/wood,
 /obj/landmark/start/job/assistant,
@@ -28107,7 +28107,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "nQh" = (
 /obj/item/device/radio/intercom/science,
 /obj/disposalpipe/segment/mail{
@@ -29444,7 +29444,7 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "oMz" = (
 /obj/mapping_helper/access/security,
 /obj/mapping_helper/firedoor_spawn,
@@ -29973,7 +29973,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "piX" = (
 /obj/machinery/computer/card/department/engineering,
 /obj/machinery/power/data_terminal,
@@ -30096,7 +30096,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "pnh" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/decal/poster/wallsign/space,
@@ -34238,7 +34238,7 @@
 	},
 /obj/mapping_helper/access/head_of_personnel,
 /turf/simulated/floor/black,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "sox" = (
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -34565,7 +34565,7 @@
 	},
 /obj/mapping_helper/access/head_of_personnel,
 /turf/simulated/floor/black,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "sCO" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -35448,7 +35448,7 @@
 "tkR" = (
 /obj/machinery/manufacturer/hop_and_uniform,
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "tll" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -36308,7 +36308,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "tMI" = (
 /obj/disposalpipe/segment,
 /obj/stool/chair/blue{
@@ -37150,7 +37150,7 @@
 	},
 /obj/mapping_helper/access/head_of_personnel,
 /turf/simulated/floor/black,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "upO" = (
 /obj/machinery/door_control{
 	id = "market_3";
@@ -37334,7 +37334,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "uuf" = (
 /turf/simulated/wall/auto/reinforced/supernorn{
 	explosion_resistance = 15;
@@ -42164,7 +42164,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "ycj" = (
 /turf/simulated/floor/yellow/side{
 	dir = 1

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -7944,7 +7944,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aEa" = (
 /obj/table/reinforced/auto,
 /obj/machinery/power/data_terminal,
@@ -15151,7 +15151,7 @@
 /area/station/bridge)
 "aZQ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aZR" = (
 /obj/storage/secure/closet/command/hop,
 /obj/machinery/light{
@@ -15159,7 +15159,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aZS" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -15170,7 +15170,7 @@
 	pixel_y = 27
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aZU" = (
 /obj/machinery/vending/cola/blue,
 /turf/simulated/floor/grey/side,
@@ -15465,7 +15465,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bbb" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -15474,7 +15474,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bbc" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -15505,7 +15505,7 @@
 	},
 /mob/living/critter/small_animal/dog/george/orwell,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bbd" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge/customs)
@@ -15734,7 +15734,7 @@
 	dir = 9;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bbS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -15746,24 +15746,24 @@
 	dir = 5;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bbT" = (
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bbU" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bbW" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bbX" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/device/radio/intercom{
@@ -16111,7 +16111,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bcY" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -16126,7 +16126,7 @@
 	dir = 8;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bda" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -16135,7 +16135,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bdb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -16144,7 +16144,7 @@
 	dir = 5;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bdc" = (
 /obj/item/device/radio/intercom{
 	dir = 1
@@ -16153,14 +16153,14 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bdd" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bdf" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -16452,7 +16452,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bdZ" = (
 /obj/table/wood/auto,
 /obj/item/reagent_containers/food/drinks/rum_spaced{
@@ -16466,7 +16466,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bea" = (
 /obj/table/wood/auto,
 /obj/machinery/recharger{
@@ -16485,7 +16485,7 @@
 	dir = 6;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "beb" = (
 /obj/disposalpipe/trunk/mail{
 	dir = 1
@@ -16716,7 +16716,7 @@
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "beT" = (
 /obj/table/reinforced/auto,
 /obj/machinery/camera{
@@ -34446,7 +34446,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "cuC" = (
 /obj/machinery/light/emergency,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -37122,7 +37122,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "cWR" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -38429,7 +38429,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "dRa" = (
 /obj/lattice{
 	dir = 4;
@@ -40372,7 +40372,7 @@
 	dir = 10;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ffW" = (
 /obj/machinery/conveyor/EW{
 	name = "cargo belt - west";
@@ -41951,7 +41951,7 @@
 	pixel_y = 23
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "gmU" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -43877,7 +43877,7 @@
 	dir = 5;
 	icon_state = "fgreen3"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "hNK" = (
 /obj/machinery/atmospherics/unary/tank/air_repressurization{
 	name = "Air Hookup Reserve Tank (Air)"
@@ -50337,7 +50337,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "mWX" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -50820,16 +50820,16 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	name = "Customs"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/security,
 /obj/mapping_helper/access/heads,
+/obj/machinery/door/airlock/pyro/maintenance{
+	req_access = null;
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/customs)
 "nph" = (
@@ -51329,7 +51329,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "nHP" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -55343,7 +55343,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "qDq" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -55511,7 +55511,7 @@
 /obj/machinery/firealarm/north,
 /obj/vehicle/segway,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "qJr" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -59378,7 +59378,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "tHP" = (
 /obj/reagent_dispensers/fueltank,
 /obj/machinery/light{

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -15508,7 +15508,7 @@
 /area/station/crew_quarters/heads)
 "bbd" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bbg" = (
 /obj/table/reinforced/auto,
 /obj/machinery/computer3/generic/personal{
@@ -15785,7 +15785,7 @@
 	},
 /obj/machinery/manufacturer/uniform,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bbZ" = (
 /obj/table/auto,
 /obj/bedsheetbin{
@@ -15804,7 +15804,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bcb" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -15820,7 +15820,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bcd" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -15833,7 +15833,7 @@
 /area/station/turret_protected/Zeta)
 "bcf" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bcg" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -16174,7 +16174,7 @@
 	},
 /obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bdg" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -16183,7 +16183,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bdh" = (
 /obj/disposalpipe/switch_junction{
 	desc = "An underfloor mail pipe.";
@@ -16199,7 +16199,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bdi" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -16232,7 +16232,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bdm" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -16502,14 +16502,14 @@
 	tag = ""
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bec" = (
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bed" = (
 /obj/stool/chair,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bee" = (
 /obj/machinery/power/data_terminal,
 /obj/cable,
@@ -16517,7 +16517,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bef" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -16741,7 +16741,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "beU" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg{
@@ -16749,7 +16749,7 @@
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "beW" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -17135,7 +17135,7 @@
 	pixel_x = 6
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "bgo" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/specialroom/freezer,
@@ -36956,7 +36956,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "cRg" = (
 /obj/landmark/pest,
 /turf/simulated/floor/specialroom/bar,
@@ -39631,7 +39631,7 @@
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "eFF" = (
 /obj/stool/chair/yellow,
 /obj/landmark/start/job/technical_trainee,
@@ -50831,7 +50831,7 @@
 /obj/mapping_helper/access/security,
 /obj/mapping_helper/access/heads,
 /turf/simulated/floor/plating,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "nph" = (
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/maintenance,
@@ -50941,7 +50941,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "ntb" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -59352,7 +59352,7 @@
 	},
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint)
+/area/station/bridge/customs)
 "tHo" = (
 /obj/machinery/plantpot,
 /turf/simulated/floor,

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -25651,10 +25651,10 @@
 /area/station/ai_monitored/storage/eva)
 "bzZ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bAb" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bAc" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
@@ -26194,14 +26194,14 @@
 	dir = 9;
 	icon_state = "blue2"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bBF" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "blue2"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bBH" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe{
 	dir = 4
@@ -26915,7 +26915,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bDA" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -26927,7 +26927,7 @@
 	dir = 10;
 	icon_state = "blue2"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bDB" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -26936,7 +26936,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "blue2"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bDC" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -26954,7 +26954,7 @@
 	dir = 6;
 	icon_state = "blue2"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bDD" = (
 /obj/machinery/light{
 	dir = 8;
@@ -27683,7 +27683,7 @@
 	},
 /obj/item_dispenser/idcarddispenser,
 /turf/simulated/floor/blueblack,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bFy" = (
 /obj/machinery/computer3/generic/bank_data,
 /obj/cable{
@@ -27691,14 +27691,14 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/blueblack,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bFz" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/blueblack,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bFA" = (
 /turf/simulated/floor/blueblack,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bFB" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/transport{
@@ -28449,18 +28449,18 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bHw" = (
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bHx" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bHy" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -28469,7 +28469,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bHA" = (
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -29209,7 +29209,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/circuit/off,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bJs" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -29218,7 +29218,7 @@
 /obj/machinery/navbeacon/mule/bridge_north/east,
 /obj/decal/mule/beacon,
 /turf/simulated/floor/circuit/off,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bJt" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -29227,7 +29227,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/circuit/off,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bJu" = (
 /obj/machinery/door/poddoor/pyro/shutters{
 	density = 0;
@@ -29242,7 +29242,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/circuit/off,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bJv" = (
 /obj/table/auto,
 /obj/machinery/recharger,
@@ -29992,25 +29992,25 @@
 /obj/disposalpipe/trunk/mail/east,
 /obj/machinery/disposal/mail/small/autoname/checkpoint/customs/east,
 /turf/simulated/floor/blueblack,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bLe" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/blueblack,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bLf" = (
 /obj/disposalpipe/switch_junction/left/south{
 	mail_tag = "customs checkpoint";
 	name = "mail junction (customs)"
 	},
 /turf/simulated/floor/blueblack,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bLg" = (
 /obj/item/device/radio/intercom/bridge{
 	broadcasting = 0;
 	dir = 8
 	},
 /turf/simulated/floor/blueblack,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bLh" = (
 /obj/table/auto,
 /obj/item/paper/book/from_file/guardbot_guide{
@@ -30707,7 +30707,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bMP" = (
 /obj/disposalpipe/switch_junction/right/south{
 	mail_tag = "bridge";
@@ -30716,13 +30716,13 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bMQ" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bMS" = (
 /obj/disposalpipe/segment/mail/bent/south,
 /turf/simulated/floor/blueblack{
@@ -31200,7 +31200,7 @@
 	dir = 5;
 	icon_state = "blue2"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bOv" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/circuit,
@@ -31653,7 +31653,7 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bPQ" = (
 /obj/machinery/disposal/brig{
 	name = "ejection chute"
@@ -31665,13 +31665,13 @@
 	dir = 10;
 	icon_state = "blue2"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bPR" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/carpet{
 	icon_state = "blue2"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bPS" = (
 /obj/table/auto,
 /obj/bedsheetbin,
@@ -31685,7 +31685,7 @@
 	dir = 6;
 	icon_state = "blue2"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bPU" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -32272,7 +32272,7 @@
 "bRy" = (
 /obj/disposalpipe/segment/ejection,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bRz" = (
 /obj/disposalpipe/segment/ejection,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -35951,7 +35951,7 @@
 	dir = 9;
 	icon_state = "blue2"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "ccA" = (
 /obj/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -56799,7 +56799,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "ffL" = (
 /obj/mesh/catwalk,
 /obj/disposalpipe/segment/mail/bent/east,
@@ -57552,7 +57552,7 @@
 	name = "Bridge"
 	},
 /turf/simulated/floor,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "fVT" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/mesh/catwalk,
@@ -59890,7 +59890,7 @@
 	name = "Bridge"
 	},
 /turf/simulated/floor,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "iiH" = (
 /obj/machinery/disposal,
 /obj/machinery/firealarm/west,
@@ -64170,7 +64170,7 @@
 	name = "Bridge"
 	},
 /turf/simulated/floor,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "mgV" = (
 /obj/submachine/seed_manipulator{
 	dir = 4
@@ -70055,7 +70055,7 @@
 	pixel_y = 15
 	},
 /turf/simulated/floor,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "rXL" = (
 /obj/storage/secure/closet/medical/medkit,
 /turf/simulated/floor/blue,
@@ -70951,7 +70951,7 @@
 	persistent_id = "customs"
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "sOV" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -72253,7 +72253,7 @@
 	name = "Bridge"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "uaM" = (
 /obj/mesh/catwalk{
 	dir = 4
@@ -72455,7 +72455,7 @@
 	dir = 5;
 	icon_state = "blue2"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "uuC" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -74735,7 +74735,7 @@
 	name = "Bridge"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "wZT" = (
 /obj/machinery/door/airlock/pyro/classic{
 	dir = 4;

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -22393,7 +22393,7 @@
 /area/station/maintenance/north)
 "brf" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "brg" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -22408,7 +22408,7 @@
 	},
 /obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "brh" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -22426,7 +22426,7 @@
 	},
 /obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bri" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -22447,7 +22447,7 @@
 	},
 /obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "brj" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -22462,7 +22462,7 @@
 	},
 /obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "brk" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/mainpod1_horizontal/vertical,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -23033,7 +23033,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bsT" = (
 /obj/table/wood/auto,
 /obj/machinery/power/data_terminal,
@@ -23042,7 +23042,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bsU" = (
 /obj/machinery/computer3/generic/bank_data,
 /obj/machinery/power/data_terminal,
@@ -23050,14 +23050,14 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bsV" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bsW" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -23065,7 +23065,7 @@
 	icon_state = "bedsheet-green"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bsX" = (
 /obj/item/device/radio/intercom/bridge{
 	broadcasting = 0
@@ -23076,7 +23076,7 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bsZ" = (
 /turf/simulated/floor/stairs{
 	dir = 4
@@ -23731,7 +23731,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "buK" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -23741,13 +23741,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/west,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "buL" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/green/fancy/innercorner/se,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "buM" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -23756,10 +23756,10 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/green/fancy/innercorner/sw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "buN" = (
 /turf/simulated/floor/carpet/green/fancy/edge/east,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "buP" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -23779,7 +23779,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "buR" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -24349,7 +24349,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bwz" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -24358,7 +24358,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/west,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bwA" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -24367,7 +24367,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/innercorner/ne,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bwB" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -24376,7 +24376,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/green/fancy/innercorner/nw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bwC" = (
 /obj/machinery/light{
 	dir = 4;
@@ -24384,7 +24384,7 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bwD" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -25195,17 +25195,17 @@
 /obj/machinery/light_switch/west,
 /mob/living/critter/small_animal/dog/george/orwell,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "byz" = (
 /obj/vehicle/segway,
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "byA" = (
 /obj/table/wood/auto,
 /obj/item/material_piece/foolsfoolsgold,
 /obj/item/stamp/hop,
 /turf/simulated/floor/carpet/green/fancy/edge,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "byB" = (
 /obj/machinery/light,
 /obj/cable{
@@ -25215,7 +25215,7 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/pen/crayon/golden,
 /turf/simulated/floor/carpet/green/fancy/edge,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "byC" = (
 /obj/machinery/door_control/bolter/new_walls/south{
 	id = "quarters_hop";
@@ -25224,7 +25224,7 @@
 	pixel_y = -21
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "byE" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/disposalpipe/segment/mail/vertical,
@@ -47859,7 +47859,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/east,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "cOx" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -58309,7 +58309,7 @@
 "gKD" = (
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "gKY" = (
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/purple,
@@ -74257,7 +74257,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wtr" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/machinery/door/poddoor/pyro/shutters{

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -20886,9 +20886,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	areastring = "Head of Personnel's Office";
+	areastring = "Head of Personnel's Quarters";
 	dir = 4;
-	name = "HoP's Office APC";
+	name = "HoP's Quarters APC";
 	pixel_x = 24
 	},
 /obj/machinery/portable_atmospherics/scrubber,

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -8461,9 +8461,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "aTf" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -8477,9 +8475,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "aTg" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -8604,9 +8600,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "aTN" = (
 /obj/table/wood/auto,
 /obj/item/reagent_containers/food/drinks/bottle/champagne{
@@ -8621,9 +8615,7 @@
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "aTP" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/captain,
@@ -10515,7 +10507,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bdu" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -10525,7 +10517,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bdw" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -10537,7 +10529,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bdx" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/left{
@@ -10545,7 +10537,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bdy" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -10633,7 +10625,7 @@
 	dir = 1;
 	icon_state = "fgreen1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "beg" = (
 /obj/table/wood/auto{
 	dir = 9
@@ -10649,14 +10641,14 @@
 	dir = 8;
 	icon_state = "fgreen1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "beh" = (
 /obj/stool/chair,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fgreen1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bei" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -10665,7 +10657,7 @@
 	dir = 1;
 	icon_state = "fgreen1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bej" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -10678,7 +10670,7 @@
 	dir = 4;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "beu" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -10705,10 +10697,10 @@
 	dir = 5;
 	icon_state = "fgreen6"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "beA" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "beB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -11301,7 +11293,7 @@
 	dir = 6;
 	icon_state = "fgreen6"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhP" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/wood,
@@ -15625,9 +15617,7 @@
 /obj/mapping_helper/access/heads,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "bON" = (
 /obj/machinery/light/incandescent,
 /obj/storage/closet/wardrobe/black/formalwear,
@@ -15787,7 +15777,7 @@
 	dir = 9;
 	icon_state = "fgreen6"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bST" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/mail{
@@ -16258,7 +16248,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "chE" = (
 /obj/machinery/vending/security_ammo,
 /turf/simulated/floor/redblack{
@@ -17032,9 +17022,7 @@
 /obj/storage/secure/closet/personal,
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "cIC" = (
 /obj/landmark/random_room/size5x3,
 /turf/simulated/floor/plating,
@@ -19690,9 +19678,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "ekr" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/machinery/door/poddoor/blast/pyro{
@@ -29113,7 +29099,7 @@
 /area/station/ranch)
 "kaZ" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kbc" = (
 /obj/cable/blue{
 	icon_state = "1-8"
@@ -30963,7 +30949,7 @@
 	dir = 8;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "lcJ" = (
 /obj/disposalpipe/junction{
 	dir = 8;
@@ -31767,7 +31753,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "lBl" = (
 /obj/storage/crate,
 /obj/item/device/analyzer/healthanalyzer{
@@ -34448,7 +34434,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "nbo" = (
 /obj/stove{
 	pixel_y = 2
@@ -38774,9 +38760,7 @@
 	},
 /obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "pwl" = (
 /obj/cable/orange{
 	icon_state = "1-8"
@@ -41156,9 +41140,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "qPe" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -44570,7 +44552,7 @@
 	dir = 10;
 	icon_state = "fgreen6"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "sOP" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail,
@@ -45235,7 +45217,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "tna" = (
 /obj/mesh/catwalk{
 	dir = 4
@@ -46395,9 +46377,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "tQU" = (
 /obj/cable/yellow{
 	icon_state = "0-2"
@@ -46736,9 +46716,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "ufg" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light/emergency{
@@ -48313,7 +48291,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vet" = (
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/grass,
@@ -48650,9 +48628,7 @@
 /obj/item/paper_bin,
 /obj/item/pen/fancy,
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "vlZ" = (
 /obj/fluid_spawner{
 	amount = 150
@@ -49376,7 +49352,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vEk" = (
 /obj/stool/bench/green/auto,
 /turf/simulated/floor/greenwhite/other{
@@ -49930,7 +49906,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vTy" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -51462,7 +51438,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wUO" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -52095,7 +52071,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "xpe" = (
 /obj/disposalpipe/trunk/west,
 /obj/machinery/disposal/small/west,
@@ -53552,7 +53528,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 
 (1,1,1) = {"
 aaa

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -22558,9 +22558,6 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "gLl" = (
-/obj/machinery/computer3/generic/secure_data{
-	dir = 8
-	},
 /obj/decoration/vent{
 	pixel_x = 1;
 	pixel_y = 32
@@ -22572,6 +22569,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/computer/stockexchange{
+	dir = 8
+	},
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -112,7 +112,7 @@
 /turf/simulated/floor/carpet/blue/standard/edge{
 	dir = 1
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "aav" = (
 /turf/simulated/wall/auto/jen/blue,
 /area/station/maintenance/inner/nw)
@@ -1881,7 +1881,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "azt" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -2039,7 +2039,7 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/blueblack,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "aAW" = (
 /obj/decal/tile_edge/line/green{
 	dir = 6;
@@ -2434,7 +2434,7 @@
 /obj/table/auto,
 /obj/random_item_spawner/desk_stuff/one_or_zero,
 /turf/simulated/floor/carpet/blue/standard/edge,
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "aGH" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -2516,7 +2516,7 @@
 	},
 /obj/random_item_spawner/desk_stuff/few,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "aIn" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -3981,7 +3981,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "bex" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -5813,7 +5813,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bGw" = (
 /turf/simulated/floor/stairs/medical{
 	dir = 4
@@ -7282,7 +7282,7 @@
 /area/station/science/artifact)
 "ced" = (
 /turf/simulated/floor/blueblack,
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "cek" = (
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/yellow/side{
@@ -7678,7 +7678,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "cjf" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -8100,7 +8100,7 @@
 /turf/simulated/floor/blueblack/corner{
 	dir = 8
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "coE" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/decal/cleanable/dirt/jen,
@@ -10008,7 +10008,7 @@
 /obj/machinery/light_switch/east,
 /mob/living/critter/small_animal/dog/george/orwell,
 /turf/simulated/floor/carpet/red/fancy/narrow/north,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "cPO" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/grime,
@@ -10318,7 +10318,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "cVJ" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
@@ -10801,7 +10801,7 @@
 /turf/simulated/floor/carpet/red/fancy/narrow{
 	dir = 4
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ddg" = (
 /obj/disposalpipe/segment/mail,
 /obj/mapping_helper/wingrille_spawn/auto,
@@ -10970,7 +10970,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "dfM" = (
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
@@ -14389,7 +14389,7 @@
 /turf/simulated/floor/carpet/blue/standard/edge{
 	dir = 6
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "egm" = (
 /turf/simulated/floor/airless/plating,
 /area/station/engine/singcore)
@@ -14627,7 +14627,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "elp" = (
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/ai_experimental/one,
@@ -14999,7 +14999,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "esw" = (
 /obj/machinery/drainage,
 /obj/cable{
@@ -16521,7 +16521,7 @@
 /obj/machinery/manufacturer/uniform,
 /obj/machinery/light/emergency,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "eTm" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -18860,7 +18860,7 @@
 	},
 /obj/railing/yellow,
 /turf/simulated/floor/black,
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "fEp" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8;
@@ -19411,7 +19411,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/blueblack,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "fMx" = (
 /obj/machinery/door/poddoor/pyro/shutters{
 	density = 0;
@@ -20291,7 +20291,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access,
 /turf/simulated/floor/black,
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "gaH" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/conveyor/EW{
@@ -21630,7 +21630,7 @@
 /turf/simulated/floor/carpet/blue/standard/edge{
 	dir = 9
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "gvN" = (
 /obj/decal/tile_edge/line/black{
 	dir = 4;
@@ -22575,7 +22575,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "gLv" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/mesh/catwalk/jen,
@@ -23173,7 +23173,7 @@
 /turf/simulated/floor/carpet/blue/standard/edge{
 	dir = 10
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "gUO" = (
 /obj/railing/orange{
 	dir = 4
@@ -23900,7 +23900,7 @@
 	pixel_y = 27
 	},
 /turf/simulated/floor/carpet/green/fancy/narrow/west,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "hgB" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/black,
@@ -24228,7 +24228,7 @@
 /area/station/maintenance/outer/ne)
 "hkH" = (
 /turf/simulated/floor/carpet/blue/standard/edge,
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "hkN" = (
 /obj/mesh/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -24259,7 +24259,7 @@
 /area/station/science/lobby)
 "hle" = (
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "hlk" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -25063,7 +25063,7 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "hxc" = (
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -26478,10 +26478,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"hWZ" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/security/checkpoint/customs)
 "hXb" = (
 /obj/table/reinforced/auto,
 /obj/machinery/networked/printer{
@@ -27010,7 +27006,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "ifg" = (
 /obj/railing/orange{
 	dir = 1
@@ -28169,7 +28165,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "izI" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -28345,6 +28341,10 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
+"iCH" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/bridge/reception)
 "iCJ" = (
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass{
@@ -28958,9 +28958,6 @@
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/west)
-"iLV" = (
-/turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/security/checkpoint/customs)
 "iLZ" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/light/small/sticky,
@@ -29246,7 +29243,7 @@
 /area/station/medical/research)
 "iRy" = (
 /turf/simulated/floor/carpet/green/fancy/narrow/se,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "iRB" = (
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/hallway/primary/southeast)
@@ -30613,7 +30610,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "jme" = (
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
@@ -31164,7 +31161,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "jvW" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -31172,7 +31169,7 @@
 /turf/simulated/floor/carpet/blue/standard/edge{
 	dir = 4
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "jwb" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 1
@@ -31202,7 +31199,7 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/blueblack,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "jwk" = (
 /obj/cable,
 /obj/cable{
@@ -32857,7 +32854,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "jUz" = (
 /obj/table/reinforced/auto,
 /obj/item/device/ticket_writer{
@@ -33700,7 +33697,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/carpet/green/fancy/narrow/north,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kgV" = (
 /obj/decal/cleanable/blood/gibs{
 	icon_state = "gib4"
@@ -33820,7 +33817,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 5
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "kjk" = (
 /obj/table/reinforced/auto,
 /obj/item/clothing/glasses/toggleable/meson{
@@ -34970,7 +34967,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kAA" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -35705,7 +35702,7 @@
 	},
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "kMG" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -36023,7 +36020,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "kQY" = (
 /obj/stool,
 /obj/decal/tile_edge/line/red{
@@ -36918,7 +36915,7 @@
 	},
 /obj/disposalpipe/trunk,
 /turf/simulated/floor/blueblack,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "lhi" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -37098,7 +37095,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "lkA" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -37250,7 +37247,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "lnT" = (
 /obj/table/wood/auto,
 /obj/computer3frame/desktop,
@@ -37286,7 +37283,7 @@
 	switchon = 1
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "log" = (
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/carpet{
@@ -37379,7 +37376,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "lpF" = (
 /obj/decal/stripe_caution,
 /obj/storage/cart/mechcart/tools,
@@ -37667,7 +37664,7 @@
 	name = "bot navigation beacon"
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "ltx" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 1;
@@ -38238,7 +38235,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "lBf" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/left{
@@ -38272,7 +38269,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "lBM" = (
 /obj/decal/stripe_delivery,
 /obj/cable{
@@ -38534,7 +38531,7 @@
 /turf/simulated/floor/carpet/red/fancy/narrow{
 	dir = 6
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "lEm" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/mesh/catwalk/jen,
@@ -38799,7 +38796,7 @@
 /turf/simulated/floor/carpet/red/fancy/narrow{
 	dir = 5
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "lHy" = (
 /obj/stool/bench/red,
 /obj/decal/tile_edge/check{
@@ -40013,7 +40010,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "lXC" = (
 /obj/reagent_dispensers/watertank/fountain,
 /obj/machinery/light/incandescent/netural,
@@ -40288,7 +40285,7 @@
 /turf/simulated/floor/carpet/blue/standard/edge{
 	dir = 1
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "mbT" = (
 /obj/table/wood/auto,
 /obj/item/crowbar,
@@ -40893,7 +40890,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/red/fancy/narrow/T_west,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "mnJ" = (
 /obj/table/wood/auto,
 /obj/decal/cleanable/desk_clutter,
@@ -41149,7 +41146,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "msG" = (
 /obj/mesh/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -41649,7 +41646,7 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "mAt" = (
 /obj/mesh/catwalk{
 	dir = 4
@@ -41833,7 +41830,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "mDc" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -42440,7 +42437,7 @@
 "mOw" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "mOC" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -44373,7 +44370,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ntd" = (
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
@@ -45508,7 +45505,7 @@
 /area/station/turret_protected/ai)
 "nMc" = (
 /turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "nMd" = (
 /obj/item/device/radio/beacon,
 /obj/landmark/gps_waypoint,
@@ -47017,6 +47014,9 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
+"okp" = (
+/turf/simulated/wall/auto/reinforced/jen/blue,
+/area/station/bridge/reception)
 "okq" = (
 /obj/shrub{
 	dir = 8
@@ -47025,7 +47025,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "okv" = (
 /obj/disposalpipe/segment/brig,
 /obj/cable{
@@ -47645,7 +47645,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "otK" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/electrical{
@@ -49441,7 +49441,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "oVR" = (
 /obj/stool/bench/blue/auto,
 /obj/machinery/light/incandescent/netural{
@@ -51856,7 +51856,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "pHv" = (
 /obj/stool/chair{
 	dir = 8
@@ -52248,7 +52248,7 @@
 /turf/simulated/floor/carpet/blue/standard/edge{
 	dir = 8
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "pNX" = (
 /obj/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/security{
@@ -52755,7 +52755,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "pWe" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -54264,7 +54264,7 @@
 	},
 /obj/random_item_spawner/desk_stuff/four,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "qvl" = (
 /obj/disposalpipe/segment/brig,
 /turf/simulated/floor,
@@ -56792,7 +56792,7 @@
 /turf/simulated/floor/blueblack/corner{
 	dir = 1
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "rjg" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -57066,7 +57066,7 @@
 /turf/simulated/floor/carpet/red/fancy/narrow{
 	dir = 10
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "rnr" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/wall/auto/reinforced/jen/blue,
@@ -57277,7 +57277,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 6
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "rrj" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -57869,7 +57869,7 @@
 /obj/random_item_spawner/desk_stuff,
 /obj/blind_switch/area/west,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "rAQ" = (
 /obj/mesh/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -58087,7 +58087,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "rFe" = (
 /obj/table/reinforced/industrial/auto,
 /obj/random_item_spawner/tools/one,
@@ -59319,7 +59319,7 @@
 /turf/simulated/floor/carpet/red/fancy/narrow{
 	dir = 8
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "rWW" = (
 /obj/table/auto,
 /obj/random_item_spawner/snacks/one_or_zero,
@@ -60109,7 +60109,7 @@
 /turf/simulated/floor/carpet/blue/standard/edge{
 	dir = 5
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "sjE" = (
 /obj/machinery/launcher_loader/east,
 /obj/decal/tile_edge/stripe/extra_big,
@@ -61523,7 +61523,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "sFh" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -62318,7 +62318,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 9
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "sTS" = (
 /obj/disposalpipe/segment/brig,
 /obj/decal/stripe_caution,
@@ -62498,7 +62498,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "sVv" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -63807,7 +63807,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/blueblack,
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "tpg" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/hos,
@@ -64925,7 +64925,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "tGx" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -66014,7 +66014,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "tWy" = (
 /obj/stool/chair/couch/blue{
 	dir = 5
@@ -66740,7 +66740,7 @@
 	},
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ulD" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -68583,7 +68583,7 @@
 /turf/simulated/floor/carpet/blue/decal{
 	dir = 8
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "uMr" = (
 /obj/lattice/auto/turf_attaching,
 /obj/machinery/light/runway_light/delay2,
@@ -69219,7 +69219,7 @@
 	req_access = null
 	},
 /turf/simulated/floor/plating/jen,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "uVt" = (
 /obj/table/wood/auto,
 /obj/item/decoration/flower_vase/vase7{
@@ -70382,7 +70382,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vmV" = (
 /obj/machinery/light/small/floor/warm,
 /turf/simulated/floor/black,
@@ -72052,7 +72052,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "vNj" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -74846,7 +74846,7 @@
 /area/station/ai_monitored/storage/eva)
 "wCp" = (
 /turf/simulated/floor/black,
-/area/station/bridge/customs)
+/area/station/bridge/reception)
 "wCq" = (
 /obj/machinery/chemicompiler_stationary,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -77053,7 +77053,7 @@
 	pixel_y = 16
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "xhg" = (
 /obj/landmark/start/job/AI,
 /obj/machinery/door_control{
@@ -80607,7 +80607,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "yga" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 10;
@@ -111420,7 +111420,7 @@ oSz
 jMF
 gai
 gai
-sBt
+okp
 rdj
 rdj
 rdj
@@ -111722,7 +111722,7 @@ tbH
 jMF
 pHq
 ced
-aah
+iCH
 rdj
 rdj
 rdj
@@ -112024,7 +112024,7 @@ piT
 jMF
 pHq
 ced
-aah
+iCH
 rdj
 rdj
 rdj
@@ -112326,7 +112326,7 @@ jMF
 jMF
 lBb
 ced
-aah
+iCH
 rdj
 rdj
 rdj
@@ -112628,7 +112628,7 @@ mCY
 otB
 riP
 ced
-aah
+iCH
 rdj
 rdj
 rdj
@@ -112930,7 +112930,7 @@ wCp
 wCp
 ltw
 ced
-aah
+iCH
 rdj
 rdj
 rdj
@@ -113232,7 +113232,7 @@ pWb
 iff
 fEj
 toV
-aah
+iCH
 rdj
 rdj
 rdj
@@ -113534,7 +113534,7 @@ tWw
 cop
 rFa
 ced
-aah
+iCH
 rdj
 rdj
 rdj
@@ -113832,11 +113832,11 @@ jMF
 mbQ
 uMj
 aGF
-sBt
+okp
 kjc
 tWw
 rqI
-aah
+iCH
 rdj
 rdj
 rdj
@@ -114134,11 +114134,11 @@ jMF
 sjt
 jvW
 ega
-iLV
+sBt
 lXy
 aIg
 qvj
-iLV
+sBt
 rdj
 rdj
 nMc
@@ -114436,13 +114436,13 @@ aav
 aav
 bJH
 aav
-iLV
+sBt
 beu
 kQB
 lhg
 esv
-hWZ
-hWZ
+aah
+aah
 nMc
 xhd
 ulA
@@ -114738,7 +114738,7 @@ gyd
 iKP
 bAd
 lJB
-iLV
+sBt
 lBA
 lpw
 fMw
@@ -115342,13 +115342,13 @@ sVI
 ixX
 ixX
 ixX
-iLV
+sBt
 gLl
 lnR
 aAT
-iLV
-hWZ
-hWZ
+sBt
+aah
+aah
 nMc
 cPJ
 mnB
@@ -115644,11 +115644,11 @@ mmy
 aon
 vNE
 vNE
-iLV
-hWZ
-hWZ
-hWZ
-iLV
+sBt
+aah
+aah
+aah
+sBt
 rdj
 rdj
 nMc

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -22569,7 +22569,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer/stockexchange{
+/obj/machinery/computer3/generic/secure_data{
 	dir = 8
 	},
 /turf/simulated/floor/blueblack{

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -20358,7 +20358,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/item_dispenser/idcarddispenser,
-/obj/machinery/computer3/generic/bank_data,
+/obj/machinery/computer3/generic/secure_data,
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
@@ -21259,7 +21259,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable,
-/obj/machinery/computer/stockexchange,
+/obj/machinery/computer3/generic/bank_data,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bKa" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -20361,12 +20361,12 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bHg" = (
-/obj/machinery/computer3/generic/secure_data,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/item_dispenser/idcarddispenser,
+/obj/machinery/computer3/generic/bank_data,
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
@@ -20383,7 +20383,7 @@
 /obj/machinery/light_switch/north,
 /mob/living/critter/small_animal/dog/george/orwell,
 /turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bHk" = (
 /obj/storage/secure/closet/command/hop,
 /obj/machinery/camera{
@@ -20397,7 +20397,7 @@
 	pixel_x = 4
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bHl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/Zeta)
@@ -20862,13 +20862,13 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/west,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bIF" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bIH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -20877,7 +20877,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/east,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bII" = (
 /obj/lattice,
 /obj/warp_beacon/research,
@@ -21267,7 +21267,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable,
-/obj/machinery/computer3/generic/bank_data,
+/obj/machinery/computer/stockexchange,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bKa" = (
@@ -21301,7 +21301,7 @@
 	},
 /obj/landmark/start/job/head_of_personnel,
 /turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bKf" = (
 /obj/cable,
 /obj/machinery/power/data_terminal,
@@ -21309,7 +21309,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bKg" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/left{
@@ -21320,7 +21320,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bKh" = (
 /obj/machinery/chem_dispenser/alcohol,
 /turf/simulated/floor/grey,
@@ -21682,7 +21682,7 @@
 	},
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bLu" = (
 /obj/table/wood/auto,
 /obj/item/paper_bin,
@@ -21690,7 +21690,7 @@
 /obj/machinery/light,
 /obj/item/stamp/hop,
 /turf/simulated/floor/black,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bLv" = (
 /obj/table/wood/auto,
 /obj/machinery/phone,
@@ -21702,7 +21702,7 @@
 	pixel_y = -21
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bLw" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/right{
@@ -21710,7 +21710,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bLx" = (
 /obj/machinery/chem_dispenser/soda,
 /turf/simulated/floor/grey,
@@ -32576,7 +32576,7 @@
 	},
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "esM" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/transport,
@@ -38926,7 +38926,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "iLH" = (
 /obj/lattice{
 	dir = 6;
@@ -45235,7 +45235,7 @@
 	},
 /obj/item/device/radio/intercom/bridge,
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "njG" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -46142,7 +46142,7 @@
 /area/station/security/main)
 "nXl" = (
 /turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "nXw" = (
 /turf/simulated/floor/engine/caution/misc{
 	dir = 8
@@ -50964,7 +50964,7 @@
 	name = "HOP Desk"
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "rtZ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/sauna)
@@ -51528,7 +51528,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/green,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "rOU" = (
 /obj/machinery/plantpot,
 /turf/simulated/floor/grass,
@@ -52536,7 +52536,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "szy" = (
 /obj/disposalpipe/switch_junction/left/west{
 	mail_tag = "ranch";
@@ -52786,7 +52786,7 @@
 	},
 /obj/blind_switch/area/south,
 /turf/simulated/floor/sanitary,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "sJj" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pod Bay"
@@ -54249,7 +54249,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "tKP" = (
 /obj/decal/tile_edge/line/black{
 	dir = 5;
@@ -57392,7 +57392,7 @@
 /area/station/storage/warehouse)
 "vTk" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "vTK" = (
 /turf/simulated/floor/escape/corner{
 	dir = 1

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -12895,9 +12895,7 @@
 	icon_state = "bedsheet-blue"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "bav" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -14399,9 +14397,7 @@
 /area/station/maintenance/southeast)
 "bic" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "bid" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -14410,9 +14406,7 @@
 /turf/simulated/floor/stairs/dark{
 	dir = 4
 	},
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "bik" = (
 /turf/simulated/floor/escape{
 	dir = 1
@@ -15043,9 +15037,7 @@
 	pixel_y = -1
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "bkQ" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/escape_horizontal,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -20383,7 +20375,7 @@
 /obj/machinery/light_switch/north,
 /mob/living/critter/small_animal/dog/george/orwell,
 /turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bHk" = (
 /obj/storage/secure/closet/command/hop,
 /obj/machinery/camera{
@@ -20397,7 +20389,7 @@
 	pixel_x = 4
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bHl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/Zeta)
@@ -20862,13 +20854,13 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/west,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bIF" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bIH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -20877,7 +20869,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/east,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bII" = (
 /obj/lattice,
 /obj/warp_beacon/research,
@@ -21301,7 +21293,7 @@
 	},
 /obj/landmark/start/job/head_of_personnel,
 /turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bKf" = (
 /obj/cable,
 /obj/machinery/power/data_terminal,
@@ -21309,7 +21301,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bKg" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/left{
@@ -21320,7 +21312,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bKh" = (
 /obj/machinery/chem_dispenser/alcohol,
 /turf/simulated/floor/grey,
@@ -21682,7 +21674,7 @@
 	},
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bLu" = (
 /obj/table/wood/auto,
 /obj/item/paper_bin,
@@ -21690,7 +21682,7 @@
 /obj/machinery/light,
 /obj/item/stamp/hop,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bLv" = (
 /obj/table/wood/auto,
 /obj/machinery/phone,
@@ -21702,7 +21694,7 @@
 	pixel_y = -21
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bLw" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/right{
@@ -21710,7 +21702,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bLx" = (
 /obj/machinery/chem_dispenser/soda,
 /turf/simulated/floor/grey,
@@ -26474,9 +26466,7 @@
 	spawn_contents = list(/obj/item/reagent_containers/food/drinks/bottle/wine,/obj/item/reagent_containers/food/drinks/bottle/tequila,/obj/item/reagent_containers/food/drinks/bottle/mead,/obj/item/reagent_containers/food/drinks/bottle/rum)
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "cfu" = (
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
 /area/station/crew_quarters/quarters_south)
@@ -32576,7 +32566,7 @@
 	},
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "esM" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/transport,
@@ -38926,7 +38916,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "iLH" = (
 /obj/lattice{
 	dir = 6;
@@ -43919,9 +43909,7 @@
 /area/station/science/artifact)
 "mmz" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "mmP" = (
 /turf/simulated/floor/caution/east,
 /area/station/quartermaster/office)
@@ -45235,7 +45223,7 @@
 	},
 /obj/item/device/radio/intercom/bridge,
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "njG" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -46142,7 +46130,7 @@
 /area/station/security/main)
 "nXl" = (
 /turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "nXw" = (
 /turf/simulated/floor/engine/caution/misc{
 	dir = 8
@@ -47364,9 +47352,7 @@
 /area/station/crew_quarters/bar)
 "oSO" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner/ne,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "oSS" = (
 /obj/landmark/gps_waypoint,
 /obj/cable{
@@ -47584,9 +47570,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "pcs" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -48927,9 +48911,7 @@
 	},
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "pXp" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -50964,7 +50946,7 @@
 	name = "HOP Desk"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "rtZ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/sauna)
@@ -51528,7 +51510,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/green,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "rOU" = (
 /obj/machinery/plantpot,
 /turf/simulated/floor/grass,
@@ -51644,9 +51626,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "rTg" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 8;
@@ -52536,7 +52516,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "szy" = (
 /obj/disposalpipe/switch_junction/left/west{
 	mail_tag = "ranch";
@@ -52786,7 +52766,7 @@
 	},
 /obj/blind_switch/area/south,
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "sJj" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pod Bay"
@@ -53645,9 +53625,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "tmv" = (
 /obj/stool/bench/yellow/auto,
 /obj/cable{
@@ -54249,7 +54227,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "tKP" = (
 /obj/decal/tile_edge/line/black{
 	dir = 5;
@@ -55157,9 +55135,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "usF" = (
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
@@ -55736,9 +55712,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/heads,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "uLX" = (
 /obj/mesh/catwalk{
 	dir = 10
@@ -56702,9 +56676,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "vrz" = (
 /obj/decal/cleanable/dirt,
 /obj/landmark/antagonist/blob,
@@ -57392,7 +57364,7 @@
 /area/station/storage/warehouse)
 "vTk" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vTK" = (
 /turf/simulated/floor/escape/corner{
 	dir = 1

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -10474,7 +10474,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable,
-/obj/machinery/computer/stockexchange,
+/obj/machinery/computer3/generic/secure_data,
 /turf/simulated/floor/black/side,
 /area/station/crew_quarters/courtroom)
 "eIK" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -718,9 +718,7 @@
 /turf/simulated/floor/blueblack/corner{
 	dir = 1
 	},
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "aoK" = (
 /obj/item/device/radio/beacon,
 /obj/disposalpipe/segment/horizontal,
@@ -2763,9 +2761,7 @@
 /obj/item/clothing/suit/bedsheet/black,
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "blV" = (
 /turf/simulated/floor/purpleblack/corner{
 	dir = 4
@@ -2820,7 +2816,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bmX" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/outer/ne{
@@ -2856,7 +2852,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 9
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bov" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -4820,9 +4816,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "chK" = (
 /obj/table/wood/round/auto,
 /obj/item/diceholder/dicebox{
@@ -4993,7 +4987,7 @@
 	pixel_y = 7
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ckn" = (
 /obj/decal/stripe_delivery,
 /turf/simulated/floor/greenblack{
@@ -5139,7 +5133,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "coD" = (
 /obj/machinery/door/airlock/pyro/glass/sci,
 /obj/cable{
@@ -6007,9 +6001,7 @@
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/black,
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "cLn" = (
 /obj/machinery/light,
 /obj/machinery/disposal/mail/qm,
@@ -6071,9 +6063,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine/caution/north,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "cMH" = (
 /obj/table/reinforced/auto,
 /obj/item/bee_egg_carton{
@@ -6314,7 +6304,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 4
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "cQL" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -6548,9 +6538,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "cVe" = (
 /obj/stool/chair/boxingrope_corner{
 	dir = 6;
@@ -7802,9 +7790,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "dzn" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/secure/ssafe{
@@ -8315,9 +8301,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "dJj" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 1
@@ -8991,9 +8975,7 @@
 /area/pasiphae/maint)
 "dZG" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "dZK" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/machinery/weapon_stand/phaser_rack,
@@ -9558,9 +9540,7 @@
 "eoL" = (
 /obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "eoW" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9992,9 +9972,7 @@
 	icon_state = "2-5"
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/east,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "eyb" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -10482,9 +10460,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "eIq" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mineral{
@@ -10530,9 +10506,7 @@
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "eIV" = (
 /obj/stool/chair{
 	dir = 1
@@ -10558,9 +10532,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/engine/caution/north,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "eKW" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -10570,7 +10542,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "eLE" = (
 /obj/machinery/drainage,
 /obj/cable{
@@ -11291,9 +11263,7 @@
 	})
 "eZe" = (
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "eZH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -11918,9 +11888,7 @@
 "foV" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "fpk" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -11934,7 +11902,7 @@
 	pixel_x = -2
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "fpO" = (
 /obj/stool/chair/office/green{
 	dir = 4
@@ -12577,9 +12545,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "fBr" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -15998,9 +15964,7 @@
 	},
 /obj/disposalpipe/segment/mail/bent/west,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "gUf" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -17295,9 +17259,7 @@
 "hrp" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "hry" = (
 /obj/decal/tile_edge/floorguide/command{
 	dir = 4
@@ -17848,9 +17810,7 @@
 /turf/simulated/floor/blueblack/corner{
 	dir = 1
 	},
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "hBr" = (
 /obj/shrub{
 	dir = 4;
@@ -18154,9 +18114,7 @@
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "hHx" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/clothing/gloves/latex,
@@ -20597,9 +20555,7 @@
 /obj/disposalpipe/segment/mail/vertical,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "iFE" = (
 /obj/machinery/light{
 	dir = 1;
@@ -20845,9 +20801,7 @@
 /area/pasiphae/bridge)
 "iLR" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "iLY" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/specialroom/arcade,
@@ -23293,7 +23247,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "jOQ" = (
 /obj/table/reinforced/auto,
 /obj/item/decoration/flower_vase,
@@ -23904,9 +23858,7 @@
 /turf/simulated/floor/yellowblack/corner{
 	dir = 8
 	},
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "kaR" = (
 /obj/machinery/traymachine/morgue{
 	dir = 8
@@ -23927,7 +23879,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kbv" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/stairs{
@@ -25209,7 +25161,7 @@
 /obj/item/paper_bin,
 /obj/item/pen/fancy,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kyY" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -25266,7 +25218,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kAn" = (
 /turf/simulated/floor/greenblack/corner{
 	dir = 4
@@ -25520,9 +25472,7 @@
 /turf/simulated/floor/yellowblack/corner{
 	dir = 8
 	},
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "kFd" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/item/device/radio/beacon,
@@ -26119,9 +26069,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "kTa" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -26458,7 +26406,7 @@
 "laB" = (
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "laM" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -28767,7 +28715,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "lWq" = (
 /obj/landmark/halloween,
 /turf/simulated/floor/black,
@@ -29166,7 +29114,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 8
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "mdI" = (
 /obj/pool/perspective{
 	dir = 5;
@@ -29402,9 +29350,7 @@
 /area/station/teleporter)
 "mhK" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "mhP" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/cable/blue{
@@ -29857,7 +29803,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 10
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "mrH" = (
 /obj/machinery/light_switch/west,
 /obj/disposalpipe/segment/food{
@@ -30095,9 +30041,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine/caution/north,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "mxM" = (
 /obj/stool/chair{
 	dir = 8
@@ -30573,9 +30517,7 @@
 /area/station/medical/medbay)
 "mIa" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "mId" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -31407,9 +31349,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "ndB" = (
 /obj/machinery/networked/secdetector{
 	area_access = 37;
@@ -31715,9 +31655,7 @@
 "nka" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "nkd" = (
 /obj/stool/chair/comfy{
 	dir = 4
@@ -31866,9 +31804,7 @@
 	},
 /obj/disposalpipe/segment/mail/bent/north,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "nmI" = (
 /obj/machinery/computer3/terminal/zeta{
 	setup_os_string = "ZETA_MAINFRAME"
@@ -32947,9 +32883,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "nIv" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -33244,9 +33178,7 @@
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "nQU" = (
 /obj/table/auto,
 /obj/item/storage/box/cocktail_doodads{
@@ -34017,9 +33949,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/engine/caution/north,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "ols" = (
 /obj/stool/chair{
 	dir = 4
@@ -35318,9 +35248,7 @@
 /area/pasiphae/crew)
 "oOV" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner/west,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "oPc" = (
 /obj/stool/chair/office/blue{
 	dir = 4
@@ -37853,7 +37781,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 6
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "pSv" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -37960,9 +37888,7 @@
 /turf/simulated/floor/engine/caution/corner{
 	dir = 1
 	},
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "pUc" = (
 /obj/machinery/networked/storage/tape_drive,
 /obj/machinery/power/data_terminal,
@@ -40442,7 +40368,7 @@
 	},
 /obj/blind_switch/area/west,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "rcw" = (
 /obj/stool/chair/pew/fancy/center{
 	dir = 1
@@ -40492,9 +40418,7 @@
 /turf/simulated/floor/yellowblack/corner{
 	dir = 8
 	},
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "req" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -40525,9 +40449,7 @@
 /obj/disposalpipe/segment/mail/vertical,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "rfe" = (
 /obj/machinery/drainage/big,
 /turf/simulated/floor/black,
@@ -41237,9 +41159,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "ryf" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41325,7 +41245,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 5
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "rzK" = (
 /obj/lattice,
 /obj/cable{
@@ -41871,9 +41791,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "rLY" = (
 /obj/decal/tile_edge/floorguide/arrow_s{
 	dir = 4
@@ -42120,7 +42038,7 @@
 "rTj" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/carpet/green/fancy/innercorner/omni,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "rTk" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -42687,9 +42605,7 @@
 /obj/forcefield/energyshield/perma/doorlink,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "sga" = (
 /turf/simulated/floor/purpleblack/corner{
 	dir = 1
@@ -43193,9 +43109,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "srd" = (
 /obj/stool/chair/red{
 	dir = 1
@@ -43657,9 +43571,7 @@
 /turf/simulated/floor/blueblack/corner{
 	dir = 1
 	},
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "sCH" = (
 /obj/machinery/siphon_lever,
 /obj/item/paper/siphon_guide{
@@ -43891,7 +43803,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "sGq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -44270,9 +44182,7 @@
 "sNC" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon11,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "sNH" = (
 /obj/decal/boxingrope{
 	dir = 8
@@ -45311,7 +45221,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "tkA" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -45380,9 +45290,7 @@
 	spawn_contents = list(/obj/item/reagent_containers/food/drinks/bottle/wine,/obj/item/reagent_containers/food/drinks/bottle/tequila,/obj/item/reagent_containers/food/drinks/bottle/mead,/obj/item/reagent_containers/food/drinks/bottle/rum)
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "tmo" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/industrial,
@@ -45548,9 +45456,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine/caution/north,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "tpJ" = (
 /obj/machinery/door/airlock/pyro/glass/sci,
 /obj/mapping_helper/firedoor_spawn,
@@ -45566,7 +45472,7 @@
 /area/station/medical/staff)
 "tqL" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "tqM" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -49180,7 +49086,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "uWN" = (
 /obj/stool/chair{
 	dir = 8
@@ -49255,9 +49161,7 @@
 	},
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "uXO" = (
 /turf/simulated/floor/redblack/corner{
 	dir = 4
@@ -49308,7 +49212,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "uYF" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
@@ -50116,9 +50020,7 @@
 /area/abandonedmedicalship/robot_trader)
 "vuv" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "vuA" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -50145,9 +50047,7 @@
 "vuR" = (
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "vvo" = (
 /obj/stool/chair/yellow{
 	dir = 4
@@ -50746,7 +50646,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 1
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vGW" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/light_switch/west,
@@ -51120,9 +51020,7 @@
 	},
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/engine/caution/corner,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "vQl" = (
 /obj/mapping_helper/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -51353,7 +51251,7 @@
 	spawn_contents = list(/obj/item/clothing/under/towel,/obj/item/clothing/under/towel)
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vUQ" = (
 /obj/machinery/door/airlock/pyro/glass/med,
 /obj/mapping_helper/access/medical,
@@ -51893,9 +51791,7 @@
 	icon_state = "4-10"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "wfh" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -52584,7 +52480,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wwm" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -52886,9 +52782,7 @@
 /turf/simulated/floor/yellowblack/corner{
 	dir = 8
 	},
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "wEz" = (
 /obj/lattice{
 	dir = 1;
@@ -53304,7 +53198,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wOT" = (
 /obj/machinery/light,
 /obj/machinery/vending/fortune,
@@ -53384,7 +53278,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wQX" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -53411,9 +53305,7 @@
 "wRm" = (
 /obj/machinery/light,
 /turf/simulated/floor/black,
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "wRx" = (
 /obj/item/storage/toilet,
 /obj/decoration/toiletholder{
@@ -54387,9 +54279,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/heads{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "xnq" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/surgery)
@@ -54528,7 +54418,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "xrx" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -54576,7 +54466,7 @@
 	},
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "xsz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -55919,9 +55809,7 @@
 /turf/simulated/floor/yellowblack/corner{
 	dir = 8
 	},
-/area/station/bridge/customs{
-	name = "Bridge Reception"
-	})
+/area/station/bridge/reception)
 "xXX" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/machinery/door/poddoor/pyro{

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -2820,9 +2820,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "bmX" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/outer/ne{
@@ -2858,9 +2856,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 9
 	},
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "bov" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -4997,9 +4993,7 @@
 	pixel_y = 7
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "ckn" = (
 /obj/decal/stripe_delivery,
 /turf/simulated/floor/greenblack{
@@ -5145,9 +5139,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "coD" = (
 /obj/machinery/door/airlock/pyro/glass/sci,
 /obj/cable{
@@ -6322,9 +6314,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 4
 	},
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "cQL" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -10503,12 +10493,12 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
 "eIu" = (
-/obj/machinery/computer3/generic/secure_data,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable,
+/obj/machinery/computer/stockexchange,
 /turf/simulated/floor/black/side,
 /area/station/crew_quarters/courtroom)
 "eIK" = (
@@ -10580,9 +10570,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "eLE" = (
 /obj/machinery/drainage,
 /obj/cable{
@@ -11946,9 +11934,7 @@
 	pixel_x = -2
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "fpO" = (
 /obj/stool/chair/office/green{
 	dir = 4
@@ -23307,9 +23293,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "jOQ" = (
 /obj/table/reinforced/auto,
 /obj/item/decoration/flower_vase,
@@ -23943,9 +23927,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/sanitary,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "kbv" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/stairs{
@@ -25227,9 +25209,7 @@
 /obj/item/paper_bin,
 /obj/item/pen/fancy,
 /turf/simulated/floor/black,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "kyY" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -25286,9 +25266,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "kAn" = (
 /turf/simulated/floor/greenblack/corner{
 	dir = 4
@@ -26480,9 +26458,7 @@
 "laB" = (
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/black,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "laM" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -28791,9 +28767,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "lWq" = (
 /obj/landmark/halloween,
 /turf/simulated/floor/black,
@@ -29192,9 +29166,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 8
 	},
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "mdI" = (
 /obj/pool/perspective{
 	dir = 5;
@@ -29885,9 +29857,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 10
 	},
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "mrH" = (
 /obj/machinery/light_switch/west,
 /obj/disposalpipe/segment/food{
@@ -37883,9 +37853,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 6
 	},
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "pSv" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -40474,9 +40442,7 @@
 	},
 /obj/blind_switch/area/west,
 /turf/simulated/floor/black,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "rcw" = (
 /obj/stool/chair/pew/fancy/center{
 	dir = 1
@@ -41359,9 +41325,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 5
 	},
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "rzK" = (
 /obj/lattice,
 /obj/cable{
@@ -42156,9 +42120,7 @@
 "rTj" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/carpet/green/fancy/innercorner/omni,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "rTk" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -43929,9 +43891,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "sGq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -45351,9 +45311,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "tkA" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -45608,9 +45566,7 @@
 /area/station/medical/staff)
 "tqL" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "tqM" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -49224,9 +49180,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "uWN" = (
 /obj/stool/chair{
 	dir = 8
@@ -49354,9 +49308,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "uYF" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
@@ -50794,9 +50746,7 @@
 /turf/simulated/floor/carpet/green/fancy/edge{
 	dir = 1
 	},
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "vGW" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/light_switch/west,
@@ -51403,9 +51353,7 @@
 	spawn_contents = list(/obj/item/clothing/under/towel,/obj/item/clothing/under/towel)
 	},
 /turf/simulated/floor/sanitary,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "vUQ" = (
 /obj/machinery/door/airlock/pyro/glass/med,
 /obj/mapping_helper/access/medical,
@@ -52636,9 +52584,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/black,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "wwm" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -53358,9 +53304,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "wOT" = (
 /obj/machinery/light,
 /obj/machinery/vending/fortune,
@@ -53440,9 +53384,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/sanitary,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "wQX" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -54586,9 +54528,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "xrx" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -54636,9 +54576,7 @@
 	},
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor/sanitary,
-/area/station/bridge/hos{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "xsz" = (
 /obj/cable{
 	icon_state = "4-8"

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -669,7 +669,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "abZ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -19883,7 +19883,7 @@
 /area/station/bridge)
 "bvL" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bvN" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/info)
@@ -20019,7 +20019,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bwr" = (
 /obj/table/reinforced/auto,
 /obj/disposalpipe/junction/right/west,
@@ -20179,7 +20179,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bxa" = (
 /mob/living/critter/small_animal/dog/blair,
 /obj/cable{
@@ -20192,19 +20192,19 @@
 	dir = 1;
 	icon_state = "fgreen1"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bxb" = (
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bxc" = (
 /obj/stool/chair/comfy/blue,
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bxd" = (
 /obj/table/wood/round/auto,
 /obj/item/stamp/hop,
@@ -20219,7 +20219,7 @@
 	dir = 4;
 	icon_state = "fgreen3"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bxe" = (
 /obj/storage/crate,
 /obj/item/clothing/suit/johnny_coat{
@@ -20503,14 +20503,14 @@
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bxX" = (
 /obj/table/wood/round/auto,
 /obj/item/item_box/gold_star,
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "byb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -29748,7 +29748,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "ceO" = (
 /obj/storage/secure/closet/engineering/engineer,
 /obj/cable{
@@ -32379,7 +32379,7 @@
 	dir = 4;
 	icon_state = "fgreen3"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "dFX" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -34108,7 +34108,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "fEz" = (
 /obj/lattice,
 /obj/mapping_helper/mob_spawn/corpse/critter/random/martian,
@@ -34672,7 +34672,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating/random,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "gqz" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 8;
@@ -38352,7 +38352,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "lvP" = (
 /obj/stool/chair/comfy/yellow{
 	dir = 4
@@ -38701,7 +38701,7 @@
 	dir = 10;
 	icon_state = "fgreen1"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "lTa" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
@@ -44852,7 +44852,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "uay" = (
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/grass{

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -669,7 +669,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "abZ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -19883,7 +19883,7 @@
 /area/station/bridge)
 "bvL" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bvN" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/info)
@@ -20019,7 +20019,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bwr" = (
 /obj/table/reinforced/auto,
 /obj/disposalpipe/junction/right/west,
@@ -20179,7 +20179,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bxa" = (
 /mob/living/critter/small_animal/dog/blair,
 /obj/cable{
@@ -20192,19 +20192,19 @@
 	dir = 1;
 	icon_state = "fgreen1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bxb" = (
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bxc" = (
 /obj/stool/chair/comfy/blue,
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bxd" = (
 /obj/table/wood/round/auto,
 /obj/item/stamp/hop,
@@ -20219,7 +20219,7 @@
 	dir = 4;
 	icon_state = "fgreen3"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bxe" = (
 /obj/storage/crate,
 /obj/item/clothing/suit/johnny_coat{
@@ -20503,14 +20503,14 @@
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bxX" = (
 /obj/table/wood/round/auto,
 /obj/item/item_box/gold_star,
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "byb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -29748,7 +29748,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ceO" = (
 /obj/storage/secure/closet/engineering/engineer,
 /obj/cable{
@@ -32379,7 +32379,7 @@
 	dir = 4;
 	icon_state = "fgreen3"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "dFX" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -34108,7 +34108,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "fEz" = (
 /obj/lattice,
 /obj/mapping_helper/mob_spawn/corpse/critter/random/martian,
@@ -34672,7 +34672,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "gqz" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 8;
@@ -38352,7 +38352,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "green1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "lvP" = (
 /obj/stool/chair/comfy/yellow{
 	dir = 4
@@ -38701,7 +38701,7 @@
 	dir = 10;
 	icon_state = "fgreen1"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "lTa" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
@@ -44852,7 +44852,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "uay" = (
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/grass{

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -1148,7 +1148,7 @@
 	dir = 9;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "acH" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -4389,7 +4389,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "akw" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -6204,7 +6204,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aoG" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -8758,7 +8758,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aur" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9260,7 +9260,7 @@
 	dir = 4;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "avf" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9567,7 +9567,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "avU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9640,7 +9640,7 @@
 	dir = 9;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "awc" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -14387,7 +14387,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aIU" = (
 /obj/disposalpipe/segment/mail{
 	dir = 8;
@@ -14469,7 +14469,7 @@
 	pixel_x = -8
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aJc" = (
 /obj/disposalpipe/segment/mail{
 	dir = 8
@@ -14592,7 +14592,7 @@
 /obj/machinery/firealarm/north,
 /obj/vehicle/segway,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aJr" = (
 /obj/disposalpipe/segment/mail{
 	dir = 8
@@ -14680,7 +14680,7 @@
 	},
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aJA" = (
 /obj/disposalpipe/segment/mail{
 	dir = 8
@@ -14839,7 +14839,7 @@
 	dir = 8
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aJV" = (
 /obj/disposalpipe/segment/mail{
 	dir = 8
@@ -18123,7 +18123,7 @@
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aTo" = (
 /obj/cable,
 /obj/disposalpipe/segment/brig{
@@ -18269,7 +18269,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aTK" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -18804,7 +18804,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aUR" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -18839,7 +18839,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aUT" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -19045,7 +19045,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aVp" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -19213,7 +19213,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aVF" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -21329,7 +21329,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bcE" = (
 /obj/item/device/radio/intercom{
 	dir = 1
@@ -22018,7 +22018,7 @@
 	dir = 9;
 	icon_state = "fgreen3"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bes" = (
 /obj/machinery/atmospherics/unary/outlet_injector/active{
 	dir = 8
@@ -26215,7 +26215,7 @@
 	},
 /mob/living/critter/small_animal/dog/george/orwell,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bqS" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 1;
@@ -35792,7 +35792,7 @@
 	dir = 5;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bPF" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -36154,7 +36154,7 @@
 	},
 /obj/machinery/computer/ATM,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bQu" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -39926,7 +39926,7 @@
 	pixel_y = 23
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bYz" = (
 /obj/shrub{
 	dir = 4;
@@ -42864,7 +42864,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "cft" = (
 /obj/storage/secure/closet/command/hos,
 /obj/machinery/light{
@@ -47557,7 +47557,7 @@
 	dir = 10;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "cnk" = (
 /obj/table/wood/auto,
 /obj/item/storage/box/nerd_kit{
@@ -48047,7 +48047,7 @@
 	dir = 6;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "coi" = (
 /obj/table/wood/auto,
 /obj/machinery/light/small,
@@ -48135,7 +48135,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "cop" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff,
@@ -49197,7 +49197,7 @@
 /area/station/crew_quarters/catering)
 "crj" = (
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "crk" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/jazz)
@@ -51122,7 +51122,7 @@
 /area/station/crew_quarters/courtroom)
 "czu" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "czv" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/hor)
@@ -51843,7 +51843,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "cLe" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -55858,7 +55858,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ipc" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/machinery/light{
@@ -60119,7 +60119,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "oQm" = (
 /obj/cable{
 	icon_state = "1-2"

--- a/maps/unused/concept_fixed.dmm
+++ b/maps/unused/concept_fixed.dmm
@@ -29595,7 +29595,7 @@
 /area/station/security/hos)
 "bgH" = (
 /turf/simulated/wall/r_wall,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bgI" = (
 /obj/storage/secure/closet/courtroom,
 /turf/simulated/floor,
@@ -29665,7 +29665,7 @@
 	},
 /obj/machinery/light/lamp,
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bgQ" = (
 /obj/table/wood{
 	dir = 5
@@ -29681,7 +29681,7 @@
 	
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bgR" = (
 /obj/machinery/door/airlock/glass{
 	name = "Bridge Checkpoint";
@@ -29825,7 +29825,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhe" = (
 /obj/cable{
 	icon_state = "2-4";
@@ -29839,7 +29839,7 @@
 	
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhf" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -29847,7 +29847,7 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/ATM,
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhg" = (
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -30012,7 +30012,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhs" = (
 /obj/table/wood{
 	tag = "icon-woodentable (WEST)";
@@ -30023,7 +30023,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bht" = (
 /obj/cable{
 	icon_state = "2-4";
@@ -30034,7 +30034,7 @@
 	
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhu" = (
 /obj/machinery/light_switch{
 	name = "E light switch";
@@ -30056,7 +30056,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhv" = (
 /obj/cable{
 	icon_state = "1-2";
@@ -30139,7 +30139,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhC" = (
 /obj/cable{
 	icon_state = "4-8";
@@ -30150,7 +30150,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/rum_spaced,
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhD" = (
 /obj/cable{
 	icon_state = "4-8";
@@ -30160,14 +30160,14 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhE" = (
 /obj/cable{
 	icon_state = "4-8";
 	
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhF" = (
 /obj/cable{
 	icon_state = "4-8";
@@ -30185,7 +30185,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhG" = (
 /obj/cable{
 	icon_state = "4-8";
@@ -30267,11 +30267,11 @@
 	},
 /obj/window/reinforced,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhO" = (
 /obj/storage/secure/closet/command/hop,
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhP" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -30279,7 +30279,7 @@
 	name = "Station Intercom (Security)"
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhQ" = (
 /obj/stool/bed,
 /obj/machinery/status_display{
@@ -30292,7 +30292,7 @@
 	},
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhR" = (
 /obj/landmark/halloween,
 /turf/simulated/floor/black,
@@ -30315,10 +30315,10 @@
 	
 	},
 /turf/simulated/wall/r_wall,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhU" = (
 /turf/simulated/wall,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bhV" = (
 /obj/machinery/light{
 	tag = "icon-tube1 (WEST)";
@@ -35293,7 +35293,7 @@
 /obj/item/coin,
 /obj/item/coin,
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "xTf" = (
 /obj/machinery/conveyor/WE{
 	id = "cargo"

--- a/maps/unused/density.dmm
+++ b/maps/unused/density.dmm
@@ -2999,7 +2999,7 @@
 /area/station/crew_quarters/garden)
 "hu" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "hv" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -3015,7 +3015,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "hw" = (
 /obj/machinery/bathtub{
 	dir = 4
@@ -3149,7 +3149,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "hL" = (
 /obj/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -3325,7 +3325,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "ii" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -3344,7 +3344,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "ij" = (
 /obj/mesh/catwalk{
 	dir = 10;
@@ -3665,7 +3665,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "iK" = (
 /obj/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -5373,8 +5373,7 @@
 /area/station/medical/medbay/surgery)
 "mx" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer/cryo{
-	dir = 4;
-	
+	dir = 4
 	},
 /turf/simulated/floor/redwhite{
 	dir = 8
@@ -6232,8 +6231,7 @@
 	name = "Magnet Area Boundary"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	
+	dir = 4
 	},
 /area/mining/magnet)
 "ou" = (

--- a/maps/unused/destiny.dmm
+++ b/maps/unused/destiny.dmm
@@ -107,9 +107,7 @@
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "aaw" = (
 /obj/item/space_thing,
 /turf/simulated/floor/grass/random/alt,
@@ -209,7 +207,7 @@
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aaU" = (
 /obj/landmark/spawner/artifact,
 /obj/cable,
@@ -226,7 +224,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aaZ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -320,11 +318,6 @@
 "abr" = (
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
-"abu" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
 "abw" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -518,12 +511,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
-"ach" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
 "ack" = (
 /obj/table/wood/auto,
 /obj/displaycase/captain{
@@ -631,13 +618,13 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "acF" = (
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "acJ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -645,7 +632,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "acK" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -655,7 +642,7 @@
 	dir = 6;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "acL" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -674,11 +661,11 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "acM" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "acO" = (
 /obj/stool/chair/office,
 /obj/landmark/start/job/head_of_personnel,
@@ -689,7 +676,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "acP" = (
 /obj/machinery/computer/card{
 	dir = 8
@@ -707,7 +694,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "acQ" = (
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
@@ -725,7 +712,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "acX" = (
 /obj/window_blinds/cog2/middle{
 	dir = 4
@@ -1244,7 +1231,7 @@
 /area/station/maintenance/northwest)
 "afk" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "afl" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -2123,17 +2110,13 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "aiT" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "aiU" = (
 /mob/living/critter/small_animal/dog/blair,
 /obj/machinery/firealarm{
@@ -2145,9 +2128,7 @@
 	dir = 6;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "aiZ" = (
 /turf/space,
 /area/shuttle/merchant_shuttle/right_station/destiny)
@@ -2203,16 +2184,6 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
-"ajB" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
 "ajE" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -2246,14 +2217,14 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ajO" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ajS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -2285,7 +2256,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ajV" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -2355,7 +2326,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "akf" = (
 /obj/machinery/shower{
 	dir = 1
@@ -2379,7 +2350,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "akh" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -4087,7 +4058,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "arW" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -5056,13 +5027,6 @@
 /obj/disposalpipe/junction,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
-"awq" = (
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
 "awt" = (
 /obj/disposalpipe/segment/food,
 /obj/cable{
@@ -5181,9 +5145,7 @@
 	dir = 10;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "awZ" = (
 /obj/machinery/light{
 	dir = 4;
@@ -8307,7 +8269,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aLg" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -8348,7 +8310,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aLn" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -9760,11 +9722,11 @@
 /area/station/maintenance/solar/west)
 "aUh" = (
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "aUk" = (
 /obj/machinery/computer/card,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "aUl" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -10215,7 +10177,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "aWK" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -10327,7 +10289,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "aXn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -10529,7 +10491,7 @@
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "aYn" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -17827,9 +17789,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "cRs" = (
 /obj/machinery/guardbot_dock,
 /obj/machinery/power/data_terminal,
@@ -17919,9 +17879,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "cTp" = (
 /obj/cable/yellow{
 	icon_state = "1-4"
@@ -18034,9 +17992,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "cUP" = (
 /obj/table/wood/auto,
 /obj/item/device/gps{
@@ -18049,9 +18005,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "cUU" = (
 /obj/rack,
 /obj/item/chem_grenade/firefighting,
@@ -18248,9 +18202,7 @@
 	dir = 5;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "cXv" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/engine,
@@ -18278,7 +18230,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "cYl" = (
 /obj/cable,
 /obj/cable{
@@ -19878,7 +19830,7 @@
 /area/station/science/lab)
 "dMT" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "dMU" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -23788,7 +23740,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "fuu" = (
 /obj/machinery/disposal/mail/small{
 	dir = 1;
@@ -23803,7 +23755,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "fuU" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -23897,7 +23849,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "fwk" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/checkpoint{
@@ -24102,16 +24054,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/security/beepsky)
-"fBs" = (
-/obj/window_blinds/cog2/left{
-	dir = 4
-	},
-/obj/cable,
-/obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
 "fBW" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -25025,7 +24967,7 @@
 /obj/cable,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "fXk" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -25319,7 +25261,7 @@
 /obj/cable,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "gdi" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -27703,7 +27645,7 @@
 /obj/cable,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "hre" = (
 /obj/landmark/gps_waypoint,
 /obj/machinery/bot/cleanbot,
@@ -28210,13 +28152,13 @@
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "hCu" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "hCD" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -28570,7 +28512,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "hLU" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 1
@@ -29945,7 +29887,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "izQ" = (
 /obj/lattice{
 	dir = 4;
@@ -30144,7 +30086,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "iFJ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -30531,7 +30473,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/random,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "iQX" = (
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
@@ -31277,7 +31219,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "jlF" = (
 /obj/machinery/vending/medical,
 /obj/item_dispenser/prescription_glasses,
@@ -37002,7 +36944,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/random,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "mjk" = (
 /obj/cable,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -39310,7 +39252,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "nrd" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 1
@@ -45547,7 +45489,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "qHX" = (
 /obj/table/reinforced/auto,
 /obj/item/kitchen/utensil/knife,
@@ -48903,7 +48845,7 @@
 	dir = 10;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "swP" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -50603,7 +50545,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/head_of_personnel,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "tnx" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -50663,7 +50605,7 @@
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "trW" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -50929,9 +50871,7 @@
 	dir = 9;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/hop)
 "tzg" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 4
@@ -54914,7 +54854,7 @@
 	},
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vsD" = (
 /obj/decal/tile_edge/line/black{
 	dir = 6;
@@ -56807,7 +56747,7 @@
 	pixel_y = 34
 	},
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "wsb" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -56826,7 +56766,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /turf/simulated/floor/black,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "wsz" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 4
@@ -57696,7 +57636,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/random,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "wLJ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
@@ -58839,7 +58779,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/random,
-/area/station/security/checkpoint/customs)
+/area/station/bridge/customs)
 "xrf" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
@@ -104486,9 +104426,9 @@ acf
 aah
 cYR
 fcx
-abu
+afk
 aat
-fBs
+hrc
 afk
 aaT
 fWL
@@ -104788,9 +104728,9 @@ acf
 bgz
 aNN
 aiC
-abu
+afk
 cRl
-ajB
+aaV
 cXT
 aaV
 aaV
@@ -105090,9 +105030,9 @@ acf
 bgB
 adX
 fjJ
-abu
+afk
 cSY
-awq
+arS
 afk
 acD
 acF
@@ -105392,7 +105332,7 @@ acf
 bgJ
 adX
 akY
-abu
+afk
 tyV
 awX
 afk
@@ -105694,7 +105634,7 @@ hoO
 ahF
 acg
 ack
-abu
+afk
 cUO
 aiS
 afk
@@ -105996,7 +105936,7 @@ acf
 hKB
 acf
 acf
-abu
+afk
 cUP
 aiT
 afk
@@ -106298,7 +106238,7 @@ acf
 bgS
 aiy
 acm
-abu
+afk
 cXp
 aiU
 afk
@@ -106600,9 +106540,9 @@ abY
 cON
 aiz
 aiz
-ach
-ach
-ach
+acM
+acM
+acM
 acM
 acM
 hBy
@@ -106902,7 +106842,7 @@ acf
 acf
 acf
 acf
-abu
+afk
 atW
 aIP
 abr

--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -9142,7 +9142,7 @@
 /obj/storage/secure/closet/command/hop,
 /obj/item/cargotele,
 /turf/simulated/floor/wood/two,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "uP" = (
 /obj/table/wood/auto,
 /obj/item/paper_bin,
@@ -9160,7 +9160,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/wood/two,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "uQ" = (
 /obj/table/wood/auto,
 /obj/item/clipboard,
@@ -9186,7 +9186,7 @@
 	pixel_x = -12
 	},
 /turf/simulated/floor/wood/two,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "uR" = (
 /obj/storage/crate{
 	desc = "Various supplies for the bar.";
@@ -9611,16 +9611,16 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/wood/two,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "vI" = (
 /obj/cable{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "vJ" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "vK" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -9633,7 +9633,7 @@
 	},
 /obj/landmark/start/job/head_of_personnel,
 /turf/simulated/floor/wood/two,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "vL" = (
 /obj/table/auto,
 /obj/item/storage/box/glassbox,
@@ -9951,7 +9951,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "wv" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -9972,10 +9972,10 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "wx" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "wy" = (
 /obj/machinery/door_control{
 	id = "dionysus_hoptalk";
@@ -9986,7 +9986,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "wz" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -10260,7 +10260,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/wood/two,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "wZ" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -10272,13 +10272,13 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "xa" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "xb" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -10287,7 +10287,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "xc" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
@@ -10530,18 +10530,18 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/wood/two,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "xD" = (
 /obj/shrub,
 /turf/simulated/floor/wood/two,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "xE" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/wood/two,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "xH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -18229,7 +18229,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/wood/two,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "Or" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -21150,7 +21150,7 @@
 	})
 "Ut" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "Uu" = (
 /obj/cable,
 /obj/cable{
@@ -23057,6 +23057,10 @@
 	icon_state = "catwalk_cross"
 	},
 /area/mining/magnet)
+"Zf" = (
+/obj/mapping_helper/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/heads)
 "Zg" = (
 /obj/decal/poster/wallsign/stencil/left/u{
 	pixel_x = -2
@@ -52860,10 +52864,10 @@ aa
 aa
 aa
 uf
-uf
+Zf
 wu
-uf
-uf
+Zf
+Zf
 aa
 aa
 aa
@@ -53160,13 +53164,13 @@ aa
 aa
 aa
 aa
-uf
-uf
+Zf
+Zf
 vH
 Oq
 wY
-uf
-uf
+Zf
+Zf
 aa
 aa
 aa
@@ -53462,13 +53466,13 @@ aa
 aa
 aa
 aa
-uf
+Zf
 uO
 vI
 ww
 wZ
 xC
-uf
+Zf
 aa
 aa
 aa
@@ -53764,13 +53768,13 @@ aa
 aa
 aa
 aa
-uf
+Zf
 uP
 vJ
 wx
 xa
 xD
-uf
+Zf
 aa
 aa
 aa

--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -8839,10 +8839,6 @@
 /area/station/medical/medbay{
 	name = "Asclepius Primary Zone"
 	})
-"uf" = (
-/obj/mapping_helper/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/bridge/hos)
 "ug" = (
 /obj/storage/closet/wardrobe/black/formalwear,
 /obj/machinery/light/small{
@@ -9142,7 +9138,7 @@
 /obj/storage/secure/closet/command/hop,
 /obj/item/cargotele,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "uP" = (
 /obj/table/wood/auto,
 /obj/item/paper_bin,
@@ -9160,7 +9156,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "uQ" = (
 /obj/table/wood/auto,
 /obj/item/clipboard,
@@ -9186,7 +9182,7 @@
 	pixel_x = -12
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "uR" = (
 /obj/storage/crate{
 	desc = "Various supplies for the bar.";
@@ -9611,16 +9607,16 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vI" = (
 /obj/cable{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vJ" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vK" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -9633,7 +9629,7 @@
 	},
 /obj/landmark/start/job/head_of_personnel,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vL" = (
 /obj/table/auto,
 /obj/item/storage/box/glassbox,
@@ -9951,7 +9947,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wv" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -9972,10 +9968,10 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wx" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wy" = (
 /obj/machinery/door_control{
 	id = "dionysus_hoptalk";
@@ -9986,7 +9982,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wz" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -10260,7 +10256,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wZ" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -10272,13 +10268,13 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "xa" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "xb" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -10287,7 +10283,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "xc" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
@@ -10298,7 +10294,7 @@
 	name = "Personnel Desk"
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
-/area/space)
+/area/station/crew_quarters/hop)
 "xd" = (
 /obj/machinery/light{
 	dir = 1;
@@ -10530,18 +10526,18 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "xD" = (
 /obj/shrub,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "xE" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "xH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -10734,9 +10730,6 @@
 /area/station/medical/maintenance{
 	name = "Asclepius Equipment Room"
 	})
-"yc" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
 "yd" = (
 /obj/machinery/vending/cards,
 /turf/simulated/floor/wood,
@@ -18229,7 +18222,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "Or" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -21150,7 +21143,7 @@
 	})
 "Ut" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "Uu" = (
 /obj/cable,
 /obj/cable{
@@ -22851,7 +22844,7 @@
 	},
 /obj/mapping_helper/access/head_of_personnel,
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
-/area/space)
+/area/station/crew_quarters/hop)
 "YK" = (
 /obj/decal/tile_edge/line/blue,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -23060,7 +23053,7 @@
 "Zf" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "Zg" = (
 /obj/decal/poster/wallsign/stencil/left/u{
 	pixel_x = -2
@@ -52863,7 +52856,7 @@ aa
 aa
 aa
 aa
-uf
+Zf
 Zf
 wu
 Zf
@@ -54378,7 +54371,7 @@ tG
 tG
 xc
 YJ
-yc
+Ut
 aa
 aa
 aa

--- a/maps/unused/horizon.dmm
+++ b/maps/unused/horizon.dmm
@@ -16089,7 +16089,7 @@
 "aVq" = (
 /obj/filing_cabinet,
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aVt" = (
 /obj/mesh/catwalk{
 	dir = 4
@@ -16317,13 +16317,13 @@
 /area/station/crew_quarters/clown)
 "aWc" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aWd" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
 /obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aWe" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
@@ -16332,7 +16332,7 @@
 	},
 /obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aWf" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -17608,7 +17608,7 @@
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aZr" = (
 /obj/table/reinforced/auto,
 /obj/cable,
@@ -17618,16 +17618,16 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aZs" = (
 /obj/table/reinforced/auto,
 /obj/item/reagent_containers/food/drinks/rum_spaced,
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aZt" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "aZu" = (
 /obj/table/wood/auto,
 /obj/item/reagent_containers/food/drinks/water,
@@ -18816,7 +18816,7 @@
 /obj/landmark/start/job/head_of_personnel,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bcp" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -18825,7 +18825,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bcq" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -18835,7 +18835,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bcr" = (
 /obj/machinery/computer/announcement{
 	announces_arrivals = 1;
@@ -19811,21 +19811,21 @@
 	dir = 1
 	},
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bfm" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bfn" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bfp" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor,
@@ -20935,12 +20935,12 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bin" = (
 /obj/machinery/light_switch/east,
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bio" = (
 /obj/machinery/computer3/generic/bank_data{
 	dir = 4
@@ -22070,7 +22070,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "blh" = (
 /obj/mesh/catwalk,
 /obj/cable{
@@ -47022,7 +47022,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "dRE" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -50866,7 +50866,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kri" = (
 /obj/machinery/light_switch/west,
 /obj/machinery/lawrack{
@@ -52338,7 +52338,7 @@
 /obj/window_blinds/cog2/middle,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "mPI" = (
 /obj/disposalpipe/segment/cargo{
 	dir = 4
@@ -57056,7 +57056,7 @@
 	},
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "uzt" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -59549,7 +59549,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/head_of_personnel,
 /turf/simulated/floor/darkblue,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ylZ" = (
 /obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4

--- a/maps/unused/horizon.dmm
+++ b/maps/unused/horizon.dmm
@@ -16336,7 +16336,7 @@
 "aWf" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aWg" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -17635,14 +17635,14 @@
 /obj/item/pen/crayon/golden,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aZv" = (
 /obj/table/wood/auto,
 /obj/item/hand_labeler,
 /obj/item_dispenser/idcarddispenser,
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aZw" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -17654,7 +17654,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aZy" = (
 /obj/machinery/light{
 	dir = 8;
@@ -18843,13 +18843,13 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "bct" = (
 /obj/cable,
 /obj/machinery/power/apc/autoname_east,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "bcv" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -19829,7 +19829,7 @@
 "bfp" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "bfr" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -19845,7 +19845,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "bfs" = (
 /obj/table/auto,
 /obj/item/storage/box/mousetraps,
@@ -20952,11 +20952,11 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "bip" = (
 /obj/stool/chair/office,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "biq" = (
 /obj/machinery/computer/card{
 	dir = 8
@@ -20966,7 +20966,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "biu" = (
 /obj/stool/chair/couch{
 	dir = 8
@@ -47010,7 +47010,7 @@
 	name = "crematorium pipe"
 	},
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "dOQ" = (
 /obj/machinery/door/airlock/pyro/command/alt{
 	dir = 8;
@@ -47101,7 +47101,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/blue/side,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "dZA" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -48125,7 +48125,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/blue/side,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "fMn" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -51214,7 +51214,7 @@
 "kVM" = (
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "kWJ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56646,7 +56646,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating/random,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "tQG" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -57399,7 +57399,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/blue/side,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "uVy" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 1
@@ -58994,7 +58994,7 @@
 "xmB" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "xmD" = (
 /obj/machinery/manufacturer/hangar,
 /turf/simulated/floor/engine,

--- a/maps/unused/manta.dmm
+++ b/maps/unused/manta.dmm
@@ -6082,7 +6082,7 @@
 /obj/item/paper_bin,
 /obj/item/pen/fancy,
 /turf/simulated/floor,
-/area/station/hos)
+/area/station/bridge/customs)
 "asB" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4;
@@ -6473,7 +6473,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/bridge/customs)
 "atM" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -6853,7 +6853,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/head_of_personnel,
 /turf/simulated/floor,
-/area/station/hos)
+/area/station/bridge/customs)
 "auR" = (
 /obj/disposalpipe/segment,
 /obj/machinery/power/apc/autoname_east,
@@ -7894,7 +7894,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/bridge/customs)
 "axy" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -8999,7 +8999,7 @@
 	dir = 8;
 	icon_state = "fgreen2"
 	},
-/area/station/hos)
+/area/station/bridge/customs)
 "aAw" = (
 /obj/stool/chair{
 	dir = 4
@@ -9014,7 +9014,7 @@
 	dir = 8;
 	icon_state = "fgreen1"
 	},
-/area/station/hos)
+/area/station/bridge/customs)
 "aAx" = (
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -9031,7 +9031,7 @@
 	dir = 8;
 	icon_state = "fgreen1"
 	},
-/area/station/hos)
+/area/station/bridge/customs)
 "aAz" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -13091,7 +13091,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/head_of_personnel,
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/crew_quarters/hop)
 "aLD" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -15421,7 +15421,7 @@
 	persistent_id = "customs"
 	},
 /turf/simulated/floor,
-/area/station/hos)
+/area/station/bridge/customs)
 "aTc" = (
 /obj/machinery/computer/card,
 /obj/machinery/power/data_terminal,
@@ -15430,21 +15430,18 @@
 	},
 /obj/item_dispenser/idcarddispenser,
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/bridge/customs)
 "aTe" = (
 /obj/filing_cabinet,
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/bridge/customs)
 "aTf" = (
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/bridge/customs)
 "aTh" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hos)
-"aTi" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hos/quarter)
+/area/station/bridge/customs)
 "aTj" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/beepsky)
@@ -15634,7 +15631,7 @@
 	pixel_y = 15
 	},
 /turf/simulated/floor,
-/area/station/hos)
+/area/station/bridge/customs)
 "aTH" = (
 /obj/stool/chair/office/blue{
 	dir = 8
@@ -15643,29 +15640,29 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/bridge/customs)
 "aTI" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/bridge/customs)
 "aTJ" = (
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/bridge/customs)
 "aTK" = (
 /mob/living/critter/small_animal/dog/blair,
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fgreen2"
 	},
-/area/station/hos)
+/area/station/bridge/customs)
 "aTL" = (
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/hos)
+/area/station/bridge/customs)
 "aTO" = (
 /obj/table/wood/auto/desk,
 /obj/item/reagent_containers/food/drinks/rum_spaced{
@@ -15677,7 +15674,7 @@
 	text = "NF"
 	},
 /turf/simulated/floor/wood,
-/area/station/hos/quarter)
+/area/station/crew_quarters/hop)
 "aTP" = (
 /obj/stool/bed,
 /obj/item/storage/secure/ssafe{
@@ -15686,13 +15683,13 @@
 /obj/item/clothing/suit/bedsheet/hop,
 /obj/landmark/start/job/head_of_personnel,
 /turf/simulated/floor/wood,
-/area/station/hos/quarter)
+/area/station/crew_quarters/hop)
 "aTQ" = (
 /obj/table/wood/auto/desk,
 /obj/item/material_piece/foolsfoolsgold,
 /obj/item/device/gps,
 /turf/simulated/floor/wood,
-/area/station/hos/quarter)
+/area/station/crew_quarters/hop)
 "aTR" = (
 /obj/machinery/computer/security/wooden_tv,
 /turf/simulated/floor/red,
@@ -15925,10 +15922,10 @@
 	dir = 4;
 	icon_state = "fgreen2"
 	},
-/area/station/hos)
+/area/station/bridge/customs)
 "aUy" = (
 /turf/simulated/floor/wood,
-/area/station/hos/quarter)
+/area/station/crew_quarters/hop)
 "aUB" = (
 /obj/machinery/light/incandescent/blueish,
 /turf/simulated/floor/plating/random,
@@ -16066,7 +16063,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/bridge/customs)
 "aUU" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -16082,7 +16079,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/bridge/customs)
 "aUV" = (
 /obj/machinery/disposal/mail/small{
 	mail_tag = "Head of Personnel's Office";
@@ -16100,7 +16097,7 @@
 	dir = 10;
 	icon_state = "fgreen2"
 	},
-/area/station/hos)
+/area/station/bridge/customs)
 "aUW" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -16117,7 +16114,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/hos)
+/area/station/bridge/customs)
 "aUX" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -16125,7 +16122,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
-/area/station/hos)
+/area/station/bridge/customs)
 "aUY" = (
 /obj/machinery/disposal/small,
 /obj/disposalpipe/trunk{
@@ -16138,7 +16135,7 @@
 	dir = 6;
 	icon_state = "fgreen2"
 	},
-/area/station/hos)
+/area/station/bridge/customs)
 "aUZ" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 4;
@@ -16156,7 +16153,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/station/hos/quarter)
+/area/station/crew_quarters/hop)
 "aVb" = (
 /obj/storage/secure/closet/command/hop,
 /obj/machinery/power/apc/autoname_east,
@@ -16170,7 +16167,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/wood,
-/area/station/hos/quarter)
+/area/station/crew_quarters/hop)
 "aVc" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -27889,7 +27886,7 @@
 	},
 /obj/storage/crate/bin/lostandfound,
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/bridge/customs)
 "bAD" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 1;
@@ -33138,7 +33135,7 @@
 	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/hos)
+/area/station/bridge/customs)
 "dna" = (
 /obj/storage/closet/emergency,
 /obj/machinery/light/incandescent/netural{
@@ -34050,7 +34047,7 @@
 	pixel_y = 20
 	},
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/bridge/customs)
 "fez" = (
 /obj/storage/crate,
 /obj/item/reagent_containers/food/drinks/fueltank,
@@ -36528,7 +36525,7 @@
 	dir = 5;
 	icon_state = "fgreen2"
 	},
-/area/station/hos)
+/area/station/bridge/customs)
 "kwX" = (
 /obj/machinery/rkit,
 /obj/machinery/light/incandescent/netural{
@@ -39491,7 +39488,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/wood,
-/area/station/hos/quarter)
+/area/station/crew_quarters/hop)
 "ruT" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -40627,7 +40624,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood,
-/area/station/hos)
+/area/station/bridge/customs)
 "uFt" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -41166,6 +41163,9 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
+"vIy" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/hop)
 "vJz" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -42085,7 +42085,7 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/wood,
-/area/station/hos/quarter)
+/area/station/crew_quarters/hop)
 "xMu" = (
 /obj/machinery/firealarm{
 	pixel_x = 1;
@@ -93507,11 +93507,11 @@ aCR
 aCY
 aDj
 aDl
-aTh
-aTh
-aTh
+vIy
+vIy
+vIy
 aLC
-aTh
+vIy
 aIt
 aBw
 aWR
@@ -93809,11 +93809,11 @@ aCW
 aQW
 aqE
 aQW
-aTi
+vIy
 aTO
 rtf
 aVa
-aTi
+vIy
 aIt
 aBw
 aWR
@@ -94111,11 +94111,11 @@ aQW
 aQW
 adP
 aSw
-aTi
+vIy
 aTP
 aUy
 aVb
-aTi
+vIy
 aVY
 aUB
 aWR
@@ -94413,11 +94413,11 @@ aQW
 iBl
 aRX
 aSx
-aTi
+vIy
 aTQ
 xMl
-aTi
-aTi
+vIy
+vIy
 anH
 aWs
 aHA
@@ -94715,10 +94715,10 @@ aQW
 aQW
 aQW
 aQW
-aTi
-aTi
-aTi
-aTi
+vIy
+vIy
+vIy
+vIy
 aVe
 aIt
 aBw

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -12954,7 +12954,7 @@
 	},
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/carpet/green/fancy,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "chL" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -13736,7 +13736,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/carpet/green/fancy,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "cKD" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -14247,7 +14247,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "djf" = (
 /obj/cable/yellow{
 	icon_state = "0-4"
@@ -14283,7 +14283,7 @@
 	id = "HOP"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "djT" = (
 /obj/lattice{
 	dir = 4;
@@ -16392,7 +16392,7 @@
 	id = "HOP"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "eXf" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk{
@@ -16755,7 +16755,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/east,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "flC" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/proto_gangway)
@@ -22041,7 +22041,7 @@
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "jSM" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -23028,7 +23028,7 @@
 	},
 /mob/living/critter/small_animal/dog/george/orwell,
 /turf/simulated/floor/carpet/green/fancy,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kIY" = (
 /obj/cable,
 /obj/cable{
@@ -23041,7 +23041,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kJE" = (
 /obj/machinery/camera{
 	c_tag = "Research Director";
@@ -23167,7 +23167,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/east,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kMV" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -27487,7 +27487,7 @@
 /obj/item/sticker/ribbon/third_place,
 /obj/item/sticker/ribbon/participant,
 /turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "olb" = (
 /obj/machinery/door/airlock/pyro/security/alt{
 	dir = 4
@@ -28325,7 +28325,7 @@
 	id = "HOP"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "oSy" = (
 /obj/lattice,
 /obj/machinery/atmospherics/binary/valve{
@@ -30498,7 +30498,7 @@
 /area/station/science/teleporter)
 "qqp" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "qqx" = (
 /turf/simulated/floor,
 /area/station/storage/primary)
@@ -34652,7 +34652,7 @@
 /area/station/hallway/arrivals)
 "tga" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "tgi" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -34812,7 +34812,7 @@
 /obj/table/wood/auto,
 /obj/item/reagent_containers/food/drinks/rum_spaced,
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "tkO" = (
 /obj/item/beach_ball,
 /turf/simulated/floor{
@@ -35522,7 +35522,7 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/carpet/green/fancy,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "tKe" = (
 /obj/machinery/recharger{
 	pixel_y = 3
@@ -35536,7 +35536,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/west,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "tKf" = (
 /turf/simulated/floor/plating,
 /area/station/science/storage)
@@ -37415,7 +37415,7 @@
 	id = "HOP"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "vgG" = (
 /obj/machinery/vending/mechanics,
 /obj/cable{
@@ -38753,7 +38753,7 @@
 "wmz" = (
 /obj/storage/secure/closet/command/hop,
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wmR" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen/freezer)
@@ -39188,7 +39188,7 @@
 "wJa" = (
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/carpet/green/fancy/edge/west,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wJA" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable/reinforced{
@@ -40118,7 +40118,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "xtN" = (
 /obj/stool/chair/office/purple{
 	dir = 1

--- a/maps/unused/ozymandias.dmm
+++ b/maps/unused/ozymandias.dmm
@@ -784,9 +784,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "akX" = (
 /obj/machinery/light{
 	dir = 1;
@@ -890,9 +888,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/heads,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "amd" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/neutral/corner{
@@ -1199,9 +1195,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/nw_se,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "aqt" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -1512,9 +1506,7 @@
 /area/station/science/bot_storage)
 "auG" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner/omni,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "auM" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -1532,9 +1524,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "auS" = (
 /obj/table/reinforced/auto,
 /obj/item/shipcomponent/secondary_system/cargo,
@@ -2148,9 +2138,7 @@
 	pixel_x = -12
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "aEI" = (
 /obj/machinery/shieldgenerator/meteorshield,
 /obj/machinery/camera{
@@ -2624,9 +2612,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "aKy" = (
 /obj/stool/bench/yellow/auto,
 /obj/machinery/power/apc/autoname_north,
@@ -2865,9 +2851,7 @@
 	},
 /obj/landmark/pest,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "aNW" = (
 /obj/mapping_helper/wingrille_spawn/auto/crystal,
 /obj/cable,
@@ -2956,9 +2940,7 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "aOO" = (
 /obj/table/auto,
 /obj/item/storage/box/mousetraps,
@@ -3147,9 +3129,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "aRJ" = (
 /obj/stool/chair/comfy{
 	dir = 4
@@ -3254,9 +3234,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "aTr" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -3867,9 +3845,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "bbF" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -4594,9 +4570,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "bmv" = (
 /obj/stool/chair/yellow{
 	dir = 4
@@ -4933,9 +4907,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/heads,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "brU" = (
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/grey,
@@ -4945,9 +4917,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "bsb" = (
 /obj/storage/cart,
 /obj/machinery/camera{
@@ -5086,9 +5056,7 @@
 	pixel_x = -12
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "btN" = (
 /obj/tug_cart,
 /turf/simulated/floor/orangeblack,
@@ -5429,9 +5397,7 @@
 /obj/machinery/light_switch/north,
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "byH" = (
 /obj/machinery/light{
 	dir = 4;
@@ -5956,9 +5922,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "bHe" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -6404,9 +6368,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "bOD" = (
 /obj/table/auto,
 /obj/machinery/phone,
@@ -6432,9 +6394,7 @@
 	pixel_x = 12
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "bOL" = (
 /obj/decal/tile_edge/floorguide/medbay{
 	dir = 1
@@ -10693,9 +10653,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "cVA" = (
 /obj/reagent_dispensers/beerkeg,
 /obj/machinery/light/small{
@@ -14017,9 +13975,7 @@
 	icon_state = "6-8"
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "dOR" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/cable{
@@ -14111,9 +14067,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "dQs" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -14438,9 +14392,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "dUz" = (
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour19;desc=Alright, my battery's getting a bit worn out. I'm heading back to my spot. See ya later.";
@@ -14732,9 +14684,7 @@
 	name = "Bridge Catering Access"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "dYK" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/transport{
@@ -15311,9 +15261,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "egA" = (
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour9;desc=Nice little kitty-corner here. Fancy teleporter through the blue door, monitoring room up the stairs, computer stuff across the hall.";
@@ -15755,9 +15703,7 @@
 	},
 /obj/machinery/light/emergency,
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "emy" = (
 /obj/table/glass/reinforced/auto,
 /obj/item/paper_bin,
@@ -16969,9 +16915,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "eAE" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/plating,
@@ -18805,9 +18749,7 @@
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "eYV" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -19035,9 +18977,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "fbs" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor,
@@ -19660,9 +19600,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "flw" = (
 /obj/railing/orange/reinforced{
 	dir = 8
@@ -19730,9 +19668,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "fmE" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -19996,9 +19932,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "fqq" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4;
@@ -20539,9 +20473,7 @@
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "fxC" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -22220,9 +22152,7 @@
 /obj/table/reinforced/bar/auto,
 /obj/machinery/phone,
 /turf/simulated/floor/carpet/blue/fancy/innercorner/ne_sw,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "fUJ" = (
 /obj/machinery/atmospherics/pipe/manifold/overfloor{
 	dir = 4
@@ -22408,9 +22338,7 @@
 /obj/machinery/atmospherics/pipe/simple,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "fXe" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable,
@@ -23174,9 +23102,7 @@
 	pixel_y = 20
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "ghH" = (
 /obj/rack,
 /obj/item/clothing/under/jersey/purple,
@@ -23360,9 +23286,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "gjQ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -24577,9 +24501,7 @@
 "gyV" = (
 /obj/table/reinforced/bar/auto,
 /turf/simulated/floor/carpet/blue/fancy/innercorner/nw_se,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "gyW" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -24918,9 +24840,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "gCR" = (
 /obj/machinery/light{
 	dir = 8;
@@ -25504,9 +25424,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "gJH" = (
 /obj/mesh/catwalk{
 	dir = 6
@@ -25913,9 +25831,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "gPC" = (
 /obj/shrub{
 	dir = 4;
@@ -26804,9 +26720,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "hbG" = (
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/engine/caution/north,
@@ -26951,9 +26865,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "hdW" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -27617,9 +27529,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "hkN" = (
 /obj/disposalpipe/segment/bent/west,
 /turf/simulated/floor/plating,
@@ -28881,9 +28791,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "hBd" = (
 /obj/reagent_dispensers/fueltank,
 /obj/cable,
@@ -30279,9 +30187,7 @@
 	pixel_x = 12
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "hWq" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
@@ -30361,9 +30267,7 @@
 	},
 /obj/item/pen/fancy,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "hXA" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 1
@@ -31041,9 +30945,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "iiP" = (
 /obj/stool/chair{
 	dir = 4
@@ -32557,9 +32459,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "iDu" = (
 /obj/machinery/bot/guardbot/old/tourguide{
 	access_lookup = "Staff Assistant";
@@ -33219,9 +33119,7 @@
 "iMp" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "iMt" = (
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
@@ -33445,9 +33343,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "iOV" = (
 /obj/machinery/door_control{
 	id = "market_north";
@@ -33875,9 +33771,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "iWx" = (
 /obj/machinery/light{
 	dir = 4;
@@ -33932,9 +33826,7 @@
 "iXm" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "iXp" = (
 /obj/stool/bench/auto,
 /turf/simulated/floor/black,
@@ -34636,9 +34528,7 @@
 "jgm" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "jgn" = (
 /turf/simulated/floor/stairs/wide/other{
 	dir = 1
@@ -34748,9 +34638,7 @@
 	pixel_x = -8
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "jii" = (
 /obj/mapping_helper/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -35022,9 +34910,7 @@
 "jle" = (
 /obj/table/wood/auto,
 /turf/simulated/floor/carpet/blue/fancy/innercorner/omni,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "jlr" = (
 /obj/cable{
 	icon_state = "2-9"
@@ -35341,9 +35227,7 @@
 	},
 /obj/vehicle/segway,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "jqh" = (
 /obj/machinery/light,
 /obj/disposalpipe/segment/horizontal,
@@ -36175,9 +36059,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "jBs" = (
 /obj/machinery/computer/supplycomp{
 	dir = 4
@@ -36626,9 +36508,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "jIJ" = (
 /obj/stool/chair/office/green{
 	dir = 8
@@ -38800,9 +38680,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "klg" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Morgue";
@@ -39081,9 +38959,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "koc" = (
 /obj/machinery/light{
 	dir = 4;
@@ -40478,9 +40354,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "kIR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41719,9 +41593,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "kZC" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/wood/two,
@@ -43831,9 +43703,7 @@
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "lCE" = (
 /obj/cable{
 	icon_state = "5-8"
@@ -44172,9 +44042,7 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "lFV" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/grey/side,
@@ -44307,9 +44175,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "lHo" = (
 /obj/table/wood/auto,
 /obj/machinery/light/lamp/black,
@@ -44580,9 +44446,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "lKx" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -45029,9 +44893,7 @@
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "lPT" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor/escape,
@@ -45598,9 +45460,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "lWP" = (
 /obj/machinery/mass_driver{
 	name = "cargo driver"
@@ -46185,9 +46045,7 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "meK" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -48516,9 +48374,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "mJN" = (
 /obj/storage/closet/biohazard,
 /turf/simulated/floor/purple/side,
@@ -48615,9 +48471,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "mLl" = (
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/grime,
@@ -48667,9 +48521,7 @@
 "mMq" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "mMA" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
@@ -49573,9 +49425,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "nav" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -51124,9 +50974,7 @@
 	pixel_y = 14
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "nzO" = (
 /obj/stool/chair{
 	dir = 4
@@ -51848,9 +51696,7 @@
 	},
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "nIb" = (
 /obj/stool/chair/office/red{
 	dir = 4
@@ -52434,9 +52280,7 @@
 	pixel_x = 20
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "nPh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -52457,9 +52301,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "nPr" = (
 /obj/decal/tile_edge/floorguide/evac{
 	dir = 1
@@ -53262,9 +53104,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "oaB" = (
 /turf/simulated/floor/blue/side{
 	dir = 8
@@ -53479,9 +53319,7 @@
 	},
 /obj/disposalpipe/junction/right/south,
 /turf/simulated/floor/stairs/wide/other,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "ocZ" = (
 /obj/storage/secure/closet/medical/medkit,
 /obj/machinery/light{
@@ -54288,9 +54126,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "onb" = (
 /obj/machinery/atmospherics/unary/tank/air_repressurization{
 	dir = 4;
@@ -55029,9 +54865,7 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "owz" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/purplewhite{
@@ -57299,9 +57133,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "pbz" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/east)
@@ -57823,9 +57655,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "pjz" = (
 /obj/storage/secure/closet/security/equipment,
 /obj/item/storage/secure/ssafe{
@@ -58061,9 +57891,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "pmC" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -58207,9 +58035,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "poh" = (
 /obj/machinery/light{
 	dir = 8;
@@ -59000,9 +58826,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "pyP" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -59620,9 +59444,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "pHI" = (
 /obj/stool/chair/red{
 	dir = 4
@@ -59853,9 +59675,7 @@
 	},
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "pJU" = (
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
@@ -60939,9 +60759,7 @@
 "pXw" = (
 /obj/machinery/light,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "pXx" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -61482,9 +61300,7 @@
 /obj/machinery/atmospherics/pipe/simple,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "qet" = (
 /obj/table/auto,
 /obj/item/clothing/gloves/yellow,
@@ -61547,9 +61363,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "qfC" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -62366,9 +62180,7 @@
 	pixel_x = 12
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "qrK" = (
 /obj/table/auto,
 /obj/item/clothing/shoes/heels/black{
@@ -62462,9 +62274,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "qtA" = (
 /obj/machinery/light{
 	dir = 8;
@@ -63102,9 +62912,7 @@
 /area/station/hangar/qm)
 "qCt" = (
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "qCu" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -63342,9 +63150,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "qFx" = (
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 4
@@ -63449,9 +63255,7 @@
 /area/station/chapel/sanctuary)
 "qGP" = (
 /turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "qGR" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
@@ -64658,9 +64462,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "qUB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -65122,9 +64924,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "rbH" = (
 /obj/submachine/chicken_incubator,
 /obj/item/reagent_containers/food/snacks/ingredient/egg{
@@ -66249,9 +66049,7 @@
 "rrT" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "rrU" = (
 /obj/machinery/bot/medbot/no_camera,
 /turf/simulated/floor/black,
@@ -67850,9 +67648,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "rNw" = (
 /obj/machinery/door_control{
 	id = "witprot_inner";
@@ -68751,9 +68547,7 @@
 /obj/disposalpipe/segment/transport,
 /obj/mapping_helper/access/heads,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "rWX" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -68928,9 +68722,7 @@
 	pixel_y = 20
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "rZu" = (
 /obj/stool/bench/blue/auto,
 /obj/machinery/light/emergency{
@@ -69237,9 +69029,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/heads,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "sdB" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -71055,9 +70845,7 @@
 /obj/table/reinforced/bar/auto,
 /obj/item/boardgame/chess,
 /turf/simulated/floor/carpet/blue/fancy/innercorner/ne_sw,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "sBd" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 4
@@ -71600,9 +71388,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "sGW" = (
 /obj/table/auto,
 /obj/item/device/multitool{
@@ -72239,9 +72025,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/heads,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "sOO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -72483,9 +72267,7 @@
 	},
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "sRr" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical{
@@ -74013,9 +73795,7 @@
 /obj/machinery/disposal/mail/autoname/bridge,
 /obj/disposalpipe/trunk/mail/east,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "tkp" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -74236,9 +74016,7 @@
 	name = "Bridge Catering Access"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "tnB" = (
 /obj/machinery/conveyor/SN{
 	name = "cargo belt - north";
@@ -74314,9 +74092,7 @@
 	icon_state = "2-5"
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "toy" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1;
@@ -75071,9 +74847,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "tyo" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -75361,9 +75135,7 @@
 /obj/machinery/light/small,
 /obj/landmark/pest,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "tBO" = (
 /obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 4
@@ -76788,9 +76560,7 @@
 /obj/disposalpipe/segment/transport,
 /obj/mapping_helper/access/heads,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "tVa" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor,
@@ -77083,9 +76853,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "tYO" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
@@ -78189,9 +77957,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "une" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -78888,9 +78654,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "uwM" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 8
@@ -80676,9 +80440,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "uRK" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -81834,9 +81596,7 @@
 /area/station/maintenance/inner/ne)
 "veK" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/lounge/port{
-	name = "Diplomatic Quarters"
-	})
+/area/station/crew_quarters/diplomat)
 "veS" = (
 /turf/simulated/floor/sanitary,
 /area/station/hydroponics/lobby{
@@ -81852,9 +81612,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "veY" = (
 /obj/stool/chair/couch{
 	dir = 8;
@@ -83006,9 +82764,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "vsi" = (
 /turf/simulated/floor,
 /area/station/hallway/secondary/north)
@@ -83132,9 +82888,7 @@
 /obj/machinery/atmospherics/pipe/simple,
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/stairs/wide,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "vud" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -84100,9 +83854,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "vFP" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -85531,9 +85283,7 @@
 "vYF" = (
 /obj/disposalpipe/segment/mail/bent/west,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "vZe" = (
 /obj/machinery/light/runway_light/delay2,
 /obj/lattice{
@@ -85559,9 +85309,7 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "vZF" = (
 /obj/stool/chair/yellow{
 	dir = 8
@@ -86214,9 +85962,7 @@
 	pixel_y = 16
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "whJ" = (
 /obj/item/device/radio/beacon,
 /obj/disposalpipe/segment/morgue,
@@ -86386,9 +86132,7 @@
 	pixel_x = -12
 	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "wkt" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/grey,
@@ -86520,9 +86264,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "wmg" = (
 /obj/table/auto,
 /obj/item/clipboard{
@@ -87312,9 +87054,7 @@
 /area/station/maintenance/inner/ne)
 "wuv" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "wuM" = (
 /obj/submachine/poster_creator{
 	dir = 8
@@ -87407,9 +87147,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "wvJ" = (
 /obj/disposalpipe/segment/mail/bent/east,
 /turf/simulated/floor/wood/two,
@@ -90944,9 +90682,7 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/heads,
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "xmQ" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -91803,9 +91539,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/grey,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "xyj" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/toilets{
@@ -92396,9 +92130,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "xFn" = (
 /obj/machinery/atmospherics/pipe/manifold/overfloor{
 	dir = 1
@@ -93305,9 +93037,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "xQH" = (
 /obj/machinery/power/collector_array,
 /obj/cable{
@@ -93796,9 +93526,7 @@
 "xXl" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "xXn" = (
 /obj/table/auto,
 /obj/item/storage/box/biohazard_bags{
@@ -94226,9 +93954,7 @@
 /area/ghostdrone_factory)
 "ycD" = (
 /turf/simulated/floor/wood/two,
-/area/station/crew_quarters/heads{
-	name = "Officers' Lounge"
-	})
+/area/station/bridge/reception)
 "ycH" = (
 /obj/machinery/light/small{
 	dir = 4;

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -5438,7 +5438,7 @@
 	req_access_txt = "19"
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "arK" = (
 /obj/noticeboard,
 /turf/simulated/wall/r_wall,
@@ -5611,20 +5611,20 @@
 "asu" = (
 /obj/stool/bed,
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "asv" = (
 /obj/machinery/light{
 	dir = 1;
 	pixel_x = -1
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "asw" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "asx" = (
 /obj/machinery/light{
 	dir = 1;
@@ -5639,7 +5639,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "asy" = (
 /obj/machinery/computer/ATM{
 	dir = 8;
@@ -5651,7 +5651,7 @@
 	name = "autoname  - SS13"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "asz" = (
 /obj/mesh/grille/steel,
 /obj/window/reinforced/west,
@@ -5661,7 +5661,7 @@
 	reinf = 1
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "asA" = (
 /obj/mesh/grille/steel,
 /obj/window/reinforced/north,
@@ -5954,23 +5954,23 @@
 /area/station/bridge)
 "aty" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "atz" = (
 /turf/simulated/floor/carpet/blue,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "atB" = (
 /obj/stool/chair{
 	dir = 8
 	},
 /obj/landmark/start/job/head_of_personnel,
 /turf/simulated/floor/carpet/blue,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "atC" = (
 /obj/machinery/computer3/generic/bank_data{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "atD" = (
 /obj/mesh/grille/steel,
 /obj/window/reinforced/west,
@@ -6369,32 +6369,32 @@
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk,
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "avj" = (
 /obj/storage/secure/closet/command/hos,
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "avk" = (
 /obj/table/wood{
 	dir = 9
 	},
 /obj/machinery/light/lamp,
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "avl" = (
 /obj/table/wood{
 	dir = 9
 	},
 /obj/item/reagent_containers/food/drinks/rum_spaced,
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "avm" = (
 /obj/table/wood{
 	dir = 9
 	},
 /obj/machinery/recharger,
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "avn" = (
 /obj/machinery/flasher{
 	id = "cell4";
@@ -6732,16 +6732,16 @@
 /obj/window/reinforced/north,
 /obj/window/reinforced/south,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "awj" = (
 /obj/mesh/grille/steel,
 /obj/window/reinforced/north,
 /obj/window/reinforced/south,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "awk" = (
 /turf/simulated/wall/r_wall,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "awl" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/north)
@@ -30468,7 +30468,7 @@
 /obj/item/currency/spacecash,
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/carpet/blue,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "sOw" = (
 /obj/machinery/camera{
 	c_tag = "Southwest firesuit storage";

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -622,8 +622,11 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/se,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aka" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
@@ -1690,7 +1693,7 @@
 /area/station/storage/warehouse)
 "aJe" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aJi" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -1812,7 +1815,7 @@
 "aKM" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "aLf" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -2929,7 +2932,7 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "bpe" = (
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
 /area/station/quartermaster/office)
@@ -3198,7 +3201,7 @@
 /obj/machinery/power/data_terminal,
 /obj/item/device/radio/intercom/bridge,
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "btk" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -3645,7 +3648,7 @@
 /area/station/maintenance/northeast)
 "bDA" = (
 /turf/simulated/floor/wood,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "bDC" = (
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
@@ -5215,7 +5218,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "cle" = (
 /obj/machinery/manufacturer/mechanic,
 /turf/simulated/floor,
@@ -7903,7 +7906,7 @@
 "dxA" = (
 /obj/decal/cleanable/fungus,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "dxE" = (
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
@@ -8079,7 +8082,7 @@
 "dAz" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "dAG" = (
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating,
@@ -9017,7 +9020,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "dTJ" = (
 /obj/machinery/disposal,
 /obj/noticeboard{
@@ -11071,7 +11074,7 @@
 "eOP" = (
 /obj/storage/secure/closet/command/hop,
 /turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "ePC" = (
 /obj/table/glass/auto,
 /obj/item/decoration/ashtray,
@@ -11412,7 +11415,7 @@
 "eVK" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "eVL" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk{
@@ -13118,7 +13121,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "fKp" = (
 /obj/disposalpipe/segment,
 /obj/item/clothing/gloves/boxing,
@@ -14531,8 +14534,10 @@
 /obj/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/cable,
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "gnY" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor,
@@ -14791,7 +14796,7 @@
 	text = "NF"
 	},
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "gvg" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -14861,7 +14866,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/blue/fancy,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "gxP" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -15301,7 +15306,7 @@
 /obj/item/clothing/suit/bedsheet/hop,
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "gKw" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -18219,7 +18224,7 @@
 /obj/decal/poster/wallsign/statistics1,
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "hYL" = (
 /obj/disposalpipe/switch_junction/left/east{
 	mail_tag = "Bar";
@@ -23420,7 +23425,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "kiS" = (
 /obj/machinery/genetics_booth,
 /obj/decal/tile_edge/stripe{
@@ -23605,7 +23610,7 @@
 "kos" = (
 /mob/living/critter/small_animal/dog/blair,
 /turf/simulated/floor/wood,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "kou" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -24425,7 +24430,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/narrow/west,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "kFk" = (
 /obj/machinery/drone_recharger,
 /obj/storage/closet/coffin/wood,
@@ -24648,7 +24653,7 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "kKI" = (
 /obj/cable{
 	icon_state = "2-5"
@@ -25190,7 +25195,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet/green/decal/outercross,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "kYA" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -25376,7 +25381,7 @@
 	},
 /obj/storage/closet/office,
 /turf/simulated/floor/carpet/green/fancy/narrow/south,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "ldC" = (
 /obj/mesh/grille/steel,
 /turf/simulated/floor/plating/airless,
@@ -25717,7 +25722,7 @@
 /obj/stool/bench/green,
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "llh" = (
 /obj/storage/closet/coffin,
 /obj/disposalpipe/segment/morgue{
@@ -26455,7 +26460,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet/green/fancy/narrow/north,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "lAM" = (
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/specialroom/gym/alt,
@@ -28215,7 +28220,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "mqB" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -28578,7 +28583,7 @@
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "mzk" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
@@ -29602,7 +29607,7 @@
 	},
 /obj/mapping_helper/access/head_of_personnel,
 /turf/simulated/floor/carpet/blue/fancy/narrow/south,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "mXd" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -33520,7 +33525,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "oEt" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -34817,7 +34822,7 @@
 	name = "HoP"
 	},
 /turf/simulated/floor/carpet/green/fancy/narrow/east,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "pmh" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/drinks/bowl{
@@ -34878,7 +34883,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "pnQ" = (
 /turf/simulated/floor/red,
 /area/station/security/secwing{
@@ -37311,7 +37316,7 @@
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/wood,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "qqF" = (
 /obj/machinery/power/smes{
 	charge = 1e+006;
@@ -37949,7 +37954,7 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "qEZ" = (
 /turf/simulated/floor/carpet/green/fancy/edge/south,
 /area/station/crew_quarters/jazz)
@@ -38408,7 +38413,7 @@
 "qPJ" = (
 /obj/stool/bench/green,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "qQa" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -38687,7 +38692,7 @@
 /area/station/security/main)
 "qXp" = (
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "qXr" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/engine/glow/blue{
@@ -39649,7 +39654,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "rvc" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Toxins Lab";
@@ -39725,7 +39730,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "rwV" = (
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
@@ -41452,7 +41457,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "shN" = (
 /obj/machinery/genetics_scanner,
 /obj/machinery/light_switch/east,
@@ -41534,7 +41539,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "siO" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
@@ -41890,7 +41895,7 @@
 /obj/machinery/power/apc/autoname_south,
 /obj/cable,
 /turf/simulated/floor/wood,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "srT" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 8;
@@ -42473,7 +42478,7 @@
 "sHg" = (
 /obj/decal/poster/wallsign/framed_award/firstbill,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "sHq" = (
 /obj/table/auto,
 /turf/simulated/floor/specialroom/arcade,
@@ -42865,6 +42870,10 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/surgery/storage)
+"sPr" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/heads)
 "sPL" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -44207,7 +44216,7 @@
 /obj/decal/poster/wallsign/statistics2,
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "tsg" = (
 /obj/machinery/light/emergency{
 	dir = 1
@@ -44778,7 +44787,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "tGj" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/ranch)
@@ -45969,7 +45978,7 @@
 /obj/item/pen/fancy,
 /obj/item/item_box/postit,
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "ujW" = (
 /obj/machinery/disposal_pipedispenser,
 /turf/simulated/floor/plating,
@@ -47479,7 +47488,7 @@
 "uTp" = (
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/wood,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "uTB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -47679,7 +47688,7 @@
 "uXO" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "uYl" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/random,
@@ -49980,16 +49989,16 @@
 /turf/simulated/floor/plating,
 /area/listeningpost/syndicate_teleporter)
 "vXH" = (
-/obj/machinery/computer/secure_data{
-	dir = 8
-	},
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/computer/stockexchange{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "vXW" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/random,
@@ -50892,7 +50901,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/narrow/eastwest,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "wrD" = (
 /obj/machinery/vehicle/escape_pod{
 	dir = 1
@@ -51128,7 +51137,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "wxp" = (
 /obj/table/glass/auto,
 /obj/random_item_spawner/tools/few,
@@ -51814,6 +51823,9 @@
 /obj/item/card_group/plain,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/the_cage)
+"wLN" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/heads)
 "wLP" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -52612,7 +52624,7 @@
 "xdJ" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "xdZ" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -53207,7 +53219,7 @@
 	},
 /obj/mapping_helper/access/head_of_personnel,
 /turf/simulated/floor/carpet/blue/fancy/narrow/north,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "xrc" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/bot_storage)
@@ -53233,7 +53245,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/bridge/hos)
+/area/station/crew_quarters/heads)
 "xrB" = (
 /obj/stool/bench/yellow/auto,
 /obj/landmark/start/job/engineer,
@@ -54997,7 +55009,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue/fancy,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "yeF" = (
 /obj/cable{
 	icon_state = "6-8"
@@ -55035,7 +55047,7 @@
 /obj/machinery/power/data_terminal,
 /obj/item/device/radio/intercom/security,
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/bridge/hos)
+/area/station/bridge/customs)
 "ygb" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/caution,
@@ -107773,7 +107785,7 @@ dOt
 pwC
 jyU
 svM
-aJe
+wLN
 rwQ
 uTp
 ruX
@@ -108075,11 +108087,11 @@ xHf
 lZK
 dPi
 nZl
-aJe
+wLN
 kFi
 kos
 ruX
-aJe
+wLN
 aVl
 sbR
 mNU
@@ -108679,11 +108691,11 @@ lEL
 mfO
 oCr
 oCr
-aJe
+wLN
 plZ
 bDA
 qqu
-aJe
+wLN
 fXt
 sKp
 uHC
@@ -108981,11 +108993,11 @@ lVm
 dby
 hLN
 eEb
-aJe
+wLN
 kiR
 srB
-aKM
-aJe
+sPr
+wLN
 uxS
 jvG
 lXc
@@ -109283,10 +109295,10 @@ qSv
 nmP
 bGN
 rbP
-aJe
+wLN
 pnM
-aJe
-aKM
+wLN
+sPr
 gUg
 fFd
 jvG
@@ -109585,7 +109597,7 @@ bwo
 mLx
 qIa
 kkM
-aJe
+wLN
 qET
 ujU
 hYG
@@ -109887,7 +109899,7 @@ vVa
 mLx
 uxx
 pQU
-aJe
+wLN
 wxi
 eOP
 tsc
@@ -110192,7 +110204,7 @@ uzJ
 sHg
 dTw
 gKu
-aKM
+sPr
 uTd
 fFd
 dWn
@@ -110491,10 +110503,10 @@ lQg
 iaQ
 ruL
 eez
-aJe
+wLN
 xrt
-aJe
-aKM
+wLN
+sPr
 qfj
 eBA
 tjb
@@ -111096,8 +111108,8 @@ fmF
 qOB
 jml
 unc
-aJe
-aJe
+wLN
+wLN
 wfe
 gmC
 wfe

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -3648,7 +3648,7 @@
 /area/station/maintenance/northeast)
 "bDA" = (
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "bDC" = (
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
@@ -5218,7 +5218,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "cle" = (
 /obj/machinery/manufacturer/mechanic,
 /turf/simulated/floor,
@@ -9020,7 +9020,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "dTJ" = (
 /obj/machinery/disposal,
 /obj/noticeboard{
@@ -11074,7 +11074,7 @@
 "eOP" = (
 /obj/storage/secure/closet/command/hop,
 /turf/simulated/floor/carpet/green/fancy/edge/south,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ePC" = (
 /obj/table/glass/auto,
 /obj/item/decoration/ashtray,
@@ -11415,7 +11415,7 @@
 "eVK" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "eVL" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk{
@@ -15306,7 +15306,7 @@
 /obj/item/clothing/suit/bedsheet/hop,
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet/green/fancy/edge/se,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "gKw" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -18224,7 +18224,7 @@
 /obj/decal/poster/wallsign/statistics1,
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "hYL" = (
 /obj/disposalpipe/switch_junction/left/east{
 	mail_tag = "Bar";
@@ -23425,7 +23425,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kiS" = (
 /obj/machinery/genetics_booth,
 /obj/decal/tile_edge/stripe{
@@ -23610,7 +23610,7 @@
 "kos" = (
 /mob/living/critter/small_animal/dog/blair,
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kou" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -24430,7 +24430,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/narrow/west,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kFk" = (
 /obj/machinery/drone_recharger,
 /obj/storage/closet/coffin/wood,
@@ -25195,7 +25195,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet/green/decal/outercross,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "kYA" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -25381,7 +25381,7 @@
 	},
 /obj/storage/closet/office,
 /turf/simulated/floor/carpet/green/fancy/narrow/south,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ldC" = (
 /obj/mesh/grille/steel,
 /turf/simulated/floor/plating/airless,
@@ -26460,7 +26460,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet/green/fancy/narrow/north,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "lAM" = (
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/specialroom/gym/alt,
@@ -28220,7 +28220,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "mqB" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -28583,7 +28583,7 @@
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "mzk" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
@@ -34822,7 +34822,7 @@
 	name = "HoP"
 	},
 /turf/simulated/floor/carpet/green/fancy/narrow/east,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "pmh" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/drinks/bowl{
@@ -34883,7 +34883,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "pnQ" = (
 /turf/simulated/floor/red,
 /area/station/security/secwing{
@@ -37316,7 +37316,7 @@
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "qqF" = (
 /obj/machinery/power/smes{
 	charge = 1e+006;
@@ -37954,7 +37954,7 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "qEZ" = (
 /turf/simulated/floor/carpet/green/fancy/edge/south,
 /area/station/crew_quarters/jazz)
@@ -39654,7 +39654,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "rvc" = (
 /obj/machinery/door/airlock/pyro/medical{
 	name = "Toxins Lab";
@@ -39730,7 +39730,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "rwV" = (
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
@@ -41457,7 +41457,7 @@
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "shN" = (
 /obj/machinery/genetics_scanner,
 /obj/machinery/light_switch/east,
@@ -41539,7 +41539,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "siO" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
@@ -41895,7 +41895,7 @@
 /obj/machinery/power/apc/autoname_south,
 /obj/cable,
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "srT" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 8;
@@ -42478,7 +42478,7 @@
 "sHg" = (
 /obj/decal/poster/wallsign/framed_award/firstbill,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "sHq" = (
 /obj/table/auto,
 /turf/simulated/floor/specialroom/arcade,
@@ -42873,7 +42873,7 @@
 "sPr" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "sPL" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -44216,7 +44216,7 @@
 /obj/decal/poster/wallsign/statistics2,
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "tsg" = (
 /obj/machinery/light/emergency{
 	dir = 1
@@ -45978,7 +45978,7 @@
 /obj/item/pen/fancy,
 /obj/item/item_box/postit,
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "ujW" = (
 /obj/machinery/disposal_pipedispenser,
 /turf/simulated/floor/plating,
@@ -47488,7 +47488,7 @@
 "uTp" = (
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "uTB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50901,7 +50901,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/narrow/eastwest,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wrD" = (
 /obj/machinery/vehicle/escape_pod{
 	dir = 1
@@ -51137,7 +51137,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/north,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wxp" = (
 /obj/table/glass/auto,
 /obj/random_item_spawner/tools/few,
@@ -51825,7 +51825,7 @@
 /area/station/maintenance/inner/the_cage)
 "wLN" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "wLP" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -53245,7 +53245,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/hop)
 "xrB" = (
 /obj/stool/bench/yellow/auto,
 /obj/landmark/start/job/engineer,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][code quality]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cleans up Head of Personnel areas on all maps. 

Generally speaking, the HoP's areas in use with this change are:
Where the HoP sleeps is: 
* `/area/station/crew_quarters/hop` "Head of Personnel's Quarters"

Where the HoP hands out IDs is either:
* `/area/station/bridge/customs` "Customs" or
* `/area/station/crew_quarters/courtroom` "Courtroom"

Customs offices are usually quite small, so it's sometimes aborbed into the courtroom area.

Removes some **very** ambiguously named area paths with duplicated names
* `/area/station/hos` ""Head of Personnel's Office"
* `/area/station/hos/quarter`  "Head of Personnel's Personal Quarter"
* `/area/station/bridge/hos` "Head of Personnel's Office"
* `/area/station/crew_quarters/heads` "Head of Personnel's Office"

Adds and applies two new area paths:
* `/area/station/crew_quarters/diplomat` "Diplomatic Quarters" was map varedited on a few maps.
* `/area/station/bridge/reception` "Bridge Reception" was map varedited on a few maps.

Mostly stops using some area paths:
* `/area/station/security/checkpoint/customs` "Customs Security Checkpoint" (still valid on Kondaru; trading dock)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map consistency. The most player-noticable change should be some clearer area names in alerts/spief objectives. 

