### PR TITLE
Revolution tracker announcement origin defines

### DIFF
--- a/_std/defines/announcement_origins.dm
+++ b/_std/defines/announcement_origins.dm
@@ -1,9 +1,12 @@
+#define ALERT_WATCHFUL_EYE "Watchful-Eye Sensor Array Update" //Weather(if not oshan) + Headrev tracker
+#define ALERT_EGERIA_PROVIDENCE "Egeria Providence Array Broadcast" //Viva la revolution!
+
 #ifdef MAP_OVERRIDE_OSHAN
 	#define ALERT_ANOMALY "Ersetu Trench Anomaly Detection"
 	#define ALERT_WEATHER "Abzu Treaty Weather Station Alert"
 #else
 	#define ALERT_ANOMALY "LRAD Anomaly Detector Alert"
-	#define ALERT_WEATHER "Watchful-Eye Sensor Array Update"
+	#define ALERT_WEATHER ALERT_WATCHFUL_EYE
 #endif
 #define ALERT_GENERAL "Frontier Authority Update"
 #define ALERT_STATION "Automated Mainframe Alert"

--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -96,8 +96,8 @@
 	waittimed = TRUE
 
 /datum/game_mode/revolution/proc/send_tracker()
-	command_alert("Foreign mutiny located [station_or_ship()]wide, a program to track revolutionary leaders have been sent to all crew member PDA's.", "Central Command Security Alert", 'sound/misc/announcement_1.ogg', alert_origin = "Watchful Eye Sensor Array Update")
-	command_alert("Relevant biometric signatures of Command have been identified. To aid with the ongoing revolution, station command can now be tracked through the transmitted PDA program.", "Unregistered Signal Insertion", alert_origin = "Egeria Providence Array Broadcast")
+	command_alert("Foreign mutiny located [station_or_ship()]wide, a program to track revolutionary leaders have been sent to all crew member PDA's.", "Central Command Security Alert", 'sound/misc/announcement_1.ogg', alert_origin = ALERT_WATCHFUL_EYE)
+	command_alert("Relevant biometric signatures of Command have been identified. To aid with the ongoing revolution, station command can now be tracked through the transmitted PDA program.", "Unregistered Signal Insertion", alert_origin = ALERT_EGERIA_PROVIDENCE)
 	var/datum/signal/signal1 = get_free_signal()
 	signal1.data_file = (new /datum/computer/file/pda_program/revheadtracker)
 	signal1.data = list("command"="file_send", "file_name" = "Revolutionary Leader Locater", "file_ext" = "PPROG", "file_size" = "1", "tag" = "auto_fileshare", "sender_name"="Central Command Distribution Line", "sender"="00000000")

--- a/code/procs/command_alert.dm
+++ b/code/procs/command_alert.dm
@@ -9,11 +9,9 @@
 	if (sound_to_play && length(sound_to_play) > 0)
 		playsound_global(world, sound_to_play, 100)
 
-#ifndef MAP_OVERRIDE_OSHAN
-	if (alert_origin == ALERT_WEATHER)
+	if (alert_origin == ALERT_WATCHFUL_EYE)
 		for_by_tcl(eye, /mob/living/critter/small_animal/floateye/watchful)
 			eye.make_jittery(rand(10, 250))
-#endif
 
 /proc/command_announcement(var/text, var/title, var/sound_to_play = "", var/css_class = "alert", var/do_sanitize = 1, volume = 100) //Slightly less conspicuous, but requires a title.
 	if(!title || !text) return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add separate alert origin define for watchful eye and if not oshan use that define for weather alerts
Check this define for if we make the eyes in the array jittery or not rather than it not being oshan and being weather alert
Add define for egeria providence array(command tracker sender)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Spotted that the rev announcement for watchful eye didnt have the - so now it will always be the same as they all use the define 
Also the eyes wouldnt jitter on oshan when the array sends the rev alert

