### PR TITLE
Fix abstract runtime error when building fleet

### DIFF
--- a/code/WorkInProgress/EmergencyPodFab.dm
+++ b/code/WorkInProgress/EmergencyPodFab.dm
@@ -203,3 +203,8 @@
 	anchored = ANCHORED
 	density = 0
 	opacity = 0
+
+/obj/machinery/macrofab/portable_oxygen
+	name = "Portable Oxygen Tank Fabricator"
+	desc = "A sophisticated machine that fabricates and pressurizes oxygen tanks."
+	createdObject = /obj/item/tank/emergency_oxygen

--- a/maps/unused/fleet.dmm
+++ b/maps/unused/fleet.dmm
@@ -2306,13 +2306,10 @@
 /turf/simulated/floor/grey,
 /area/station/science/tenebrae)
 "fL" = (
-/obj/machinery/macrofab{
-	createdObject = /obj/item/tank/emergency_oxygen;
-	desc = "A sophisticated machine that fabricates and pressurizes oxygen tanks.";
-	name = "Tank Fabricator";
+/obj/decal/tile_edge/line/blue,
+/obj/machinery/macrofab/portable_oxygen{
 	pixel_y = -4
 	},
-/obj/decal/tile_edge/line/blue,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/maru)
 "fM" = (
@@ -7923,25 +7920,19 @@
 	name = "Dionysus Cryocore"
 	})
 "sk" = (
-/obj/machinery/macrofab{
-	createdObject = /obj/item/tank/emergency_oxygen;
-	desc = "A sophisticated machine that fabricates and pressurizes oxygen tanks.";
-	name = "Tank Fabricator";
+/obj/decal/tile_edge/line/blue,
+/obj/machinery/macrofab/portable_oxygen{
 	pixel_y = -4
 	},
-/obj/decal/tile_edge/line/blue,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/locker{
 	name = "Hammer Crew Quarters"
 	})
 "sl" = (
-/obj/machinery/macrofab{
-	createdObject = /obj/item/tank/emergency_oxygen;
-	desc = "A sophisticated machine that fabricates and pressurizes oxygen tanks.";
-	name = "Tank Fabricator";
+/obj/decal/tile_edge/line/blue,
+/obj/machinery/macrofab/portable_oxygen{
 	pixel_y = -4
 	},
-/obj/decal/tile_edge/line/blue,
 /turf/simulated/floor/grey,
 /area/station/medical/staff{
 	name = "Asclepius Quarters"
@@ -8192,13 +8183,10 @@
 	name = "Dionysus Cryocore"
 	})
 "sN" = (
-/obj/machinery/macrofab{
-	createdObject = /obj/item/tank/emergency_oxygen;
-	desc = "A sophisticated machine that fabricates and pressurizes oxygen tanks.";
-	name = "Tank Fabricator";
+/obj/decal/tile_edge/line/blue,
+/obj/machinery/macrofab/portable_oxygen{
 	pixel_y = -4
 	},
-/obj/decal/tile_edge/line/blue,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/utility{
 	name = "Dionysus Cryocore"
@@ -21119,10 +21107,7 @@
 	pixel_x = -12
 	},
 /obj/decal/tile_edge/line/blue,
-/obj/machinery/macrofab{
-	createdObject = /obj/item/tank/emergency_oxygen;
-	desc = "A sophisticated machine that fabricates and pressurizes oxygen tanks.";
-	name = "Tank Fabricator";
+/obj/machinery/macrofab/portable_oxygen{
 	pixel_y = -4
 	},
 /turf/simulated/floor/grass,
@@ -21408,13 +21393,10 @@
 	name = "Erebus Primary Zone"
 	})
 "Ve" = (
-/obj/machinery/macrofab{
-	createdObject = /obj/item/tank/emergency_oxygen;
-	desc = "A sophisticated machine that fabricates and pressurizes oxygen tanks.";
-	name = "Tank Fabricator";
+/obj/decal/tile_edge/line/blue,
+/obj/machinery/macrofab/portable_oxygen{
 	pixel_y = -4
 	},
-/obj/decal/tile_edge/line/blue,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/tenebrae)
 "Vf" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add new macrofab subtype: `/obj/machinery/macrofab/portable_oxygen`
Replace map varedited macrofabs on fleet


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
`/obj/machinery/macrofab/pod_wars` is marked as abstract, which then extends up to `/obj/machinery/macrofab`

Stop runtimes when testing changes against all possible maps and less map varedits.