### PR TITLE
SMES units can be broken and fixed

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,0 @@
-{
-  "singleQuote": true
-}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/code/datums/components/equipment_fault.dm
+++ b/code/datums/components/equipment_fault.dm
@@ -378,6 +378,44 @@ TYPEINFO(/datum/component/equipment_fault)
 			if (zamus_dumb_power_popups)
 				new /obj/maptext_junk/power(get_turf(M), change = -M.power_usage * mult, channel = M.power_channel)
 
+/datum/component/equipment_fault/dangerously_shorted
+	///base probability to shock each tick
+	var/static/base_probability = 10
+	///current probability to shock on this process tick
+	var/current_prob
+	///increase in probability per process tick
+	var/static/prob_raise = 5
+
+/datum/component/equipment_fault/dangerously_shorted/Initialize(tool_flags)
+	. = COMPONENT_INCOMPATIBLE
+	if(istype(parent, /obj/machinery/power))
+		. = ..()
+
+/datum/component/equipment_fault/dangerously_shorted/ef_process(obj/machinery/M, mult)
+	. = TRUE
+	elecflash(M)
+	if(probmult(current_prob))
+		src.ef_perform_fault(M)
+		src.current_prob = src.base_probability
+	else
+		src.current_prob += src.prob_raise
+
+/datum/component/equipment_fault/dangerously_shorted/ef_perform_fault(obj/machinery/M)
+	if(..())
+		M.visible_message(SPAN_ALERT("[M] sparks violently!"))
+
+		var/list/mob/targets = list()
+		for (var/mob/mob in hearers(8, M.loc))
+			if (mob.invisibility >= INVIS_AI_EYE) continue
+			targets.Add(mob)
+
+		if (!length(targets))
+			elecflash(M.loc, power=5, exclude_center=FALSE)
+			return
+
+		var/target = pick(targets)
+		arcFlash(M, target, 200000) // TODO: maybe some sort of PNET check?
+
 
 /datum/component/equipment_fault/faulty_wiring
 	fault_delay = 45 SECONDS

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -92,7 +92,7 @@ TYPEINFO(/obj/machinery/power/smes)
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"Set Power Output", PROC_REF(_set_output_mechchomp))
 
 		if (!terminal)
-			status |= BROKEN
+			status |= POWEROFF
 			return
 
 		terminal.master = src
@@ -101,7 +101,7 @@ TYPEINFO(/obj/machinery/power/smes)
 
 
 /obj/machinery/power/smes/update_icon()
-	if (status & BROKEN)
+	if (status & (BROKEN|POWEROFF))
 		ClearAllOverlays()
 		return
 
@@ -168,7 +168,7 @@ TYPEINFO(/obj/machinery/power/smes)
 
 /obj/machinery/power/smes/process(mult)
 
-	if (status & BROKEN)
+	if (status & (BROKEN|POWEROFF))
 		return
 
 
@@ -180,6 +180,9 @@ TYPEINFO(/obj/machinery/power/smes)
 	// Had to revert a hack here that caused SMES to continue charging despite insufficient power coming in on the input (terminal) side.
 	if (terminal)
 		charge(mult)
+	else
+		status |= POWEROFF
+		return
 
 	if (online)		// if outputting
 		if (prob(5))

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -134,11 +134,11 @@ TYPEINFO(/obj/machinery/power/smes)
 		return
 	switch(severity)
 		if(2)
-			if (prob(25))
+			if (prob(50))
 				src.set_broken()
 				return
 		if(3)
-			if (prob(20))
+			if (prob(25))
 				src.set_broken()
 
 /obj/machinery/power/smes/proc/chargedisplay()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -15,6 +15,9 @@ TYPEINFO(/obj/machinery/power/smes/magical)
 		charge = INFINITY
 		..()
 
+	set_broken()
+		return TRUE
+
 TYPEINFO(/obj/machinery/power/smes)
 	mats = list("metal" = 40,
 				"conductive_high" = 30,
@@ -120,6 +123,23 @@ TYPEINFO(/obj/machinery/power/smes)
 	if (clevel>0)
 		I = SafeGetOverlayImage("chargedisp",'icons/obj/power.dmi',"smes-og[clevel]")
 		UpdateOverlays(I, "chargedisp")
+
+/obj/machinery/power/smes/set_broken()
+	if(..()) return
+	AddComponent(/datum/component/equipment_fault/dangerously_shorted, tool_flags = TOOL_WIRING | TOOL_SOLDERING | TOOL_WRENCHING | TOOL_SCREWING | TOOL_PRYING)
+
+/obj/machinery/power/smes/ex_act(severity)
+	. = ..()
+	if (QDELETED(src))
+		return
+	switch(severity)
+		if(2)
+			if (prob(25))
+				src.set_broken()
+				return
+		if(3)
+			if (prob(20))
+				src.set_broken()
 
 /obj/machinery/power/smes/proc/chargedisplay()
 	return round(5.5*charge/capacity)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds new fault: Dangerously Shorted. Repeatedly does weak elecflashes and has an escalating probability of doing a strong arcflash to a nearby target. SMES units have this fault.

Changes SMES units that do not have a terminal to change state to NOPOWER (from broken), with related checks for the status.

Explosions that do not qdel the SMES unit will roll for causing it to break. Magical SMES units cannot break.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More dynamic equipment states for machinery.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)SMES units broken by explosions will emit dangerous shocks and stop charging. They can be repaired with common engineering tools and wires.
```
