### PR TITLE
Cooking recipe datums use lists

### DIFF
--- a/code/datums/controllers/process/world.dm
+++ b/code/datums/controllers/process/world.dm
@@ -143,19 +143,9 @@ input:checked + div { display: block; }
 			tmp2 += "<th>[bicon(R.output)][initial(item_path.name)]</th><td>"
 		else
 			tmp2 += "<th>???</th><td>"
-
-		if (R.item1)
-			var/atom/item_path = R.item1
-			tmp2 += "<div class='item' title=\"[html_encode(initial(item_path.name))]\">[bicon(R.item1)][R.amt1 > 1 ? "<span>x[R.amt1]</span>" : ""]</div>"
-		if (R.item2)
-			var/atom/item_path = R.item2
-			tmp2 += "<div class='item' title=\"[html_encode(initial(item_path.name))]\">[bicon(R.item2)][R.amt2 > 1 ? "<span>x[R.amt2]</span>" : ""]</div>"
-		if (R.item3)
-			var/atom/item_path = R.item3
-			tmp2 += "<div class='item' title=\"[html_encode(initial(item_path.name))]\">[bicon(R.item3)][R.amt3 > 1 ? "<span>x[R.amt3]</span>" : ""]</div>"
-		if (R.item4)
-			var/atom/item_path = R.item4
-			tmp2 += "<div class='item' title=\"[html_encode(initial(item_path.name))]\">[bicon(R.item4)][R.amt4 > 1 ? "<span>x[R.amt4]</span>" : ""]</div>"
+		for(var/I in R.ingredients)
+			var/atom/item_path = I
+			tmp2 += "<div class='item' title=\"[html_encode(initial(item_path.name))]\">[bicon(I)][R.ingredients[I] > 1 ? "<span>x[R.ingredients[I]]</span>" : ""]</div>"
 
 		tmp2 += "</td><td class='x'>[R.cookbonus >= 10 ? "[round(R.cookbonus / 2)] HI" : "[round(R.cookbonus)] LO"]</td></tr>"
 

--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -1,13 +1,6 @@
 ABSTRACT_TYPE(/datum/cookingrecipe)
 /datum/cookingrecipe
-	var/item1 = null
-	var/item2 = null
-	var/item3 = null
-	var/item4 = null
-	var/amt1 = 1
-	var/amt2 = 1
-	var/amt3 = 1
-	var/amt4 = 1
+	var/list/ingredients
 	var/cookbonus = null // how much cooking it needs to get a healing bonus
 	var/output = null // what you get from this recipe
 	var/useshumanmeat = 0 // used for naming of human meat dishes after their victims
@@ -29,62 +22,68 @@ ABSTRACT_TYPE(/datum/cookingrecipe/mixer)
 
 
 /datum/cookingrecipe/oven/burger/humanburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/humanmeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/humanmeat = 1)
 	cookbonus = 13
 	output = /obj/item/reagent_containers/food/snacks/burger/humanburger
 	useshumanmeat = 1
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/fishburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/burger/fishburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/synthburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat = 1)
 	cookbonus = 13
 	output = /obj/item/reagent_containers/food/snacks/burger/synthburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/slugburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/lesserSlug
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/lesserSlug = 1)
 	cookbonus = 13
 	output = /obj/item/reagent_containers/food/snacks/burger/slugburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/spicychickensandwich_2
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget/spicy
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget/spicy = 1)
 	cookbonus = 13
 	output = /obj/item/reagent_containers/food/snacks/burger/chicken/spicy
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/spicychickensandwich
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget
-	item3 = /obj/item/reagent_containers/food/snacks/plant/chili
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget = 1,
+	/obj/item/reagent_containers/food/snacks/plant/chili = 1)
 	cookbonus = 13
 	output = /obj/item/reagent_containers/food/snacks/burger/chicken/spicy
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/chickensandwich
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget = 1)
 	cookbonus = 13
 	output = /obj/item/reagent_containers/food/snacks/burger/chicken
 	category = "Burgers"
-
 
 ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 /datum/cookingrecipe/oven/burger
 	specialOutput(obj/submachine/ourCooker)
 		//this is dumb and assumes the second thing is always the meat but it usually is so :iiam:
-		var/obj/item/possibly_meat = locate(src.item2) in ourCooker
+		var/obj/item/possibly_meat = locate(ingredients[2]) in ourCooker
 		if (possibly_meat?.reagents?.get_reagent_amount("crime") >= 5)
 			var/obj/item/reagent_containers/food/snacks/burger/burgle/burgle = new()
 			possibly_meat.transfer_all_reagents(burgle)
@@ -92,8 +91,9 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 		return new src.output()
 
 /datum/cookingrecipe/oven/burger/mysteryburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat = 1)
 	cookbonus = 13
 	output = /obj/item/reagent_containers/food/snacks/burger/mysteryburger
 	category = "Burgers"
@@ -2264,3 +2264,4 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 	item3 = /obj/item/reagent_containers/food/snacks/condiment/syrup //technically this should be GOLDEN syrup but this works too
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/dessert_batch/flapjack
+

--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -99,700 +99,746 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/cheeseburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/burger/cheeseburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/wcheeseburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/gcheeseslice
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/gcheeseslice = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/burger/wcheeseburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/cheeseburger_m
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
-	amt3 = 2
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 2)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/burger/cheeseburger_m
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/luauburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat
-	item3 = /obj/item/reagent_containers/food/snacks/plant/pineappleslice
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 1,
+	/obj/item/reagent_containers/food/snacks/plant/pineappleslice = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/luauburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/coconutburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/plant/coconutmeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/plant/coconutmeat = 1)
 	cookbonus = 13
 	output = /obj/item/reagent_containers/food/snacks/burger/coconutburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/tikiburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat
-	item3 = /obj/item/reagent_containers/food/snacks/plant/pineappleslice
-	item4 = /obj/item/reagent_containers/food/snacks/plant/coconutmeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 1,
+	/obj/item/reagent_containers/food/snacks/plant/pineappleslice = 1,
+	/obj/item/reagent_containers/food/snacks/plant/coconutmeat = 1)
 	cookbonus = 18
 	output = /obj/item/reagent_containers/food/snacks/burger/tikiburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/monkeyburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat = 1)
 	cookbonus = 13
 	output = /obj/item/reagent_containers/food/snacks/burger/monkeyburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/buttburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/clothing/head/butt
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/clothing/head/butt = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/buttburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/synthbuttburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/clothing/head/butt/synth
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/clothing/head/butt/synth = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/buttburger/synth
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/cyberbuttburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/clothing/head/butt/cyberbutt
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/clothing/head/butt/cyberbutt = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/buttburger/cyber
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/synthheartburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/organ/heart/synth
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/organ/heart/synth = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/heartburger/synth
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/cyberheartburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/organ/heart/cyber
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/organ/heart/cyber = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/heartburger/cyber
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/flockheartburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/organ/heart/flock
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/organ/heart/flock = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/heartburger/flock
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/heartburger
-	item1 = /obj/item/organ/heart
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/dough
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/organ/heart = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/heartburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/flockburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/organ/brain/flockdrone
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget/flock = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/flockburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/brainburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/organ/brain
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/organ/brain = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/brainburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/synthbrainburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/organ/brain/synth
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/organ/brain/synth= 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/brainburger/synth
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/cyberbrainburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/organ/brain/latejoin
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/organ/brain/latejoin = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/brainburger/cyber
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/flockbrainburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/organ/brain/flockdrone
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/organ/brain/flockdrone = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/brainburger/flock
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/roburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/parts/robot_parts/head
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/parts/robot_parts/head = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/roburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/cheeseborger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/parts/robot_parts/head
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/parts/robot_parts/head = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/cheeseborger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/baconburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon = 1)
 	cookbonus = 13
 	output = /obj/item/reagent_containers/food/snacks/burger/baconburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/baconator
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat
-	amt2 = 2
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
-	amt3 = 2
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 2)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/burger/bigburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/butterburger
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/butter
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/burger/butterburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/aburgination
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/changeling
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/dough
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/changeling = 1)
 	cookbonus = 6 // still mostly raw, since we don't kill it
 	output = /obj/item/reagent_containers/food/snacks/burger/aburgination
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/burger/monster
-	item1 = /obj/item/reagent_containers/food/snacks/burger/bigburger
-	amt1 = 4
+	ingredients = list(/obj/item/reagent_containers/food/snacks/burger/bigburger = 4)
 	cookbonus = 20
 	output = /obj/item/reagent_containers/food/snacks/burger/monsterburger
 	category = "Burgers"
 
 /datum/cookingrecipe/oven/swede_mball
-	item1 = /obj/item/reagent_containers/food/snacks/meatball
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/flour
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/egg
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/meatball = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/flour = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/swedishmeatball
 
 /datum/cookingrecipe/oven/donkpocket
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/meatball
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/meatball = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/donkpocket/warm
 
 /datum/cookingrecipe/oven/honkpocket
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/meatball
-	item3 = /obj/item/instrument/bikehorn
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/meatball = 1,
+	/obj/item/instrument/bikehorn = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/donkpocket/honk/warm
 
 /datum/cookingrecipe/oven/donkpocket2
-	item1 = /obj/item/reagent_containers/food/snacks/donkpocket
+	ingredients = list(/obj/item/reagent_containers/food/snacks/donkpocket = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/donkpocket/warm
 
 /datum/cookingrecipe/oven/donut
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_circle
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/sugar
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_circle = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/sugar = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/donut
 
 /datum/cookingrecipe/oven/bagel
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_circle
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/dough_circle = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/bagel
 
 /datum/cookingrecipe/oven/crumpet //another good idea for this is to cook a trumpet
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/holey_dough
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/holey_dough = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/crumpet
 
 /datum/cookingrecipe/oven/ice_cream_cone
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/sugar
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/sugar = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/ice_cream_cone
 
 /datum/cookingrecipe/oven/nougat
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/honey
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/sugar
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/honey = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/sugar = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/candy/nougat
 
 /datum/cookingrecipe/oven/candy_cane
-	item1 = /obj/item/plant/herb/mint
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/sugar
+	ingredients = list(\
+	/obj/item/plant/herb/mint = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/sugar = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/candy/candy_cane
 
 /datum/cookingrecipe/oven/waffles
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/waffles
 
 /datum/cookingrecipe/oven/spaghetti_p
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti = 1)
 	cookbonus = 16
 	output = /obj/item/reagent_containers/food/snacks/spaghetti
 	category = "Pasta"
 
 /datum/cookingrecipe/oven/spaghetti_t
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/ketchup
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/ketchup = 1)
 	cookbonus = 16
 	output = /obj/item/reagent_containers/food/snacks/spaghetti/sauce
 	category = "Pasta"
 
 /datum/cookingrecipe/oven/spaghetti_s
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/hotsauce
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/hotsauce = 1)
 	cookbonus = 16
 	output = /obj/item/reagent_containers/food/snacks/spaghetti/spicy
 	category = "Pasta"
 
 /datum/cookingrecipe/oven/spaghetti_m
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti
-	item2 = /obj/item/reagent_containers/food/snacks/meatball
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti = 1,
+	/obj/item/reagent_containers/food/snacks/meatball = 1)
 	cookbonus = 16
 	output = /obj/item/reagent_containers/food/snacks/spaghetti/meatball
 	category = "Pasta"
 
 /datum/cookingrecipe/oven/lasagna
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/pasta/sheet
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/ketchup
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
-	amt3 = 2
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/pasta/sheet = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/ketchup = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 2)
 	cookbonus = 16
 	output = /obj/item/reagent_containers/food/snacks/lasagna
 	category = "Pasta"
 
 /datum/cookingrecipe/oven/alfredo
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 16
 	output = /obj/item/reagent_containers/food/snacks/spaghetti/alfredo
 	category = "Pasta"
 
 /datum/cookingrecipe/oven/chickenparm
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/ketchup
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/ketchup = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget = 1)
 	cookbonus = 16
 	output = /obj/item/reagent_containers/food/snacks/spaghetti/chickenparm
 	category = "Pasta"
 
 /datum/cookingrecipe/oven/chickenalfredo
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget = 1)
 	cookbonus = 16
 	output = /obj/item/reagent_containers/food/snacks/spaghetti/chickenalfredo
 	category = "Pasta"
 
 /datum/cookingrecipe/oven/spaghetti_pg
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/ketchup
-	item3 = /obj/item/reagent_containers/food/snacks/pizza
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/pasta/spaghetti = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/ketchup = 1,
+	/obj/item/reagent_containers/food/snacks/pizza = 1)
 	cookbonus = 16
 	output = /obj/item/reagent_containers/food/snacks/spaghetti/pizzaghetti
 	category = "Pasta"
 
 /datum/cookingrecipe/oven/spooky_bread
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item3 = /obj/item/reagent_containers/food/snacks/ectoplasm
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ectoplasm = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/spooky
 	category = "Bread"
 
 /datum/cookingrecipe/oven/elvis_bread
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/plant/banana
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/peanutbutter
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/plant/banana = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/peanutbutter = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/elvis
 	category = "Bread"
 
 /datum/cookingrecipe/oven/banana_bread
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/plant/banana
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/sugar
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/plant/banana = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/sugar = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/banana
 	category = "Bread"
 
 /datum/cookingrecipe/oven/banana_bread_alt
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/plant/banana
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/plant/banana = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/banana
 	category = "Bread"
 
 /datum/cookingrecipe/oven/cornbread1
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/plant/corn
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/plant/corn = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/corn
 	category = "Bread"
 
 /datum/cookingrecipe/oven/cornbread2
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/plant/corn
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/plant/corn = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet
 	category = "Bread"
 
 /datum/cookingrecipe/oven/cornbread3
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/plant/corn
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/sugar
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/plant/corn = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/sugar = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet
 	category = "Bread"
 
 /datum/cookingrecipe/oven/cornbread4
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/plant/corn
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/honey
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/plant/corn = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/honey = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet/honey
 	category = "Bread"
 
 /datum/cookingrecipe/oven/pumpkin_bread
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/plant/pumpkin
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/plant/pumpkin = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/pumpkin
 	category = "Bread"
 
 /datum/cookingrecipe/oven/bread
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/dough = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/breadloaf
 	category = "Bread"
 
 /datum/cookingrecipe/oven/honeywheat_bread
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/honey
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/honey = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/honeywheat
 	category = "Bread"
 
 /datum/cookingrecipe/oven/brain_bread
-	item1 = /obj/item/reagent_containers/food/snacks/breadloaf
-	item2 = /obj/item/organ/brain
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/organ/brain = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/brain
 	category = "Bread"
 
 /datum/cookingrecipe/oven/toast_bread
-	item1 = /obj/item/reagent_containers/food/snacks/breadloaf
+	ingredients = list(/obj/item/reagent_containers/food/snacks/breadloaf = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/toast
 	category = "Bread"
 
 /datum/cookingrecipe/oven/toast
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
+	ingredients = list(/obj/item/reagent_containers/food/snacks/breadslice)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/breadslice/toastslice
 	category = "Toast"
 
 /datum/cookingrecipe/oven/toast_banana
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/banana
+	ingredients = list(/obj/item/reagent_containers/food/snacks/breadslice/banana)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/breadslice/toastslice/banana
 	category = "Toast"
 
 /datum/cookingrecipe/oven/toast_brain
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/brain
+	ingredients = list(/obj/item/reagent_containers/food/snacks/breadslice/brain)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/breadslice/toastslice/brain
 	category = "Toast"
 
 /datum/cookingrecipe/oven/toast_elvis
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/elvis
+	ingredients = list(/obj/item/reagent_containers/food/snacks/breadslice/elvis)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/breadslice/toastslice/elvis
 	category = "Toast"
 
 /datum/cookingrecipe/oven/toast_spooky
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/spooky
+	ingredients = list(/obj/item/reagent_containers/food/snacks/breadslice/spooky)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/breadslice/toastslice/spooky
 	category = "Toast"
 
 /datum/cookingrecipe/oven/toasted_french
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/french
+	ingredients = list(/obj/item/reagent_containers/food/snacks/breadslice/french)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/breadslice/toastslice/french
 	category = "Toast"
 
 /datum/cookingrecipe/oven/sandwich_m_h
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/humanmeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/humanmeat = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/meat_h
 	useshumanmeat = 1
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/sandwich_m_m
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/meat_m
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/sandwich_m_s
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/meat_s
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/sandwich_c
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
-	amt2 = 2
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 2)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/cheese
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/sandwich_p
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/peanutbutter
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/peanutbutter = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/pb
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/sandwich_p_h
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/peanutbutter
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/honey
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/peanutbutter = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/honey = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/pbh
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/sandwich_blt
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/tomatoslice
-	item4 = /obj/item/reagent_containers/food/snacks/plant/lettuce
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon= 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/tomatoslice = 1,
+	/obj/item/reagent_containers/food/snacks/plant/lettuce = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/blt
 	category = "Sandwich"
 
 
 /datum/cookingrecipe/oven/elviswich_m_h
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/elvis
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/humanmeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/elvis = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/humanmeat = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/elvis_meat_h
 	useshumanmeat = 1
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/c_butty
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/ketchup
-	item3 = /obj/item/reagent_containers/food/snacks/fries
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 2,
+	/obj/item/reagent_containers/food/snacks/condiment/ketchup = 1,
+	/obj/item/reagent_containers/food/snacks/fries = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/c_butty
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/elviswich_m_m
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/elvis
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/elvis = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/elvis_meat_m
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/elviswich_m_s
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/elvis
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/elvis = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/elvis_meat_s
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/elviswich_c
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/elvis
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
-	amt2 = 2
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/elvis = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 2)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/elvis_cheese
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/elviswich_p
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/elvis
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/peanutbutter
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/elvis = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/peanutbutter = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/elvis_pb
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/elviswich_p_h
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/elvis
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/peanutbutter
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/honey
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/elvis = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/peanutbutter = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/honey = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/elvis_pbh
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/elviswich_blt
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/elvis
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/tomatoslice
-	item4 = /obj/item/reagent_containers/food/snacks/plant/lettuce
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/elvis = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/tomatoslice = 1,
+	/obj/item/reagent_containers/food/snacks/plant/lettuce = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/elvis_blt
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/scarewich_c
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/spooky
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
-	amt2 = 2
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/spooky = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 2)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/spooky_cheese
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/scarewich_p
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/spooky
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/peanutbutter
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/spooky = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/peanutbutter = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/spooky_pb
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/scarewich_p_h
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/spooky
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/peanutbutter
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/honey
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/spooky = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/peanutbutter = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/honey = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/spooky_pbh
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/scarewich_h
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/spooky
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/humanmeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/spooky = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/humanmeat = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/spooky_meat_h
 	useshumanmeat = 1
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/scarewich_m
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/spooky
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/spooky = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/spooky_meat_m
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/scarewich_s
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/spooky
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/spooky = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/spooky_meat_s
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/scarewich_blt
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/spooky
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/tomatoslice
-	item4 = /obj/item/reagent_containers/food/snacks/plant/lettuce
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/spooky = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/tomatoslice = 1,
+	/obj/item/reagent_containers/food/snacks/plant/lettuce = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/spooky_blt
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/sandwich_mb //Original meatball sub recipe
-	item1 = /obj/item/reagent_containers/food/snacks/meatball
-	item2 = /obj/item/reagent_containers/food/snacks/breadloaf
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
-	item4 = /obj/item/reagent_containers/food/snacks/condiment/ketchup
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadloaf = 1,
+	/obj/item/reagent_containers/food/snacks/meatball = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/ketchup = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/sandwich/meatball
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/sandwich_mbalt //Secondary recipe that uses the baguette
-	item1 = /obj/item/reagent_containers/food/snacks/meatball
-	item2 = /obj/item/baguette
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
-	item4 = /obj/item/reagent_containers/food/snacks/condiment/ketchup
+	ingredients = list(\
+	/obj/item/baguette = 1,
+	/obj/item/reagent_containers/food/snacks/meatball = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/ketchup = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/sandwich/meatball
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/sandwich_egg
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/eggsalad
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 2,
+	/obj/item/reagent_containers/food/snacks/eggsalad = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/sandwich/eggsalad
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/sandwich_bm //Original banh mi recipe
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon/raw
-	item2 = /obj/item/reagent_containers/food/snacks/breadloaf/honeywheat
-	item3 = /obj/item/reagent_containers/food/snacks/plant/carrot
-	item4 = /obj/item/reagent_containers/food/snacks/plant/cucumber
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadloaf/honeywheat = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon/raw = 1,
+	/obj/item/reagent_containers/food/snacks/plant/carrot = 1,
+	/obj/item/reagent_containers/food/snacks/plant/cucumber = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/sandwich/banhmi
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/sandwich_bmalt //Secondary recipe that uses the baguette
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon/raw
-	item2 = /obj/item/baguette
-	item3 = /obj/item/reagent_containers/food/snacks/plant/carrot
-	item4 = /obj/item/reagent_containers/food/snacks/plant/cucumber
+	ingredients = list(\
+	/obj/item/baguette = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon/raw = 1,
+	/obj/item/reagent_containers/food/snacks/plant/carrot = 1,
+	/obj/item/reagent_containers/food/snacks/plant/cucumber = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/sandwich/banhmi
 	category = "Sandwich"
 
 /datum/cookingrecipe/oven/sandwich_custom
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	amt1 = 2
+	ingredients =  list(/obj/item/reagent_containers/food/snacks/breadslice = 2)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/sandwich
 	category = "Sandwich"
@@ -951,7 +997,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 		return customSandwich
 
 /datum/cookingrecipe/oven/pizza_custom
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/pizza_base
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/pizza_base = 1)
 	cookbonus = 18
 	output = /obj/item/reagent_containers/food/snacks/pizza/bespoke
 	category = "Pizza"
@@ -964,499 +1010,540 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 			return P.bake_pizza()
 
 /datum/cookingrecipe/oven/cheesetoast
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/toastcheese
 	category = "Toast (Meal)"
 
 
 /datum/cookingrecipe/oven/bacontoast
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/toastbacon
 	category = "Toast (Meal)"
 
 /datum/cookingrecipe/oven/eggtoast
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	amt2 = 2
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 2)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/toastegg
 	category = "Toast (Meal)"
 
 /datum/cookingrecipe/oven/elvischeesetoast
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/elvis
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/elvis = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/toastcheese/elvis
 	category = "Toast (Meal)"
 
 /datum/cookingrecipe/oven/elvisbacontoast
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/elvis
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/elvis = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/toastbacon/elvis
 	category = "Toast (Meal)"
 
 /datum/cookingrecipe/oven/elviseggtoast
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice/elvis
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	amt2 = 2
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice/elvis = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 2)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/toastegg/elvis
 	category = "Toast (Meal)"
 
 /datum/cookingrecipe/oven/breakfast
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	amt2 = 2
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 2)
 	cookbonus = 16
 	output = /obj/item/reagent_containers/food/snacks/breakfast
 
 /datum/cookingrecipe/mixer/wonton_wrapper
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/flour
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/flour = 2)
 	cookbonus = 1
 	output = /obj/item/reagent_containers/food/snacks/wonton_spawner
 
 /datum/cookingrecipe/oven/taco_shell
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/tortilla
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/tortilla = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/taco
 
 /datum/cookingrecipe/oven/eggnog
-	item1 = /obj/item/reagent_containers/food/drinks/milk
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	amt2 = 3
+	ingredients = list(\
+	/obj/item/reagent_containers/food/drinks/milk = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 3)
 	cookbonus = 3
 	output = /obj/item/reagent_containers/food/drinks/eggnog
 
 // Pastries and bread-likes
 
 /datum/cookingrecipe/oven/baguette
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_strip
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/flour
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_strip = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/flour = 1)
 	cookbonus = 8
 	output = /obj/item/baguette
 	category = "Pastries and bread-likes" // not sorry
 
 /datum/cookingrecipe/oven/garlicbread
-	item1 = /obj/item/baguette
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/butter
-	item3 = /obj/item/reagent_containers/food/snacks/plant/garlic
+	ingredients = list(\
+	/obj/item/baguette = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1,
+	/obj/item/reagent_containers/food/snacks/plant/garlic = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/garlicbread
 	category = "Pastries and bread-likes"
 
 /datum/cookingrecipe/oven/garlicbread_ch
-	item1 = /obj/item/baguette
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
-	item3 = /obj/item/reagent_containers/food/snacks/plant/garlic
-	item4 = /obj/item/reagent_containers/food/snacks/ingredient/butter
+	ingredients = list(\
+	/obj/item/baguette = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1,
+	/obj/item/reagent_containers/food/snacks/plant/garlic = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/garlicbread_ch
 	category = "Pastries and bread-likes"
 
 /datum/cookingrecipe/oven/painauchocolat
-	item1 = /obj/item/reagent_containers/food/snacks/candy/chocolate
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/butter
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/candy/chocolate = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/painauchocolat
 	category = "Pastries and bread-likes"
 
 /datum/cookingrecipe/oven/croissant
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/butter
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/croissant
 	category = "Pastries and bread-likes"
 
 /datum/cookingrecipe/oven/danish_apple
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/butter
-	item3 = /obj/item/reagent_containers/food/snacks/plant/apple
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1,
+	/obj/item/reagent_containers/food/snacks/plant/apple = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/danish_apple
 	category = "Pastries and bread-likes"
 
 /datum/cookingrecipe/oven/danish_cherry
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/butter
-	item3 = /obj/item/reagent_containers/food/snacks/plant/cherry
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1,
+	/obj/item/reagent_containers/food/snacks/plant/cherry = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/danish_cherry
 	category = "Pastries and bread-likes"
 
 /datum/cookingrecipe/oven/danish_blueb
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/butter
-	item3 = /obj/item/reagent_containers/food/snacks/plant/blueberry
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1,
+	/obj/item/reagent_containers/food/snacks/plant/blueberry = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/danish_blueb
 	category = "Pastries and bread-likes"
 
 /datum/cookingrecipe/oven/danish_weed
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/butter
-	item3 = /obj/item/plant/herb/cannabis
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1,
+	/obj/item/plant/herb/cannabis = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/danish_weed
 	category = "Pastries and bread-likes"
 
 /datum/cookingrecipe/oven/danish_cheese
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/butter
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/danish_cheese
 	category = "Pastries and bread-likes"
 
 /datum/cookingrecipe/oven/fairybread
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/sugar
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/butter
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/sugar = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/fairybread
 	category = "Pastries and bread-likes"
 
 /datum/cookingrecipe/oven/cinnamonbun
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/butter
-	item3 = /obj/item/reagent_containers/food/snacks/plant/cinnamon
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1,
+	/obj/item/reagent_containers/food/snacks/plant/cinnamon = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/cinnamonbun
 	category = "Pastries and bread-likes"
 
 /datum/cookingrecipe/oven/chocolate_cherry
-	item1 = /obj/item/reagent_containers/food/snacks/candy/chocolate
-	item2 = /obj/item/reagent_containers/food/snacks/plant/cherry
-	item3 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/candy/chocolate = 1,
+	/obj/item/reagent_containers/food/snacks/plant/cherry = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 3
 	output = /obj/item/reagent_containers/food/snacks/chocolate_cherry
 
 //Cookies
 /datum/cookingrecipe/oven/stroopwafel
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_cookie
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/syrup
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_cookie = 2,
+	/obj/item/reagent_containers/food/snacks/condiment/syrup = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/stroopwafel
 	category = "Cookies"
 
 /datum/cookingrecipe/oven/cookie
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_cookie
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/dough_cookie)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/cookie
 	category = "Cookies"
 
 /datum/cookingrecipe/oven/cookie_iron
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_cookie
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/ironfilings
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_cookie = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/ironfilings = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/cookie/metal
 	category = "Cookies"
 
 /datum/cookingrecipe/oven/cookie_chocolate_chip
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_cookie
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/chocchips
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_cookie = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/chocchips = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/cookie/chocolate_chip
 	category = "Cookies"
 
 /datum/cookingrecipe/oven/cookie_oatmeal
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_cookie
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/oatmeal
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_cookie = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/oatmeal = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/cookie/oatmeal
 	category = "Cookies"
 
 /datum/cookingrecipe/oven/cookie_bacon
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_cookie
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_cookie = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/cookie/bacon
 	category = "Cookies"
 
 /datum/cookingrecipe/oven/cookie_jaffa
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_cookie
-	item2 = /obj/item/reagent_containers/food/snacks/plant/orange
-	item3 = /obj/item/reagent_containers/food/snacks/candy/chocolate
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_cookie = 1,
+	/obj/item/reagent_containers/food/snacks/plant/orange = 1,
+	/obj/item/reagent_containers/food/snacks/candy/chocolate = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/cookie/jaffa
 	category = "Cookies"
 
 /datum/cookingrecipe/oven/cookie_spooky
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_cookie
-	item2 = /obj/item/reagent_containers/food/snacks/ectoplasm
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_cookie = 1,
+	/obj/item/reagent_containers/food/snacks/ectoplasm = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/cookie/spooky
 	category = "Cookies"
 
 /datum/cookingrecipe/oven/cookie_butter
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_cookie
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/butter
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_cookie = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/cookie/butter
 	category = "Cookies"
 
 /datum/cookingrecipe/oven/cookie_peanut
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_cookie
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/peanutbutter
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_cookie = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/peanutbutter = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/cookie/peanut
 	category = "Cookies"
 
 //Moon pies!
 /datum/cookingrecipe/oven/moon_pie
-	item1 = /obj/item/reagent_containers/food/snacks/cookie
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cookie = 2,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/moon_pie
 	category = "Moon Pies"
 
 /datum/cookingrecipe/oven/moon_pie_iron
-	item1 = /obj/item/reagent_containers/food/snacks/cookie/metal
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cookie/metal = 2,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/moon_pie/metal
 	category = "Moon Pies"
 
 /datum/cookingrecipe/oven/moon_pie_chips
-	item1 = /obj/item/reagent_containers/food/snacks/cookie/chocolate_chip
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cookie/chocolate_chip = 2,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/moon_pie/chocolate_chip
 	category = "Moon Pies"
 
 /datum/cookingrecipe/oven/moon_pie_oatmeal
-	item1 = /obj/item/reagent_containers/food/snacks/cookie/oatmeal
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cookie/oatmeal = 2,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/moon_pie/oatmeal
 	category = "Moon Pies"
 
 /datum/cookingrecipe/oven/moon_pie_bacon
-	item1 = /obj/item/reagent_containers/food/snacks/cookie/bacon
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cookie/bacon = 2,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/moon_pie/bacon
 	category = "Moon Pies"
 
 /datum/cookingrecipe/oven/moon_pie_jaffa
-	item1 = /obj/item/reagent_containers/food/snacks/cookie/jaffa
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cookie/jaffa = 2,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/moon_pie/jaffa
 	category = "Moon Pies"
 
 /datum/cookingrecipe/oven/moon_pie_spooky
-	item1 = /obj/item/reagent_containers/food/snacks/cookie/spooky
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cookie/spooky = 2,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/moon_pie/spooky
 	category = "Moon Pies"
 
 /datum/cookingrecipe/oven/moon_pie_chocolate
-	item1 = /obj/item/reagent_containers/food/snacks/cookie/chocolate_chip
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
-	item3 = /obj/item/reagent_containers/food/snacks/candy/chocolate
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cookie/chocolate_chip = 2,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1,
+	/obj/item/reagent_containers/food/snacks/candy/chocolate = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/moon_pie/chocolate
 	category = "Moon Pies"
 
 /datum/cookingrecipe/oven/onionchips
-	item1 = /obj/item/reagent_containers/food/snacks/onion_slice
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/plant/garlic
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/onion_slice = 2,
+	/obj/item/reagent_containers/food/snacks/plant/garlic = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheese = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/onionchips
 
 /datum/cookingrecipe/oven/fries
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/chips
+	ingredients = (/obj/item/reagent_containers/food/snacks/ingredient/chips)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/fries
 
 /datum/cookingrecipe/oven/chilifries
-	item1 = /obj/item/reagent_containers/food/snacks/fries
-	item2 = /obj/item/reagent_containers/food/snacks/plant/chili
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/fries = 1,
+	/obj/item/reagent_containers/food/snacks/plant/chili = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheese = 1)
 	cookbonus = 3
 	output = /obj/item/reagent_containers/food/snacks/chilifries
 
 /datum/cookingrecipe/oven/chilifries_alt //Secondary recipe for chili cheese fries
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/chips
-	item2 = /obj/item/reagent_containers/food/snacks/plant/chili
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/chips = 1,
+	/obj/item/reagent_containers/food/snacks/plant/chili = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheese = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/chilifries
 
 /datum/cookingrecipe/oven/poutine
-	item1 = /obj/item/reagent_containers/food/snacks/fries
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/gravyboat
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/fries = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/gravyboat = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheese = 1)
 	cookbonus = 3
 	output = /obj/item/reagent_containers/food/snacks/chilifries/poutine
 
 /datum/cookingrecipe/oven/poutine_alt
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/chips
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/gravyboat
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/chips = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/gravyboat = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheese = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/chilifries/poutine
 
 /datum/cookingrecipe/oven/bakedpotato
-	item1 = /obj/item/reagent_containers/food/snacks/plant/potato
+	ingredients = list(/obj/item/reagent_containers/food/snacks/plant/potato)
 	cookbonus = 16
 	output = /obj/item/reagent_containers/food/snacks/bakedpotato
 
 /datum/cookingrecipe/oven/hotdog
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meatpaste
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/meatpaste)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/hotdog
 
 /datum/cookingrecipe/oven/steak_h
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/humanmeat
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/meat/humanmeat)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/steak_h
 	useshumanmeat = 1
 
 /datum/cookingrecipe/oven/steak_m
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/steak_m
 
 /datum/cookingrecipe/oven/steak_s
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/steak_s
 
 /datum/cookingrecipe/oven/steak_ling
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/changeling
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/changeling)
 	cookbonus = 12 // tough meat
 	output = /obj/item/reagent_containers/food/snacks/steak_ling
 
 /datum/cookingrecipe/oven/fish_fingers
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/fish_fingers
 
 /datum/cookingrecipe/oven/shrimp
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/fish/shrimp
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/meat/fish/shrimp)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/shrimp
 
 /datum/cookingrecipe/oven/bacon
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon/raw
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon/raw)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon
 
 /datum/cookingrecipe/oven/turkey
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/turkey
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/turkey)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/turkey
 
 /datum/cookingrecipe/oven/pie_strawberry
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/plant/strawberry
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/plant/strawberry = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/pie/strawberry
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_cherry
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/plant/cherry
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/plant/cherry = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/pie/cherry
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_blueberry
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/plant/blueberry
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/plant/blueberry = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/pie/blueberry
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_raspberry
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/plant/raspberry
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/plant/raspberry = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/pie/raspberry
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_blackberry
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/plant/raspberry/blackberry
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/plant/raspberry/blackberry = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/pie/blackberry
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_apple
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/plant/apple
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/plant/apple = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/pie/apple
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_lime
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/plant/lime
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/plant/lime = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/pie/lime
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_lemon
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/plant/lemon
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/plant/lemon = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/pie/lemon
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_slurry
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/plant/slurryfruit
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/plant/slurryfruit = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/pie/slurry
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_pumpkin
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/plant/pumpkin
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/plant/pumpkin = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/pie/pumpkin
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_chocolate
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/candy/chocolate
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/candy/chocolate = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/pie/chocolate
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_anything/pie_cream
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/pie/cream
 	category = "Pies"
 	base_pie_name = "cream pie"
 
 /datum/cookingrecipe/oven/pie_anything
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/egg
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/pie/anything
 	category = "Pies"
@@ -1478,11 +1565,11 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 		var/found2 = 0
 		for (var/obj/item/T in ourCooker.contents)
 
-			if (T.type == item1 && !found1)
+			if (T.type == ingredients[1] && !found1)
 				found1 = TRUE
 				continue
 
-			if (T.type == item2 && !found2)
+			if (T.type == ingredients[2] && !found2)
 				found2 = TRUE
 				continue
 
@@ -1528,199 +1615,213 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 		return custom_pie
 
 /datum/cookingrecipe/oven/pie_custard
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/custard
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/custard = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/pie/custard
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_bacon
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/pie/bacon
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_ass
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/clothing/head/butt
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/clothing/head/butt = 1)
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/pie/ass
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pot_pie
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget
-	item3 = /obj/item/reagent_containers/food/snacks/plant/carrot
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget = 1,
+	/obj/item/reagent_containers/food/snacks/plant/carrot = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/pie/pot
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_weed
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget
-	item3 = /obj/item/plant/herb/cannabis
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget = 1,
+	/obj/item/plant/herb/cannabis = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/pie/weed
 	category = "Pies"
 
 /datum/cookingrecipe/oven/pie_fish
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet
-	item3 = /obj/item/reagent_containers/food/snacks/plant/potato
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet = 1,
+	/obj/item/reagent_containers/food/snacks/plant/potato = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/pie/fish
 	category = "Pies"
 
 /datum/cookingrecipe/mixer/custard
-	item1 = /obj/item/reagent_containers/food/drinks/milk
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/egg
+	ingredients = list(\
+	/obj/item/reagent_containers/food/drinks/milk = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/condiment/custard
 
 /datum/cookingrecipe/mixer/gruel
-	item1 = /obj/item/reagent_containers/food/snacks/yuck
-	amt1 = 3
+	ingredients = list(/obj/item/reagent_containers/food/snacks/yuck = 3)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/soup/gruel
 
 /datum/cookingrecipe/oven/porridge
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/rice
-	amt1 = 2
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/rice = 2)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/soup/porridge
 
 /datum/cookingrecipe/oven/oatmeal
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/oatmeal
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/oatmeal)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/soup/oatmeal
 
 /datum/cookingrecipe/oven/tomsoup
-	item1 = /obj/item/reagent_containers/food/snacks/plant/tomato
-	amt1 = 2
+	ingredients = list(/obj/item/reagent_containers/food/snacks/plant/tomato = 2)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/soup/tomato
 
 /datum/cookingrecipe/oven/mint_chutney
-	item1 = /obj/item/plant/herb/mint
-	item2 = /obj/item/reagent_containers/food/snacks/plant/chili
-	item3 = /obj/item/reagent_containers/food/snacks/plant/garlic
-	item4 = /obj/item/reagent_containers/food/snacks/plant/onion
+	ingredients = list(\
+	/obj/item/plant/herb/mint = 1,
+	/obj/item/reagent_containers/food/snacks/plant/chili = 1,
+	/obj/item/reagent_containers/food/snacks/plant/garlic = 1,
+	/obj/item/reagent_containers/food/snacks/plant/onion = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/soup/mint_chutney
 
 /datum/cookingrecipe/oven/refried_beans
-	item1 = /obj/item/reagent_containers/food/snacks/plant/bean
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/plant/bean = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/soup/refried_beans
 
 /datum/cookingrecipe/oven/chili
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat
-	item2 = /obj/item/reagent_containers/food/snacks/plant/chili
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 1,
+	/obj/item/reagent_containers/food/snacks/plant/chili = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/soup/chili
 
 /datum/cookingrecipe/oven/queso
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
-	item2 = /obj/item/reagent_containers/food/snacks/plant/chili
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/cheese = 1,
+	/obj/item/reagent_containers/food/snacks/plant/chili = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/soup/queso
 
 /datum/cookingrecipe/oven/superchili
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat
-	item2 = /obj/item/reagent_containers/food/snacks/plant/chili
-	item3 = /obj/item/reagent_containers/food/snacks/condiment/hotsauce
-	amt3 = 2
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 1,
+	/obj/item/reagent_containers/food/snacks/plant/chili = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/hotsauce = 2)
 	cookbonus = 16
 	output = /obj/item/reagent_containers/food/snacks/soup/superchili
 
 /datum/cookingrecipe/oven/ultrachili
-	item1 = /obj/item/reagent_containers/food/snacks/soup/chili
-	item2 = /obj/item/reagent_containers/food/snacks/soup/superchili
-	item3 = /obj/item/reagent_containers/food/snacks/plant/chili
-	item4 = /obj/item/reagent_containers/food/snacks/condiment/hotsauce
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 1,
+	/obj/item/reagent_containers/food/snacks/soup/superchili = 1,
+	/obj/item/reagent_containers/food/snacks/plant/chili = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/hotsauce = 1)
 	cookbonus = 20
 	output = /obj/item/reagent_containers/food/snacks/soup/ultrachili
 
 /datum/cookingrecipe/oven/salad
-	item1 = /obj/item/reagent_containers/food/snacks/plant/lettuce
-	amt1 = 2
+	ingredients = list(/obj/item/reagent_containers/food/snacks/plant/lettuce = 2)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/salad
 
 /datum/cookingrecipe/oven/creamofamanita
-	item1 = /obj/item/reagent_containers/food/snacks/mushroom/amanita
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/mushroom/amanita = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/soup/creamofmushroom/amanita
 
 /datum/cookingrecipe/oven/creamofpsilocybin
-	item1 = /obj/item/reagent_containers/food/snacks/mushroom/psilocybin
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/mushroom/psilocybin = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/soup/creamofmushroom/psilocybin
 
 /datum/cookingrecipe/oven/creamofmushroom
-	item1 = /obj/item/reagent_containers/food/snacks/mushroom
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/mushroom = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/soup/creamofmushroom
 
 //Delightful Halloween Recipes
 /datum/cookingrecipe/oven/candy_apple
-	item1 = /obj/item/reagent_containers/food/snacks/plant/apple/stick
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/sugar
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/plant/apple/stick = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/sugar = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/candy/candy_apple
 
 /datum/cookingrecipe/oven/candy_apple_poison
-	item1 = /obj/item/reagent_containers/food/snacks/plant/apple/stick/poison
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/sugar
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/plant/apple/stick/poison = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/sugar = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/candy/candy_apple/poison
 
 //Cakes!
 /datum/cookingrecipe/mixer/cake_batter
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	amt2 = 2
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 2)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/cake_batter
 
 /datum/cookingrecipe/oven/cake_cream
-	item1 = /obj/item/reagent_containers/food/snacks/cake_batter
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cake_batter = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/cream = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/cake/cream
 	category = "Cakes"
 
 /datum/cookingrecipe/oven/cake_chocolate
-	item1 = /obj/item/reagent_containers/food/snacks/cake_batter
-	item2 = /obj/item/reagent_containers/food/snacks/candy/chocolate
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cake_batter = 1,
+	/obj/item/reagent_containers/food/snacks/candy/chocolate = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/cake/chocolate
 	category = "Cakes"
 
 /datum/cookingrecipe/oven/cake_meat
-	item1 = /obj/item/reagent_containers/food/snacks/cake_batter
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cake_batter = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/cake/meat
 	category = "Cakes"
 
 /datum/cookingrecipe/oven/cake_bacon
-	item1 = /obj/item/reagent_containers/food/snacks/cake_batter
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon
-	amt2 = 3
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cake_batter = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon = 3)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/cake/bacon
 	category = "Cakes"
 
 /datum/cookingrecipe/oven/cake_true_bacon
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/bacon
-	amt1 = 7
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/meat/bacon = 7)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/cake/true_bacon
 	category = "Cakes"
@@ -1728,8 +1829,9 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 #ifdef XMAS
 
 /datum/cookingrecipe/oven/cake_fruit
-	item1 = /obj/item/reagent_containers/food/snacks/yuck/burn
-	item2 = /obj/item/reagent_containers/food/snacks/yuck
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/yuck = 1,
+	/obj/item/reagent_containers/food/snacks/yuck/burn = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/fruit_cake
 	category = "Cakes"
@@ -1746,7 +1848,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 #endif
 
 /datum/cookingrecipe/oven/cake_custom
-	item1 = /obj/item/reagent_containers/food/snacks/cake_batter
+	ingredients = list(/obj/item/reagent_containers/food/snacks/cake_batter = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/cake
 	category = "Cakes"
@@ -1787,7 +1889,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 
 
 /datum/cookingrecipe/oven/cake_custom_item
-	item1 = /obj/item/reagent_containers/food/snacks/cake/cream
+	ingredients = list(/obj/item/reagent_containers/food/snacks/cake/cream = 1)
 	cookbonus = 14
 	output = /obj/item/cake_item
 	category = "Cakes"
@@ -1806,8 +1908,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 		return B
 
 /datum/cookingrecipe/mixer/mix_cake_custom
-	item1 = /obj/item/reagent_containers/food/snacks/cake_batter
-	amt1 = 1
+	ingredients = list(/obj/item/reagent_containers/food/snacks/cake_batter = 1)
 	output = null
 
 	specialOutput(var/obj/submachine/ourCooker)
@@ -1815,7 +1916,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 			return null
 
 		for (var/obj/item/I in ourCooker.contents)
-			if (istype(I, item1))
+			if (istype(I, ingredients[1]))
 				continue
 			else if (istype(I,/obj/item/reagent_containers/food/snacks/))
 				var/obj/item/reagent_containers/food/snacks/cake_batter/batter = new
@@ -1832,134 +1933,139 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 
 
 /datum/cookingrecipe/oven/omelette
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/omelette
 
 /datum/cookingrecipe/oven/omelette_bee
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/egg/bee
-	amt1 = 2
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/egg/bee = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/omelette/bee
 
 /datum/cookingrecipe/mixer/pancake_batter
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/drinks/milk
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	amt3 = 2
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/drinks/milk = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 2)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/ingredient/pancake_batter
 
 /datum/cookingrecipe/oven/pancake
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/pancake_batter
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/pancake_batter = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/pancake
 
 /datum/cookingrecipe/mixer/mashedpotatoes
-	item1 = /obj/item/reagent_containers/food/snacks/plant/potato
-	amt1 = 3
+	ingredients = list(/obj/item/reagent_containers/food/snacks/plant/potato = 3)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/mashedpotatoes
 
 /datum/cookingrecipe/mixer/mashedbrains
-	item1 = /obj/item/organ/brain
+	ingredients = list(/obj/item/organ/brain = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/mashedbrains
 
 /datum/cookingrecipe/mixer/meatpaste
-	item1 =  /obj/item/reagent_containers/food/snacks/ingredient/meat
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/meat)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/ingredient/meatpaste
 
 /datum/cookingrecipe/mixer/soysauce
-	item1 =  /obj/item/reagent_containers/food/snacks/plant/soy
+	ingredients = list(/obj/item/reagent_containers/food/snacks/plant/soy)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/condiment/soysauce
 
 /datum/cookingrecipe/mixer/gravy
-	item1 =  /obj/item/reagent_containers/food/snacks/ingredient/meatpaste
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/flour
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/meatpaste = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/flour = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/condiment/gravyboat
 
 /datum/cookingrecipe/mixer/fishpaste
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/ingredient/fishpaste
 
 /datum/cookingrecipe/oven/burger/sloppyjoe
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meatpaste
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meatpaste = 1)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/burger/sloppyjoe
 
 /datum/cookingrecipe/oven/meatloaf
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meatpaste
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	item3 = /obj/item/reagent_containers/food/snacks/breadloaf
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/meatpaste = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 1,
+	/obj/item/reagent_containers/food/snacks/breadloaf = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/meatloaf
 
 /datum/cookingrecipe/oven/cereal_box
-    item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-    item2 = /obj/item/reagent_containers/food/snacks/condiment/chocchips
-    cookbonus = 4
-    output = /obj/item/reagent_containers/food/snacks/cereal_box
-
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/chocchips = 1)
+	cookbonus = 4
+	output = /obj/item/reagent_containers/food/snacks/cereal_box
 
 /datum/cookingrecipe/oven/cereal_honey
-    item1 = /obj/item/reagent_containers/food/snacks/cereal_box
-    item2 = /obj/item/reagent_containers/food/snacks/ingredient/honey
-    cookbonus = 4
-    output = /obj/item/reagent_containers/food/snacks/cereal_box/honey
-
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cereal_box = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/honey = 1)
+	cookbonus = 4
+	output = /obj/item/reagent_containers/food/snacks/cereal_box/honey
 
 /datum/cookingrecipe/oven/cereal_tanhony
-    item1 = /obj/item/reagent_containers/food/snacks/cereal_box
-    item2 = /obj/item/reagent_containers/food/snacks/plant/banana
-    cookbonus = 4
-    output = /obj/item/reagent_containers/food/snacks/cereal_box/tanhony
-
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cereal_box = 1,
+	/obj/item/reagent_containers/food/snacks/plant/banana = 1)
+	cookbonus = 4
+	output = /obj/item/reagent_containers/food/snacks/cereal_box/tanhony
 
 /datum/cookingrecipe/oven/cereal_roach
-    item1 = /obj/item/reagent_containers/food/snacks/cereal_box
-    item2 = /obj/item/reagent_containers/food/snacks/candy/chocolate
-    cookbonus = 4
-    output = /obj/item/reagent_containers/food/snacks/cereal_box/roach
-
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cereal_box = 1,
+	/obj/item/reagent_containers/food/snacks/candy/chocolate = 1)
+	cookbonus = 4
+	output = /obj/item/reagent_containers/food/snacks/cereal_box/roach
 
 /datum/cookingrecipe/oven/cereal_syndie
-    item1 = /obj/item/reagent_containers/food/snacks/cereal_box
-    item2 = /obj/item/uplink_telecrystal
-    cookbonus = 4
-    output = /obj/item/reagent_containers/food/snacks/cereal_box/syndie
-
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cereal_box = 1,
+	/obj/item/uplink_telecrystal = 1)
+	cookbonus = 4
+	output = /obj/item/reagent_containers/food/snacks/cereal_box/syndie
 
 /datum/cookingrecipe/oven/cereal_flock
-    item1 = /obj/item/reagent_containers/food/snacks/cereal_box
-    item2 = /obj/item/organ/brain/flockdrone
-    cookbonus = 4
-    output = /obj/item/reagent_containers/food/snacks/cereal_box/flock
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/cereal_box = 1,
+	/obj/item/organ/brain/flockdrone = 1)
+	cookbonus = 4
+	output = /obj/item/reagent_containers/food/snacks/cereal_box/flock
 
 /datum/cookingrecipe/oven/granola_bar
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/honey
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/oatmeal
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/honey = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/oatmeal = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/granola_bar
 
 /datum/cookingrecipe/oven/hardboiled
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/egg
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/egg)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/ingredient/egg/hardboiled
 
 /datum/cookingrecipe/oven/chocolate_egg
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	item2 = /obj/item/reagent_containers/food/snacks/candy/chocolate
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 1,
+	/obj/item/reagent_containers/food/snacks/candy/chocolate = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/ingredient/egg/chocolate
 
@@ -1967,7 +2073,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 		if (!length(ourCooker.contents))
 			return new src.output()
 		for (var/obj/item/item in ourCooker.contents)
-			if (istypes(item, list(src.item1, src.item2)))
+			if (istypes(item, list(src.ingredients[1], src.ingredients[2])))
 				continue
 			if (item.w_class > W_CLASS_SMALL)
 				continue
@@ -1977,228 +2083,253 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 			return choc_egg
 
 /datum/cookingrecipe/oven/eggsalad
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/egg/hardboiled
-	item2 = /obj/item/reagent_containers/food/snacks/salad
-	item3 = /obj/item/reagent_containers/food/snacks/condiment/mayo
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/egg/hardboiled = 1,
+	/obj/item/reagent_containers/food/snacks/salad = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/mayo = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/eggsalad
 
 /datum/cookingrecipe/oven/biscuit
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/flour
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/flour = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/biscuit
 
 /datum/cookingrecipe/oven/dog_biscuit
-	item1 = /obj/item/reagent_containers/food/snacks/granola_bar
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meatpaste
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/peanutbutter
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/granola_bar = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meatpaste = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/peanutbutter = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/cookie/dog
 
 /datum/cookingrecipe/oven/hardtack
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/ironfilings
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/ironfilings = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/hardtack
 
 /datum/cookingrecipe/oven/macguffin
-	item1 = /obj/item/reagent_containers/food/snacks/emuffin
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/cheeseslice
-	item4 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	amt1 = 2
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/emuffin = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/cheeseslice = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 2)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/macguffin
 
 /datum/cookingrecipe/oven/haggis
-	item1 = /obj/item/organ
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/oatmeal
-	item3 = /obj/item/reagent_containers/food/snacks/plant/onion
+	ingredients = list(\
+	/obj/item/organ = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/oatmeal = 1,
+	/obj/item/reagent_containers/food/snacks/plant/onion = 1)
 	cookbonus = 18
 	output = /obj/item/reagent_containers/food/snacks/haggis
 
 /datum/cookingrecipe/oven/haggass
-	item1 = /obj/item/clothing/head/butt
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/oatmeal
-	item3 = /obj/item/reagent_containers/food/snacks/plant/onion
+	ingredients = list(\
+	/obj/item/clothing/head/butt = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/oatmeal = 1,
+	/obj/item/reagent_containers/food/snacks/plant/onion = 1)
 	cookbonus = 18
 	output = /obj/item/reagent_containers/food/snacks/haggis/ass
 
 /datum/cookingrecipe/oven/scotch_egg
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/egg
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/scotch_egg
 
 /datum/cookingrecipe/oven/rice_ball
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/rice
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/rice = 1)
 	cookbonus = 5
 	output = /obj/item/reagent_containers/food/snacks/rice_ball
 
 /datum/cookingrecipe/oven/nigiri_roll
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet_slice
-	item2 = /obj/item/reagent_containers/food/snacks/rice_ball
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet_slice = 1,
+	/obj/item/reagent_containers/food/snacks/rice_ball = 1)
 	cookbonus = 2
 	output = /obj/item/reagent_containers/food/snacks/nigiri_roll
 
 /datum/cookingrecipe/oven/sushi_roll
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet
-	item2 = /obj/item/reagent_containers/food/snacks/rice_ball
-	amt2 = 2
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/seaweed
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/fish/fillet= 1,
+	/obj/item/reagent_containers/food/snacks/rice_ball = 2,
+	/obj/item/reagent_containers/food/snacks/ingredient/seaweed = 1)
 	cookbonus = 2
 	output = /obj/item/reagent_containers/food/snacks/sushi_roll
 
 /datum/cookingrecipe/oven/riceandbeans
-	item1 = /obj/item/reagent_containers/food/snacks/plant/bean
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/rice
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/plant/bean = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/rice = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/riceandbeans
 
 /datum/cookingrecipe/oven/friedrice
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/rice
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	item3 = /obj/item/reagent_containers/food/snacks/plant/onion
-	item4 = /obj/item/reagent_containers/food/snacks/plant/garlic
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/rice = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 1,
+	/obj/item/reagent_containers/food/snacks/plant/onion = 1,
+	/obj/item/reagent_containers/food/snacks/plant/garlic = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/friedrice
 
 /datum/cookingrecipe/oven/omurice
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/rice
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	item3 = /obj/item/reagent_containers/food/snacks/condiment/ketchup
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/rice = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/ketchup = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/omurice
 
 /datum/cookingrecipe/oven/risotto
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/rice
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/butter
-	item3 = /obj/item/reagent_containers/food/snacks/plant/onion
-	item4 = /obj/item/reagent_containers/food/snacks/plant/garlic
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/rice = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 1,
+	/obj/item/reagent_containers/food/snacks/plant/onion = 1,
+	/obj/item/reagent_containers/food/snacks/plant/garlic = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/risotto
 
 /datum/cookingrecipe/oven/tandoorichicken
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/currypowder
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget
-	item3 = /obj/item/reagent_containers/food/snacks/plant/chili
-	item4 = /obj/item/reagent_containers/food/snacks/plant/garlic
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/currypowder = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget = 1,
+	/obj/item/reagent_containers/food/snacks/plant/chili = 1,
+	/obj/item/reagent_containers/food/snacks/plant/garlic = 1)
 	cookbonus = 18
 	output = /obj/item/reagent_containers/food/snacks/tandoorichicken
 
 /datum/cookingrecipe/oven/potatocurry
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/currypowder
-	item2 = /obj/item/reagent_containers/food/snacks/plant/potato
-	item3 = /obj/item/reagent_containers/food/snacks/plant/carrot
-	item4 = /obj/item/reagent_containers/food/snacks/plant/peas
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/currypowder = 1,
+	/obj/item/reagent_containers/food/snacks/plant/potato = 1,
+	/obj/item/reagent_containers/food/snacks/plant/carrot = 1,
+	/obj/item/reagent_containers/food/snacks/plant/peas = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/potatocurry
 
 /datum/cookingrecipe/oven/coconutcurry
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/currypowder
-	item2 = /obj/item/reagent_containers/food/snacks/plant/coconutmeat
-	item3 = /obj/item/reagent_containers/food/snacks/plant/carrot
-	item4 = /obj/item/reagent_containers/food/snacks/ingredient/rice
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/currypowder = 1,
+	/obj/item/reagent_containers/food/snacks/plant/coconutmeat = 1,
+	/obj/item/reagent_containers/food/snacks/plant/carrot = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/rice = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/coconutcurry
 
 /datum/cookingrecipe/oven/chickenpineapplecurry
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/currypowder
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget
-	item3 = /obj/item/reagent_containers/food/snacks/plant/chili
-	item4 = /obj/item/reagent_containers/food/snacks/plant/pineappleslice
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/currypowder = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget = 1,
+	/obj/item/reagent_containers/food/snacks/plant/chili = 1,
+	/obj/item/reagent_containers/food/snacks/plant/pineappleslice = 1)
 	cookbonus = 7
 	output = /obj/item/reagent_containers/food/snacks/chickenpineapplecurry
 
 /datum/cookingrecipe/oven/ramen_bowl
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/wheat_noodles/ramen
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/soysauce
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/seaweed
-	item4 = /obj/item/reagent_containers/food/snacks/ingredient/egg/hardboiled
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/wheat_noodles/ramen = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/soysauce = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/seaweed = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg/hardboiled = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/ramen_bowl
 
 /datum/cookingrecipe/oven/udon_bowl
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/wheat_noodles/udon
-	item2 = /obj/item/reagent_containers/food/snacks/condiment/soysauce
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/seaweed
-	item4 = /obj/item/reagent_containers/food/snacks/ingredient/kamaboko
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/wheat_noodles/udon = 1,
+	/obj/item/reagent_containers/food/snacks/condiment/soysauce = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/seaweed = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/kamaboko = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/udon_bowl
 
 /datum/cookingrecipe/oven/curry_udon_bowl
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/wheat_noodles/udon
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/currypowder
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/seaweed
-	item4 = /obj/item/reagent_containers/food/snacks/ingredient/egg/hardboiled
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/wheat_noodles/ramen = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/currypowder = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/seaweed = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg/hardboiled = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/curry_udon_bowl
 
 /datum/cookingrecipe/oven/mapo_tofu_meat
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat
-	item2 = /obj/item/reagent_containers/food/snacks/plant/chili
-	item3 = /obj/item/reagent_containers/food/snacks/plant/soy
-	item4 = /obj/item/reagent_containers/food/snacks/plant/onion
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat = 1,
+	/obj/item/reagent_containers/food/snacks/plant/chili = 1,
+	/obj/item/reagent_containers/food/snacks/plant/soy = 1,
+	/obj/item/reagent_containers/food/snacks/plant/onion = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/mapo_tofu_meat
 
 /datum/cookingrecipe/oven/mapo_tofu_synth
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat
-	item2 = /obj/item/reagent_containers/food/snacks/plant/chili
-	item3 = /obj/item/reagent_containers/food/snacks/plant/soy
-	item4 = /obj/item/reagent_containers/food/snacks/plant/onion
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat = 1,
+	/obj/item/reagent_containers/food/snacks/plant/chili = 1,
+	/obj/item/reagent_containers/food/snacks/plant/soy = 1,
+	/obj/item/reagent_containers/food/snacks/plant/onion = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/mapo_tofu_synth
 
 /datum/cookingrecipe/oven/cheesewheel
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/cheese
-	amt1 = 2
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/cheese = 2)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/cheesewheel
 
 /datum/cookingrecipe/oven/ratatouille
-	item1 = /obj/item/reagent_containers/food/snacks/plant/cucumber
-	item2 = /obj/item/reagent_containers/food/snacks/plant/tomato
-	item3 = /obj/item/reagent_containers/food/snacks/plant/eggplant
-	item4 = /obj/item/reagent_containers/food/snacks/plant/garlic
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/plant/cucumber = 1,
+	/obj/item/reagent_containers/food/snacks/plant/tomato = 1,
+	/obj/item/reagent_containers/food/snacks/plant/eggplant = 1,
+	/obj/item/reagent_containers/food/snacks/plant/garlic = 1)
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/ratatouille
 
 /datum/cookingrecipe/oven/churro
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_strip
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/sugar
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_strip = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/sugar = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/dippable/churro
 
 /datum/cookingrecipe/oven/french_toast
-	item1 = /obj/item/reagent_containers/food/snacks/breadslice
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	amt2 = 2
-	item3 = /obj/item/reagent_containers/food/drinks/milk
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/breadslice = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 2,
+	/obj/item/reagent_containers/food/drinks/milk = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/french_toast
 
 /datum/cookingrecipe/oven/zongzi
-	item1 = /obj/item/reagent_containers/food/snacks/plant/bamboo
-	item2 = /obj/item/reagent_containers/food/snacks/rice_ball
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/meat
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/plant/bamboo = 1,
+	/obj/item/reagent_containers/food/snacks/rice_ball = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat = 1)
 	cookbonus = 8
 	output = /obj/item/reagent_containers/food/snacks/zongzi
 
 /datum/cookingrecipe/oven/beefood
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/honey
-	item2 = /obj/item/plant/wheat
-	item3 = /obj/item/reagent_containers/food/snacks/yuck
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/honey = 1,
+	/obj/item/plant/wheat = 1,
+	/obj/item/reagent_containers/food/snacks/yuck = 1)
 	cookbonus = 22
 	output = /obj/item/reagent_containers/food/snacks/beefood
 
 /datum/cookingrecipe/oven/b_cupcake
-	item1 = /obj/item/reagent_containers/food/snacks/beefood
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/sugar
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/royal_jelly
-	item4 = /obj/item/device/light/candle/small
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/beefood = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/sugar = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/royal_jelly = 1,
+	/obj/item/device/light/candle/small = 1)
 	cookbonus = 22
 	output = /obj/item/reagent_containers/food/snacks/b_cupcake
 
@@ -2217,14 +2348,16 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 		return b_cupcake
 
 /datum/cookingrecipe/mixer/butters
-	item1 = /obj/item/clothing/head/butt
-	item2 = /obj/item/reagent_containers/food/drinks/milk
+	ingredients = list(\
+	/obj/item/clothing/head/butt = 1,
+	/obj/item/reagent_containers/food/drinks/milk = 1)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/condiment/butters
 
 /datum/cookingrecipe/oven/lipstick
-	item1 = /obj/item/pen/crayon
-	item2 = /obj/item/item_box/figure_capsule
+	ingredients = list(\
+	/obj/item/pen/crayon = 1,
+	/obj/item/item_box/figure_capsule = 1)
 	cookbonus = 10
 	output = /obj/item/pen/crayon/lipstick
 
@@ -2240,28 +2373,30 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 		return lipstick
 
 /datum/cookingrecipe/oven/melted_sugar
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/sugar
-	item2 = /obj/item/plate/tray
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/sugar = 1,
+	/obj/item/plate/tray = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/ingredient/melted_sugar
 
 /datum/cookingrecipe/mixer/brownie_batter
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/egg
-	amt2 = 2
-	item3 = /obj/item/reagent_containers/food/snacks/candy/chocolate
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/dough_s = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/egg = 2,
+	/obj/item/reagent_containers/food/snacks/candy/chocolate = 1)
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/ingredient/brownie_batter
 
 /datum/cookingrecipe/oven/brownie_batch
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/brownie_batter
+	ingredients = list(/obj/item/reagent_containers/food/snacks/ingredient/brownie_batter)
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/dessert_batch/brownie
 
 /datum/cookingrecipe/oven/flapjack_batch
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/oatmeal
-	item2 = /obj/item/reagent_containers/food/snacks/ingredient/butter
-	item3 = /obj/item/reagent_containers/food/snacks/condiment/syrup //technically this should be GOLDEN syrup but this works too
+	ingredients = list(\
+	/obj/item/reagent_containers/food/snacks/ingredient/oatmeal = 1,
+	/obj/item/reagent_containers/food/snacks/ingredient/butter = 2,
+	/obj/item/reagent_containers/food/snacks/condiment/syrup = 1) //technically this should be GOLDEN syrup but this works too
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/dessert_batch/flapjack
 

--- a/code/obj/machinery/food_and_drink/mixer.dm
+++ b/code/obj/machinery/food_and_drink/mixer.dm
@@ -36,7 +36,7 @@ TYPEINFO(/obj/machinery/mixer)
 			src.recipes = list()
 
 		if (!src.recipes.len)
-/*			src.recipes += new /datum/cookingrecipe/mixer/mix_cake_custom(src)
+			src.recipes += new /datum/cookingrecipe/mixer/mix_cake_custom(src)
 			src.recipes += new /datum/cookingrecipe/mixer/pancake_batter(src)
 			src.recipes += new /datum/cookingrecipe/mixer/brownie_batter(src)
 			src.recipes += new /datum/cookingrecipe/mixer/cake_batter(src)
@@ -50,7 +50,7 @@ TYPEINFO(/obj/machinery/mixer)
 			src.recipes += new /datum/cookingrecipe/mixer/butters(src)
 			src.recipes += new /datum/cookingrecipe/mixer/soysauce(src)
 			src.recipes += new /datum/cookingrecipe/mixer/gravy(src)
-*/
+
 		src.blender_off = image(src.icon, "blender_off")
 		src.blender_powered = image(src.icon, "blender_powered")
 		src.blender_working = image(src.icon, "blender_working")

--- a/code/obj/machinery/food_and_drink/mixer.dm
+++ b/code/obj/machinery/food_and_drink/mixer.dm
@@ -36,7 +36,7 @@ TYPEINFO(/obj/machinery/mixer)
 			src.recipes = list()
 
 		if (!src.recipes.len)
-			src.recipes += new /datum/cookingrecipe/mixer/mix_cake_custom(src)
+/*			src.recipes += new /datum/cookingrecipe/mixer/mix_cake_custom(src)
 			src.recipes += new /datum/cookingrecipe/mixer/pancake_batter(src)
 			src.recipes += new /datum/cookingrecipe/mixer/brownie_batter(src)
 			src.recipes += new /datum/cookingrecipe/mixer/cake_batter(src)
@@ -50,7 +50,7 @@ TYPEINFO(/obj/machinery/mixer)
 			src.recipes += new /datum/cookingrecipe/mixer/butters(src)
 			src.recipes += new /datum/cookingrecipe/mixer/soysauce(src)
 			src.recipes += new /datum/cookingrecipe/mixer/gravy(src)
-
+*/
 		src.blender_off = image(src.icon, "blender_off")
 		src.blender_powered = image(src.icon, "blender_powered")
 		src.blender_working = image(src.icon, "blender_working")
@@ -194,22 +194,17 @@ TYPEINFO(/obj/machinery/mixer)
 
 		var/output = null // /obj/item/reagent_containers/food/snacks/yuck
 		var/derivename = 0
-		for (var/datum/cookingrecipe/R in src.recipes)
-			to_remove.len = 0
-			if (R.item1)
-				if (!bowl_checkitem(R.item1, R.amt1)) continue
-			if (R.item2)
-				if (!bowl_checkitem(R.item2, R.amt2)) continue
-			if (R.item3)
-				if (!bowl_checkitem(R.item3, R.amt3)) continue
-			if (R.item4)
-				if (!bowl_checkitem(R.item4, R.amt4)) continue
-			output = R.specialOutput(src)
-			if (!output)
-				output = R.output
-			if (R.useshumanmeat)
-				derivename = 1
-			break
+		check_recipe:
+			for (var/datum/cookingrecipe/R in src.recipes)
+				to_remove.len = 0
+				for(var/I in R.ingredients)
+					if (!bowl_checkitem(I, R.ingredients[I])) continue check_recipe
+				output = R.specialOutput(src)
+				if (!output)
+					output = R.output
+				if (R.useshumanmeat)
+					derivename = 1
+				break
 
 		if (!isnull(output))
 			var/obj/item/reagent_containers/food/snacks/F

--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -548,7 +548,7 @@ TYPEINFO(/obj/submachine/chef_oven)
 			src.recipes = list()
 
 		if (!src.recipes.len)
-/*			src.recipes += new /datum/cookingrecipe/oven/haggass(src)
+			src.recipes += new /datum/cookingrecipe/oven/haggass(src)
 			src.recipes += new /datum/cookingrecipe/oven/haggis(src)
 			src.recipes += new /datum/cookingrecipe/oven/scotch_egg(src)
 			src.recipes += new /datum/cookingrecipe/oven/omelette_bee(src)
@@ -803,7 +803,7 @@ TYPEINFO(/obj/submachine/chef_oven)
 			src.recipes += new /datum/cookingrecipe/oven/turkey(src)
 			src.recipes += new /datum/cookingrecipe/oven/melted_sugar(src)
 			src.recipes += new /datum/cookingrecipe/oven/brownie_batch(src)
-*/
+
 			// store the list for later
 			oven_recipes = src.recipes
 

--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -404,6 +404,7 @@ TYPEINFO(/obj/submachine/ice_cream_dispenser)
 
 var/list/oven_recipes = list()
 
+
 TYPEINFO(/obj/submachine/chef_oven)
 	mats = 18
 
@@ -517,22 +518,10 @@ TYPEINFO(/obj/submachine/chef_oven)
 		if (!possible)
 			return
 
-		if (possible.item1)
-			var/atom/item_path = possible.item1
+		for(var/I in possible.ingredients)
+			var/atom/item_path = I
 			src.possible_recipe_icons += icon2base64(icon(initial(item_path.icon), initial(item_path.icon_state)), "chef_oven-\ref[src]")
-			src.possible_recipe_names += "[initial(item_path.name)][possible.amt1 > 1 ? " x[possible.amt1]" : ""]"
-		if (possible.item2)
-			var/atom/item_path = possible.item2
-			src.possible_recipe_icons += icon2base64(icon(initial(item_path.icon), initial(item_path.icon_state)), "chef_oven-\ref[src]")
-			src.possible_recipe_names += "[initial(item_path.name)][possible.amt2 > 1 ? " x[possible.amt2]" : ""]"
-		if (possible.item3)
-			var/atom/item_path = possible.item3
-			src.possible_recipe_icons += icon2base64(icon(initial(item_path.icon), initial(item_path.icon_state)), "chef_oven-\ref[src]")
-			src.possible_recipe_names += "[initial(item_path.name)][possible.amt3 > 1 ? " x[possible.amt3]" : ""]"
-		if (possible.item4)
-			var/atom/item_path = possible.item4
-			src.possible_recipe_icons += icon2base64(icon(initial(item_path.icon), initial(item_path.icon_state)), "chef_oven-\ref[src]")
-			src.possible_recipe_names += "[initial(item_path.name)][possible.amt4 > 1 ? " x[possible.amt4]" : ""]"
+			src.possible_recipe_names += "[initial(item_path.name)][possible.ingredients[I] > 1 ? " x[possible.ingredients[I]]" : ""]"
 
 		if (ispath(possible.output))
 			var/atom/item_path = possible.output
@@ -559,7 +548,7 @@ TYPEINFO(/obj/submachine/chef_oven)
 			src.recipes = list()
 
 		if (!src.recipes.len)
-			src.recipes += new /datum/cookingrecipe/oven/haggass(src)
+/*			src.recipes += new /datum/cookingrecipe/oven/haggass(src)
 			src.recipes += new /datum/cookingrecipe/oven/haggis(src)
 			src.recipes += new /datum/cookingrecipe/oven/scotch_egg(src)
 			src.recipes += new /datum/cookingrecipe/oven/omelette_bee(src)
@@ -814,7 +803,7 @@ TYPEINFO(/obj/submachine/chef_oven)
 			src.recipes += new /datum/cookingrecipe/oven/turkey(src)
 			src.recipes += new /datum/cookingrecipe/oven/melted_sugar(src)
 			src.recipes += new /datum/cookingrecipe/oven/brownie_batch(src)
-
+*/
 			// store the list for later
 			oven_recipes = src.recipes
 
@@ -1047,14 +1036,8 @@ TYPEINFO(/obj/submachine/chef_oven)
 		return null
 
 	proc/OVEN_can_cook_recipe(datum/cookingrecipe/recipe)
-		if (recipe.item1)
-			if (!OVEN_checkitem(recipe.item1, recipe.amt1)) return FALSE
-		if (recipe.item2)
-			if (!OVEN_checkitem(recipe.item2, recipe.amt2)) return FALSE
-		if (recipe.item3)
-			if (!OVEN_checkitem(recipe.item3, recipe.amt3)) return FALSE
-		if (recipe.item4)
-			if (!OVEN_checkitem(recipe.item4, recipe.amt4)) return FALSE
+		for(var/I in recipe.ingredients)
+			if (!OVEN_checkitem(I, recipe.ingredients[I])) return FALSE
 
 		return TRUE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This pr changes `datum/cookingrecipe` to store its ingredients as a list rather than a block of eight separate variables.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Needed to start somewhere to clean up cooking code. While doing this I uncovered a bunch of other horrible things and while I have ideas for those, I'm trying to keep things manageable.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)Cooking recipe code has been changed internally, please report any issues that crop up
```
