### PR TITLE
Radioactive clothing and items makes you glow

### DIFF
--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -23,6 +23,8 @@ TYPEINFO(/datum/component/radioactive)
 	var/_backup_color = null //so hacky
 	/// Internal, store of turf glow overlay
 	var/static/image/_turf_glow = null
+	/// Internal, reference to light component
+	var/datum/component/loctargeting/simple_light/our_light
 
 	Initialize(radStrength=100, decays=FALSE, neutron=FALSE, effectRange=1)
 		if(!istype(parent,/atom) || parent.type == /turf/space) //exact type check to exclude ocean floors
@@ -63,7 +65,12 @@ TYPEINFO(/datum/component/radioactive)
 			src._backup_color = PA.color
 			PA.add_filter("radiation_color_\ref[src]", 1, color_matrix_filter(normalize_color_to_matrix(PA.color ? PA.color : "#FFF")))
 			PA.color = null
-		PA.add_simple_light("radiation_light_\ref[src]", rgb2num(color))
+		var/list/color_composition = rgb2num(color)
+		var/R = color_composition[1]
+		var/G = color_composition[2]
+		var/B = color_composition[3]
+		var/A = color_composition[4]
+		our_light = PA.AddComponent(/datum/component/loctargeting/simple_light, R, G, B, A, TRUE)
 		if(istype(PA, /turf))
 			if(isnull(src._turf_glow))
 				src._turf_glow = image('icons/effects/effects.dmi', "greyglow")
@@ -85,6 +92,7 @@ TYPEINFO(/datum/component/radioactive)
 			global.processing_items.Remove(parent)
 		global.processing_items.Remove(src)
 		PA.remove_simple_light("radiation_light_\ref[src]")
+		qdel(src.our_light)
 		PA.remove_filter("radiation_outline_\ref[src]")
 		PA.remove_filter("radiation_color_\ref[src]")
 		PA.ClearSpecificOverlays("radiation_overlay_\ref[src]")

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -66,11 +66,7 @@ TYPEINFO(/datum/component/radioactive)
 			PA.add_filter("radiation_color_\ref[src]", 1, color_matrix_filter(normalize_color_to_matrix(PA.color ? PA.color : "#FFF")))
 			PA.color = null
 		var/list/color_composition = rgb2num(color)
-		var/R = color_composition[1]
-		var/G = color_composition[2]
-		var/B = color_composition[3]
-		var/A = color_composition[4]
-		our_light = PA.AddComponent(/datum/component/loctargeting/simple_light, R, G, B, A, TRUE)
+		our_light = PA.AddComponent(/datum/component/loctargeting/simple_light, color_composition[1], color_composition[2], color_composition[3], color_composition[4], TRUE)
 		if(istype(PA, /turf))
 			if(isnull(src._turf_glow))
 				src._turf_glow = image('icons/effects/effects.dmi', "greyglow")
@@ -92,7 +88,7 @@ TYPEINFO(/datum/component/radioactive)
 			global.processing_items.Remove(parent)
 		global.processing_items.Remove(src)
 		PA.remove_simple_light("radiation_light_\ref[src]")
-		qdel(src.our_light)
+		QDEL_NULL(src.our_light)
 		PA.remove_filter("radiation_outline_\ref[src]")
 		PA.remove_filter("radiation_color_\ref[src]")
 		PA.ClearSpecificOverlays("radiation_overlay_\ref[src]")


### PR DESCRIPTION
[FEATURE][GAME OBJECTS]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes `component/radioactive` to use `component/loctargeting/simple_light` instead of `add_simple_light`, resulting in the simple_light being visible on a mob holding or wearing something radioactive.

(Note: Items in your pocket will have their radiation glow shine through, though not in your backpack or belt. This is also a little weird but is overall cleaner behavior)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I wish to glow obnoxiously. See below, I do not currently glow when dripped out in cerenkite.
![image](https://github.com/user-attachments/assets/7c4e8f59-6377-486a-829a-8f8e7588fd70)

I now glow when wearing an irresponsible amount of radioactive material.
![image](https://github.com/user-attachments/assets/a9c2335a-6df6-4a43-bf2a-4755d436b284)


It's also just weird that something loses its very noticeable glow when you pick it up, when conceivably it would still be visibly glowing. This also fixes the (admittedly funny) bug where radioactive items would glow in your inventory, like so:
![image](https://github.com/user-attachments/assets/28049034-e941-4783-b8f0-f838c58c582d)
![image](https://github.com/user-attachments/assets/ed2026af-183f-4082-8c62-761923399042)
1st image = before, 2nd image = after

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Nexusuxen
(+)The glow from radioactive stuff will still shine around you even when you equip or pick them up.
```
