### PR TITLE
Rockworms no longer eat thier own poop

### DIFF
--- a/code/mob/living/critter/mining_critter.dm
+++ b/code/mob/living/critter/mining_critter.dm
@@ -379,6 +379,12 @@
 	butcherable = BUTCHER_ALLOWED
 	var/tamed = FALSE
 	var/seek_ore = TRUE
+	var/food_blacklist = list(\
+	/obj/item/raw_material/shard,
+	/obj/item/raw_material/scrap_metal,
+	/obj/item/raw_material/gemstone,
+	/obj/item/raw_material/uqill,
+	/obj/item/raw_material/fibrilith)
 	var/eaten = 0
 	var/const/rocks_per_gem = 10
 
@@ -408,7 +414,7 @@
 
 	attackby(obj/item/I, mob/M)
 		if(istype(I, /obj/item/raw_material) && !isdead(src))
-			if((istype(I, /obj/item/raw_material/shard)) || (istype(I, /obj/item/raw_material/scrap_metal)))
+			if((istypes(I, food_blacklist)))
 				src.visible_message("[M] tries to feed [src] but they won't take it!")
 				return
 			if (src.tamed)
@@ -427,8 +433,7 @@
 	seek_food_target(var/range = 5)
 		. = list()
 		for (var/obj/item/raw_material/ore in view(range, get_turf(src)))
-			if (istype(ore, /obj/item/raw_material/shard)) continue
-			if (istype(ore, /obj/item/raw_material/scrap_metal)) continue
+			if (istypes(ore, food_blacklist)) continue
 			if (!(istype(ore, /obj/item/raw_material/rock)) && prob(30)) continue // can eat not rocks with lower chance
 			. += ore
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds a `food_blacklist` variable to rockworms that dictates what types of raw material they can eat. Anything on the blacklist can't be fed to them, and they will not seek it out to eat. Uqill, fibrilith, and gemstones--which is what rockworms spit out--have been added to this blacklist.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Kinda weird that they were eating their own waste before. Makes keeping rockworms for rare ores slightly easier.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)Rockworms no longer eat their own poop.
```
