### PR TITLE
Fix critter gun limb ranged attacks not respecting low cooldowns

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -704,7 +704,6 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 	if (HH && (HH.can_range_attack || HH.can_special_attack()) && HH.limb)
 		HH.limb.attack_range(target, src, params)
 		HH.set_cooldown_overlay()
-		src.lastattacked = get_weakref(src)
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
[INTERNAL][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a bug where critter gun limb ranged attacks with a cooldown lower than the usual click delay were limited by click delay


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix