### PR TITLE
Access-locks the Atlas mass driver

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1722,8 +1722,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aie" = (
-/obj/machinery/launcher_loader/east,
-/turf/simulated/floor/plating,
+/obj/machinery/activation_button/driver_button{
+	id = "chapelgun";
+	name = "Funerary Driver Button"
+	},
+/turf/simulated/wall/auto/supernorn,
 /area/station/chapel/sanctuary)
 "aii" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -3782,13 +3785,6 @@
 	dir = 1
 	},
 /area/station/turret_protected/ai)
-"avN" = (
-/obj/machinery/conveyor/WE{
-	name = "cargo belt - east";
-	operating = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
 "avP" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/bay)
@@ -10672,10 +10668,6 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "dzn" = (
-/obj/machinery/conveyor/WE{
-	name = "cargo belt - east";
-	operating = 1
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	id = "chapel";
@@ -10860,15 +10852,6 @@
 	icon_state = "engine_caution_south"
 	},
 /area/station/engine/combustion_chamber)
-"dOL" = (
-/obj/machinery/conveyor/WE{
-	name = "cargo belt - east";
-	operating = 1
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 4
-	},
-/area/station/chapel/sanctuary)
 "dOP" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
@@ -12657,21 +12640,12 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/engine)
 "gsT" = (
-/obj/machinery/conveyor/WE{
-	name = "cargo belt - east";
-	operating = 1
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
 	name = "autoname - SS13";
 	pixel_y = 20;
 	tag = ""
-	},
-/obj/machinery/door_control{
-	id = "chapel";
-	name = "Chapel Airlock Control";
-	pixel_y = 28
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -82357,8 +82331,8 @@ acz
 aey
 chL
 afO
-ahi
-dOL
+aie
+akI
 ajR
 aiG
 ajN
@@ -82962,7 +82936,7 @@ aaa
 aaa
 aaa
 ahf
-avN
+ahb
 ahf
 aaa
 aaa
@@ -83264,7 +83238,7 @@ aaa
 aaa
 aaa
 ahf
-aie
+ahc
 ahf
 aaa
 aaa
@@ -83565,9 +83539,9 @@ aaa
 aaa
 aaa
 aaa
-ahf
-ahb
-ahf
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83867,9 +83841,9 @@ aaa
 aaa
 aaa
 aaa
-ahf
-ahc
-ahf
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -82331,7 +82331,7 @@ acz
 aey
 chL
 afO
-aie
+ahi
 akI
 ajR
 aiG
@@ -82633,8 +82633,8 @@ acz
 acz
 acz
 ach
-ahf
-dzn
+aie
+akG
 ahf
 aiJ
 aiJ
@@ -82936,7 +82936,7 @@ aaa
 aaa
 aaa
 ahf
-ahb
+dzn
 ahf
 aaa
 aaa
@@ -83238,7 +83238,7 @@ aaa
 aaa
 aaa
 ahf
-ahc
+ahb
 ahf
 aaa
 aaa
@@ -83539,9 +83539,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+ahf
+ahc
+ahf
 aaa
 aaa
 aaa

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -10681,6 +10681,7 @@
 	id = "chapel";
 	req_access_txt = "1"
 	},
+/obj/mapping_helper/access/chapel_office,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This replaces the Atlas mass driver with one that requires chaplain access to open.
![image](https://github.com/user-attachments/assets/80337045-9d10-4dc6-a1f6-5a5ea840125a)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The mass driver is access-locked on every other station, and it's pretty weird that Atlas' is the only one that isn't.

