### PR TITLE
Mechanics Reconstruction Kit requires CE access to unlock

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1585,7 +1585,7 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 		return A
 
 /datum/supply_packs/complex/electronics_kit
-	name = "Mechanics Reconstruction Kit"
+	name = "Mechanics Reconstruction Kit (Cardlocked \[Chief Engineer])"
 	desc = "1x Ruckingenur frame, 1x Manufacturer frame, 1x reclaimer frame, 1x device analyzer, 1x soldering iron"
 	category = "Engineering Department"
 	contains = list(/obj/item/electronics/scanner,
@@ -1595,8 +1595,9 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 					/obj/machinery/manufacturer/mechanic,
 					/obj/machinery/portable_reclaimer)
 	cost = PAY_TRADESMAN*10
-	containertype = /obj/storage/crate
-	containername = "Mechanics Reconstruction Kit"
+	containertype = /obj/storage/secure/crate/eng
+	access = access_engineering_chief
+	containername = "Mechanics Reconstruction Kit (Cardlocked \[Chief Engineer])"
 
 /datum/supply_packs/complex/barbershop_kit
 	name = "Barbershop Kit"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the existing Mechanics Reconstruction Kit that contains a new Ruckingenur and tools to use it require CE access to unlock.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A major departmental feature and potential force multiplier like the ruck shouldn't be set up wtihout CE knowledge/approval.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)The Mechanics Reconstruction Kit requires Chief Engineer access to unlock.
```
