### PR TITLE
Add radio ship to the list of teleportable places.

### DIFF
--- a/code/datums/teleport.dm
+++ b/code/datums/teleport.dm
@@ -24,5 +24,7 @@ proc/generate_teleareas() //Turns out nukies could deploy to the wizards den all
 		if(istype(area, /area/wizard_station))
 			teleareas[area.name] = area
 		if (istype(area, /area/radiostation))
-			teleareas[area.name] = area
+			var/turf/T = area.contents[1]
+			if (!isrestrictedz(T?.z))
+				teleareas[area.name] = area
 	sortList(teleareas, /proc/cmp_text_asc)

--- a/code/datums/teleport.dm
+++ b/code/datums/teleport.dm
@@ -23,4 +23,6 @@ proc/generate_teleareas() //Turns out nukies could deploy to the wizards den all
 				teleareas[area.name] = area
 		if(istype(area, /area/wizard_station))
 			teleareas[area.name] = area
+		if (istype(area, /area/radiostation))
+			teleareas[area.name] = area
 	sortList(teleareas, /proc/cmp_text_asc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add the radio ship to the list of teleportable places via `get_teleareas()`

This only affects observers, wizards, and santa/krampus; nukies are limited to station areas via filter.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Easier for observers to hop on over to the radio station when Stuff Is Going Down.