### PR TITLE
Silicons use some power when attacking mobs with items

### DIFF
--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -267,8 +267,8 @@ ADMIN_INTERACT_PROCS(/mob/living/silicon, proc/pick_law_rack)
 
 /mob/living/silicon/weapon_attack(atom/target, obj/item/W, reach, params)
 	. = ..()
-	if (src.cell && ismob(target))
-		src.cell.use(W.stamina_cost)
+	if (ismob(target))
+		src.cell?.use(W.stamina_cost)
 
 /mob/living/proc/process_killswitch()
 	return

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -265,6 +265,11 @@ ADMIN_INTERACT_PROCS(/mob/living/silicon, proc/pick_law_rack)
 /mob/living/silicon/say_decorate(message)
 	. = monospace_say_regex.Replace(message, SPAN_MONOSPACE("$1"))
 
+/mob/living/silicon/weapon_attack(atom/target, obj/item/W, reach, params)
+	. = ..()
+	if (src.cell && ismob(target))
+		src.cell.use(W.stamina_cost)
+
 /mob/living/proc/process_killswitch()
 	return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][silicons]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Charge silicons power equal to the stamina use cost of the item when attacking mobs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Slightly more power usage based on player actions over the course of the round.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Silicons use power when attacking mobs with tools.
```