### PR TITLE
Reduce the stamina damage of the wrench and crowbar

### DIFF
--- a/code/obj/item/tool/crowbar.dm
+++ b/code/obj/item/tool/crowbar.dm
@@ -15,7 +15,7 @@
 
 	force = 7
 	throwforce = 7
-	stamina_damage = 35
+	stamina_damage = 25
 	stamina_cost = 12
 	stamina_crit_chance = 10
 

--- a/code/obj/item/tool/wrench.dm
+++ b/code/obj/item/tool/wrench.dm
@@ -13,7 +13,7 @@
 
 	force = 5
 	throwforce = 7
-	stamina_damage = 40
+	stamina_damage = 30
 	stamina_cost = 14
 	stamina_crit_chance = 15
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Wrench stamina damage from 40 to 30
* Crowbar stamina damage from 35 to 25

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I feel like that is a lot of stamina damage.

Other damge points of reference:
* Air tank: 55 stamina damage
* Toolbox: 50 stamina damage
* Extinguisher: 25 stamina damage
* Baseline item: 15 stamina damage