### PR TITLE
Regulate Nonhuman antag objectives between classic and rp

### DIFF
--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -693,11 +693,7 @@ ABSTRACT_TYPE(/datum/multigrab_target)
 	var/absorb_count
 
 	set_up()
-#ifdef RP_MODE
-		absorb_count = clamp(round((ticker.minds.len - 1) * 0.75), 1, 6)
-#else
-		absorb_count = min(10, (ticker.minds.len - 1))
-#endif
+		absorb_count = clamp(round((ticker.minds.len - 1) / 4), 2, 6)
 		explanation_text = "Absorb the DNA of at least [absorb_count] more crew members in addition to the one you started with, and escape on the shuttle alive."
 
 	check_completion()
@@ -720,11 +716,7 @@ ABSTRACT_TYPE(/datum/multigrab_target)
 	var/bloodcount
 
 	set_up()
-#ifdef RP_MODE
-		bloodcount = rand(40,80) * 10
-#else
-		bloodcount = rand(60,100) * 10
-#endif
+		bloodcount = rand(50,90) * 10
 		explanation_text = "Accumulate at least [bloodcount] units of blood in total."
 
 	check_completion()
@@ -1471,11 +1463,7 @@ ABSTRACT_TYPE(/datum/multigrab_target)
 	var/powergoal
 
 	set_up()
-#ifdef RP_MODE
 		powergoal = rand(350,400) * 10
-#else
-		powergoal = rand(450,500) * 10
-#endif
 		explanation_text = "Accumulate at least [powergoal] units of charge in total."
 
 	check_completion()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes Vampire, Arcfiend and Changeling objectives to be the same between RP and classic.
Rebalances changeling objective to not require eating a majority of the lobby on lowpop

**Changeling Absorb:**
Classic - Everyone except yourself to a maximum of 10
RP - 3/4ths of the lobby, between 1 and 6.
New: - 1/4th of the lobby, between 2 and 6
![image](https://github.com/user-attachments/assets/68487ea6-64fa-44bf-a866-313b8b12c93d)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pure number change objective differences between RP and classic aren't particularly necessary, and objectives shouldnt have you kill a majority of the crew to complete them on lowpop

