### PR TITLE
Change Oubliette medal obtainment method

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -102,18 +102,7 @@ ABSTRACT_TYPE(/datum/objective/crew/headofsecurity)
 			return 1
 		else
 			return 0
-/datum/objective/crew/headofsecurity/brig
-	explanation_text = "Have at least one antagonist cuffed in the brig at the end of the round." //can be dead as people usually suicide
-	medal_name = "Suitable? How about the Oubliette?!"
-	var/static/check_result = null
-	check_completion()
-		if(isnull(check_result))
-			check_result = FALSE
-			for(var/datum/mind/M in ticker.minds)
-				if(M.special_role && M.current && !isobserver(M.current) && istype(get_area(M.current),/area/station/security/brig) && M.current.hasStatus("handcuffed")) //think that's everything...
-					check_result = TRUE
-					break
-		return check_result
+
 /datum/objective/crew/headofsecurity/centcom
 	explanation_text = "Bring at least one antagonist back to CentCom in handcuffs for interrogation. You must accompany them on the escape shuttle." //can also be dead I guess
 	medal_name = "Dead or alive, you're coming with me"
@@ -198,16 +187,7 @@ ABSTRACT_TYPE(/datum/objective/crew/chiefengineer)
 		return check_result
 
 ABSTRACT_TYPE(/datum/objective/crew/securityofficer)
-// grabbed the HoS's two antag-related objectives cause they work just fine for regular sec too, so...?
-	/*brig
-		explanation_text = "Have at least one antagonist cuffed in the brig at the end of the round." //can be dead as people usually suicide
-		medal_name = "Suitable? How about the Oubliette?!"
-		check_completion()
-			for(var/datum/mind/M in ticker.minds)
-				if(M.special_role && M.current && !isobserver(M.current) && istype(get_area(M.current),/area/station/security/brig) && M.current.hasStatus("handcuffed")) //think that's everything...
-					return 1
-			return 0
-	*/
+
 /datum/objective/crew/securityofficer/centcom
 	explanation_text = "Bring at least one antagonist back to CentCom in handcuffs for interrogation. You must accompany them on the escape shuttle." //can also be dead I guess
 	medal_name = "Dead or alive, you're coming with me"

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -1222,32 +1222,6 @@
 		else
 			boutput(activator, SPAN_ALERT("You need to be a cyborg to use this, you goof!"))
 
-/*
-/datum/achievementReward/secbelt
-	title = "(Skin) Security Toolbelt"
-	desc = "Turns your worn Utility Belt into a Security Toolbelt."
-	required_medal = "Suitable? How about the Oubliette?!"
-
-	rewardActivate(var/mob/living/carbon/human/activator)
-
-	rewardActivate(var/mob/activator)
-		if (!ishuman(activator))
-			return
-
-		var/mob/living/carbon/human/H = activator
-
-		if (H.belt && istype(H.belt, /obj/item/storage/belt/utility))
-			var/obj/item/storage/belt/utility/M = H.belt
-			var/prev = M.name
-			M.icon_state = "secbelt"
-			M.item_state = "secbelt"
-			M.name = "security toolbelt"
-			M.real_name = "security toolbelt"
-			M.desc = "For the trend-setting Security Officer on the go. (Base Item: [prev])"
-			H.set_clothing_icon_dirty()
-		return
-*/
-
 /datum/achievementReward/goldenGun
 	title = "Golden Gun"
 	desc = "Gold plates a shotgun, hunting rifle, detective revolver, or AK-47 you're holding."

--- a/code/obj/machinery/floorflusher.dm
+++ b/code/obj/machinery/floorflusher.dm
@@ -156,6 +156,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/floorflusher, proc/flush)
 			boutput(M, "You fall into [src].")
 			src.visible_message("[M] falls into [src].")
 			M.set_loc(src)
+			if(istype(get_area(src), /area/station/security/brig))
+				M.unlock_medal("Suitable? How about the Oubliette?!", 1)
+				boutput(world,SPAN_SUCCESS("IT WORKED"))
 			flush = 1
 			update()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the "Have an antagonist in the brig at roundend" Head of Security Objective
Removes the commented out code for the secoff version of this objective and the security belt reward from the associated medal.
The "Suitable? How about the Oubliette?!" medal is now obtained by being flushed down a brig chute.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This objective was removed from Officer presumably because it encouraged giving extra time just to get the objective done, HoS whitelisted players won't do this essentially making the objective pure luck as to if you complete it while also having it. This medal is also HoS specific making it unobtainable to most players, which isn't very cool.

Being flushed out the brig is also still relevant as an oubliette is essentially prison cell that's just a pit with bars covering the top, not too different from the brig chute.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Changed how the "Suitable? How about the Oubliette?!" medal is obtained. See the PR or Wiki for details!
```
