### PR TITLE
Allow admins to change the type of meteors for custom meteor shower events

### DIFF
--- a/_std/text.dm
+++ b/_std/text.dm
@@ -38,6 +38,13 @@ var/list/lowercase_letters = list("a", "b", "c", "d", "e", "f", "g", "h", "i", "
 
 	return uppertext(copytext(t, 1, 2)) + copytext(t, 2)
 
+/proc/capitalize_each_word(t as text)
+	var/list/split = splittext(t, " ")
+	var/list/words = list()
+	for (var/word in split)
+		words += capitalize(word)
+	return list2text(words, " ")
+
 /// Returns true if the given string has a vowel
 /proc/isVowel(var/t as text)
 	return findtextEx(lowertext(t), "aeiouåäö") > 0

--- a/code/modules/admin/buildmodes/throw.dm
+++ b/code/modules/admin/buildmodes/throw.dm
@@ -1,14 +1,5 @@
-/datum/buildmode/throw
-	name = "Throw"
-	desc = {"***********************************************************<br>
-Left Click on mob/obj             = Select thrown object<br>
-Right Click                       = Throw object<br>
-Right Click on Buildmode Button   = Select throw flag<br>
-***********************************************************"}
-	icon_state = "buildmode4"
-	var/tmp/throwing = null
-	///yes this is manually maintained
-	var/list/throwflags = list(
+///yes this is manually maintained
+var/global/list/throwflags = list(
 		"THROW_NORMAL" = THROW_NORMAL,\
 		"THROW_CHAIRFLIP" = THROW_CHAIRFLIP,\
 		"THROW_GUNIMPACT" = THROW_GUNIMPACT,\
@@ -18,6 +9,16 @@ Right Click on Buildmode Button   = Select throw flag<br>
 		"THROW_THROUGH_WALL" = THROW_THROUGH_WALL,\
 		"THROW_GIB" = THROW_GIB,\
 	 )
+
+/datum/buildmode/throw
+	name = "Throw"
+	desc = {"***********************************************************<br>
+Left Click on mob/obj             = Select thrown object<br>
+Right Click                       = Throw object<br>
+Right Click on Buildmode Button   = Select throw flag<br>
+***********************************************************"}
+	icon_state = "buildmode4"
+	var/tmp/throwing = null
 	var/throwflag = THROW_NORMAL
 
 	click_left(atom/object, var/ctrl, var/alt, var/shift)
@@ -31,11 +32,11 @@ Right Click on Buildmode Button   = Select throw flag<br>
 			M.throw_at(get_turf(object), 10, 1, allow_anchored = ANCHORED, throw_type = src.throwflag)
 
 	click_mode_right(ctrl, alt, shift)
-		var/flag_string = tgui_input_list(usr, "Choose throw flag", "Throw flag", src.throwflags)
-		src.throwflag = src.throwflags[flag_string]
+		var/flag_string = tgui_input_list(usr, "Choose throw flag", "Throw flag", global.throwflags)
+		src.throwflag = global.throwflags[flag_string]
 		src.update_button_text()
 
 	update_button_text()
-		for (var/flag_string in src.throwflags)
-			if (src.throwflags[flag_string] == src.throwflag)
+		for (var/flag_string in global.throwflags)
+			if (global.throwflags[flag_string] == src.throwflag)
 				return ..("[src.throwing] - [flag_string]")

--- a/code/modules/events/meteor_shower.dm
+++ b/code/modules/events/meteor_shower.dm
@@ -264,6 +264,8 @@ var/global/meteor_shower_active = 0
 		if (use_custom_name == "Yes")
 			custom_name = input(usr, "Custom name to replace 'meteor shower':", src.name, src.shower_name)
 
+		message_admins("[key_name(usr)] created a custom meteor event throwing [amtinput] [used_meteor_typepath] at [delinput] ticks apart.")
+		logTheThing(LOG_ADMIN, usr, "created a custom meteor event throwing [amtinput] [used_meteor_typepath] at [delinput] ticks apart.")
 		src.event_effect(source,amtinput,dirinput,delinput,timinput,spdinput,transmute_material_instead,used_meteor_typepath,throw_flag,custom_name)
 		return
 

--- a/code/modules/events/meteor_shower.dm
+++ b/code/modules/events/meteor_shower.dm
@@ -223,7 +223,7 @@ var/global/meteor_shower_active = 0
 		var/is_custom_type = alert(usr, "Specify a custom mob/obj path as meteor?", src.name, "Yes", "No")
 
 		if (is_custom_type == "Yes")
-			used_meteor_typepath = get_one_match(input("Type path", "Type path", "[used_meteor_typepath]"), /atom)
+			used_meteor_typepath = get_one_match(input("Type path", src.name, "[used_meteor_typepath]"), /atom)
 
 		var/amtinput = input(usr,"How many meteors? (10~50++)",src.name) as num|null
 		if (!isnum(amtinput) || amtinput < 1)

--- a/code/modules/events/meteor_shower.dm
+++ b/code/modules/events/meteor_shower.dm
@@ -114,7 +114,7 @@ var/global/meteor_shower_active = 0
 		var/commins = round((ticker.round_elapsed_ticks + warning_delay - ticker.round_elapsed_ticks)/10 ,1)
 		commins = max(0,commins)
 		if (random_events.announce_events)
-			command_alert("[comsev] [shower_name] approaching [comdir]. Impact in [commins] seconds.", "Meteor Alert", alert_origin = ALERT_WEATHER)
+			command_alert("[comsev] [shower_name] approaching [comdir]. Impact in [commins] seconds.", "[capitalize_each_word(shower_name)] Alert", alert_origin = ALERT_WEATHER)
 			playsound_global(world, 'sound/machines/disaster_alert.ogg', 60)
 			// for all directions, just give, uh, up
 			// todo: someone make shields have an all-sides option
@@ -124,7 +124,7 @@ var/global/meteor_shower_active = 0
 
 		SPAWN(warning_delay)
 			if (random_events.announce_events)
-				command_alert("The [shower_name] has reached the [station_or_ship()]. Brace for impact.", "Meteor Alert", alert_origin = ALERT_WEATHER)
+				command_alert("The [shower_name] has reached the [station_or_ship()]. Brace for impact.", "[capitalize_each_word(shower_name)] Alert", alert_origin = ALERT_WEATHER)
 				playsound_global(world, 'sound/machines/disaster_alert.ogg', 60)
 
 	#ifndef UNDERWATER_MAP


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[admin][event]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Allows for a custom typepath, throw flag, and name to be selected and provided to the meteor storm event
* Reworks the meteor shower event to check against type paths instead of types, and updates related variable to be clearer
* Removes meatier shower event, as the base event is now fully customizable to do the same thing.
* Moves the list of throws in buildmode up to a global so we can reuse it

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![image](https://github.com/user-attachments/assets/01b7bb2b-8974-4cee-84b5-be214a6779ca)
![image](https://github.com/user-attachments/assets/e48d126c-ce5a-4612-be38-68267998387e)

