### PR TITLE
Fix HoS things having varedited req_access_txt

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -57262,9 +57262,7 @@
 /turf/simulated/floor,
 /area/station/medical/medbay/surgery)
 "sgg" = (
-/obj/machinery/computer/secure_data/detective_computer{
-	req_access_txt = "1"
-	},
+/obj/machinery/computer/secure_data/detective_computer,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -15

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -11317,9 +11317,7 @@
 	},
 /area/station/security/hos)
 "biT" = (
-/obj/storage/secure/closet/command/hos{
-	req_access_txt = "37"
-	},
+/obj/storage/secure/closet/command/hos,
 /obj/item/device/radio/intercom/brig{
 	dir = 1
 	},
@@ -17879,9 +17877,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/storage/secure/crate/gear/armory/equipment{
-	req_access_txt = "37"
-	},
+/obj/storage/secure/crate/gear/armory/equipment,
 /turf/simulated/floor/redblack{
 	dir = 9
 	},
@@ -22978,9 +22974,7 @@
 	},
 /area/station/bridge)
 "grF" = (
-/obj/machinery/computer/secure_data/detective_computer{
-	req_access_txt = "37"
-	},
+/obj/machinery/computer/secure_data/detective_computer,
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet{
 	dir = 1;

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -18583,9 +18583,7 @@
 	},
 /area/station/crew_quarters/kitchen)
 "fAO" = (
-/obj/machinery/computer/secure_data/detective_computer{
-	req_access_txt = "1"
-	},
+/obj/machinery/computer/secure_data/detective_computer,
 /obj/cable{
 	icon_state = "0-2"
 	},

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -26890,9 +26890,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "bsV" = (
-/obj/machinery/computer/secure_data/detective_computer{
-	req_access_txt = "1"
-	},
+/obj/machinery/computer/secure_data/detective_computer,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 15

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -29592,9 +29592,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "pFY" = (
-/obj/machinery/computer/secure_data/detective_computer{
-	req_access_txt = "1"
-	},
+/obj/machinery/computer/secure_data/detective_computer,
 /obj/machinery/turretid{
 	name = "Armory Perimeter Turret deactivation control";
 	req_access = list(37);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes varedited accesses from the following things found in HoS' office/armory
- HoS office forensic records (detective computer) was varedited to sec access, not necessary as the HoS has forensics access
- Donut 2 HoS locker had HoS access varedited onto it!?!?!?!?
- Donut 2 Equipment crate also had HoS access varedited onto it, this will break it authing.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Someone's gotta stop these mappers and their evil varediting.
