### PR TITLE
Accurate pinpointer arrow

### DIFF
--- a/code/modules/items/specials/ItemSpecials.dm
+++ b/code/modules/items/specials/ItemSpecials.dm
@@ -38,6 +38,28 @@
 				return NORTHEAST
 	return NORTH
 
+/proc/get_dir_accurate(var/atom/source, var/atom/target) // Get the closest direction rather than prioritizing a certain axis
+	if(!source || !target)
+		CRASH("Invalid Params for get_dir_alt: Source:[identify_object(source)] Target:[identify_object(target)]")
+	var/dir_angle = get_angle(source, target)
+	switch(dir_angle)
+		if(22.5 to 67.5)
+			return NORTHEAST
+		if(67.5 to 112.5)
+			return EAST
+		if(112.5 to 157.5)
+			return SOUTHEAST
+		if(157.5 to 181, -181 to -157.5)
+			return SOUTH
+		if(-67.5 to -22.5)
+			return NORTHWEST
+		if(-112.5 to -67.5)
+			return WEST
+		if(-157.5 to -112.5)
+			return SOUTHWEST
+		else
+			return NORTH
+
 /proc/get_dir_pixel(var/atom/source, var/atom/target, params) //Get_dir using pixel coordinates of mouse
 	var/dx = (target.x - source.x) * 32
 	var/dy = (target.y - source.y) * 32

--- a/code/modules/items/specials/ItemSpecials.dm
+++ b/code/modules/items/specials/ItemSpecials.dm
@@ -40,7 +40,7 @@
 
 /proc/get_dir_accurate(var/atom/source, var/atom/target) // Get the closest direction rather than prioritizing a certain axis
 	if(!source || !target)
-		CRASH("Invalid Params for get_dir_alt: Source:[identify_object(source)] Target:[identify_object(target)]")
+		CRASH("Invalid Params for get_dir_accurate: Source:[identify_object(source)] Target:[identify_object(target)]")
 	var/dir_angle = get_angle(source, target)
 	switch(dir_angle)
 		if(22.5 to 67.5)

--- a/code/obj/item/pinpointer.dm
+++ b/code/obj/item/pinpointer.dm
@@ -100,7 +100,7 @@ TYPEINFO(/obj/item/pinpointer)
 				if(ismob(src.loc))
 					boutput(src.loc, SPAN_ALERT("Pinpointer target out of range."))
 				return
-			src.set_dir(get_dir(src,target))
+			src.set_dir(get_dir_accurate(src,target))
 			var/dist = GET_DIST(src,target)
 			switch(dist)
 				if(0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game objects][qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Adds a new proc called "get_dir_accurate(source, target)", which prioritizes the direction closest to where you want to go, rather than the default "get_dir()" proc, which prioritizes diagonals.
- Gives the new proc to the pinpointer

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- More advanced pinpointer arrow technology

