### PR TITLE
Artifact Name Consistency

### DIFF
--- a/code/obj/artifacts/artifact_items/dimensional_key.dm
+++ b/code/obj/artifacts/artifact_items/dimensional_key.dm
@@ -112,7 +112,7 @@
 
 /datum/artifact/dimensional_key
 	associated_object = /obj/item/artifact/dimensional_key
-	type_name = "Dimensional key"
+	type_name = "Dimensional Key"
 	type_size = ARTIFACT_SIZE_TINY
 	rarity_weight = 200
 	validtypes = list("eldritch", "precursor")

--- a/code/obj/artifacts/artifact_items/gun_cell.dm
+++ b/code/obj/artifacts/artifact_items/gun_cell.dm
@@ -62,7 +62,7 @@
 
 /datum/artifact/energyammo
 	associated_object = /obj/item/ammo/power_cell/self_charging/artifact
-	type_name = "Small power cell"
+	type_name = "Small Power Cell"
 	type_size = ARTIFACT_SIZE_TINY
 	rarity_weight = 0
 	validtypes = list("ancient","eldritch","precursor")

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -79,7 +79,7 @@
 
 /datum/artifact/powercell
 	associated_object = /obj/item/cell/artifact
-	type_name = "Large power cell"
+	type_name = "Large Power Cell"
 	type_size = ARTIFACT_SIZE_TINY
 	rarity_weight = 350
 	validtypes = list("ancient","martian","wizard","precursor")

--- a/code/obj/artifacts/artifact_machines/emoter.dm
+++ b/code/obj/artifacts/artifact_machines/emoter.dm
@@ -5,7 +5,7 @@
 
 /datum/artifact/emoter
 	associated_object = /obj/machinery/artifact/emoter
-	type_name = "Emote Forcer Field" //this was brown note originally
+	type_name = "Emote-stimulation Field" //this was brown note originally
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 350
 	validtypes = list("martian","eldritch","precursor")

--- a/code/obj/artifacts/artifact_machines/gas_radiator.dm
+++ b/code/obj/artifacts/artifact_machines/gas_radiator.dm
@@ -5,7 +5,7 @@
 
 /datum/artifact/gas_radiator
 	associated_object = /obj/machinery/artifact/gas_radiator
-	type_name = "Gas radiator"
+	type_name = "Gas Radiator"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 450
 	validtypes = list("ancient","martian","eldritch","precursor")

--- a/code/obj/artifacts/artifact_machines/plant_helper.dm
+++ b/code/obj/artifacts/artifact_machines/plant_helper.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/plant_helper
 	associated_object = /obj/machinery/artifact/plant_helper
-	type_name = "Plant waterer"
+	type_name = "Plant Enhancer"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 350
 	validtypes = list("martian","precursor")

--- a/code/obj/artifacts/artifact_objects/augmentor.dm
+++ b/code/obj/artifacts/artifact_objects/augmentor.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/augmentor
 	associated_object = /obj/artifact/augmentor
-	type_name = "Surgery machine (cyborg/synth)"
+	type_name = "Surgery Machine (cyborg/synth)"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 350
 	validtypes = list("ancient","precursor")
@@ -348,7 +348,7 @@
 
 /datum/artifact/augmentor/limb_augmentor
 	associated_object = /obj/artifact/augmentor/limb_augmentor
-	type_name = "Surgery machine (artifact limbs)"
+	type_name = "Surgery Machine (artifact limbs)"
 	rarity_weight = 200
 	validtypes = list("eldritch", "martian", "precursor")
 	limited_use = TRUE

--- a/code/obj/artifacts/artifact_objects/borgifier.dm
+++ b/code/obj/artifacts/artifact_objects/borgifier.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/borgifier
 	associated_object = /obj/artifact/borgifier
-	type_name = "Cyborg converter"
+	type_name = "Cyborg Converter"
 	type_size = ARTIFACT_SIZE_LARGE
 	rarity_weight = 200
 	validtypes = list("ancient")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SCIENCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Capitalizes previously inconsistent artifact names, and changes Emote Field and Plant Waterer to more fitting names.
![image](https://github.com/user-attachments/assets/e7135a22-e810-4112-baa3-5722dcd3c9c5)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Capitalization and to more clearly reflect what each artifact does.