### PR TITLE
Refactor NTSC baton state changing

### DIFF
--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -155,7 +155,7 @@ TYPEINFO(/obj/item/baton)
 						src.is_active = FALSE
 						if (istype(src, /obj/item/baton/ntso)) //since ntso batons have some extra stuff, we need to set their state var to the correct value to make this work
 							var/obj/item/baton/ntso/B = src
-							B.state = EXTENDO_BATON_OPEN_AND_OFF
+							B.set_state(EXTENDO_BATON_OPEN_AND_OFF, user)
 		else if (amount > 0)
 			SEND_SIGNAL(src, COMSIG_CELL_CHARGE, src.cost_normal * amount)
 
@@ -433,12 +433,6 @@ TYPEINFO(/obj/item/baton/ntso)
 	//bascially overriding is_active, but it's kinda hacky in that they both are used jointly
 	var/state = EXTENDO_BATON_OPEN_AND_ON
 
-	//change for later for more interestings whatsits
-	// can_stun(var/requires_electricity = 0, var/amount = 1, var/mob/user)
-	// 	..(requires_electricity, amount, user)
-	// 	if (state == EXTENDO_BATON_CLOSED_AND_OFF || state == EXTENDO_BATON_OPEN_AND_OFF)
-	// 		return 0
-
 	attack_self(mob/user as mob)
 		src.add_fingerprint(user)
 		//never should happen but w/e
@@ -450,45 +444,7 @@ TYPEINFO(/obj/item/baton/ntso)
 			return
 
 		//move to next state
-		switch (src.state)
-			if (EXTENDO_BATON_CLOSED_AND_OFF)		//move to open/on state
-				if (!(SEND_SIGNAL(src, COMSIG_CELL_CHECK_CHARGE, cost_normal) & CELL_SUFFICIENT_CHARGE)) //ugly copy pasted code to move to next state if its depowered, cleanest solution i could think of
-					boutput(user, SPAN_ALERT("The [src.name] doesn't have enough power to be turned on."))
-					src.state = EXTENDO_BATON_OPEN_AND_OFF
-					src.is_active = FALSE
-					src.w_class = W_CLASS_NORMAL
-					src.force = 7
-					playsound(src, 'sound/misc/lightswitch.ogg', 75, TRUE, -1)
-					boutput(user, SPAN_NOTICE("The [src.name] is now open and unpowered."))
-					src.UpdateIcon()
-					user.update_inhands()
-					return
-
-				//this is the stuff that normally happens
-				src.state = EXTENDO_BATON_OPEN_AND_ON
-				src.is_active = TRUE
-				boutput(user, SPAN_NOTICE("The [src.name] is now open and on."))
-				src.w_class = W_CLASS_NORMAL
-				src.force = 7
-				playsound(src, "sparks", 75, 1, -1)
-			if (EXTENDO_BATON_OPEN_AND_ON)		//move to open/off state
-				src.state = EXTENDO_BATON_OPEN_AND_OFF
-				src.is_active = FALSE
-				src.w_class = W_CLASS_NORMAL
-				src.force = 7
-				playsound(src, 'sound/misc/lightswitch.ogg', 75, TRUE, -1)
-				boutput(user, SPAN_NOTICE("The [src.name] is now open and unpowered."))
-				// playsound(src, "sparks", 75, 1, -1)
-			if (EXTENDO_BATON_OPEN_AND_OFF)		//move to closed/off state
-				src.state = EXTENDO_BATON_CLOSED_AND_OFF
-				src.is_active = FALSE
-				src.w_class = W_CLASS_SMALL
-				src.force = 1
-				boutput(user, SPAN_NOTICE("The [src.name] is now closed."))
-				playsound(src, "sparks", 75, 1, -1)
-
-		src.UpdateIcon()
-		user.update_inhands()
+		src.cycle_state(user)
 
 	do_stun(mob/user, mob/victim, type, stun_who)
 		. = ..()
@@ -517,12 +473,51 @@ TYPEINFO(/obj/item/baton/ntso)
 				return
 		..()
 
-	emp_act()
-		if (state == EXTENDO_BATON_OPEN_AND_ON)
-			state = EXTENDO_BATON_OPEN_AND_OFF
-		src.is_active = FALSE
-		usr?.show_text("The [src.name] is now open and unpowered.", "blue")
-		src.process_charges(-INFINITY)
+	proc/cycle_state(mob/user)
+		switch (src.state)
+			if (EXTENDO_BATON_CLOSED_AND_OFF)
+				src.set_state(EXTENDO_BATON_OPEN_AND_ON, user)
+			if (EXTENDO_BATON_OPEN_AND_ON)		//move to open/off state
+				src.set_state(EXTENDO_BATON_OPEN_AND_OFF, user)
+			if (EXTENDO_BATON_OPEN_AND_OFF)		//move to closed/off state
+				src.set_state(EXTENDO_BATON_CLOSED_AND_OFF, user)
+
+	proc/set_state(var/state, var/mob/user)
+		if (src.state == state)
+			return
+		switch(state)
+			if(EXTENDO_BATON_OPEN_AND_ON)		//move to open/on state
+				if (!(SEND_SIGNAL(src, COMSIG_CELL_CHECK_CHARGE, cost_normal) & CELL_SUFFICIENT_CHARGE)) //ugly copy pasted code to move to next state if its depowered, cleanest solution i could think of
+					src.set_state(EXTENDO_BATON_OPEN_AND_OFF)
+					boutput(user, SPAN_NOTICE("The [src.name] doesn't have enough power to turn on!"))
+					return
+				src.is_active = TRUE
+				src.state = EXTENDO_BATON_OPEN_AND_ON
+				src.w_class = W_CLASS_NORMAL
+				src.force = 7
+				boutput(user, SPAN_NOTICE("The [src.name] is now open and on."))
+				playsound(src, "sparks", 75, 1, -1)
+			if(EXTENDO_BATON_OPEN_AND_OFF)
+				src.is_active = FALSE
+				src.state = EXTENDO_BATON_OPEN_AND_OFF
+				src.w_class = W_CLASS_NORMAL
+				src.force = 7
+				boutput(user, SPAN_NOTICE("The [src.name] is now open and unpowered."))
+				playsound(src, 'sound/misc/lightswitch.ogg', 75, TRUE, -1)
+			if(EXTENDO_BATON_CLOSED_AND_OFF)
+				src.is_active = FALSE
+				src.state = EXTENDO_BATON_CLOSED_AND_OFF
+				src.w_class = W_CLASS_SMALL
+				src.force = 1
+				boutput(user, SPAN_NOTICE("The [src.name] is now closed."))
+			else
+				logTheThing(LOG_DEBUG, user, "Extendable stun baton ([src.type]) set_state() was called with an invalid argument ([state]), aborting. Last touched by: [src.fingerprintslast ? "[src.fingerprintslast]" : "*null*"]")
+
+		SPAWN(0)
+		src.UpdateIcon()
+		user.update_inhands()
+
+
 
 
 TYPEINFO(/obj/item/baton/windup)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactors NTSC baton changing modes to be a set_state(state) proc rather than on the attack_self


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Code quality and maybe it will help someone (probably future me when it annoys me next) fix #21132 