### PR TITLE
Fix buried gauntlet critters not counting towards alive critter count

### DIFF
--- a/code/datums/components/gauntlet_critter.dm
+++ b/code/datums/components/gauntlet_critter.dm
@@ -15,6 +15,9 @@ TYPEINFO(/datum/component/gauntlet_critter)
 
 /datum/component/gauntlet_critter/proc/gauntlet_death()
 	global.gauntlet_controller.decreaseCritters(parent)
+	SPAWN(1 SECOND)
+		showswirl(get_turf(parent))
+		qdel(parent)
 
 /datum/component/gauntlet_critter/UnregisterFromParent()
 	if (ismobcritter(parent))

--- a/code/datums/gauntlet/crittergauntlet.dm
+++ b/code/datums/gauntlet/crittergauntlet.dm
@@ -246,21 +246,8 @@
 					waiting--
 			else
 				if (waiting <= 0)
-					var/live = 0
 					var/pc = 0
-					for (var/obj/critter/C in gauntlet)
-						if (!C.alive)
-							showswirl(get_turf(C))
-							qdel(C)
-						else
-							live++
-					for (var/mob/living/critter/C in gauntlet)
-						if (isdead(C))
-							showswirl(get_turf(C))
-							qdel(C)
-						else
-							live++
-					if (!live)
+					if (length(src.critters_left) == 0)
 						finishWave()
 					for (var/mob/living/M in gauntlet)
 						if (!isdead(M) && M.client)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Use the gauntlet critter component to do death effects and use the existing critter counter to track alive critters instead of checking/calculating every eigth process tick


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22991