### PR TITLE
Clean Syndieop access

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2339,6 +2339,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 /datum/job/special/syndicate_specialist
 	linkcolor = SYNDICATE_LINK_COLOR
 	name = "Syndicate Special Operative"
+	access_string = "Syndicate Operative" // "All Access" + Syndie Shuttle
 	limit = 0
 	wages = 0
 	allow_traitors = FALSE
@@ -2369,10 +2370,6 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	radio_announcement = FALSE
 	add_to_manifest = FALSE
 	special_spawn_location = LANDMARK_SYNDICATE
-
-	New()
-		..()
-		src.access = syndicate_spec_ops_access()
 
 	special_setup(var/mob/living/carbon/human/M)
 		..()

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -200,6 +200,8 @@
 	switch(job)
 		if("Nanotrasen Responder")
 			return get_all_accesses() + list(access_centcom)
+		if("Syndicate Operative")
+			return get_all_accesses() + list(access_syndicate_shuttle)
 		// --------------------------- Heads of staff
 		if("Captain")
 			return get_all_accesses()
@@ -368,21 +370,6 @@
 				access_research, access_research_director, access_dwaine_superuser, access_engineering_atmos, access_medical_director, access_special_club,
 				access_researchfoyer, access_telesci, access_artlab, access_robotdepot, access_money)
 #endif
-
-/proc/syndicate_spec_ops_access() //syndie spec ops need to get out of the listening post.
-	return list(access_security, access_brig, access_forensics_lockers,
-				access_medical, access_medlab, access_morgue, access_securitylockers,
-				access_tox, access_tox_storage, access_chemistry, access_carrypermit,
-				access_change_ids, access_ai_upload,
-				access_teleporter, access_eva, access_heads, access_captain, access_all_personal_lockers, access_head_of_personnel,
-				access_chapel_office, access_kitchen, access_medical_lockers, access_pathology,
-				access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_supply_console, access_hydro, access_ranch, access_mail,
-				access_engineering, access_maint_tunnels,
-				access_tech_storage, access_engineering_storage, access_engineering_eva,
-				access_engineering_power, access_engineering_engine,
-				access_engineering_control, access_engineering_mechanic, access_engineering_chief, access_mining, access_mining_outpost,
-				access_research, access_research_director, access_dwaine_superuser, access_engineering_atmos, access_medical_director, access_special_club, access_syndicate_shuttle,
-				access_researchfoyer, access_artlab, access_telesci, access_robotdepot)
 
 // Generated at round start.
 var/list/access_name_lookup = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces /proc/syndicate_spec_ops_access() with the access_string "Syndicate Operative" that returns all access + syndie shuttle.

May require secret change:
syndicate_spec_ops_access() -> get_access("Syndicate Operative")


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The only differences between get_all_accesses and syndicate_spec_ops_access is that nobody updates the syndie access and it has syndicate access.

