### PR TITLE
Name Hand-Assembled Cleanbots

### DIFF
--- a/code/modules/robotics/bot/cleanbot.dm
+++ b/code/modules/robotics/bot/cleanbot.dm
@@ -16,21 +16,39 @@
 	w_class = W_CLASS_NORMAL
 	flags = TABLEPASS
 	var/created_cleanbot_type = /obj/machinery/bot/cleanbot
+	var/created_name = "Cleanbot"
 
-	attackby(var/obj/item/parts/robot_parts/P, mob/user as mob)
-		if (!istype(P, /obj/item/parts/robot_parts/arm/))
+	attackby(var/obj/item/I, mob/user as mob)
+		if (!istype(I, /obj/item/parts/robot_parts/arm/) && !istype(I, /obj/item/pen))
 			return
 
-		var/obj/machinery/bot/cleanbot/A = new created_cleanbot_type
-		if (user.r_hand == src || user.l_hand == src)
-			A.set_loc(get_turf(user))
-		else
-			A.set_loc(get_turf(src))
+		if(istype(I, /obj/item/parts/robot_parts/arm))
+			var/obj/machinery/bot/cleanbot/A = new created_cleanbot_type
+			if (user.r_hand == src || user.l_hand == src)
+				A.set_loc(get_turf(user))
+			else
+				A.set_loc(get_turf(src))
 
-		boutput(user, "You add the robot arm to the bucket and sensor assembly! Beep boop!")
-		qdel(P)
-		qdel(src)
-		return
+			boutput(user, "You add the robot arm to the bucket and sensor assembly! Beep boop!")
+			A.name = src.created_name
+			qdel(I)
+			qdel(src)
+			return
+
+		if (istype(I, /obj/item/pen))
+			var/t = input(user, "Enter new robot name", src.name, src.created_name) as null|text
+			if (!t)
+				return
+			if(t && t != src.name && t != src.created_name)
+				phrase_log.log_phrase("bot-clean", t)
+				t = strip_html(replacetext(t, "'",""))
+				t = copytext(t, 1, 45)
+			if (!t)
+				return
+			if (!in_interact_range(src, user) && src.loc != user)
+				return
+
+			src.created_name = t
 
 	red
 		icon_state = "bucket_proxy-red"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This just lets you use a pen on a bucket-and-sensor array in order to give your cleanbot a custom name.

![image](https://github.com/user-attachments/assets/731f57c9-b081-4b72-a123-dcda051b7862)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
For fun!


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Jan.antilles
(+)Hand-assembled cleanbots can now be named with a pen before adding the final robot arm.
```
