### PR TITLE
Emagged IDs keep special accesses

### DIFF
--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -299,9 +299,13 @@ TYPEINFO(/obj/item/card/emag)
 		return FALSE
 	var/list/all_accesses = get_all_accesses()
 	var/bonus_access = list() // preserve accesses which are otherwise unobtainable
+	var/special_accesses = list(access_maxsec, access_armory)
 	for (var/access in src.access)
 		if (!(access in all_accesses))
-			bonus_access += list(access)
+			if((access in special_accesses) && prob(33))
+				bonus_access += list(access)
+			else
+				bonus_access += list(access)
 	src.access = bonus_access // clear what used to be there
 	for (var/i = rand(2,25), i > 0, i--)
 		var/new_access = pick(all_accesses)

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -297,16 +297,16 @@ TYPEINFO(/obj/item/card/emag)
 		if (user && E)
 			user.show_text("You run [E] over [src], but nothing seems to happen.", "red")
 		return FALSE
-	src.access = list() // clear what used to be there
 	var/list/all_accesses = get_all_accesses()
+	var/bonus_access = list() // preserve accesses which are otherwise unobtainable
+	for (var/access in src.access)
+		if (!(access in all_accesses))
+			bonus_access += list(access)
+	src.access = bonus_access // clear what used to be there
 	for (var/i = rand(2,25), i > 0, i--)
 		var/new_access = pick(all_accesses)
 		src.access += new_access
 		all_accesses -= new_access
-		if (istype(src, /obj/item/card/id/syndicate)) // Nuke ops unable to exit their station (Convair880).
-			src.access += access_syndicate_shuttle
-		if (istype(src, /obj/item/card/id/syndicate/commander)) // Commander unable to play their cool tunes
-			src.access += access_syndicate_commander
 		DEBUG_MESSAGE("[get_access_desc(new_access)] added to [src]")
 	user?.show_text("You run [E] over [src], scrambling its access.", "red")
 	logTheThing(LOG_STATION, user || usr, "emagged [src], scrambling its access and granting random access at [log_loc(user || usr)].")

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -298,14 +298,10 @@ TYPEINFO(/obj/item/card/emag)
 			user.show_text("You run [E] over [src], but nothing seems to happen.", "red")
 		return FALSE
 	var/list/all_accesses = get_all_accesses()
-	var/bonus_access = list() // preserve accesses which are otherwise unobtainable
-	var/special_accesses = list(access_maxsec, access_armory)
+	var/bonus_access = list() // have a chance to keep some special accesses
 	for (var/access in src.access)
-		if (!(access in all_accesses))
-			if((access in special_accesses) && prob(33))
-				bonus_access += list(access)
-			else
-				bonus_access += list(access)
+		if (!(access in all_accesses) && prob(20))
+			bonus_access += list(access)
 	src.access = bonus_access // clear what used to be there
 	for (var/i = rand(2,25), i > 0, i--)
 		var/new_access = pick(all_accesses)

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -425,9 +425,13 @@
 					else
 						// preserve accesses which are otherwise unobtainable
 						var/bonus_access = list()
+						var/special_accesses = list(access_maxsec, access_armory)
 						for (var/access in src.modify.access)
 							if (!(access in get_all_accesses())) //fuck this proc name
-								bonus_access += list(access)
+								if((access in special_accesses) && prob(33))
+									bonus_access += list(access)
+								else
+									bonus_access += list(access)
 						src.modify.access = get_access(t1) + bonus_access
 						logTheThing(LOG_STATION, usr, "changes the access and assignment on the ID card (<b>[src.modify.registered]</b>) to <b>[t1]</b>.")
 

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -425,13 +425,9 @@
 					else
 						// preserve accesses which are otherwise unobtainable
 						var/bonus_access = list()
-						var/special_accesses = list(access_maxsec, access_armory)
 						for (var/access in src.modify.access)
 							if (!(access in get_all_accesses())) //fuck this proc name
-								if((access in special_accesses) && prob(33))
-									bonus_access += list(access)
-								else
-									bonus_access += list(access)
+								bonus_access += list(access)
 						src.modify.access = get_access(t1) + bonus_access
 						logTheThing(LOG_STATION, usr, "changes the access and assignment on the ID card (<b>[src.modify.registered]</b>) to <b>[t1]</b>.")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Emagging an ID card now has a 20% chance per access not in get_all_accesses(), to keep that access

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These accesses tend to otherwise be unobtainable and so should not be easily removable.
Syndicate IDs had special behaviour to keep their special accesses but if a non-syndicate ID had syndie access it would be removed on emagging. 
Prevents removing HoS/armory access without destroying the card, but I have never seen anyone emag the HoS ID with intent to remove their access as to emag it you first have to have it, and antags tend to like free entry to the armory.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Emagged IDs now have a chance to keep any special accesses, such as Armory, Centcom, and Azone accesses.
```
