### PR TITLE
stop artifact faults making dead things speak

### DIFF
--- a/code/obj/artifacts/faults.dm
+++ b/code/obj/artifacts/faults.dm
@@ -190,6 +190,8 @@ ABSTRACT_TYPE(/datum/artifact_fault/messager/)
 	deploy(var/obj/O,var/mob/living/user,var/atom/cosmeticSource)
 		if (..())
 			return
+		if(isdead(user))
+			return
 		if(src.say_instead)
 			var/msg = "[prob(20)?"":";"][generate_message(O, user)]"
 			if(prob(20))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a check for isdead and return early if so when the messager artifact fault is run, so that artifacts don't make dead people send says to deadchat


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22980
