### PR TITLE
Fix some cargo pads not sending PDA notifications

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1301,11 +1301,11 @@
 	dir = 1;
 	light_type = /obj/item/light/tube/yellowish
 	},
-/obj/submachine/cargopad,
 /obj/noticeboard/persistent{
 	name = "Cargo persistent notice board";
 	persistent_id = "cargo"
 	},
+/obj/submachine/cargopad/qm,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "afv" = (
@@ -12195,14 +12195,12 @@
 /turf/simulated/floor,
 /area/station/ranch)
 "fOM" = (
-/obj/submachine/cargopad{
-	name = "Mineral Magnet Pad"
-	},
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
 	},
 /obj/machinery/oreaccumulator,
+/obj/submachine/cargopad/magnet,
 /turf/simulated/floor/grime,
 /area/station/mining/magnet)
 "fPi" = (
@@ -17508,13 +17506,11 @@
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
 "nol" = (
-/obj/submachine/cargopad{
-	name = "Robotics Workshop Pad"
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
 	},
 /obj/machinery/light/incandescent,
+/obj/submachine/cargopad/robotics,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "nqV" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -9956,9 +9956,7 @@
 /turf/simulated/floor,
 /area/station/hangar/science)
 "bxs" = (
-/obj/submachine/cargopad{
-	name = "Artifact Lab Pad"
-	},
+/obj/submachine/cargopad/artlab,
 /turf/simulated/floor/caution/misc{
 	dir = 6
 	},
@@ -15985,10 +15983,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "fkB" = (
-/obj/submachine/cargopad{
-	name = "Mineral Magnet Pad"
-	},
 /obj/machinery/oreaccumulator,
+/obj/submachine/cargopad/magnet,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -25464,10 +25460,8 @@
 /area/station/crew_quarters/kitchen)
 "lQC" = (
 /obj/machinery/light,
-/obj/submachine/cargopad{
-	name = "Robotics Workshop Pad"
-	},
 /obj/machinery/portable_reclaimer,
+/obj/submachine/cargopad/robotics,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "lRb" = (
@@ -29368,9 +29362,7 @@
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "oKd" = (
-/obj/submachine/cargopad{
-	name = "Botany Pad"
-	},
+/obj/submachine/cargopad/hydroponic,
 /turf/simulated/floor/caution/misc{
 	dir = 6
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -20410,9 +20410,7 @@
 /turf/simulated/floor,
 /area/station/hangar/main)
 "bvE" = (
-/obj/submachine/cargopad{
-	name = "Pod Bay Pad"
-	},
+/obj/submachine/cargopad/podbay,
 /turf/simulated/floor,
 /area/station/hangar/main)
 "bvF" = (
@@ -22106,9 +22104,7 @@
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "bEq" = (
-/obj/submachine/cargopad{
-	name = "Mineral Magnet Pad"
-	},
+/obj/submachine/cargopad/magnet,
 /turf/simulated/floor/plating/airless,
 /area/station/mining/magnet)
 "bEs" = (
@@ -23147,10 +23143,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/submachine/cargopad{
-	name = "Cargo Bay Pad"
-	},
 /obj/disposalpipe/segment/mail,
+/obj/submachine/cargopad/qm,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bJJ" = (
@@ -24658,9 +24652,7 @@
 	},
 /area/station/crew_quarters/bar)
 "bOR" = (
-/obj/submachine/cargopad{
-	name = "Mechanical Workshop Pad"
-	},
+/obj/submachine/cargopad/mechanics,
 /turf/simulated/floor,
 /area/station/engine/elect)
 "bOT" = (
@@ -31388,9 +31380,7 @@
 /turf/simulated/floor,
 /area/station/science/artifact)
 "clR" = (
-/obj/submachine/cargopad{
-	name = "Artifact Lab Pad"
-	},
+/obj/submachine/cargopad/artlab,
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "clT" = (
@@ -31570,12 +31560,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/submachine/cargopad{
-	name = "Robotics Workshop Pad"
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
+/obj/submachine/cargopad/robotics,
 /turf/simulated/floor,
 /area/station/medical/robotics)
 "cmr" = (
@@ -49041,9 +49029,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "mlq" = (
-/obj/submachine/cargopad{
-	name = "Botany Pad"
-	},
+/obj/submachine/cargopad/hydroponic,
 /turf/simulated/floor/grime,
 /area/station/storage/hydroponics)
 "mlt" = (

--- a/maps/density2.dmm
+++ b/maps/density2.dmm
@@ -2988,9 +2988,7 @@
 /turf/simulated/floor/auto/dirt,
 /area/station/crew_quarters/garden/sunlight)
 "sw" = (
-/obj/submachine/cargopad{
-	name = "Mineral Magnet Pad"
-	},
+/obj/submachine/cargopad/magnet,
 /turf/simulated/floor/plating/airless,
 /area/station/quartermaster/magnet)
 "sz" = (
@@ -3471,9 +3469,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/submachine/cargopad{
-	name = "Cargo Bay Pad"
-	},
+/obj/submachine/cargopad/qm,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "vO" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -1327,9 +1327,7 @@
 /area/station/science/hall)
 "agZ" = (
 /obj/landmark/spawner/artifact,
-/obj/submachine/cargopad{
-	name = "Artifact Lab Pad"
-	},
+/obj/submachine/cargopad/artlab,
 /turf/simulated/floor/white/checker2{
 	dir = 8
 	},
@@ -3616,9 +3614,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/office)
 "auF" = (
-/obj/submachine/cargopad{
-	name = "Pod Bay Pad"
-	},
+/obj/submachine/cargopad/podbay,
 /turf/simulated/floor,
 /area/station/hangar/main)
 "auG" = (
@@ -13527,7 +13523,7 @@
 /area/station/engine/engineering)
 "bxb" = (
 /obj/item/device/radio/beacon,
-/obj/submachine/cargopad{
+/obj/submachine/cargopad/mechanics{
 	name = "Engineering Pad"
 	},
 /turf/simulated/floor/yellow,
@@ -16026,12 +16022,10 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/pool)
 "cgU" = (
-/obj/submachine/cargopad{
-	name = "Research Outpost Pad"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/submachine/cargopad/researchoutpost,
 /turf/simulated/floor,
 /area/station/science/hall)
 "chE" = (
@@ -33674,9 +33668,7 @@
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
 "mKQ" = (
-/obj/submachine/cargopad{
-	name = "Botany Pad"
-	},
+/obj/submachine/cargopad/hydroponic,
 /turf/simulated/floor/green/side{
 	dir = 9
 	},
@@ -41436,9 +41428,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "qYg" = (
-/obj/submachine/cargopad{
-	name = "Mechanical Workshop Pad"
-	},
+/obj/submachine/cargopad/mechanics,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "qYK" = (
@@ -46940,9 +46930,7 @@
 /turf/simulated/floor/white/checker,
 /area/station/medical/medbay/pharmacy)
 "ukm" = (
-/obj/submachine/cargopad{
-	name = "Mineral Magnet Pad"
-	},
+/obj/submachine/cargopad/magnet,
 /turf/simulated/floor/plating/airless,
 /area/station/mining/magnet)
 "ukA" = (
@@ -49144,9 +49132,7 @@
 	},
 /area/station/medical/medbay/surgery)
 "vxl" = (
-/obj/submachine/cargopad{
-	name = "Cargo Bay Pad"
-	},
+/obj/submachine/cargopad/qm,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "vxO" = (
@@ -49721,9 +49707,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/submachine/cargopad{
-	name = "Robotics Pad"
-	},
+/obj/submachine/cargopad/robotics,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -11823,13 +11823,11 @@
 /obj/machinery/light/incandescent/warm{
 	dir = 8
 	},
-/obj/submachine/cargopad{
-	name = "Cargo Teleport Pad"
-	},
 /obj/decal/tile_edge/line/yellow{
 	dir = 8;
 	icon_state = "line1"
 	},
+/obj/submachine/cargopad/qm,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "duo" = (
@@ -23091,14 +23089,12 @@
 /turf/simulated/floor/red/checker,
 /area/station/security/checkpoint/sec_foyer)
 "gSY" = (
-/obj/submachine/cargopad{
-	name = "Artifact Lab Pad"
-	},
 /obj/disposalpipe/segment,
 /obj/item/cargotele{
 	pixel_x = 5;
 	pixel_y = 8
 	},
+/obj/submachine/cargopad/artlab,
 /turf/simulated/floor/plating/jen,
 /area/station/science/artifact)
 "gTe" = (
@@ -46687,15 +46683,13 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "ohz" = (
-/obj/submachine/cargopad{
-	name = "Robotics Workshop Pad"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 10;
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/submachine/cargopad/robotics,
 /turf/simulated/floor/circuit/off,
 /area/station/medical/robotics)
 "ohB" = (
@@ -58091,10 +58085,8 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "rGw" = (
-/obj/submachine/cargopad{
-	name = "Botany Pad"
-	},
 /obj/storage/secure/crate/bee/loaded,
+/obj/submachine/cargopad/hydroponic,
 /turf/simulated/floor/wood/five,
 /area/station/hydroponics/bay)
 "rGI" = (
@@ -65528,9 +65520,7 @@
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
 "tQv" = (
-/obj/submachine/cargopad{
-	name = "Mineral Magnet Pad"
-	},
+/obj/submachine/cargopad/magnet,
 /turf/simulated/floor/black/grime,
 /area/station/mining/staff_room)
 "tQG" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -44355,9 +44355,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/submachine/cargopad{
-	name = "Mining Pad"
-	},
+/obj/submachine/cargopad/magnet,
 /turf/simulated/floor/grey,
 /area/station/mining/magnet)
 "mys" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -46984,8 +46984,8 @@
 /turf/simulated/floor/engine,
 /area/station/crew_quarters/bar)
 "tYz" = (
-/obj/submachine/cargopad{
-	name = "Mining Gear Room Pad"
+/obj/submachine/cargopad/magnet{
+	name = "Mining Staff Room"
 	},
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -7255,9 +7255,7 @@
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "ayY" = (
-/obj/submachine/cargopad{
-	name = "Artifact Lab Pad"
-	},
+/obj/submachine/cargopad/artlab,
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "ayZ" = (
@@ -12592,10 +12590,8 @@
 /turf/space/fluid/nospawn,
 /area/space)
 "aRK" = (
-/obj/submachine/cargopad{
-	name = " Research Outpost Pod Bay Pad"
-	},
 /obj/machinery/light_switch/auto,
+/obj/submachine/cargopad/researchoutpost,
 /turf/simulated/floor,
 /area/research_outpost/hangar)
 "aRM" = (
@@ -21881,8 +21877,8 @@
 /turf/simulated/floor/caution/east,
 /area/station/mining/staff_room)
 "bDg" = (
-/obj/submachine/cargopad{
-	name = "Mineral Magnet Pad"
+/obj/submachine/cargopad/magnet{
+	name = "Mining Staff Room"
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
@@ -23884,9 +23880,6 @@
 /turf/simulated/floor/caution/east,
 /area/station/quartermaster/office)
 "bKn" = (
-/obj/submachine/cargopad{
-	name = "Cargo Bay Pad"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 0;
@@ -23898,6 +23891,7 @@
 	name = "Cargo persistent notice board";
 	persistent_id = "cargo"
 	},
+/obj/submachine/cargopad/qm,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bKo" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mapping][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace most `/obj/submachine/cargopad` on in-rotation maps with the relevant subtype.

These subtypes specify mailgroups, which alert related staff that something has been sent.

There are still a few pads that will not alert people, but would require adding new pad subtypes:
Donut2: Security Equipment Room pad
Nadir: Security Pod Bay pad
Oshan: Catering Pod Bay pad, Security Pod Bay pad

In addition there's one pad on Kondaru that doesn't have a subtype, but also would not alert anyone:
Kondaru: Utility Room pad

The existing Pod Bay pad does not notify anyone, but the subtype is used for consistency across maps.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22971
Less map var-edits
Map name & functionality consistency