### PR TITLE
Stop ghost drones from picking up special wizard staffs

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -1162,13 +1162,13 @@
 
 	onUpdate() //check for special conditions that could interrupt the picking-up here.
 		..()
-		if(BOUNDS_DIST(owner, target) > 0 || picker == null || target == null || owner == null) //If the thing is suddenly out of range, interrupt the action. Also interrupt if the user or the item disappears.
+		if(BOUNDS_DIST(owner, target) > 0 || picker == null || target == null || owner == null || !can_act(src.owner)) //If the thing is suddenly out of range, interrupt the action. Also interrupt if the user or the item disappears.
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
 	onStart()
 		..()
-		if(BOUNDS_DIST(owner, target) > 0 || picker == null || target == null || owner == null || picker.working)  //If the thing is out of range, interrupt the action. Also interrupt if the user or the item disappears.
+		if(BOUNDS_DIST(owner, target) > 0 || picker == null || target == null || owner == null || picker.working || !can_act(src.owner))  //If the thing is out of range, interrupt the action. Also interrupt if the user or the item disappears.
 			interrupt(INTERRUPT_ALWAYS)
 			return
 		else
@@ -1217,6 +1217,8 @@
 		if(picker == null || owner == null) //Interrupt if the user or the magpicker disappears.
 			interrupt(INTERRUPT_ALWAYS)
 			return
+		if (!can_act(src.owner))
+			interrupt(INTERRUPT_ALWAYS)
 
 	onStart()
 		..()

--- a/code/obj/item/magtractor.dm
+++ b/code/obj/item/magtractor.dm
@@ -93,6 +93,8 @@ TYPEINFO(/obj/item/magtractor)
 	afterattack(atom/A, mob/user as mob)
 		if (!A) return 0
 
+		if (!can_act(user)) return 0
+
 		if (!src.holding)
 			if (!isitem(A)) return 0
 			if (BOUNDS_DIST(get_turf(src), get_turf(A)) > 0)

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -190,6 +190,12 @@
 		..()
 		return
 
+	attackby(obj/item/W, mob/user, params)
+		if (istype(W, /obj/item/magtractor))
+			src.do_brainmelt(user, 2)
+			return
+		. = ..()
+
 	mouse_drop(atom/over_object, src_location, over_location, over_control, params)
 		if (iswizard(usr) || check_target_immunity(usr))
 			. = ..()
@@ -261,6 +267,13 @@
 				zap_person(user)
 				return
 		else ..()
+
+	attackby(obj/item/W, mob/user, params)
+		if (istype(W, /obj/item/magtractor))
+			src.zap_person(user)
+			user.changeStatus("unconscious", 3 SECONDS) // stop magtractoring it
+			return
+		. = ..()
 
 	pull(mob/user)
 		if(check_target_immunity(user))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Prevent starting/continuing magtractor actions while unable to act
* Apply cthulu/thunder staff effects when attacked by a magtractor
* Add a special unconscious apply to thunder staff-magtractor interactions

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22999