### PR TITLE
fix dimensional key OOB when buckled

### DIFF
--- a/code/obj/artifacts/artifact_items/dimensional_key.dm
+++ b/code/obj/artifacts/artifact_items/dimensional_key.dm
@@ -167,7 +167,10 @@ ABSTRACT_TYPE(/obj/art_fissure_objs/cross_dummy)
 			AM.set_loc(get_step(src.exit_turf, turn(AM.dir, 180)))
 			SPAWN(0.001) // just a really low value
 				AM.set_loc(src.exit_turf)
-
+				if (istype(AM, /obj/stool)) // i dont like this but buckled is weird as shit
+					var/obj/stool/stool = AM
+					if (stool.buckled_guy)
+						stool.buckled_guy.set_loc(src.exit_turf)
 		else
 			return ..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
we have to move the buckled person alongside what they're buckled into, or they'll remain on an OOB turf inside the dimensional rift general area but outside the doored area.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #22965