### PR TITLE
Fix null.notes when loading instruments.dm

### DIFF
--- a/code/modules/items/instruments/instruments.dm
+++ b/code/modules/items/instruments/instruments.dm
@@ -72,6 +72,7 @@
 				newcontext.note = i
 				contextActions += newcontext
 
+	initialize(player_caused_init)
 		if (src.use_new_interface)
 			var/datum/instrument_data/instr_data = src.sound_bank.bank[initial(src.name)]
 			src.notes = instr_data.notes


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][runtime]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Move the notes initilaization to initialize instead of new


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix `code/modules/items/instruments/instruments.dm,77: Cannot read null.notes`