### PR TITLE
Fix construction for SMES units 

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -59,6 +59,21 @@ TYPEINFO(/obj/machinery/power/smes)
 			term.set_dir(get_dir(Q, iloc))
 		..()
 
+/obj/machinery/power/smes/was_deconstructed_to_frame(mob/user)
+	if (src.terminal)
+		qdel(src.terminal)
+		src.terminal = null
+	. = ..()
+
+/obj/machinery/power/smes/was_built_from_frame(mob/user, newly_built)
+	if (newly_built)
+		src.charge = 0
+		deconstruct_flags = DECON_SIMPLE
+	var/obj/machinery/power/terminal/term = new /obj/machinery/power/terminal(get_step(src, src.dir))
+	term.set_dir(get_dir(term, src))
+	src.terminal = term
+	. = ..()
+
 /obj/machinery/power/smes/emp_act()
 	..()
 	src.online = 0

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -69,8 +69,17 @@ TYPEINFO(/obj/machinery/power/smes)
 	if (newly_built)
 		src.charge = 0
 		deconstruct_flags = DECON_SIMPLE
-	var/obj/machinery/power/terminal/term = new /obj/machinery/power/terminal(get_step(src, src.dir))
-	term.set_dir(get_dir(term, src))
+	var/obj/machinery/power/terminal/term
+	for (var/direction in cardinal)
+		for (var/obj/machinery/power/terminal/potential_term in get_turf(get_step(src, direction)))
+			if (potential_term.dir == get_dir(potential_term, src))
+				term = potential_term
+				break
+		if (term)
+			break
+	if (!term)
+		term = new /obj/machinery/power/terminal(get_step(src, src.dir))
+		term.set_dir(get_dir(term, src))
 	src.terminal = term
 	. = ..()
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -72,7 +72,7 @@ TYPEINFO(/obj/machinery/power/smes)
 	var/obj/machinery/power/terminal/term
 	for (var/direction in cardinal)
 		for (var/obj/machinery/power/terminal/potential_term in get_turf(get_step(src, direction)))
-			if (potential_term.dir == get_dir(potential_term, src))
+			if (isnull(potential_term.master) && potential_term.dir == get_dir(potential_term, src))
 				term = potential_term
 				break
 		if (term)
@@ -124,6 +124,11 @@ TYPEINFO(/obj/machinery/power/smes)
 
 		UpdateIcon()
 
+/obj/machinery/power/smes/disposing()
+	. = ..()
+	if (src.terminal)
+		src.terminal.master = null
+		src.terminal = null
 
 /obj/machinery/power/smes/update_icon()
 	if (status & (BROKEN|POWEROFF))

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -118,6 +118,8 @@ TYPEINFO(/obj/machinery/power/smes)
 
 		if (!terminal)
 			status |= POWEROFF
+			src.charging = FALSE
+			src.online = FALSE
 			return
 
 		terminal.master = src
@@ -156,6 +158,8 @@ TYPEINFO(/obj/machinery/power/smes)
 
 /obj/machinery/power/smes/set_broken()
 	if(..()) return
+	src.online = FALSE
+	src.charging = FALSE
 	AddComponent(/datum/component/equipment_fault/dangerously_shorted, tool_flags = TOOL_WIRING | TOOL_SOLDERING | TOOL_WRENCHING | TOOL_SCREWING | TOOL_PRYING)
 
 /obj/machinery/power/smes/ex_act(severity)
@@ -220,6 +224,8 @@ TYPEINFO(/obj/machinery/power/smes)
 		charge(mult)
 	else
 		status |= POWEROFF
+		src.online = FALSE
+		src.charging = FALSE
 		src.UpdateIcon()
 		return
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -81,6 +81,7 @@ TYPEINFO(/obj/machinery/power/smes)
 		term = new /obj/machinery/power/terminal(get_step(src, src.dir))
 		term.set_dir(get_dir(term, src))
 	src.terminal = term
+	term.master = src
 	. = ..()
 
 /obj/machinery/power/smes/emp_act()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -200,10 +200,15 @@ TYPEINFO(/obj/machinery/power/smes)
 		src.output = clamp((newoutput), 0 , SMESMAXCHARGELEVEL)
 
 /obj/machinery/power/smes/process(mult)
-
-	if (status & (BROKEN|POWEROFF))
+	if (status & BROKEN)
 		return
 
+	if (status & POWEROFF)
+		if (src.terminal)
+			status &= ~POWEROFF
+			src.UpdateIcon()
+		else
+			return
 
 	//store machine state to see if we need to update the icon overlays
 	var/last_disp = chargedisplay()
@@ -215,6 +220,7 @@ TYPEINFO(/obj/machinery/power/smes)
 		charge(mult)
 	else
 		status |= POWEROFF
+		src.UpdateIcon()
 		return
 
 	if (online)		// if outputting

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -27,6 +27,10 @@
 			var/obj/machinery/power/apc/APC = src.master
 			if (APC.terminal == src)
 				APC.terminal = null
+		if (istype(src.master, /obj/machinery/power/smes))
+			var/obj/machinery/power/smes/SMES = src.master
+			if (SMES.terminal == src)
+				SMES.terminal = null
 	..()
 
 /obj/machinery/power/terminal/hide(var/i)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
smes units need power terminals to function, this makes them put down terminals when building and pick up when deconning.

also newly constructed units start with 0 power, no free 20 MW power

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
constructed SMES units don't do anything right now