### PR TITLE
Makes chem condensers cheaper

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -868,7 +868,7 @@
 
 /datum/manufacture/condenser
 	name = "Chemical Condenser"
-	item_requirements = list("molitz" = 5)
+	item_requirements = list("crystal" = 5)
 	item_outputs = list(/obj/item/reagent_containers/glass/plumbing/condenser)
 	create = 1
 	time = 5 SECONDS
@@ -876,7 +876,7 @@
 
 /datum/manufacture/fractionalcondenser
 	name = "Fractional Condenser"
-	item_requirements = list("molitz" = 6)
+	item_requirements = list("crystal" = 6)
 	item_outputs = list(/obj/item/reagent_containers/glass/plumbing/condenser/fractional)
 	create = 1
 	time = 5 SECONDS
@@ -884,7 +884,7 @@
 
 /datum/manufacture/dropper_funnel
 	name = "Dropper Funnel"
-	item_requirements = list("molitz" = 3)
+	item_requirements = list("crystal" = 3)
 	item_outputs = list(/obj/item/reagent_containers/glass/plumbing/dropper)
 	create = 1
 	time = 5 SECONDS
@@ -892,7 +892,7 @@
 
 /datum/manufacture/portable_dispenser
 	name = "Portable Dispenser"
-	item_requirements = list("molitz" = 3,
+	item_requirements = list("crystal" = 3,
 							 "metal" = 2,
 							 "miracle" = 2)
 	item_outputs = list(/obj/item/reagent_containers/glass/plumbing/dispenser)

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -876,7 +876,7 @@
 
 /datum/manufacture/fractionalcondenser
 	name = "Fractional Condenser"
-	item_requirements = list("crystal" = 6)
+	item_requirements = list("molitz" = 6)
 	item_outputs = list(/obj/item/reagent_containers/glass/plumbing/condenser/fractional)
 	create = 1
 	time = 5 SECONDS
@@ -884,7 +884,7 @@
 
 /datum/manufacture/dropper_funnel
 	name = "Dropper Funnel"
-	item_requirements = list("crystal" = 3)
+	item_requirements = list("molitz" = 3)
 	item_outputs = list(/obj/item/reagent_containers/glass/plumbing/dropper)
 	create = 1
 	time = 5 SECONDS
@@ -892,7 +892,7 @@
 
 /datum/manufacture/portable_dispenser
 	name = "Portable Dispenser"
-	item_requirements = list("crystal" = 3,
+	item_requirements = list("molitz" = 3,
 							 "metal" = 2,
 							 "miracle" = 2)
 	item_outputs = list(/obj/item/reagent_containers/glass/plumbing/dispenser)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just changes the molitz in the condenser's recipe to crystal in general. Previously did this for all glassware.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A scientist can gather some crystal stuff but I've had a handful of rounds where molitz just isn't available, or isn't sold until halfway through the round.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CalliopeSoups
(+)Chem condensers now accept any crystal material.
```
