### PR TITLE
Fix runtimeDetails crash error

### DIFF
--- a/code/error_handling.dm
+++ b/code/error_handling.dm
@@ -15,7 +15,7 @@ var/global/blame_for_runtimes = FALSE
 	var/invalid = !istype(E) //what the fuck is this byond
 	runtime_count++
 
-	if (!runtimeDetails) runtimeDetails = list()
+	if (!runtimeDetails) CRASH("runtimeDetails list not initialized, how the fuck did this happen?")
 
 	//Save the runtime into our persistent, uh, "storage"
 	runtimeDetails["[length(runtimeDetails) + 1]"] = list(

--- a/code/world/initialization/1_preMapLoad.dm
+++ b/code/world/initialization/1_preMapLoad.dm
@@ -5,6 +5,7 @@
  * YOU WILL BE SENT TO THE CRUSHER IF YOU TOUCH THIS UNNECESSAIRLY
  */
 /world/proc/Genesis()
+	global.runtimeDetails = list()
 #ifdef LIVE_SERVER
 	world.log = file("data/errors.log")
 #endif


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][ci]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
so runtimeDetails should exist and if it *doesn't* exist or is somehow nulled mid-round it should blow up, so instead of automatically making a list and potentially paving over the mid-round nulled issue, make setting it to a list literally the first thing we do in preMapLoad.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix build fail:
``` 
Errors detected!
Runtime checking failed due to missing runtimeDetails global list
```