### PR TITLE
Lawyer Legal License "badge" and all job badges use paths

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -50,7 +50,7 @@
 	var/receives_miranda = FALSE
 	var/list/receives_implants = null //! List of object paths of implant types given on spawn.
 	var/receives_disk = FALSE //! Job spawns with cloning data disk, can specify a type
-	var/receives_badge = FALSE
+	var/obj/item/clothing/suit/security_badge/badge = null //! Typepath of the badge to spawn the player with
 	var/announce_on_join = FALSE //! On join, send message to all players indicating who is fulfilling the role; primarily for heads of staff
 	var/radio_announcement = TRUE //! The announcement computer will send a message when the player joins after round-start.
 	var/list/alt_names = list()
@@ -344,7 +344,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	cant_spawn_as_rev = TRUE
 	announce_on_join = TRUE
 	receives_disk = /obj/item/disk/data/floppy/sec_command
-	receives_badge = TRUE
+	badge = /obj/item/clothing/suit/security_badge
 	show_in_id_comp = FALSE
 	receives_implants = list(/obj/item/implant/health/security/anti_mindhack)
 	items_in_backpack = list(/obj/item/device/flash)
@@ -526,7 +526,7 @@ ABSTRACT_TYPE(/datum/job/security)
 	cant_spawn_as_rev = TRUE
 	receives_implants = list(/obj/item/implant/health/security/anti_mindhack)
 	receives_disk = /obj/item/disk/data/floppy/security
-	receives_badge = TRUE
+	badge = /obj/item/clothing/suit/security_badge
 	slot_back = list(/obj/item/storage/backpack/security)
 	slot_belt = list(/obj/item/device/pda2/security)
 	slot_jump = list(/obj/item/clothing/under/rank/security)
@@ -587,7 +587,7 @@ ABSTRACT_TYPE(/datum/job/security)
 	wages = PAY_TRADESMAN
 	trait_list = list("training_drinker")
 	access_string = "Detective"
-	receives_badge = TRUE
+	badge = /obj/item/clothing/suit/security_badge
 	cant_spawn_as_rev = TRUE
 	can_join_gangs = FALSE
 	allow_antag_fallthrough = FALSE
@@ -1163,7 +1163,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	wages = PAY_DOCTORATE
 	access_string = "Lawyer"
 	limit = 0
-	receives_badge = TRUE
+	badge = /obj/item/clothing/suit/security_badge/attorney
 	slot_jump = list(/obj/item/clothing/under/misc/lawyer)
 	slot_foot = list(/obj/item/clothing/shoes/black)
 	slot_lhan = list(/obj/item/storage/briefcase)
@@ -1185,7 +1185,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	can_join_gangs = FALSE
 	cant_spawn_as_con = TRUE
 	cant_spawn_as_rev = TRUE
-	receives_badge = TRUE
+	badge = /obj/item/clothing/suit/security_badge
 	receives_miranda = TRUE
 	slot_back = list(/obj/item/storage/backpack/withO2)
 	slot_belt = list(/obj/item/device/pda2/security)
@@ -1217,7 +1217,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	wages = PAY_UNTRAINED
 	access_string = "Hall Monitor"
 	cant_spawn_as_rev = TRUE
-	receives_badge = /obj/item/clothing/suit/security_badge/paper
+	badge = /obj/item/clothing/suit/security_badge/paper
 	slot_belt = list(/obj/item/device/pda2)
 	slot_jump = list(/obj/item/clothing/under/color/red)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
@@ -1483,7 +1483,7 @@ ABSTRACT_TYPE(/datum/job/special/random)
 	access_string = "Inspector"
 	receives_miranda = TRUE
 	cant_spawn_as_rev = TRUE
-	receives_badge = /obj/item/clothing/suit/security_badge/nanotrasen
+	badge = /obj/item/clothing/suit/security_badge/nanotrasen
 	slot_card = /obj/item/card/id/nt_specialist
 	slot_back = list(/obj/item/storage/backpack)
 	slot_belt = list(/obj/item/device/pda2/ntofficial)
@@ -2187,7 +2187,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 	linkcolor = CIVILIAN_LINK_COLOR
 	wages = PAY_UNTRAINED
 	starting_mutantrace = /datum/mutantrace/cow
-	receives_badge = TRUE
+	badge = /obj/item/clothing/suit/security_badge
 	change_name_on_spawn = TRUE
 	access_string = "Rancher" // it didnt actually have a unique string
 	slot_jump = list(/obj/item/clothing/under/rank/det)
@@ -2449,7 +2449,7 @@ ABSTRACT_TYPE(/datum/job/special/nt)
 	allow_spy_theft = FALSE
 	can_join_gangs = FALSE
 	cant_spawn_as_rev = TRUE
-	receives_badge = /obj/item/clothing/suit/security_badge/nanotrasen
+	badge = /obj/item/clothing/suit/security_badge/nanotrasen
 	receives_implants = list(/obj/item/implant/health/security/anti_mindhack)
 	access_string = "Nanotrasen Responder" // "All Access" + Centcom
 
@@ -2465,6 +2465,7 @@ ABSTRACT_TYPE(/datum/job/special/nt)
 	name = "Nanotrasen Special Operative"
 	trait_list = list("training_security")
 	receives_miranda = TRUE
+	badge = /obj/item/clothing/suit/security_badge/shielded
 	slot_belt = list(/obj/item/storage/belt/security/ntso)
 	slot_suit = list(/obj/item/clothing/suit/space/ntso)
 	slot_head = list(/obj/item/clothing/head/helmet/space/ntso)
@@ -2704,7 +2705,7 @@ ABSTRACT_TYPE(/datum/job/daily)
 	wages = PAY_DOCTORATE
 	access_string = "Lawyer"
 	limit = 4
-	receives_badge = TRUE
+	badge = /obj/item/clothing/suit/security_badge/attorney
 	slot_jump = list(/obj/item/clothing/under/misc/lawyer)
 	slot_foot = list(/obj/item/clothing/shoes/black)
 	slot_lhan = list(/obj/item/storage/briefcase)

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2465,7 +2465,6 @@ ABSTRACT_TYPE(/datum/job/special/nt)
 	name = "Nanotrasen Special Operative"
 	trait_list = list("training_security")
 	receives_miranda = TRUE
-	badge = /obj/item/clothing/suit/security_badge/shielded
 	slot_belt = list(/obj/item/storage/belt/security/ntso)
 	slot_suit = list(/obj/item/clothing/suit/space/ntso)
 	slot_head = list(/obj/item/clothing/head/helmet/space/ntso)

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -2233,6 +2233,16 @@ ABSTRACT_TYPE(/obj/item/clothing/suit/sweater_vest)
 		else
 			. = "It's the HoS's old war medal, you heard they got it for their acts of heroism in the war."
 
+/obj/item/clothing/suit/security_badge/attorney
+	name = "legal license"
+	desc = "A very tasteful business card that exudes professionalism. It even has a watermark."
+	icon = 'icons/obj/writing.dmi'
+	icon_state = "businesscard"
+	inhand_image_icon = 'icons/mob/inhand/overcoat/hand_suit_gimmick.dmi'
+	item_state = "security_badge_paper"
+	wear_image_icon = 'icons/mob/clothing/overcoats/worn_suit_gimmick.dmi'
+	wear_state = "security_badge_paper"
+
 /obj/item/clothing/suit/snow
 	name = "snow suit"
 	desc = "A thick padded suit that protects against extreme cold temperatures."

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -609,12 +609,8 @@ Equip items from body traits.
 
 				D.name = "data disk - '[src.real_name]'"
 
-			if(JOB.receives_badge)
-				var/obj/item/clothing/suit/security_badge/badge
-				if (ispath(JOB.receives_badge))
-					badge = new JOB.receives_badge(src)
-				else
-					badge = new /obj/item/clothing/suit/security_badge(src)
+			if(JOB.badge)
+				var/obj/item/clothing/suit/security_badge/badge = new JOB.badge(src)
 				if (!src.equip_if_possible(badge, SLOT_WEAR_SUIT))
 					src.equip_if_possible(badge, SLOT_IN_BACKPACK)
 				badge.badge_owner_name = src.real_name


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new badge type for lawyer/attorney job: legal license. It acts like a business card you can pin to your lapel and otherwise use like a badge.

This also changes the job datum code to require a path for the job badge.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stop using a trinary state for a single badge var (boolean TRUE/FALSE + type override)
Lawyers getting sec shield badges is a little weird

## Screenshot
![image](https://github.com/user-attachments/assets/7ae9f4f9-4141-487b-ab63-be84b9fe1090)


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Lawyers get a special legal license they can show off.
```
