### PR TITLE
Remove req_access_txt from carts

### DIFF
--- a/maps/cogwip/kappa.dmm
+++ b/maps/cogwip/kappa.dmm
@@ -242,7 +242,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4;
-	
+
 	},
 /turf/space/cavern,
 /area/space)
@@ -250,7 +250,7 @@
 /obj/structure/girder/reinforced,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 10;
-	
+
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/space)
@@ -282,7 +282,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/airless/plating,
 /area/space)
@@ -297,21 +297,21 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/airless/engine/caution/north,
 /area/space)
 "bb" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/plating,
 /area/space)
 "bc" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4;
-	
+
 	},
 /obj/pool/perspective{
 	tag = "icon-pool (WEST)";
@@ -581,14 +581,14 @@
 "bT" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -624,11 +624,11 @@
 "cb" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	
+
 	},
 /obj/fluid_spawner{
 	amount = 2700
@@ -650,11 +650,11 @@
 "ce" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10;
-	
+
 	},
 /obj/fluid_spawner{
 	amount = 2700
@@ -689,14 +689,14 @@
 "ck" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "cl" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -885,7 +885,7 @@
 /obj/machinery/door/airlock/pyro,
 /obj/cable{
 	icon_state = "1-2";
-	
+
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/door/firedoor/pyro,
@@ -1809,14 +1809,14 @@
 /obj/mesh/catwalk,
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/airless/plating,
 /area/space)
 "fI" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4;
-	
+
 	},
 /turf/simulated/wall/auto/asteroid/comet/ice_dense,
 /area/space)
@@ -1827,7 +1827,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 10;
-	
+
 	},
 /turf/space/cavern,
 /area/space)
@@ -1893,7 +1893,7 @@
 /obj/mesh/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/overfloor{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/airless/plating,
 /area/space)
@@ -1904,7 +1904,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 1;
-	
+
 	},
 /turf/space/cavern,
 /area/space)
@@ -1917,14 +1917,14 @@
 "fW" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 6;
-	
+
 	},
 /turf/simulated/floor,
 /area/space)
 "fX" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 10;
-	
+
 	},
 /turf/simulated/floor,
 /area/space)
@@ -1968,7 +1968,7 @@
 /obj/structure/girder/reinforced,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 5;
-	
+
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/space)
@@ -1982,7 +1982,7 @@
 "gg" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor,
 /area/space)
@@ -2049,14 +2049,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/airless/plating,
 /area/space)
 "gp" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2066,11 +2066,11 @@
 "gr" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2089,7 +2089,7 @@
 /obj/mapping_helper/wingrille_spawn/reinforced/full,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6;
-	
+
 	},
 /turf/simulated/floor/plating,
 /area/space)
@@ -2097,7 +2097,7 @@
 /obj/mapping_helper/wingrille_spawn/reinforced/full,
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/plating,
 /area/space)
@@ -2110,18 +2110,18 @@
 "gw" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "gx" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2184,11 +2184,11 @@
 "gF" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2239,11 +2239,11 @@
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2960,18 +2960,18 @@
 "iT" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	
+
 	},
 /obj/fluid_spawner{
 	amount = 2700
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
 	dir = 5;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3353,7 +3353,7 @@
 /obj/disposalpipe/trunk/east,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3423,8 +3423,7 @@
 /obj/item/chem_grenade/metalfoam,
 /obj/storage/cart/mechcart{
 	desc = "A big rolling supply cart equipped for handling hull breaches.";
-	name = "breach repair cart";
-	req_access_txt = "40"
+	name = "breach repair cart"
 	},
 /turf/simulated/floor/black,
 /area/space)
@@ -3531,7 +3530,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3543,7 +3542,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3555,36 +3554,36 @@
 /obj/disposalpipe/trunk/west,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 1;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "kw" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10;
-	
+
 	},
 /obj/fluid_spawner{
 	amount = 2700
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 9;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "kx" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3592,18 +3591,18 @@
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "kz" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
-	
+
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9;
-	
+
 	},
 /turf/simulated/floor/pool,
 /area/space)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -58276,10 +58276,7 @@
 /turf/space,
 /area/station/turret_protected/armory_outside)
 "wFB" = (
-/obj/storage/cart/mechcart{
-	desc = "A big rolling supply cart equipped for handling hull breaches.";
-	name = "breach repair cart"
-	},
+/obj/storage/cart/mechcart/breach,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -58278,8 +58278,7 @@
 "wFB" = (
 /obj/storage/cart/mechcart{
 	desc = "A big rolling supply cart equipped for handling hull breaches.";
-	name = "breach repair cart";
-	req_access_txt = "40"
+	name = "breach repair cart"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -17738,9 +17738,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "bop" = (
-/obj/storage/cart/hotdog{
-	req_access_txt = "28"
-	},
+/obj/storage/cart/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -20878,9 +20878,7 @@
 /obj/item/device/radio/intercom/botany{
 	dir = 1
 	},
-/obj/storage/cart/hotdog{
-	req_access_txt = "28"
-	},
+/obj/storage/cart/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,

--- a/maps/unused/crash_gimmick.dmm
+++ b/maps/unused/crash_gimmick.dmm
@@ -6838,9 +6838,7 @@
 /obj/item/body_bag,
 /obj/item/body_bag,
 /obj/item/body_bag,
-/obj/storage/cart/forensic{
-	req_access_txt = "4"
-	},
+/obj/storage/cart/forensic,
 /obj/item/clothing/head/det_hat{
 	desc = "Ugh, gross.";
 	name = "fedora"

--- a/maps/unused/manta.dmm
+++ b/maps/unused/manta.dmm
@@ -20000,9 +20000,7 @@
 	},
 /area/station/chapel/sanctuary)
 "bgj" = (
-/obj/storage/cart/hotdog{
-	req_access_txt = "28"
-	},
+/obj/storage/cart/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,

--- a/maps/unused/ozymandias.dmm
+++ b/maps/unused/ozymandias.dmm
@@ -53397,8 +53397,7 @@
 /obj/machinery/bot/firebot,
 /obj/storage/cart/mechcart{
 	desc = "A big rolling supply cart packed with firebots.";
-	name = "firebot cart";
-	req_access_txt = "40"
+	name = "firebot cart"
 	},
 /obj/machinery/light/small{
 	dir = 8;
@@ -58085,8 +58084,7 @@
 /obj/machinery/bot/firebot,
 /obj/storage/cart/mechcart{
 	desc = "A big rolling supply cart packed with firebots.";
-	name = "firebot cart";
-	req_access_txt = "40"
+	name = "firebot cart"
 	},
 /turf/simulated/floor/redblack{
 	dir = 8

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -22298,9 +22298,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/storage/cart/hotdog{
-	req_access_txt = "28"
-	},
+/obj/storage/cart/hotdog,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bxb" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes req_access_txt varedits from all /obj/storage/carts
(I have no idea why kappa.dmm does this with every single change I do to it, i'm just editing the actual code here not the maps so its not strongdmm doing anything)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These aren't secure or lockable, the access does nothing.
