### PR TITLE
Emitter EMAG act: blocks silicon interaction

### DIFF
--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -1363,7 +1363,7 @@ TYPEINFO(/obj/machinery/emitter)
 
 //Send a signal over our link, if possible.
 /obj/machinery/emitter/proc/post_status(var/target_id, var/key, var/value, var/key2, var/value2, var/key3, var/value3)
-	if(!src.link || !target_id)
+	if(!src.link || src.emagged || !target_id)
 		return
 
 	var/datum/signal/signal = get_free_signal()

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -1145,6 +1145,7 @@ TYPEINFO(/obj/machinery/emitter)
 	var/shot_number = 0
 	var/state = UNWRENCHED
 	var/locked = 1
+	var/emagged = FALSE
 	//Remote control stuff
 	var/net_id = null
 	var/obj/machinery/power/data_terminal/link = null
@@ -1211,6 +1212,9 @@ TYPEINFO(/obj/machinery/emitter)
 	..()
 
 /obj/machinery/emitter/attack_ai(mob/user as mob)
+	if (src.emagged)
+		boutput(user, SPAN_NOTICE("Unable to interface with [src]!"))
+		return
 	if(state == WELDED)
 		if(src.active==1)
 			if(tgui_alert(user, "Turn off the emitter?","Switch",list("Yes","No")) == "Yes")
@@ -1378,7 +1382,7 @@ TYPEINFO(/obj/machinery/emitter)
 
 //What do we do with an incoming command?
 /obj/machinery/emitter/receive_signal(datum/signal/signal)
-	if(!src.link)
+	if(!src.link || src.emagged)
 		return
 	if(!signal || !src.net_id || signal.encryption)
 		return
@@ -1414,6 +1418,11 @@ TYPEINFO(/obj/machinery/emitter)
 		icon_state = "Emitter"
 
 	return
+
+/obj/machinery/emitter/emag_act(mob/user, obj/item/card/emag/E)
+	if (!src.emagged)
+		boutput(user, SPAN_ALERT("\The [src] shorts out its remote connectivity controls!"))
+		src.emagged = TRUE
 
 /obj/machinery/emitter/assault
 	name = "prototype assault emitter"

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -1424,6 +1424,11 @@ TYPEINFO(/obj/machinery/emitter)
 		boutput(user, SPAN_ALERT("\The [src] shorts out its remote connectivity controls!"))
 		src.emagged = TRUE
 
+/obj/machinery/emitter/demag(mob/user)
+	. = ..()
+	if (src.emagged)
+		src.emagged = FALSE
+
 /obj/machinery/emitter/assault
 	name = "prototype assault emitter"
 	desc = "Shoots a VERY high power laser when active. The ID lock appears to have been messily smashed off."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives singularity emitters an emagged variable for tracking. When emagged, prevent `attack_ai` (i.e. silicon enable/disabling) and send/recieve signals from working.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Make singularity sabotage or weaponized emitters harder to immediately counter by an observant AI or cyborg (with a 6TC item).

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Singularity Emitters have an emag interaction.
```
