### PR TITLE
Pick up empty paper bins with empty hands

### DIFF
--- a/code/modules/writing/paper.dm
+++ b/code/modules/writing/paper.dm
@@ -625,13 +625,16 @@
 	if (paper)
 		user.put_in_hand_or_drop(paper)
 	else
-		if (src.amount_left >= 1 && user) //Wire: Fix for Cannot read null.loc (&& user)
-			src.amount_left--
-			var/obj/item/P = new bin_type(src)
-			user.put_in_hand_or_drop(P)
-			if (rand(1,100) == 13 && istype(P, /obj/item/paper))
-				var/obj/item/paper/PA = P
-				PA.info = "Help me! I am being forced to code SS13 and It won't let me leave."
+		if (user) //Wire: Fix for Cannot read null.loc (user)
+			if (src.amount_left >= 1)
+				src.amount_left--
+				var/obj/item/P = new bin_type(src)
+				user.put_in_hand_or_drop(P)
+				if (rand(1,100) == 13 && istype(P, /obj/item/paper))
+					var/obj/item/paper/PA = P
+					PA.info = "Help me! I am being forced to code SS13 and It won't let me leave."
+			else
+				user.put_in_hand_or_drop(src)
 	src.update()
 
 /obj/item/paper_bin/attack_self(mob/user as mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If a paper bin is empty and the user clicks with an open hand, the user gets the paper bin.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #23043
General usability with paperbins