### PR TITLE
Set the on-spawn timer of timers and proximity sensors to 5 seconds

### DIFF
--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -731,8 +731,7 @@ Contains:
 
 /obj/item/assembly/timer_ignite_pipebomb/New()
 	..()
-	var/obj/item/device/timer/new_trigger = new /obj/item/device/timer(src)
-	new_trigger.time = 5 SECONDS //have a time already set up and don't blow up unsuspecting users on use
+	var/obj/item/new_trigger = new /obj/item/device/timer(src)
 	var/obj/item/new_applier = new /obj/item/device/igniter(src)
 	var/obj/item/pipebomb/bomb/new_target = new src.pipebomb_path(src)
 	if(src.bomb_strength)

--- a/code/obj/item/device/prox_sensor.dm
+++ b/code/obj/item/device/prox_sensor.dm
@@ -6,7 +6,7 @@ TYPEINFO(/obj/item/device/prox_sensor)
 	icon_state = "motion0"
 	var/armed = FALSE
 	var/timing = FALSE
-	var/time = 0
+	var/time = 5 SECONDS
 	var/last_tick = null
 	var/const/max_time = 600 SECONDS
 	var/const/min_time = 0

--- a/code/obj/item/device/timer.dm
+++ b/code/obj/item/device/timer.dm
@@ -6,7 +6,7 @@ TYPEINFO(/obj/item/device/timer)
 	icon_state = "timer0"
 	item_state = "electronic"
 	var/timing = 0
-	var/time = null
+	var/time = 5 SECONDS
 	var/last_tick = 0
 	var/const/max_time = 600 SECONDS
 	var/const/min_time = 0


### PR DESCRIPTION
[balance][game objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR sets the timer of timers and proximity sensors on-spawn to 5 seconds. You are still able to decrease them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

With the new assemblies, a common mistake people have reported is activating secured pipebomb assemblies before setting the timer in unsecured state. Because timers starts at 0 seconds, this has caused quite a few people to explode themselves.

While this is a very clear case of skill issue, this also kinda feels bad. So to give the people a little helping hand, this PR set the initial timer to one common used by bombs. This does not affect any functionality whatsoever, so you can always set it down to 0, if you want.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Promity sensors and timers start out a a 5 second timer. You are still able to set them to a lower time, if you want.
```
