### PR TITLE
Remove redundant mine code handling dumping out live mines out of storages

### DIFF
--- a/code/modules/storage/storage.dm
+++ b/code/modules/storage/storage.dm
@@ -256,11 +256,6 @@
 			I.layer = initial(I.layer)
 			if(SEND_SIGNAL(I, COMSIG_ITEM_STORAGE_INTERACTION, user))
 				I.visible_message(SPAN_ALERT("[I] triggers as it falls on the ground!"))
-			else if (istype(I, /obj/item/mine))
-				var/obj/item/mine/M = I
-				if (M.armed && M.used_up != TRUE)
-					M.visible_message(SPAN_ALERT("[M] triggers as it falls on the ground!"))
-					M.triggered(user)
 
 /// using storage item in hand
 /datum/storage/proc/storage_item_attack_self(mob/user)


### PR DESCRIPTION
[internal][code quality]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR removes redundant code regarding dumping live mines out of storages

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

#22115 added `COMSIG_ITEM_STORAGE_INTERACTION`, which is now used to make any live mousetraps/mines go off when interacting with storages. In the PR, i forgot to remove the old piece of code which handled that behaviour.

