### PR TITLE
Fixes the recipe for brain bread

### DIFF
--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -551,7 +551,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 
 /datum/cookingrecipe/oven/brain_bread
 	ingredients = list(\
-	/obj/item/reagent_containers/food/snacks/ingredient/dough = 1,
+	/obj/item/reagent_containers/food/snacks/breadloaf = 1,
 	/obj/item/organ/brain = 1)
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/breadloaf/brain


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes the recipe for brain bread back to its pre-refactor state, ensuring that it is actually cookable.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Did you know that unlike every other bread recipe, brain bread requires an already-baked loaf to make? This is because if it used dough like every other recipe, it would conflict with the one for brainburgers. I did not know this when I was 100 lines deep in a refactor that should have been how things were all along, and now I'm here.

Fixes #23039

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)Brain bread can be made again
```
