### PR TITLE
Cancelling camera view as a skeleton puts you back in your head

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2831,9 +2831,12 @@ Tries to put an item in an available backpack, belt storage, pocket, or hand slo
 		src.update_colorful_parts()
 	return W
 
-
-/mob/living/carbon/human/set_eye()
-	..()
+/mob/living/carbon/human/set_eye(atom/new_eye, new_pixel_x = 0, new_pixel_y = 0)
+	if (new_eye == null && isskeleton(src))
+		var/datum/mutantrace/skeleton/skeleton = src.mutantrace
+		if (skeleton.head_tracker)
+			new_eye = skeleton.head_tracker
+	..(new_eye, new_pixel_x, new_pixel_y)
 	src.update_sight()
 
 /mob/living/carbon/human/heard_say(var/mob/other, var/message)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][mutrantraces]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a human mob's eye is set to null (i.e. return to default view), add a check for the skeleton mutantace and head tracker, then redirect the new eye location to the head.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #21066
Fix #22566