### PR TITLE
AI-only cameras use separate network 

### DIFF
--- a/_std/defines/camera.dm
+++ b/_std/defines/camera.dm
@@ -37,3 +37,5 @@
 #define CAMERA_NETWORK_STICKERS	"stickers"
 /// Cargo routing cameras
 #define CAMERA_NETWORK_CARGO	"cargo"
+/// AI-only cameras
+#define CAMERA_NETWORK_AI_ONLY	"ai"

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -99,6 +99,7 @@ var/global/list/ai_emotions = list("Annoyed" = "ai_annoyed-dol", \
 		CAMERA_NETWORK_RANCH,
 		CAMERA_NETWORK_SCIENCE,
 		CAMERA_NETWORK_CARGO,
+		CAMERA_NETWORK_AI_ONLY,
 	)
 	var/classic_move = 1 //Ordinary AI camera movement
 	var/obj/machinery/camera/current = null

--- a/code/modules/camera/camera.dm
+++ b/code/modules/camera/camera.dm
@@ -23,9 +23,7 @@
 	anchored = ANCHORED
 	/// Can't be destroyed by explosions
 	var/invuln = FALSE
-	/// Cameras only the AI can see through
-	var/ai_only = FALSE
-	/// Cant be snipped by wirecutters
+		/// Cant be snipped by wirecutters
 	var/reinforced = FALSE
 	/// automatically offsets and snaps to perspective walls. Not for televisions or internal cameras.
 	var/sticky = FALSE
@@ -72,8 +70,8 @@
 							/area/station/turret_protected/AIbasecore1,
 							/area/station/turret_protected/ai_upload_foyer)
 	if (locate(area) in aiareas)
-		src.ai_only = TRUE
 		src.prefix = "AI"
+		src.network = CAMERA_NETWORK_AI_ONLY
 
 	if (src.sticky)
 		autoposition(src.alternate_sprites)
@@ -338,8 +336,9 @@
 /// AI only camera
 /obj/machinery/camera/auto/AI
 	name = "autoname - AI"
+	network = CAMERA_NETWORK_AI_ONLY
 	prefix = "AI"
-	ai_only = TRUE // TODO: Make this a separate network instead of a flag
+	color = "#9999cc"
 
 /// Mining outpost cameras
 /obj/machinery/camera/auto/mining

--- a/code/modules/camera/camera.dm
+++ b/code/modules/camera/camera.dm
@@ -23,7 +23,7 @@
 	anchored = ANCHORED
 	/// Can't be destroyed by explosions
 	var/invuln = FALSE
-		/// Cant be snipped by wirecutters
+	/// Cant be snipped by wirecutters
 	var/reinforced = FALSE
 	/// automatically offsets and snaps to perspective walls. Not for televisions or internal cameras.
 	var/sticky = FALSE

--- a/code/modules/camera/camera.dm
+++ b/code/modules/camera/camera.dm
@@ -72,6 +72,7 @@
 	if (locate(area) in aiareas)
 		src.prefix = "AI"
 		src.network = CAMERA_NETWORK_AI_ONLY
+		src.color = "#9999cc"
 
 	if (src.sticky)
 		autoposition(src.alternate_sprites)

--- a/code/modules/camera/monitor.dm
+++ b/code/modules/camera/monitor.dm
@@ -12,8 +12,7 @@ TYPEINFO(/obj/item/device/camera_viewer)
 	var/obj/machinery/camera/current = null
 	// Sin but we need to know for disposing to clear viewer list on current
 	var/mob/last_viewer = null
-	var/can_view_ai = FALSE
-
+	
 	disposing()
 		src.disconnect_user(src.last_viewer)
 		..()
@@ -57,9 +56,7 @@ TYPEINFO(/obj/item/device/camera_viewer)
 
 		for (var/obj/machinery/camera/camera as anything in cameras)
 			if (camera.network in src.camera_networks)
-				if (camera.ai_only && !src.can_view_ai)
-					continue
-				displayed_cameras[text("[][]", camera.c_tag, (camera.camera_status ? null : " (Deactivated)"))] = camera
+								displayed_cameras[text("[][]", camera.c_tag, (camera.camera_status ? null : " (Deactivated)"))] = camera
 
 		var/selected_camera = tgui_input_list(user, "Which camera should you change to?", "Camera Selection", sortList(displayed_cameras, /proc/cmp_text_asc))
 
@@ -127,6 +124,6 @@ TYPEINFO(/obj/item/device/camera_viewer)
 		CAMERA_NETWORK_TELESCI,
 		CAMERA_NETWORK_STICKERS,
 		CAMERA_NETWORK_CARGO,
+		CAMERA_NETWORK_AI_ONLY,
 	)
-	can_view_ai = TRUE
 	default_material = "miracle"

--- a/code/modules/camera/monitor.dm
+++ b/code/modules/camera/monitor.dm
@@ -12,7 +12,7 @@ TYPEINFO(/obj/item/device/camera_viewer)
 	var/obj/machinery/camera/current = null
 	// Sin but we need to know for disposing to clear viewer list on current
 	var/mob/last_viewer = null
-	
+
 	disposing()
 		src.disconnect_user(src.last_viewer)
 		..()
@@ -56,7 +56,7 @@ TYPEINFO(/obj/item/device/camera_viewer)
 
 		for (var/obj/machinery/camera/camera as anything in cameras)
 			if (camera.network in src.camera_networks)
-								displayed_cameras[text("[][]", camera.c_tag, (camera.camera_status ? null : " (Deactivated)"))] = camera
+				displayed_cameras[text("[][]", camera.c_tag, (camera.camera_status ? null : " (Deactivated)"))] = camera
 
 		var/selected_camera = tgui_input_list(user, "Which camera should you change to?", "Camera Selection", sortList(displayed_cameras, /proc/cmp_text_asc))
 

--- a/code/obj/machinery/computer/security.dm
+++ b/code/obj/machinery/computer/security.dm
@@ -92,7 +92,7 @@
 
 		if(!closest)
 			return
-		else if (!closest.camera_status || closest.ai_only)
+		else if (!closest.camera_status || !(closest.network in src.camera_networks))
 			boutput(user, SPAN_ALERT("ERROR. Cannot connect to camera."))
 			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 10, 0)
 			return

--- a/code/obj/machinery/computer/security/security_cameras_chui.dm
+++ b/code/obj/machinery/computer/security/security_cameras_chui.dm
@@ -42,7 +42,7 @@ chui/window/security_cameras
 			if (C.network in owner.camera_networks)
 				. = "[C.c_tag][C.camera_status ? null : " (Deactivated)"]"
 				// Don't draw if it's in favorites or AI core/upload
-				if ((C in owner.favorites) || C.ai_only)
+				if ((C in owner.favorites))
 					continue
 				// &#128190; is save symbol
 				cameras_list += \


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[rework][
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Replace the `ai_only` camera variable with a new "ai" camera network
* Let AIs see the network
* Give AI cameras a distinct recolor

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Now that all camera viewers use a list of camera networks, instead of a separately tracked variable we can instead place them on an isolated camera network.

## Screenshot
Atlas AI area showing color-tinted cameras
![image](https://github.com/user-attachments/assets/2cf7c15d-dc86-497d-9ce5-e14022c7b6c4)

