### PR TITLE
Security badge crops "NT" from the start of job titles

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -2168,10 +2168,13 @@ ABSTRACT_TYPE(/obj/item/clothing/suit/sweater_vest)
 	proc/show_off_badge(var/mob/user, var/mob/target = null)
 		if(ON_COOLDOWN(user, "showoff_item", SHOWOFF_COOLDOWN))
 			return
+		var/regex/nt_regex = new(@"^[Nn]ano[Tt]rasen\b")
+		var/job_to_show = replacetext(badge_owner_job, nt_regex, "") //Remove NT so you get "Nanotrasen's Finest Security Consultant"
+		var/descriptive_text = "[SPAN_BOLD("[bicon(src)] Nanotrasen's Finest [job_to_show]: [badge_owner_name].")]"
 		if (istype(target))
-			user.visible_message("[user] flashes the badge at [target.name]: <br>[SPAN_BOLD("[bicon(src)] Nanotrasen's Finest [badge_owner_job]: [badge_owner_name].")]", "You show off the badge to [target.name]: <br>[SPAN_BOLD("[bicon(src)] Nanotrasen's Finest [badge_owner_job] [badge_owner_name].")]")
+			user.visible_message("[user] flashes the badge at [target.name]: <br>[descriptive_text]", "You show off the badge to [target.name]: <br>[descriptive_text]")
 		else
-			user.visible_message("[user] flashes the badge: <br>[SPAN_BOLD("[bicon(src)] Nanotrasen's Finest [badge_owner_job]: [badge_owner_name].")]", "You show off the badge: <br>[SPAN_BOLD("[bicon(src)] Nanotrasen's Finest [badge_owner_job] [badge_owner_name].")]")
+			user.visible_message("[user] flashes the badge: <br>[descriptive_text]", "You show off the badge: <br>[descriptive_text]")
 		actions.start(new /datum/action/show_item(user, src, "badge"), user)
 
 	attack_self(mob/user as mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Showing off a security badge now chops off the "Nanotrasen" at the front of a job name for the text in chat
"Nanotrasen's Finest Nanotrasen Security Consultant" -> "Nanotrasen's Finest Security Consultant"
"Nanotrasen's Finest Nanotrasen Commander" -> "Nanotrasen's Finest Commander"
"Nanotrasen's Finest Nanotrasen Special Operative" -> "Nanotrasen's Finest Special Operative"


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reads better
