### PR TITLE
SMES gene is rarer, but can be made with a gene combination

### DIFF
--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -86,7 +86,7 @@
 	desc = "Protects the subject's cellular structure from electrical energy."
 	id = "resist_electric"
 	effectType = EFFECT_TYPE_POWER
-	probability = 66
+	probability = 33
 	blockCount = 3
 	blockGaps = 3
 	stability_loss = 15

--- a/code/modules/medical/genetics/combo_recipes.dm
+++ b/code/modules/medical/genetics/combo_recipes.dm
@@ -41,6 +41,10 @@ ABSTRACT_TYPE(/datum/geneticsrecipe)
 	required_effects = list("radioactive","glowy")
 	result = /datum/bioEffect/rad_resist
 
+/datum/geneticsrecipe/elec_resist
+	required_effects = list("colorshift","glowy")
+	result = /datum/bioEffect/elecres
+
 /datum/geneticsrecipe/alch_resist
 	required_effects = list("drunk","detox")
 	result = /datum/bioEffect/alcres


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Lowers the natural spawn probability of SMES Human from 66 to 33
* Adds a combination recipe: Glowy and Trichochromatic Shift (i.e. "Your hair stands on end.")

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
SMES Human neutralizes a few antagonist abilities, notably a lot of arcfiend's kit, and prevents shocks from e.g. door/vendor hacking. Despite this, it is very common to find.

Making it rarer will reduce the consistency of having it in the booth early-round, while providing a recipe makes it possible for geneticists to build if needed.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)The SMES Human gene is as rare as x-ray/gamma ray. There is a gene combination recipe to create it.
```