### PR TITLE
Fix blood steal triggering cooldown when target too far away

### DIFF
--- a/code/modules/antagonists/vampire/abilities/blood_steal.dm
+++ b/code/modules/antagonists/vampire/abilities/blood_steal.dm
@@ -18,13 +18,16 @@
 		var/mob/living/M = holder.owner
 		var/datum/abilityHolder/vampire/V = holder
 
+		if (!V.can_bite(target, is_pointblank = 0))
+			return CAST_ATTEMPT_FAIL_NO_COOLDOWN
+
 		if (actions.hasAction(M, /datum/action/bar/private/icon/vamp_blood_suc))
 			boutput(M, SPAN_ALERT("You are already performing a Bite action and cannot start a Blood Steal."))
-			return 1
+			return CAST_ATTEMPT_FAIL_NO_COOLDOWN
 
-		if (isnpc(target))
-			boutput(M, SPAN_ALERT("The blood of this target would provide you with no sustenance."))
-			return 1
+		if (GET_DIST(M, target) > 7)
+			boutput(M, SPAN_ALERT("That target is too far away!"))
+			return CAST_ATTEMPT_FAIL_NO_COOLDOWN
 
 		. = ..()
 		actions.start(new/datum/action/bar/private/icon/vamp_ranged_blood_suc(M,V,target, src), M)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add the `can_bite` check while attempting to cast and return early if it fails
Add a range check while attempting to cast and return early if it fails
Remove the isnpc check as `can_bite` handles it.

These checks are also used in the actionbar, but because they're checked after the action bar starts the cooldown is locked in. Checking these before the action bar stops the cooldown from occurring.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #23085