### PR TITLE
Make adding target items or additional items onto assemblies put it in your hand.

### DIFF
--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -444,6 +444,7 @@ Contains:
 	manipulated_item.master = src
 	manipulated_item.layer = initial(manipulated_item.layer)
 	user.u_equip(manipulated_item)
+	user.u_equip(src)
 	manipulated_item.set_loc(src)
 	manipulated_item.add_fingerprint(user)
 	src.w_class = max(src.w_class, manipulated_item.w_class)
@@ -463,6 +464,7 @@ Contains:
 	if(src.requires_admin_messaging())
 		message_admins("A [src.name] was created at [log_loc(src)]. Created by: [key_name(user)]")
 	// Since the assembly was done, return TRUE
+	user.put_in_hand_or_drop(src)
 	return TRUE
 
 /obj/item/assembly/proc/add_additional_component(var/atom/to_combine_atom, var/mob/user)
@@ -477,6 +479,7 @@ Contains:
 	manipulated_item.master = src
 	manipulated_item.layer = initial(manipulated_item.layer)
 	user.u_equip(manipulated_item)
+	user.u_equip(src)
 	manipulated_item.set_loc(src)
 	manipulated_item.add_fingerprint(user)
 	boutput(user, "You attach the [manipulated_item.name] to the [src.name].")
@@ -495,6 +498,7 @@ Contains:
 	src.UpdateIcon()
 	src.UpdateName()
 	// Since the assembly was done, return TRUE
+	user.put_in_hand_or_drop(src)
 	return TRUE
 
 


### PR DESCRIPTION
[Bug][Game Objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes assemblies to be tried to be put into your hand whenever you add additional items onto them-

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Since modifying your assembly by adding items can change its size class, it was possible to change the size of an assembly while it was in an inventory or your pocket.

That way, when you have a trigger/igniter-assembly in your pocket and add a pipebomb onto it, you suddenly had a pipebomb in your pocket that should normally be too large for it. This PR fixes this unintentional behaviour.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Adding items onto assemblies puts the finished assembly into your hand.
```
