### PR TITLE
Set other people's internals for belt, hands, & pocket slots

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -729,7 +729,7 @@
 			if(!HAS_FLAG(target.wear_mask.c_flags, MASKINTERNALS))
 				interrupt(INTERRUPT_ALWAYS)
 				return
-			var/list/eq_list = list(src.target.back, src.target.belt, src.target.l_store, src.target.r_store, src.target.r_hand, src.target.l_hand)
+			var/list/eq_list = list(src.target.back, src.target.belt, src.target.r_hand, src.target.l_hand, src.target.l_store, src.target.r_store)
 			for(var/I in eq_list)
 				if(!istype(I, /obj/item/tank))
 					continue

--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -714,34 +714,32 @@
 		..()
 		if(owner && target && BOUNDS_DIST(owner, target) == 0)
 			SEND_SIGNAL(owner, COMSIG_MOB_CLOAKING_DEVICE_DEACTIVATE)
-			if(remove_internals)
-				target.internal.add_fingerprint(owner)
-				for (var/obj/ability_button/tank_valve_toggle/T in target.internal.ability_buttons)
-					T.icon_state = "airoff"
-				target.internal = null
+		if(remove_internals)
+			target.internal.add_fingerprint(owner)
+			for (var/obj/ability_button/tank_valve_toggle/T in target.internal.ability_buttons)
+				T.icon_state = "airoff"
+			target.internal = null
+			target.update_inv()
+			for(var/mob/O in AIviewers(owner))
+				O.show_message(SPAN_ALERT("<B>[owner] removes [target]'s internals!</B>"), 1)
+		else
+			if (!istype(target.wear_mask, /obj/item/clothing/mask))
+				interrupt(INTERRUPT_ALWAYS)
+				return
+			if(!HAS_FLAG(target.wear_mask.c_flags, MASKINTERNALS))
+				interrupt(INTERRUPT_ALWAYS)
+				return
+			var/list/eq_list = list(src.target.back, src.target.belt, src.target.l_store, src.target.r_store, src.target.r_hand, src.target.l_hand)
+			for(var/I in eq_list)
+				if(!istype(I, /obj/item/tank))
+					continue
+				var/obj/item/tank/tank = I
+				tank.toggle_valve()
 				target.update_inv()
-				for(var/mob/O in AIviewers(owner))
-					O.show_message(SPAN_ALERT("<B>[owner] removes [target]'s internals!</B>"), 1)
-			else
-				if (!istype(target.wear_mask, /obj/item/clothing/mask))
-					interrupt(INTERRUPT_ALWAYS)
-					return
-				if(!HAS_FLAG(target.wear_mask.c_flags, MASKINTERNALS))
-					interrupt(INTERRUPT_ALWAYS)
-					return
-				var/list/eq_list = target.get_equipped_items(TRUE)
-				if(target.r_hand) eq_list += target.r_hand
-				if(target.l_hand) eq_list += target.l_hand
-				for(var/I in eq_list)
-					if(istype(I, /obj/item/tank))
-						var/obj/item/tank/tank = I
-						target.internal = I
-						target.update_inv()
-						tank.icon_state = "airon"
-						for(var/mob/M in AIviewers(target, 1))
-							M.show_message(text("[] is now running on internals.", src.target), 1)
-						target.internal.add_fingerprint(owner)
-						return
+				for(var/mob/M in AIviewers(target, 1))
+					M.show_message(text("[] is now running on internals.", src.target), 1)
+				target.internal.add_fingerprint(owner)
+				return
 			interrupt(INTERRUPT_ALWAYS)
 			return
 

--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -726,15 +726,24 @@
 				if (!istype(target.wear_mask, /obj/item/clothing/mask))
 					interrupt(INTERRUPT_ALWAYS)
 					return
-				else
-					if (istype(target.back, /obj/item/tank))
-						target.internal = target.back
+				if(!HAS_FLAG(target.wear_mask.c_flags, MASKINTERNALS))
+					interrupt(INTERRUPT_ALWAYS)
+					return
+				var/list/eq_list = target.get_equipped_items(TRUE)
+				if(target.r_hand) eq_list += target.r_hand
+				if(target.l_hand) eq_list += target.l_hand
+				for(var/I in eq_list)
+					if(istype(I, /obj/item/tank))
+						var/obj/item/tank/tank = I
+						target.internal = I
 						target.update_inv()
-						for (var/obj/ability_button/tank_valve_toggle/T in target.internal.ability_buttons)
-							T.icon_state = "airon"
+						tank.icon_state = "airon"
 						for(var/mob/M in AIviewers(target, 1))
 							M.show_message(text("[] is now running on internals.", src.target), 1)
 						target.internal.add_fingerprint(owner)
+						return
+			interrupt(INTERRUPT_ALWAYS)
+			return
 
 /datum/action/bar/icon/handcuffSet //This is used when you try to handcuff someone.
 	duration = 40

--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -712,8 +712,9 @@
 				remove_internals = 0
 	onEnd()
 		..()
-		if(owner && target && BOUNDS_DIST(owner, target) == 0)
-			SEND_SIGNAL(owner, COMSIG_MOB_CLOAKING_DEVICE_DEACTIVATE)
+		if(!owner || !target || !BOUNDS_DIST(owner, target) == 0)
+			return
+		SEND_SIGNAL(owner, COMSIG_MOB_CLOAKING_DEVICE_DEACTIVATE)
 		if(remove_internals)
 			target.internal.add_fingerprint(owner)
 			for (var/obj/ability_button/tank_valve_toggle/T in target.internal.ability_buttons)
@@ -729,7 +730,7 @@
 			if(!HAS_FLAG(target.wear_mask.c_flags, MASKINTERNALS))
 				interrupt(INTERRUPT_ALWAYS)
 				return
-			var/list/eq_list = list(src.target.back, src.target.belt, src.target.r_hand, src.target.l_hand, src.target.l_store, src.target.r_store)
+			var/list/eq_list = list(src.target.back, src.target.belt, src.target.r_hand, src.target.l_hand, src.target.r_store, src.target.l_store)
 			for(var/I in eq_list)
 				if(!istype(I, /obj/item/tank))
 					continue

--- a/code/datums/inventory.dm
+++ b/code/datums/inventory.dm
@@ -61,7 +61,7 @@
 		return FALSE
 	if(!HAS_FLAG(src.human.wear_mask.c_flags, MASKINTERNALS))
 		return FALSE
-	var/list/eq_list = list(src.human.back, src.human.belt, src.human.r_hand, src.human.l_hand, src.human.l_store, src.human.r_store)
+	var/list/eq_list = list(src.human.back, src.human.belt, src.human.r_hand, src.human.l_hand, src.human.r_store, src.human.l_store)
 	for(var/I in eq_list)
 		if(istype(I, /obj/item/tank))
 			return TRUE

--- a/code/datums/inventory.dm
+++ b/code/datums/inventory.dm
@@ -61,7 +61,7 @@
 		return FALSE
 	if(!HAS_FLAG(src.human.wear_mask.c_flags, MASKINTERNALS))
 		return FALSE
-	var/list/eq_list = list(src.human.back, src.human.belt, src.human.l_store, src.human.r_store, src.human.r_hand, src.human.l_hand)
+	var/list/eq_list = list(src.human.back, src.human.belt, src.human.r_hand, src.human.l_hand, src.human.l_store, src.human.r_store)
 	for(var/I in eq_list)
 		if(istype(I, /obj/item/tank))
 			return TRUE

--- a/code/datums/inventory.dm
+++ b/code/datums/inventory.dm
@@ -61,15 +61,10 @@
 		return FALSE
 	if(!HAS_FLAG(src.human.wear_mask.c_flags, MASKINTERNALS))
 		return FALSE
-	var/list/eq_list = src.human.get_equipped_items(TRUE)
-	if(src.human.r_hand) eq_list += src.human.r_hand
-	if(src.human.l_hand) eq_list += src.human.l_hand
+	var/list/eq_list = list(src.human.back, src.human.belt, src.human.l_store, src.human.r_store, src.human.r_hand, src.human.l_hand)
 	for(var/I in eq_list)
 		if(istype(I, /obj/item/tank))
 			return TRUE
-	//var/obj/ability_button/tank_valve_toggle/valve = src.human.getAbility(/obj/ability_button/tank_valve_toggle)
-	//if(valve)
-	//	return TRUE
 	return FALSE
 
 /datum/humanInventory/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)

--- a/code/datums/inventory.dm
+++ b/code/datums/inventory.dm
@@ -53,8 +53,24 @@
 		"slots" = slots,
 		"handcuffed" = src.human.hasStatus("handcuffed"),
 		"internal" = src.human.internal != null,
-		"canSetInternal" = istype(src.human.wear_mask, /obj/item/clothing/mask) && istype(src.human.back, /obj/item/tank) && !src.human.internal
+		"canSetInternal" = src.can_set_internal()
 	)
+
+/datum/humanInventory/proc/can_set_internal()
+	if(src.human.internal || !istype(src.human.wear_mask, /obj/item/clothing/mask))
+		return FALSE
+	if(!HAS_FLAG(src.human.wear_mask.c_flags, MASKINTERNALS))
+		return FALSE
+	var/list/eq_list = src.human.get_equipped_items(TRUE)
+	if(src.human.r_hand) eq_list += src.human.r_hand
+	if(src.human.l_hand) eq_list += src.human.l_hand
+	for(var/I in eq_list)
+		if(istype(I, /obj/item/tank))
+			return TRUE
+	//var/obj/ability_button/tank_valve_toggle/valve = src.human.getAbility(/obj/ability_button/tank_valve_toggle)
+	//if(valve)
+	//	return TRUE
+	return FALSE
 
 /datum/humanInventory/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()


### PR DESCRIPTION
[player actions][bug]

## About the PR 
- Now checks for belt, hands, and pocket slots for gas tanks.
- Priority is back -> belt -> hands -> pocket
- Fix for #10668

## Why's this needed? 
Can set internals for mini tanks & pocket tanks. Can set internals for other people's held gas tanks.

```changelog
(u)LorrMaster
(+)Can set other people's internals in slots other than the back.
```
