### PR TITLE
Unmap DetNet intercoms

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -24215,12 +24215,6 @@
 	},
 /area/station/quartermaster/office)
 "hje" = (
-/obj/item/device/radio/intercom/detnet/security{
-	dir = 8
-	},
-/obj/item/device/radio/intercom/detnet/security{
-	dir = 8
-	},
 /obj/storage/cart/forensic/detective,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -26054,7 +26048,7 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "inl" = (
-/obj/item/device/radio/intercom/detnet/detective{
+/obj/item/device/radio/intercom/security{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/grime,

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -15022,7 +15022,7 @@
 /area/station/engine/proto)
 "dSD" = (
 /obj/machinery/computer/security/wooden_tv,
-/obj/item/device/radio/intercom/detnet/detective,
+/obj/item/device/radio/intercom/brig,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "dSY" = (
@@ -20086,7 +20086,6 @@
 /area/station/medical/research)
 "ijd" = (
 /obj/storage/secure/closet/security/forensics,
-/obj/item/device/radio/intercom/brig,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "ijm" = (
@@ -32246,7 +32245,7 @@
 /area/station/hallway/primary/central)
 "rzl" = (
 /obj/machinery/computer/secure_data/detective_computer,
-/obj/item/device/radio/intercom/detnet/security,
+/obj/item/device/radio/intercom/security,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "rzv" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove detnet intercoms from Donut2 and Mushroom


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These are not meant to be mapped, they have the actual security and detective frequencies and live in detnet VR so the detective can still hear sec comms while inside.

