### PR TITLE
TGUI Respawn as Job

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1091,13 +1091,18 @@ var/list/fun_images = list()
 	H.JobEquipSpawned("Staff Assistant", 1)
 	H.update_colorful_parts()
 
-/client/proc/respawn_as_job(var/datum/job/J in (job_controls.staple_jobs|job_controls.special_jobs|job_controls.hidden_jobs|job_controls.savefile_get_job_names(src)))
+/client/proc/respawn_as_job()
 	set name = "Respawn As Job"
 	set desc = "Respawn yourself as a given job. Instantly. Right where you stand."
 	SET_ADMIN_CAT(ADMIN_CAT_SELF)
 	set popup_menu = 0
 	ADMIN_ONLY
 	SHOW_VERB_DESC
+	var/datum/job/job_list = job_controls.staple_jobs | job_controls.special_jobs | job_controls.hidden_jobs | job_controls.savefile_get_job_names(src)
+	var/datum/job/J = tgui_input_list(src.mob, "Please, select a job!", "Respawn As Job", job_list, "Staff Assistant")
+	if(!J)
+		return
+
 	if(istext(J))
 		var/idx = job_controls.savefile_get_job_names(src)?.Find(J)
 		if(job_controls.cloudsave_load(src, idx))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1099,7 +1099,7 @@ var/list/fun_images = list()
 	ADMIN_ONLY
 	SHOW_VERB_DESC
 	var/datum/job/job_list = job_controls.staple_jobs | job_controls.special_jobs | job_controls.hidden_jobs | job_controls.savefile_get_job_names(src)
-	var/datum/job/J = tgui_input_list(src.mob, "Please, select a job!", "Respawn As Job", job_list, "Staff Assistant")
+	var/datum/job/J = tgui_input_list(src.mob, "Select a job", "Respawn As Job", job_list, "Staff Assistant")
 	if(!J)
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the admin respawn as job command to use a tgui input list


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Searchability better than just spamming the first letter of the job until you find the one you want. Will help with debugging a bunch.
![image](https://github.com/user-attachments/assets/da4bab01-f19e-4932-9374-028e52558930)![image](https://github.com/user-attachments/assets/7309957d-2300-4051-9a7b-ad82694dd4a3)


