### PR TITLE
Wiki button now opens your job's wiki page

### DIFF
--- a/code/interface.dm
+++ b/code/interface.dm
@@ -72,7 +72,7 @@
 			set name = "Wiki"
 			set desc = "Open the Wiki in your browser"
 			set hidden = 1
-			src << link("http://wiki.ss13.co")
+			src << link(generate_ingame_wiki_link(src))
 
 		map()
 			set category = "Commands"
@@ -103,3 +103,10 @@
 	. += "?sx=[T.x]&sy=[T.y]&zoom=0"
 	if (T.z == Z_LEVEL_DEBRIS)
 		. += "&layer=debris"
+
+/proc/generate_ingame_wiki_link(client/our_user)
+	. = "https://wiki.ss13.co/"
+	if (our_user.mob.mind?.assigned_role)
+		var/datum/job/Job = find_job_in_controller_by_string(our_user.mob.mind?.assigned_role)
+		if(Job.wiki_link)
+			. = Job.wiki_link


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If the client's mob has an assigned role and that assigned role has a wiki link, send the user to the role's page rather than the main page.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
QoL by taking you to a relevant page, most pages experienced players use (for me these are Chemicals and Food and Drink) are linked on the job's page they are playing but if not you can search for it just as easily. Opening a new player's wiki to the guide for the job they are actively playing is also better than making them find their job in the big long list of jobs.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Clicking the Wiki button now opens your job's wiki page
```
