### PR TITLE
Reduces ocean clutter to improve client performance

### DIFF
--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -168,25 +168,25 @@
 				if (prob(1))
 					new /obj/item/seashell(src)
 			else
-				if (prob(5))
+				if (prob(2))
 					new /obj/item/seashell(src)
 
 		if (spawningFlags & SPAWN_PLANTS)
-			if (prob(8))
+			if (prob(4))
 				var/obj/plant = pick( src.z == 5 ? childrentypesof(/obj/sea_plant) : (childrentypesof(/obj/sea_plant) - /obj/sea_plant/anemone/lit) )
 				var/obj/sea_plant/P = new plant(src)
 				//mbc : bleh init() happens BFORRE this, most likely
 				P.initialize()
 
 		if (spawningFlags & SPAWN_PLANTSMANTA)
-			if (prob(8))
+			if (prob(4))
 				var/obj/plant = pick( src.z == 5 ? childrentypesof(/obj/sea_plant_manta) : (childrentypesof(/obj/sea_plant_manta) - /obj/sea_plant_manta/anemone/lit) )
 				var/obj/sea_plant_manta/P = new plant(src)
 				//mbc : bleh init() happens BFORRE this, most likely
 				P.initialize()
 
 		if (spawningFlags & SPAWN_ACID_DOODADS)
-			if (prob(8))
+			if (prob(4))
 				var/obj/doodad = pick( childrentypesof(/obj/nadir_doodad) )
 				var/obj/nadir_doodad/D = new doodad(src)
 				D.initialize()
@@ -197,7 +197,7 @@
 				new /obj/critter/gunbot/drone/buzzdrone/fish(src)
 			else if (src.z == 5 && prob(1) && prob(4))
 				new /obj/critter/gunbot/drone/gunshark(src)
-			else if (prob(1) && prob(20))
+			else if (prob(1) && prob(15))
 				var/mob/fish = pick(childrentypesof(/mob/living/critter/aquatic/fish))
 				new fish(src)
 			else if (src.z == 5 && prob(1) && prob(9) && prob(90))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Severely reduces the amount of random plants and seashells that spawn on ocean maps.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Oshan has always been notorious for FPS problems, now Neon is also displaying this issue.
Maybe that has something to do with the ~13,000 extra objects on the station z-level. Just maybe.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Reduced ocean clutter spawns in an attempt to improve client performance.
```
