### PR TITLE
Remove ocean turf lighting

### DIFF
--- a/_std/defines/lag.dm
+++ b/_std/defines/lag.dm
@@ -85,8 +85,6 @@
 #define OVERLOAD_PLAYERCOUNT 120
 /// when pcount is above this number on round start, increase ticklag to SEMIOVERLOADED_WORLD_TICKLAG to try to maintain smoothness
 #define SEMIOVERLOAD_PLAYERCOUNT 85
-/// when pcount is above this number on game load, dont generate lighting surrounding the station because it lags the map to heck
-#define OSHAN_LIGHT_OVERLOAD 18
 /// whenn pcount is >= this number, slow Life() processing a bit
 #define SLOW_LIFE_PLAYERCOUNT 85
 /// whenn pcount is >= this number, slow Life() processing a lot

--- a/code/datums/controllers/process/fluid_spawner.dm
+++ b/code/datums/controllers/process/fluid_spawner.dm
@@ -15,44 +15,12 @@ var/global/obj/fluid/ocean_fluid_obj = null
 /datum/controller/process/fluid_turfs
 	var/tmp/list/processing_fluid_turfs
 	var/add_reagent_amount = 500
-	var/do_light_gen = 1
-
-	proc/handle_light_generating_turfs(lagcheck_at = LAG_REALTIME)
-		if (do_light_gen)
-			for (var/_F in by_cat[TR_CAT_LIGHT_GENERATING_TURFS])
-				var/turf/space/fluid/F = _F
-				F.make_light()
-				LAGCHECK(lagcheck_at)
-
-			if(TR_CAT_LIGHT_GENERATING_TURFS in by_cat)
-				by_cat[TR_CAT_LIGHT_GENERATING_TURFS].len = 0
-
-		/*
-		for (var/turf/space/fluid/F in light_generating_fluid_turfs)
-			var/bordering = 0
-			for (var/dir in cardinal)
-				var/turf/T = get_step(F,dir)
-				if(IS_VALID_FLUID_TURF(T) && !FLUID_SPAWNER_TURF_BLOCKED(T))
-					if (!(F in processing_fluid_turfs))
-						src.processing_fluid_turfs.Add(F)
-				if (!istype(T,/turf/space))
-					bordering = 1
-			if (bordering && !F.light)
-				F.make_light()
-			LAGCHECK(LAG_REALTIME)
-		light_generating_fluid_turfs.len = 0*/
 
 	setup()
 		name = "Fluid_Turfs"
 		schedule_interval = 5 SECONDS
 
 		src.processing_fluid_turfs = global.processing_fluid_turfs
-
-		SPAWN(20 SECONDS)
-			if (total_clients() >= OSHAN_LIGHT_OVERLOAD)
-				do_light_gen = 0
-
-			handle_light_generating_turfs(90)
 
 	copyStateFrom(datum/controller/process/target)
 		var/datum/controller/process/fluid_turfs/old_fluid_turfs = target
@@ -62,8 +30,6 @@ var/global/obj/fluid/ocean_fluid_obj = null
 		var/adjacent_space = 0
 		var/adjacent_block = 0
 		var/turf/t
-
-		handle_light_generating_turfs()
 
 		for (var/turf/space/fluid/T in processing_fluid_turfs)
 			if (!T || !T.ocean_canpass()) continue
@@ -91,10 +57,6 @@ var/global/obj/fluid/ocean_fluid_obj = null
 					if (F)
 						F.last_depth_level = 3 //lol hardcode for ocean depth when a new puddle forms
 						F.group.last_depth_level = 3
-
-			if (adjacent_space >= 4)
-				if (T.light)
-					T.light.disable()
 
 			if (adjacent_space + adjacent_block >= 4)
 				processing_fluid_turfs.Remove(T)

--- a/code/modules/fluids/fluid_commands.dm
+++ b/code/modules/fluids/fluid_commands.dm
@@ -155,15 +155,6 @@ client/proc/replace_space_exclusive()
 		map_currently_underwater = 1
 
 
-client/proc/update_ocean_lighting()
-	ADMIN_ONLY
-	SPAWN(0)
-		for(var/turf/space/fluid/S in world)
-			S.update_light()
-			LAGCHECK(LAG_REALTIME)
-		message_admins("Finished space light update!!!")
-
-
 client/proc/dereplace_space()
 	set name = "Unoceanify"
 	set desc = "uh oh."

--- a/code/modules/fluids/fluid_turf.dm
+++ b/code/modules/fluids/fluid_turf.dm
@@ -11,10 +11,6 @@
 #define SPAWN_HOSTILE 128
 #define SPAWN_ACID_DOODADS 256
 
-
-/turf/proc/make_light() //dummyproc so we can inherit
-	.=0
-
 /turf/space/fluid
 	name = "ocean floor"
 	icon = 'icons/turf/outdoors.dmi'
@@ -40,18 +36,8 @@
 
 	turf_flags = FLUID_MOVE
 
-	var/datum/light/point/light = 0
-	var/light_r = 0.16
-	var/light_g = 0.6
-	var/light_b = 0.8
-
-	var/light_brightness = 0.8
-	var/light_height = 3
-
 	var/spawningFlags = SPAWN_DECOR | SPAWN_PLANTS | SPAWN_FISH
 	var/randomIcon = 1
-
-	var/generateLight = 1 //do we sometimes generate a special light?
 
 	var/captured = 0 //Thermal vent collector on my tile? (messy i know, but faster lookups later)
 
@@ -98,39 +84,6 @@
 		src.name = ocean_name
 		#endif
 
-		if(ocean_color)
-			var/fluid_color = hex_to_rgb_list(ocean_color)
-			light_r = fluid_color[1] / 255
-			light_g = fluid_color[2] / 255
-			light_b = fluid_color[3] / 255
-
-		//let's replicate old behavior
-		if (generateLight)
-			generateLight = 0
-			if (z != 3) //nono z3
-				for (var/dir in alldirs)
-					var/turf/T = get_step(src,dir)
-					if (istype(T, /turf/simulated))
-						generateLight = 1
-						break
-
-		if (generateLight)
-			START_TRACKING_CAT(TR_CAT_LIGHT_GENERATING_TURFS)
-
-	Del()
-		. = ..()
-		if (generateLight)
-			STOP_TRACKING_CAT(TR_CAT_LIGHT_GENERATING_TURFS)
-
-	make_light()
-		if (!light)
-			light = new
-			light.attach(src)
-		light.set_brightness(light_brightness)
-		light.set_color(light_r, light_g, light_b)
-		light.set_height(light_height)
-		light.enable()
-
 	proc/bake_light()
 
 
@@ -138,14 +91,6 @@
 		for(var/obj/overlay/tile_effect/lighting/L in src)
 			src.icon = getFlatIcon(L)
 			qdel(L)
-
-	proc/update_light()
-		if (light)
-			light.disable()
-			light.set_brightness(light_brightness)
-			light.set_color(light_r, light_g, light_b)
-			light.set_height(light_height)
-			light.enable()
 
 //space/fluid/ReplaceWith() this is for future ctrl Fs
 	ReplaceWith(var/what, var/keep_old_material = 1, var/handle_air = 1, var/handle_dir = NORTH, force = 0)
@@ -249,9 +194,7 @@
 		if(notifier.ocean_canpass())
 			processing_fluid_turfs |= src
 		else
-			if (processing_fluid_turfs.Remove(src))
-				if (src.light)
-					src.light.disable()
+			processing_fluid_turfs.Remove(src)
 
 	Entered(atom/movable/A as mob|obj) //MBC : I was too hurried and lazy to make this actually apply reagents on touch. this is a note to myself. FUCK YOUUU
 		..()
@@ -308,7 +251,6 @@
 	icon_state = "pit"
 	spawningFlags = 0
 	randomIcon = FALSE
-	generateLight = FALSE
 
 	allow_hole = FALSE
 
@@ -371,7 +313,6 @@
 	temperature = TRENCH_TEMP
 	fullbright = 0
 	luminosity = 1
-	generateLight = 0
 	allow_hole = 0
 #ifdef MAP_OVERRIDE_NADIR
 	spawningFlags = SPAWN_LOOT | SPAWN_HOSTILE | SPAWN_ACID_DOODADS
@@ -421,7 +362,6 @@
 /turf/space/fluid/cenote
 	fullbright = 0
 	luminosity = 1
-	generateLight = 0
 	spawningFlags = null
 	allow_hole = 0
 	icon_state = "cenote"
@@ -444,7 +384,6 @@
 //Manta
 /turf/space/fluid/manta
 	luminosity = 1
-	generateLight = 0
 	spawningFlags = SPAWN_PLANTSMANTA
 	turf_flags = MANTA_PUSH
 
@@ -491,7 +430,6 @@ TYPEINFO_NEW(/turf/simulated/floor/auto/elevator_shaft)
 /turf/space/fluid/acid
 	name = "acid sea floor"
 	spawningFlags = SPAWN_ACID_DOODADS
-	generateLight = 0
 	temperature = TRENCH_TEMP
 
 	clear


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the point lights from fluid turfs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These don't actually appear to work and are disabled above 18 players anyway due to apparently causing lag. I'm trying to eliminate causes of water map lag and this seems like a good thing to target.
![image](https://github.com/user-attachments/assets/483625da-f4fe-48da-bcc8-6bcb599e3b4c)
