### PR TITLE
Allow plasmastone to be added to pipe bombs

### DIFF
--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1672,7 +1672,7 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 	 							/obj/item/reagent_containers/food/snacks/ectoplasm, /obj/item/scrap, /obj/item/raw_material/scrap_metal, /obj/item/cell,/obj/item/cable_coil,\
 	 							/obj/item/item_box/medical_patches, /obj/item/item_box/gold_star, /obj/item/item_box/assorted/stickers, /obj/item/material_piece/cloth,\
 	 							/obj/item/raw_material/shard, /obj/item/raw_material/telecrystal, /obj/item/instrument, /obj/item/reagent_containers/food/snacks/ingredient/butter,\
-	 							/obj/item/rcd_ammo, /obj/item/raw_material/plasmastone, /obj/item/material_piece/plasmastone))
+	 							/obj/item/rcd_ammo, /obj/item/raw_material/plasmastone, /obj/item/material_piece/plasmastone)
 
 	get_help_message(dist, mob/user)
 		switch(src.state)

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1672,7 +1672,7 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 	 							/obj/item/reagent_containers/food/snacks/ectoplasm, /obj/item/scrap, /obj/item/raw_material/scrap_metal, /obj/item/cell,/obj/item/cable_coil,\
 	 							/obj/item/item_box/medical_patches, /obj/item/item_box/gold_star, /obj/item/item_box/assorted/stickers, /obj/item/material_piece/cloth,\
 	 							/obj/item/raw_material/shard, /obj/item/raw_material/telecrystal, /obj/item/instrument, /obj/item/reagent_containers/food/snacks/ingredient/butter,\
-	 							/obj/item/rcd_ammo)
+	 							/obj/item/rcd_ammo, /obj/item/raw_material/plasmastone, /obj/item/material_piece/plasmastone))
 
 	get_help_message(dist, mob/user)
 		switch(src.state)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Actually allows plasmastone (both its ore and bar form) to be inserted into pipe bomb frames. This allows the bomb to produce plasma gas after detonation, and you can find evidence that this was intended through both the code itself and on the in-game "Terra cell improvised explosive manual", which is a paper found in the Listening Post that instructs Traitors on how to build and stuff bombs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The code was already there for `proc/pipebomb_stuffing`, but the objects were never added to the `allowed_items` list.

[Game Objects] [Bug]
