### PR TITLE
add area check for random rooms

### DIFF
--- a/assets/maps/random_rooms/3x3/duckbot_80.dmm
+++ b/assets/maps/random_rooms/3x3/duckbot_80.dmm
@@ -1,11 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/simulated/floor/plating,
-/area/space)
+/area/dmm_suite/clear_area)
 "e" = (
 /obj/machinery/bot/duckbot,
 /turf/simulated/floor/plating,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 a

--- a/assets/maps/random_rooms/3x3/fakeboardisplay.dmm
+++ b/assets/maps/random_rooms/3x3/fakeboardisplay.dmm
@@ -4,34 +4,34 @@
 	dir = 9
 	},
 /turf/simulated/floor/marble/black,
-/area/space)
+/area/dmm_suite/clear_area)
 "c" = (
 /obj/item/device/light/floodlight/starts_on/fixed{
 	dir = 5
 	},
 /turf/simulated/floor/marble/black,
-/area/space)
+/area/dmm_suite/clear_area)
 "i" = (
 /obj/item/device/light/floodlight/starts_on/fixed{
 	dir = 6
 	},
 /turf/simulated/floor/marble/black,
-/area/space)
+/area/dmm_suite/clear_area)
 "n" = (
 /turf/simulated/floor/marble,
-/area/space)
+/area/dmm_suite/clear_area)
 "p" = (
 /obj/item/device/light/floodlight/starts_on/fixed{
 	dir = 10
 	},
 /turf/simulated/floor/marble/black,
-/area/space)
+/area/dmm_suite/clear_area)
 "r" = (
 /obj/railing/velvet{
 	pixel_y = 23
 	},
 /turf/simulated/floor/marble,
-/area/space)
+/area/dmm_suite/clear_area)
 "A" = (
 /obj/item/boarvessel/forgery{
 	pixel_y = 10;
@@ -42,7 +42,7 @@
 /obj/machinery/light/small/floor,
 /obj/effects/lightshaft,
 /turf/simulated/floor/marble/black,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 i

--- a/assets/maps/random_rooms/3x3/strangeflower_50.dmm
+++ b/assets/maps/random_rooms/3x3/strangeflower_50.dmm
@@ -8,7 +8,7 @@
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "f" = (
 /obj/decal/cleanable/blood/tracks,
 /obj/decal/cleanable/writing{
@@ -23,7 +23,7 @@
 /turf/simulated/floor/grasstodirt{
 	dir = 5
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "k" = (
 /obj/candle_light{
 	pixel_y = 7;
@@ -35,7 +35,7 @@
 /turf/simulated/floor/grasstodirt{
 	dir = 8
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "n" = (
 /obj/candle_light{
 	pixel_y = 7
@@ -44,7 +44,7 @@
 /turf/simulated/floor/grasstodirt{
 	dir = 4
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "D" = (
 /obj/decal/cleanable/blood/tracks{
 	dir = 10
@@ -52,18 +52,18 @@
 /turf/simulated/floor/grasstodirt{
 	dir = 9
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "G" = (
 /obj/decal/cleanable/ash,
 /turf/simulated/floor/grasstodirt,
-/area/space)
+/area/dmm_suite/clear_area)
 "K" = (
 /obj/decal/alienflower{
 	dir = 6
 	},
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/grass,
-/area/space)
+/area/dmm_suite/clear_area)
 "U" = (
 /obj/candle_light{
 	pixel_x = 11
@@ -75,7 +75,7 @@
 /turf/simulated/floor/grasstodirt{
 	dir = 6
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "V" = (
 /obj/candle_light{
 	pixel_x = -7
@@ -84,7 +84,7 @@
 /turf/simulated/floor/grasstodirt{
 	dir = 10
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 U

--- a/assets/maps/random_rooms/3x3/summoning.dmm
+++ b/assets/maps/random_rooms/3x3/summoning.dmm
@@ -5,7 +5,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "l" = (
 /obj/cable/hotpink{
 	icon_state = "0-4"
@@ -18,7 +18,7 @@
 	},
 /obj/cable/yellow,
 /turf/simulated/floor/plating/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "s" = (
 /obj/cable/hotpink{
 	icon_state = "0-8"
@@ -31,7 +31,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "x" = (
 /obj/cable/hotpink{
 	icon_state = "0-2"
@@ -40,7 +40,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "z" = (
 /obj/cable{
 	icon_state = "4-10"
@@ -53,7 +53,7 @@
 	},
 /obj/machinery/light/small/floor/purpleish,
 /turf/simulated/floor/plating/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "L" = (
 /obj/cable{
 	icon_state = "4-9"
@@ -66,7 +66,7 @@
 	},
 /obj/machinery/light/small/floor/purpleish,
 /turf/simulated/floor/plating/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "N" = (
 /obj/cable{
 	icon_state = "6-8"
@@ -79,7 +79,7 @@
 	},
 /obj/machinery/light/small/floor/purpleish,
 /turf/simulated/floor/plating/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "Q" = (
 /obj/cable{
 	icon_state = "5-8"
@@ -92,7 +92,7 @@
 	},
 /obj/machinery/light/small/floor/purpleish,
 /turf/simulated/floor/plating/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "T" = (
 /obj/cable/hotpink{
 	icon_state = "0-2"
@@ -106,7 +106,7 @@
 	},
 /obj/item/storage/pill_bottle,
 /turf/simulated/floor/plating/random,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 z

--- a/assets/maps/random_rooms/3x5/SLUGZONE_5.dmm
+++ b/assets/maps/random_rooms/3x5/SLUGZONE_5.dmm
@@ -1,11 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/simulated/nicegrass/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "j" = (
 /obj/machinery/light/small/floor/greenish,
 /turf/simulated/nicegrass/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "k" = (
 /obj/machinery/light/small/floor/greenish,
 /obj/decal/cleanable/writing{
@@ -13,7 +13,7 @@
 	pixel_y = 30
 	},
 /turf/simulated/nicegrass/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "r" = (
 /obj/machinery/light/small/floor/greenish,
 /obj/decal/cleanable/writing{
@@ -21,27 +21,27 @@
 	pixel_y = -30
 	},
 /turf/simulated/nicegrass/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "A" = (
 /mob/living/critter/small_animal/slug{
 	pixel_y = 15;
 	dir = 8
 	},
 /turf/simulated/nicegrass/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "J" = (
 /mob/living/critter/small_animal/slug/snail{
 	pixel_x = 15
 	},
 /turf/simulated/nicegrass/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "Q" = (
 /obj/item/clothing/head/party/random{
 	pixel_y = 9;
 	pixel_x = -3
 	},
 /turf/simulated/nicegrass/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "R" = (
 /obj/item/clothing/head/party/random,
 /obj/decal/cleanable/writing{
@@ -49,13 +49,13 @@
 	pixel_x = 30
 	},
 /turf/simulated/nicegrass/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "X" = (
 /obj/shrub{
 	dir = 4
 	},
 /turf/simulated/nicegrass/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "Y" = (
 /mob/living/critter/small_animal/slug{
 	pixel_x = 10
@@ -65,7 +65,7 @@
 	pixel_x = -30
 	},
 /turf/simulated/nicegrass/random,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 j

--- a/assets/maps/random_rooms/3x5/cabeeno_75.dmm
+++ b/assets/maps/random_rooms/3x5/cabeeno_75.dmm
@@ -6,7 +6,7 @@
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 10
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "f" = (
 /obj/item/storage/secure/ssafe/loot{
 	pixel_x = -28
@@ -30,32 +30,32 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/dmm_suite/clear_area)
 "g" = (
 /obj/stool/bar,
 /mob/living/critter/small_animal/bee,
 /turf/simulated/floor/carpet/red/fancy/edge,
-/area/space)
+/area/dmm_suite/clear_area)
 "i" = (
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 5
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "l" = (
 /obj/submachine/slot_machine/cash,
 /turf/simulated/floor/black,
-/area/space)
+/area/dmm_suite/clear_area)
 "m" = (
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 8
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "p" = (
 /obj/stool/bar,
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 1
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "r" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -65,7 +65,7 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/dmm_suite/clear_area)
 "v" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -78,7 +78,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/dmm_suite/clear_area)
 "x" = (
 /obj/table/reinforced/roulette,
 /obj/item/currency/spacecash/really_small{
@@ -101,24 +101,24 @@
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 4
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "B" = (
 /obj/stool/chair/office/syndie,
 /mob/living/critter/small_animal/bee/fancy,
 /turf/simulated/floor/black,
-/area/space)
+/area/dmm_suite/clear_area)
 "H" = (
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 9
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "M" = (
 /obj/stool/bar,
 /mob/living/critter/small_animal/bee/small,
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 6
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "N" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
@@ -147,7 +147,7 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/black,
-/area/space)
+/area/dmm_suite/clear_area)
 "Z" = (
 /obj/roulette_table_w,
 /obj/item/currency/spacecash/really_small,
@@ -175,7 +175,7 @@
 	pixel_y = -2
 	},
 /turf/simulated/floor/carpet/red,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 f

--- a/assets/maps/random_rooms/3x5/fishingtrip.dmm
+++ b/assets/maps/random_rooms/3x5/fishingtrip.dmm
@@ -4,7 +4,7 @@
 /obj/item/reagent_containers/food/fish/random,
 /obj/decal/stage_edge,
 /turf/simulated/floor/twotone/blue,
-/area/space)
+/area/dmm_suite/clear_area)
 "c" = (
 /obj/machinery/light/incandescent{
 	dir = 1
@@ -14,20 +14,20 @@
 	pixel_x = 8
 	},
 /turf/simulated/floor/swampgrass,
-/area/space)
+/area/dmm_suite/clear_area)
 "h" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/blue,
-/area/space)
+/area/dmm_suite/clear_area)
 "i" = (
 /turf/simulated/floor/stairs/wood2,
-/area/space)
+/area/dmm_suite/clear_area)
 "o" = (
 /obj/machinery/light/incandescent{
 	dir = 1
 	},
 /turf/simulated/floor/swampgrass,
-/area/space)
+/area/dmm_suite/clear_area)
 "t" = (
 /obj/item/fishing_rod/basic{
 	pixel_x = 6;
@@ -42,11 +42,11 @@
 	pixel_x = 12
 	},
 /turf/simulated/floor/wood,
-/area/space)
+/area/dmm_suite/clear_area)
 "w" = (
 /obj/decal/cleanable/paper,
 /turf/simulated/floor/twotone/blue,
-/area/space)
+/area/dmm_suite/clear_area)
 "B" = (
 /obj/item/cigbutt{
 	pixel_x = 2;
@@ -57,23 +57,23 @@
 	pixel_x = 8
 	},
 /turf/simulated/floor/swampgrass,
-/area/space)
+/area/dmm_suite/clear_area)
 "E" = (
 /turf/simulated/floor/swampgrass,
-/area/space)
+/area/dmm_suite/clear_area)
 "I" = (
 /turf/simulated/floor/swampgrass_edging,
-/area/space)
+/area/dmm_suite/clear_area)
 "Q" = (
 /obj/storage/crate/freezer{
 	desc = "A cooler to keep your fresh catches in.";
 	name = "cooler"
 	},
 /turf/simulated/floor/swampgrass,
-/area/space)
+/area/dmm_suite/clear_area)
 "R" = (
 /turf/simulated/floor/twotone/blue,
-/area/space)
+/area/dmm_suite/clear_area)
 "Z" = (
 /obj/item/reagent_containers/food/drinks/bottle/fancy_beer{
 	pixel_y = -3
@@ -86,7 +86,7 @@
 	pixel_x = -12
 	},
 /turf/simulated/floor/wood,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 c

--- a/assets/maps/random_rooms/5x3/cats.dmm
+++ b/assets/maps/random_rooms/5x3/cats.dmm
@@ -3,49 +3,49 @@
 /obj/stool/bee_bed,
 /mob/living/critter/small_animal/cat/synth,
 /turf/simulated/floor/carpet/blue/fancy/edge,
-/area/space)
+/area/dmm_suite/clear_area)
 "e" = (
 /obj/stool/bee_bed,
 /mob/living/critter/small_animal/cat/synth,
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 9
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "k" = (
 /obj/decal/cleanable/dirt/dirt5,
 /turf/simulated/floor/carpet/blue,
-/area/space)
+/area/dmm_suite/clear_area)
 "n" = (
 /turf/simulated/floor/carpet/blue,
-/area/space)
+/area/dmm_suite/clear_area)
 "p" = (
 /obj/decal/cleanable/dirt/dirt5,
 /turf/simulated/floor/carpet/blue/fancy/edge,
-/area/space)
+/area/dmm_suite/clear_area)
 "q" = (
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 1
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "v" = (
 /obj/item/gardentrowel,
 /obj/decal/cleanable/dirt/dirt5,
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 8
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "w" = (
 /obj/machinery/hydro_growlamp,
 /obj/decal/cleanable/dirt/dirt2,
 /obj/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "y" = (
 /obj/machinery/plantpot,
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 1
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "G" = (
 /obj/potted_plant{
 	icon_state = "plant7"
@@ -53,33 +53,33 @@
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 6
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "H" = (
 /obj/item/reagent_containers/food/fish/salmon,
 /turf/simulated/floor/plating/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "M" = (
 /obj/item/seedplanter,
 /turf/simulated/floor/plating/random,
-/area/space)
+/area/dmm_suite/clear_area)
 "O" = (
 /obj/stool/bee_bed,
 /mob/living/critter/small_animal/cat/synth,
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 4
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "W" = (
 /obj/machinery/light/small/floor/warm,
 /obj/decal/cleanable/dirt/dirt3,
 /turf/simulated/floor/carpet/blue,
-/area/space)
+/area/dmm_suite/clear_area)
 "Z" = (
 /obj/machinery/hydro_growlamp,
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 10
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 e

--- a/assets/maps/random_rooms/5x3/gamerpad.dmm
+++ b/assets/maps/random_rooms/5x3/gamerpad.dmm
@@ -6,7 +6,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/wood/two,
-/area/space)
+/area/dmm_suite/clear_area)
 "h" = (
 /obj/item/toy/plush/small/bunny{
 	pixel_x = 5;
@@ -31,7 +31,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/carpet/arcade,
-/area/space)
+/area/dmm_suite/clear_area)
 "k" = (
 /obj/item/clothing/lanyard{
 	name = "convention badge";
@@ -61,10 +61,10 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/arcade,
-/area/space)
+/area/dmm_suite/clear_area)
 "m" = (
 /turf/simulated/floor/carpet/arcade,
-/area/space)
+/area/dmm_suite/clear_area)
 "n" = (
 /obj/item/crushed_can{
 	pixel_y = 7;
@@ -74,7 +74,7 @@
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 4
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "o" = (
 /obj/table/wood/auto/desk,
 /obj/machinery/computer3/generic/personal{
@@ -94,7 +94,7 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/ne{
 	dir = 9
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "u" = (
 /obj/item/toy/figure/patreon{
 	pixel_y = 9;
@@ -126,7 +126,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/carpet/arcade,
-/area/space)
+/area/dmm_suite/clear_area)
 "w" = (
 /obj/item/storage/backpack/bearpack{
 	pixel_y = 11;
@@ -142,7 +142,7 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/north{
 	dir = 8
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "z" = (
 /obj/table/wood/auto/desk,
 /obj/item/clothing/ears/earmuffs{
@@ -181,7 +181,7 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/se{
 	dir = 5
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "E" = (
 /obj/decal/xmas_lights{
 	name = "LED lightstring";
@@ -189,7 +189,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood/two,
-/area/space)
+/area/dmm_suite/clear_area)
 "F" = (
 /obj/item/clothing/suit/bedsheet/captain,
 /obj/item/toy/plush/small/possum,
@@ -200,7 +200,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/arcade,
-/area/space)
+/area/dmm_suite/clear_area)
 "H" = (
 /obj/item/toy/plush/small,
 /obj/machinery/light/lamp,
@@ -212,7 +212,7 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/sw{
 	dir = 6
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "K" = (
 /obj/item/toy/figure/patreon{
 	pixel_y = -1;
@@ -240,11 +240,11 @@
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 10
 	},
-/area/space)
+/area/dmm_suite/clear_area)
 "S" = (
 /obj/decoration/ceilingfan,
 /turf/simulated/floor/wood/two,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 F

--- a/assets/maps/random_rooms/5x3/robotspoker.dmm
+++ b/assets/maps/random_rooms/5x3/robotspoker.dmm
@@ -57,7 +57,7 @@
 	},
 /obj/machinery/light/small/floor/cool/very,
 /turf/simulated/floor/wood/seven,
-/area/space)
+/area/dmm_suite/clear_area)
 "G" = (
 /obj/table/wood/auto,
 /obj/item/device/light/zippo{

--- a/assets/maps/random_rooms/5x3/sugarrush.dmm
+++ b/assets/maps/random_rooms/5x3/sugarrush.dmm
@@ -17,10 +17,10 @@
 	rand_pos = 0
 	},
 /turf/simulated/floor/wood/four,
-/area/space)
+/area/dmm_suite/clear_area)
 "s" = (
 /turf/simulated/floor/wood/four,
-/area/space)
+/area/dmm_suite/clear_area)
 "w" = (
 /obj/rack/lunar,
 /obj/item/reagent_containers/food/snacks/candy/jellybean/someflavor{
@@ -39,14 +39,14 @@
 	rand_pos = 0
 	},
 /turf/simulated/floor/wood/four,
-/area/space)
+/area/dmm_suite/clear_area)
 "F" = (
 /obj/table/wood/round/auto,
 /obj/item/storage/goodybag{
 	rand_pos = 1
 	},
 /turf/simulated/floor/wood/four,
-/area/space)
+/area/dmm_suite/clear_area)
 "N" = (
 /obj/rack/lunar,
 /obj/item/reagent_containers/food/snacks/candy/jellybean/someflavor{
@@ -65,11 +65,11 @@
 	rand_pos = 0
 	},
 /turf/simulated/floor/wood/four,
-/area/space)
+/area/dmm_suite/clear_area)
 "W" = (
 /obj/machinery/light/small/floor/cool/very,
 /turf/simulated/floor/wood/four,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 F

--- a/assets/maps/random_rooms/5x3/teaparty_40.dmm
+++ b/assets/maps/random_rooms/5x3/teaparty_40.dmm
@@ -16,14 +16,14 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/grasslush/thinner,
-/area/space)
+/area/dmm_suite/clear_area)
 "b" = (
 /obj/stool/chair/comfy{
 	pixel_y = 19;
 	dir = 1
 	},
 /turf/simulated/floor/grasslush/thinner,
-/area/space)
+/area/dmm_suite/clear_area)
 "d" = (
 /obj/table/clothred/auto,
 /obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{
@@ -32,7 +32,7 @@
 	layer = 4
 	},
 /turf/simulated/floor/grasslush/thin,
-/area/space)
+/area/dmm_suite/clear_area)
 "k" = (
 /obj/decoration/regallamp{
 	icon_state = "lamp_regal_lit";
@@ -51,7 +51,7 @@
 	pixel_x = 16
 	},
 /turf/simulated/floor/grasslush/thinner,
-/area/space)
+/area/dmm_suite/clear_area)
 "m" = (
 /obj/decoration/regallamp{
 	icon_state = "lamp_regal_lit";
@@ -71,7 +71,7 @@
 	layer = 1
 	},
 /turf/simulated/floor/grasslush/thinner,
-/area/space)
+/area/dmm_suite/clear_area)
 "n" = (
 /obj/stool/chair/material/mauxite{
 	layer = 2.89;
@@ -82,7 +82,7 @@
 	pixel_y = -5
 	},
 /turf/simulated/floor/grasslush/thinner,
-/area/space)
+/area/dmm_suite/clear_area)
 "o" = (
 /obj/stool/chair/comfy/throne_gold{
 	pixel_x = 10;
@@ -96,7 +96,7 @@
 	desc = "They've been expecting you!"
 	},
 /turf/simulated/floor/grasslush/thinner,
-/area/space)
+/area/dmm_suite/clear_area)
 "s" = (
 /obj/stool/chair/dining/scrap{
 	layer = 2.89;
@@ -108,21 +108,21 @@
 	layer = 2.89
 	},
 /turf/simulated/floor/grasslush/thinner,
-/area/space)
+/area/dmm_suite/clear_area)
 "w" = (
 /obj/stool/chair/dining/wood{
 	dir = 1;
 	pixel_y = 13
 	},
 /turf/simulated/floor/grasslush/thinner,
-/area/space)
+/area/dmm_suite/clear_area)
 "z" = (
 /obj/stool/chair/comfy/barber_chair{
 	pixel_y = 16;
 	dir = 1
 	},
 /turf/simulated/floor/grasslush/thinner,
-/area/space)
+/area/dmm_suite/clear_area)
 "A" = (
 /obj/table/clothred/auto,
 /obj/item/reagent_containers/food/drinks/tea{
@@ -141,7 +141,7 @@
 	layer = 4
 	},
 /turf/simulated/floor/grasslush/thin,
-/area/space)
+/area/dmm_suite/clear_area)
 "Q" = (
 /obj/decoration/regallamp{
 	icon_state = "lamp_regal_lit";
@@ -161,7 +161,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/grasslush/thinner,
-/area/space)
+/area/dmm_suite/clear_area)
 "U" = (
 /obj/stool/chair/office/red{
 	pixel_x = -8;
@@ -175,7 +175,7 @@
 	pixel_x = -8
 	},
 /turf/simulated/floor/grasslush/thinner,
-/area/space)
+/area/dmm_suite/clear_area)
 "W" = (
 /obj/table/clothred/auto,
 /obj/item/plate,
@@ -201,7 +201,7 @@
 	},
 /obj/machinery/light/small/floor/harsh,
 /turf/simulated/floor/grasslush/thin,
-/area/space)
+/area/dmm_suite/clear_area)
 "X" = (
 /obj/stool/chair/dining/regal{
 	pixel_y = -6;
@@ -217,7 +217,7 @@
 	name = "pocketwatch"
 	},
 /turf/simulated/floor/grasslush/thinner,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 m

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield1a.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield1a.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "k" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 "u" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "Z" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 a

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield1b.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield1b.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "k" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 "u" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "Z" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 a

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield1c.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield1c.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "k" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 "u" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "Z" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 a

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield1d_50.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield1d_50.dmm
@@ -1,13 +1,13 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "u" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "Z" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 a

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield2a.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield2a.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "s" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "G" = (
 /obj/storage/crate/trench_loot/tools2,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 "V" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 a

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield2b.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield2b.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "s" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "G" = (
 /obj/storage/crate/trench_loot/ship2,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 "V" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 a

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield2c.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield2c.dmm
@@ -1,13 +1,13 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "s" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "V" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 a

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield3a.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield3a.dmm
@@ -1,19 +1,19 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "l" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "s" = (
 /obj/item/raw_material/miracle{
 	pixel_y = 21
 	},
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "Y" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 l

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield3b.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield3b.dmm
@@ -1,10 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "l" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "X" = (
 /obj/storage/crate/trench_loot,
 /obj/item/device/gps,
@@ -14,10 +14,10 @@
 /obj/item/reagent_containers/food/snacks/plant/corn,
 /obj/item/reagent_containers/food/snacks/plant/corn,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 "Y" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 l

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield3c.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield3c.dmm
@@ -1,33 +1,33 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "d" = (
 /obj/decal/cleanable/machine_debris{
 	icon_state = "gib6"
 	},
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "j" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 "l" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "A" = (
 /obj/decal/cleanable/machine_debris,
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "B" = (
 /obj/decal/cleanable/machine_debris{
 	icon_state = "gib3"
 	},
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "Y" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 l

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield4a.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield4a.dmm
@@ -1,26 +1,26 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "j" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "m" = (
 /obj/item/raw_material/cobryl{
 	pixel_y = 22;
 	pixel_x = -4
 	},
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "G" = (
 /obj/item/raw_material/cobryl{
 	pixel_y = 22
 	},
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "T" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 j

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield4b.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield4b.dmm
@@ -1,13 +1,13 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "j" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "T" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 j

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield4c.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield4c.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "j" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "z" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 "T" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 j

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield5a.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield5a.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "k" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "Q" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "V" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 a

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield5b.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield5b.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "k" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "Q" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "V" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 a

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield5c.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield5c.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "k" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "Q" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "V" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 a

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield5d_50.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield5d_50.dmm
@@ -1,13 +1,13 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "k" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "Q" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 a

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield6a.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield6a.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "f" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "m" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "G" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 f

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield6b.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield6b.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "f" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "m" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "G" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 f

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield6c.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield6c.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "f" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "m" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "G" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 f

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield7a.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield7a.dmm
@@ -1,30 +1,30 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "d" = (
 /obj/decal/cleanable/machine_debris{
 	icon_state = "gib7"
 	},
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "f" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "v" = (
 /obj/decal/cleanable/machine_debris{
 	icon_state = "gib3"
 	},
 /obj/beacon_deployer,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 "y" = (
 /obj/decal/cleanable/machine_debris,
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "M" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 f

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield7b.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield7b.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "z" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "B" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 "V" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 z

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield7c.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield7c.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "z" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "M" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 "V" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 z

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield8a.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield8a.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "j" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "m" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "I" = (
 /obj/storage/crate/trench_loot/escape,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 a

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield8b.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield8b.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "d" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "v" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 "V" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 d

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield8c.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield8c.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "d" = (
 /turf/space/fluid/acid,
-/area/space)
+/area/dmm_suite/clear_area)
 "H" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 "V" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 d

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield9a.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield9a.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "k" = (
 /turf/space/fluid,
-/area/space)
+/area/dmm_suite/clear_area)
 "K" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "V" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 K

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield9b.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield9b.dmm
@@ -1,17 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/space/fluid,
-/area/space)
+/area/dmm_suite/clear_area)
 "u" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "w" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "J" = (
 /obj/landmark/spawner/artifact,
 /turf/space/fluid/acid/clear,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 u

--- a/assets/maps/random_rooms/nadir_rocks/7x5/rockfield9c.dmm
+++ b/assets/maps/random_rooms/nadir_rocks/7x5/rockfield9c.dmm
@@ -1,21 +1,21 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/space/fluid,
-/area/space)
+/area/dmm_suite/clear_area)
 "u" = (
 /turf/unsimulated/wall/trench,
-/area/space)
+/area/dmm_suite/clear_area)
 "w" = (
 /turf/unsimulated/wall/trench/side,
-/area/space)
+/area/dmm_suite/clear_area)
 "O" = (
 /obj/random_item_spawner/landmine,
 /turf/space/fluid,
-/area/space)
+/area/dmm_suite/clear_area)
 "S" = (
 /obj/fakeobject/beacon,
 /turf/space/fluid,
-/area/space)
+/area/dmm_suite/clear_area)
 "X" = (
 /obj/storage/secure/crate/gear/syndicate,
 /obj/item/raw_material/miracle{
@@ -42,7 +42,7 @@
 	pixel_x = 1
 	},
 /turf/space/fluid,
-/area/space)
+/area/dmm_suite/clear_area)
 
 (1,1,1) = {"
 u

--- a/code/modules/worldgen/RandomRoomRuntimeChecker.dm
+++ b/code/modules/worldgen/RandomRoomRuntimeChecker.dm
@@ -29,6 +29,7 @@ var/global/loaded_prefab_path
 	boutput(world, SPAN_ALERT("Generating random rooms..."))
 	var/list/room_types = get_map_prefabs(/datum/mapPrefab/random_room)
 	boutput(world, SPAN_ALERT("Found [length(room_types)] random rooms..."))
+	var/list/bad_prefabs = list()
 	for (var/room_type in room_types)
 		var/datum/mapPrefab/random_room/R = room_types[room_type]
 		var/turf/T = locate(1+AST_MAPBORDER, 1+AST_MAPBORDER, Z_LEVEL_STATION)
@@ -38,9 +39,14 @@ var/global/loaded_prefab_path
 		boutput(world, SPAN_ALERT("Prefab placement [R.prefabPath][R.required?" (REQUIRED)":""] succeeded. [T] @ [log_loc(T)]"))
 		global.loaded_prefab_path = R.prefabPath
 		check_map_correctness()
+		// we don't have a ref to prefab in `check_map_correctness` so we do the check here
+		var/turf/other_corner = locate(T.x + R.prefabSizeX, T.y + R.prefabSizeY, T.z)
+		for(var/turf/T2 in block(T, other_corner))
+			if (!istype(get_area(T2, /area/dmm_suite/clear_area)))
+				bad_prefabs += R.prefabPath
+				break
 		sleep(1 SECOND)
 		// cleanup
-		var/turf/other_corner = locate(T.x + R.prefabSizeX, T.y + R.prefabSizeY, T.z)
 		for(var/turf/T2 in block(T, other_corner))
 			for(var/x in T2)
 				try
@@ -49,6 +55,8 @@ var/global/loaded_prefab_path
 					;
 			T2.ReplaceWithSpaceForce()
 	global.loaded_prefab_path = null
+	if (length(bad_prefabs))
+		CRASH("Random rooms using non `/area/dmm_suite/clear_area` areas:\n"+ jointext(bad_prefabs, "\n"))
 	boutput(world, SPAN_ALERT("Generated prefabs Level in [((world.timeofday - startTime)/10)] seconds!"))
 #else
 	CRASH("This proc only works if CI_RUNTIME_CHECKING is defined")

--- a/code/modules/worldgen/RandomRoomRuntimeChecker.dm
+++ b/code/modules/worldgen/RandomRoomRuntimeChecker.dm
@@ -39,14 +39,9 @@ var/global/loaded_prefab_path
 		boutput(world, SPAN_ALERT("Prefab placement [R.prefabPath][R.required?" (REQUIRED)":""] succeeded. [T] @ [log_loc(T)]"))
 		global.loaded_prefab_path = R.prefabPath
 		check_map_correctness()
-		// we don't have a ref to prefab in `check_map_correctness` so we do the check here
-		var/turf/other_corner = locate(T.x + R.prefabSizeX, T.y + R.prefabSizeY, T.z)
-		for(var/turf/T2 in block(T, other_corner))
-			if (!istype(get_area(T2), /area/dmm_suite/clear_area))
-				bad_prefabs += R.prefabPath
-				break
 		sleep(1 SECOND)
 		// cleanup
+		var/turf/other_corner = locate(T.x + R.prefabSizeX, T.y + R.prefabSizeY, T.z)
 		for(var/turf/T2 in block(T, other_corner))
 			for(var/x in T2)
 				try

--- a/code/modules/worldgen/RandomRoomRuntimeChecker.dm
+++ b/code/modules/worldgen/RandomRoomRuntimeChecker.dm
@@ -42,7 +42,7 @@ var/global/loaded_prefab_path
 		// we don't have a ref to prefab in `check_map_correctness` so we do the check here
 		var/turf/other_corner = locate(T.x + R.prefabSizeX, T.y + R.prefabSizeY, T.z)
 		for(var/turf/T2 in block(T, other_corner))
-			if (!istype(get_area(T2, /area/dmm_suite/clear_area)))
+			if (!istype(get_area(T2), /area/dmm_suite/clear_area))
 				bad_prefabs += R.prefabPath
 				break
 		sleep(1 SECOND)

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -25,7 +25,7 @@ if grep -P 'step_[xy]' assets/maps/**/*.dmm maps/**/*.dmm;	then
     st=1
 fi;
 
-if grep -P '^\/area(?!\/dmm_suite\/clear_area)' assets/maps/random_rooms/**/*.dm; then
+if grep -P '^\/area(?!\/dmm_suite\/clear_area)' assets/maps/random_rooms/**/*.dmm; then
 	echo "ERROR: random room uses non '/area/dmm_suite/clear' area"
 	st=1
 fi;

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -26,8 +26,8 @@ if grep -P 'step_[xy]' assets/maps/**/*.dmm maps/**/*.dmm;	then
 fi;
 
 if grep -P '^\/area(?!\/dmm_suite\/clear_area)' assets/maps/random_rooms/**/*.dmm; then
-	echo "ERROR: random room uses non '/area/dmm_suite/clear' area"
-	st=1
+    echo "ERROR: random room uses non '/area/dmm_suite/clear' area"
+    st=1
 fi;
 
 # We check for this as well to ensure people aren't actually using this mapping effect in their maps.

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -25,6 +25,11 @@ if grep -P 'step_[xy]' assets/maps/**/*.dmm maps/**/*.dmm;	then
     st=1
 fi;
 
+if grep -P '^\/area(?!\/dmm_suite\/clear_area)' assets/maps/random_rooms/**/*.dm; then
+	echo "ERROR: random room uses non '/area/dmm_suite/clear' area"
+	st=1
+fi;
+
 # We check for this as well to ensure people aren't actually using this mapping effect in their maps.
 if grep -P '/obj/merge_conflict_marker' assets/maps/**/*.dmm maps/**/*.dmm; then
     echo "ERROR: Merge conflict markers detected in map, please resolve all merge failures!"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][code quality]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
use grep to check random rooms for any areas that do not match `/area/dmm_suite/clear_area`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fix foreground parallax effects like oshan caustics from showing up in some interior random rooms

general code quality

Proof it catches things: https://github.com/pgmzeta/goonstation/actions/runs/14674768178/job/41188934168

