### PR TITLE
Slightly buff glass pipeshot + boneshot

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1004,10 +1004,14 @@ toxic - poisons
 	name = "glass"
 	sname = "glass"
 	icon_state = "glass"
-	dissipation_delay = 2
-	dissipation_rate = 2
+	dissipation_delay = 4
+	dissipation_rate = 1
 	implanted = null
-	damage = 6
+	damage = 3
+	on_hit(atom/hit, dirflag, obj/projectile/proj)
+		var/mob/M = hit
+		take_bleeding_damage(M, proj.shooter, 2, DAMAGE_CUT, 1, override_bleed_level=2) //easily cause level 2 bleeds
+		..()
 
 /datum/projectile/bullet/improvscrap
 	name = "fragments"
@@ -1023,7 +1027,7 @@ toxic - poisons
 	sname = "bone"
 	icon_state = "boneproj"
 	dissipation_delay = 1
-	dissipation_rate = 3
+	dissipation_rate = 1
 	damage_type = D_KINETIC
 	hit_type = DAMAGE_BLUNT
 	implanted = null

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -211,7 +211,8 @@ ABSTRACT_TYPE(/datum/projectile/special)
 		var/obj/projectile/FC = initialize_projectile(PT, F, P.xo, P.yo, P.shooter)
 		FC.rotateDirection(rand(0-spread_angle_variance,spread_angle_variance))
 		FC.internal_speed = rand(speed_min,speed_max)
-		FC.travelled = rand(0,dissipation_variance)
+		var/dissipation_ratio = (FC.internal_speed-speed_min) / (speed_max-speed_min)
+		FC.travelled = dissipation_variance * (1-dissipation_ratio)
 		FC.launch()
 		FC.spread = P.spread + dissipation_variance
 /datum/projectile/special/spreader/buckshot_burst/plasglass
@@ -232,13 +233,13 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	name = "glass"
 	sname = "glass"
 	cost = 1
-	pellets_to_fire = 7
+	pellets_to_fire = 12
 	casing = /obj/item/casing/shotgun/pipe
 	shot_sound = 'sound/weapons/shotgunshot.ogg'
 	speed_max = 36
-	speed_min = 28
-	spread_angle_variance = 30
-	dissipation_variance = 40
+	speed_min = 20
+	spread_angle_variance = 20
+	dissipation_variance = 96
 
 /datum/projectile/special/spreader/buckshot_burst/scrap
 	spread_projectile_type = /datum/projectile/bullet/improvscrap
@@ -261,10 +262,10 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	pellets_to_fire = 3
 	casing = /obj/item/casing/shotgun/pipe
 	shot_sound = 'sound/weapons/shotgunshot.ogg'
-	speed_max = 30
-	speed_min = 20
+	speed_max = 40
+	speed_min = 30
 	spread_angle_variance = 25
-	dissipation_variance = 40
+	dissipation_variance = 20
 
 /datum/projectile/special/spreader/buckshot_burst/nails
 	name = "nails"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes spreadshot dissipation_variance to correlate with projectile speed, which looks a little more rational.

Changes regular glass pipe shot to fire lots more pellets with lower damage. They also cause double the bleed and a flat blood penalty, unlike most pipeshot's 1 bleed.
This gives it a niche of being good at terrorizing crowds and stacking up debuffs. It still does respectable damage up close.

Additionally buffs boneshot to shoot more than 3 tiles away.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Give glass pipeshot a fun niche, even if it's not super necessary or super strong. The projectile count shouldn't matter as much now pipeshot is restricted in what can load it.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(+)Glass pipeshot now shoots more pellets and causes heavier bleeding, at the cost of some damage.
(+)Bone pipeshot can now shoot 3x as far.
```
