### PR TITLE
More syndicate antag checks

### DIFF
--- a/_std/macros/antagchecks.dm
+++ b/_std/macros/antagchecks.dm
@@ -1,11 +1,20 @@
 
 // Macros with abilityHolder or mutantrace defines are used for more than antagonist checks, so don't replace them with mind.special_role.
+
+//Trained Syndicate operatives (e.g. not syndie-backed like revs or spiefs)
 #define istraitor(x) (istype(x, /mob/living/carbon/human) && x:mind && (x:mind:get_antagonist(ROLE_TRAITOR) || x:mind:get_antagonist(ROLE_HARDMODE_TRAITOR)))
+#define isnukeop(x) (istype(x, /mob/living/carbon/human) && x:mind && (x:mind:get_antagonist(ROLE_NUKEOP) || x:mind:get_antagonist(ROLE_NUKEOP_COMMANDER)))
+#define issleeperagent(x) (istype(x, /mob/living/carbon/human) && x:mind && x:mind:get_antagonist(ROLE_SLEEPER_AGENT))
+#define issyndicateagent(x) (istype(x, /mob/living/carbon/human) && x:mind && x:mind:get_antagonist(ROLE_SYNDICATE_AGENT))
+#define isnukeopgunbot(x) (istype(x, /mob/living/critter/robotic/gunbot/syndicate) && x:mind && x:mind:get_antagonist(ROLE_NUKEOP_GUNBOT))
+#define istrainedsyndie(x) (istraitor(x) || isnukeop(x) || issleeperagent(x) || issyndicateagent(x) || isnukeopgunbot(x) || isomnitraitor(x))
+
+#define isomnitraitor(x) (istype(x, /mob/living/carbon/human) && x:mind && x:mind:get_antagonist(ROLE_OMNITRAITOR))
+#define issawflybuddy(x) (istrainedsyndie(x) || isspythief(x))
 #define isrevolutionary(x) (istype(x, /mob/living/carbon/human) && x:mind && (x:mind:get_antagonist(ROLE_HEAD_REVOLUTIONARY) || x:mind:get_antagonist(ROLE_REVOLUTIONARY)))
 #define isconspirator(x) (istype(x, /mob/living/carbon/human) && x:mind && x:mind:get_antagonist(ROLE_CONSPIRATOR))
 #define ischangeling(x) (istype(x, /mob/living/carbon/human) && x:get_ability_holder(/datum/abilityHolder/changeling) != null)
 #define isabomination(x) (istype(x, /mob/living/carbon/human) && x:mutantrace && istype(x:mutantrace, /datum/mutantrace/abomination))
-#define isnukeop(x) (istype(x, /mob/living/carbon/human) && x:mind && (x:mind:get_antagonist(ROLE_NUKEOP) || x:mind:get_antagonist(ROLE_NUKEOP_COMMANDER)))
 #define isvampire(x) ((istype(x, /mob/living/carbon/human) || istype(x, /mob/living/critter)) && x:get_ability_holder(/datum/abilityHolder/vampire) != null)
 #define isvampiricthrall(x) (istype(x, /mob/living/carbon/human) && x:get_ability_holder(/datum/abilityHolder/vampiric_thrall) != null)
 #define iswizard(x) ((istype(x, /mob/living/carbon/human) || istype(x, /mob/living/critter)) && x:get_ability_holder(/datum/abilityHolder/wizard) != null)
@@ -16,7 +25,6 @@
 #define ispoltergeist(x) istype(x, /mob/living/intangible/wraith/poltergeist)
 #define isarcfiend(x) (istype(x, /mob/living/carbon/human) && x:get_ability_holder(/datum/abilityHolder/arcfiend) != null)
 #define ispirate(x) (istype(x, /mob/living/carbon/human) && x:mind && (x:mind:get_antagonist(ROLE_PIRATE) || x:mind:get_antagonist(ROLE_PIRATE_FIRST_MATE) || x:mind:get_antagonist(ROLE_PIRATE_CAPTAIN)))
-#define issawflybuddy(x) ((istraitor(x)) || isnukeop(x) || isspythief(x) || isnukeopgunbot(x))
 
 #define isblob(x) istype(x, /mob/living/intangible/blob_overmind)
 #define isspythief(x) (istype(x, /mob/living/carbon/human) && x:mind && x:mind:get_antagonist(ROLE_SPY_THIEF))
@@ -30,6 +38,5 @@
 #define ismartian(x) (istype(x, /mob/living/critter/martian) || (istype(x, /mob/living/carbon/human) && x:mutantrace && istype(x:mutantrace, /datum/mutantrace/martian)))
 #define isprematureclone(x) (istype(x, /mob/living/carbon/human) && x:mutantrace && istype(x:mutantrace, /datum/mutantrace/premature_clone))
 #define iskudzuman(x) (istype(x, /mob/living/carbon/human) && x:mutantrace && istype(x:mutantrace, /datum/mutantrace/kudzu))
-#define isnukeopgunbot(x) (istype(x, /mob/living/critter/robotic/gunbot/syndicate) && x:mind && x:mind:get_antagonist(ROLE_NUKEOP_GUNBOT))
 #define issawfly(x) (istype(x, /mob/living/critter/robotic/sawfly))
 #define iszombie(x) (istype(x, /mob/living/critter/zombie) || istype(x, /mob/living/carbon/human) && x:mutantrace && istype(x:mutantrace, /datum/mutantrace/zombie))

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -153,7 +153,7 @@
 		var/list/goods_for_purchase = goods_sell.Copy()
 		// Illegal goods for syndicate traitors
 		if (illegal)
-			if(usr.mind && (istraitor(usr) || isspythief(usr) || isnukeop(usr) || usr.mind.special_role == ROLE_SLEEPER_AGENT || usr.mind.special_role == ROLE_OMNITRAITOR))
+			if(usr.mind && istrainedsyndie(usr))
 				goods_for_purchase += goods_illegal
 		if (href_list["purchase"])
 			src.temp =buy_dialogue + "<HR><BR>"

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -433,7 +433,7 @@ TYPEINFO(/obj/shrub/syndicateplant)
 		MAKE_DEFAULT_RADIO_PACKET_COMPONENT(src.net_id, "control", FREQ_HYDRO)
 
 	get_desc(dist, mob/user)
-		if(istraitor(user) || isnukeop(user) || user.mind?.get_antagonist(ROLE_SLEEPER_AGENT)) //no issleeperagent() >:(
+		if(istrainedsyndie(user))
 			. += SPAN_ALERT("<b>The latest in syndicate spy technology. </b>")
 		else
 			. += "Is that an antenna? "

--- a/code/obj/machinery/door/door_control.dm
+++ b/code/obj/machinery/door/door_control.dm
@@ -678,7 +678,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door_control, proc/toggle)
 	if (ON_COOLDOWN(src, "scan", 2 SECONDS))
 		return
 	playsound(src.loc, 'sound/effects/handscan.ogg', 50, 1)
-	if (user.mind?.get_antagonist(ROLE_SLEEPER_AGENT) || user.mind?.get_antagonist(ROLE_TRAITOR) || user.mind?.get_antagonist(ROLE_NUKEOP) || user.mind?.get_antagonist(ROLE_NUKEOP_COMMANDER))
+	if (istrainedsyndie(user))
 		user.visible_message(SPAN_NOTICE("The [src] accepts the biometrics of the user and beeps, granting you access."))
 		src.toggle()
 		if (src.entrance_scanner)

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -608,11 +608,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 		return FALSE
 
 	get_desc(dist, mob/user)
-		var/can_user_recognize = !extremely_convincing && \
-			( \
-				user?.mind?.get_antagonist(ROLE_NUKEOP) || user?.mind?.get_antagonist(ROLE_NUKEOP_COMMANDER) || \
-				dist <= src.recognizable_range || (FACTION_SYNDICATE in user?.faction) \
-			)
+		var/can_user_recognize = !extremely_convincing && (istrainedsyndie(user) || dist <= src.recognizable_range)
 		if(isnull(src.our_bomb?.deref()) || can_user_recognize)
 			. = "<br>An extremely powerful balloon capable of deceiving the whole station."
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sort syndicate role checks to the top of antagchecks.dm
Add issleeperagent, issyndicateagent (generic syndie role) and isomnitraitor defines
Add istrainedsyndie check which applies to all roles that can access the post and are trained syndicate operatives (Traitors, Sleepers, Nukeops, Nukeop gunbots, Generic syndies and Omnitraitors)
Sawfly buddies upgraded to include all trained syndies +spiefs
Listening post, CARL and syndicate shrub now check for istrainedsyndicate.

## Resulting changes:
- Generic operatives, omnitraitors and nukeop gunbots can access the listening post
- Generic operatives, sleeper agents and omnitraitors are sawfly buddies
- Spy thieves cannot access the secret CARL entries (they don't have access anyway)
- All syndicate agents can identify fake nukes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Rather than checking for the long list of antag roles for these various syndicate checks, have one unified check that includes generic ops and omnitraitors
