### PR TITLE
Replace most door/window with windoor on cogmap2

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -54177,14 +54177,6 @@
 	icon_state = "green2"
 	},
 /area/listeningpost)
-"dnT" = (
-/obj/window/east,
-/obj/machinery/vending/jobclothing/syndicate,
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "green2"
-	},
-/area/listeningpost)
 "dnU" = (
 /obj/table/auto,
 /obj/machinery/recharger,
@@ -54249,16 +54241,8 @@
 	},
 /area/listeningpost)
 "dob" = (
-/obj/window/east,
-/obj/shrub{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	level = 1.9
-	},
-/turf/simulated/floor/carpet{
-	dir = 4;
-	icon_state = "green2"
-	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
 /area/listeningpost)
 "doc" = (
 /turf/simulated/floor/grey/side{
@@ -54311,15 +54295,10 @@
 	},
 /area/listeningpost)
 "dok" = (
-/obj/machinery/door/window{
-	dir = 4;
-	name = "bunk";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "green2"
-	},
+/turf/simulated/floor,
 /area/listeningpost)
 "dol" = (
 /obj/submachine/ATM,
@@ -57056,11 +57035,11 @@
 /obj/table/reinforced/auto,
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/cashreg,
-/obj/machinery/door/window/northleft{
-	name = "Medical Booth";
-	req_access_txt = "5"
-	},
 /obj/decal/stripe_delivery,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 1
+	},
+/obj/mapping_helper/access/medical,
 /turf/simulated/floor,
 /area/station/medical/medbooth)
 "fXH" = (
@@ -57343,15 +57322,15 @@
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/door/window/eastleft{
-	name = "Hydroponics"
-	},
 /obj/noticeboard/persistent{
 	name = "Botany persistent notice board";
 	persistent_id = "botany"
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/hydro,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "gpa" = (
@@ -58854,6 +58833,13 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"hLB" = (
+/obj/machinery/vending/jobclothing/syndicate,
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "green2"
+	},
+/area/listeningpost)
 "hLF" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -61900,10 +61886,10 @@
 "kmq" = (
 /obj/table/reinforced/auto,
 /obj/mapping_helper/firedoor_spawn,
-/obj/machinery/door/window/eastright{
-	name = "Mechanic's Lab";
-	req_access_txt = "45"
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
 	},
+/obj/mapping_helper/access/engineering_mechanic,
 /turf/simulated/floor,
 /area/station/engine/elect)
 "kmy" = (
@@ -66462,6 +66448,17 @@
 	dir = 10
 	},
 /area/station/hallway/secondary/entry)
+"ozD" = (
+/obj/shrub{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant";
+	level = 1.9
+	},
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "green2"
+	},
+/area/listeningpost)
 "ozR" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -68646,13 +68643,13 @@
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
 /obj/mapping_helper/firedoor_spawn,
-/obj/machinery/door/window/eastleft{
-	name = "Mechanic's Lab";
-	req_access_txt = "45"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/mapping_helper/access/engineering_mechanic,
 /turf/simulated/floor,
 /area/station/engine/elect)
 "qEw" = (
@@ -73737,6 +73734,12 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/locker)
+"vLn" = (
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "green2"
+	},
+/area/listeningpost)
 "vMH" = (
 /obj/mesh/catwalk{
 	dir = 9
@@ -74811,10 +74814,9 @@
 	opacity = 0
 	},
 /obj/machinery/cashreg,
-/obj/machinery/door/window/westright{
-	dir = 1;
-	name = "Chemistry";
-	req_access_txt = "33"
+/obj/mapping_helper/access/chemistry,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/science/chemistry)
@@ -153926,7 +153928,7 @@ aab
 aab
 aab
 aab
-aaa
+aab
 aaa
 aaa
 aaa
@@ -154229,8 +154231,8 @@ aab
 aab
 aab
 aab
-aaa
-aaa
+aab
+aab
 aaa
 aaa
 aaa
@@ -154527,11 +154529,11 @@ aaF
 aan
 aan
 aan
-aab
-aab
-aab
-aab
-aab
+dnA
+dnA
+dnA
+dnA
+dnA
 aab
 aaa
 aaa
@@ -154830,12 +154832,12 @@ aan
 aan
 dFC
 dnA
-dnA
-dnA
-dnA
+dnR
+dnZ
+doi
 dnA
 aab
-aaa
+aab
 aaa
 aaa
 aaa
@@ -155132,9 +155134,9 @@ aan
 aan
 kPd
 dnA
-dnR
-dnZ
-doi
+dnS
+doa
+doj
 dnA
 aab
 aab
@@ -155434,9 +155436,9 @@ dnq
 mNY
 dnq
 dnA
-dnS
-doa
-doj
+hLB
+ozD
+vLn
 dnA
 aab
 aab
@@ -155736,7 +155738,7 @@ dmJ
 ygE
 dnA
 dnA
-dnT
+dob
 dob
 dok
 dnA


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace most `door/window` doors with `windoor`s on cogmap2
The remaining `door/window` are in the bathrooms and I'm not sure how best to change that without major mapping updates.
Slightly expands the listening post to allow for full-size windows and a proper door instead of thindows

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
windoors can be hacked and bolted, door/window cant  