### PR TITLE
Remove req_access_txt from Neon

### DIFF
--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -9767,8 +9767,7 @@
 "gFn" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
-	name = "External Access";
-	req_access_txt = null
+	name = "External Access"
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
@@ -21943,7 +21942,7 @@
 "piq" = (
 /obj/machinery/computer/announcement{
 	name = "Radio Station Announcement Computer";
-	req_access_txt = ""
+	req_access = null
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -23402,8 +23401,7 @@
 "qgQ" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
-	name = "External Access";
-	req_access_txt = null
+	name = "External Access"
 	},
 /obj/mapping_helper/access/cargo,
 /turf/simulated/floor/plating,
@@ -33942,9 +33940,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA)
 "xhn" = (
-/obj/storage/cart/hotdog{
-	req_access_txt = "28"
-	},
+/obj/storage/cart/hotdog,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/north)
 "xho" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes all four req_access_txt defines from Neon

2 doors with it varedited to null (the default value)
Cart with it varedited to kitchen access (carts dont use access)
Radio station announcement computer uses req_access = null instead


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Code quality
