### PR TITLE
Remove req_access_txt from assets/maps

### DIFF
--- a/assets/maps/prefabs/planet/prefab_planet_angry_birds.dmm
+++ b/assets/maps/prefabs/planet/prefab_planet_angry_birds.dmm
@@ -64,8 +64,7 @@
 /area/noGenerate)
 "B" = (
 /obj/machinery/door/airlock/pyro/classic{
-	dir = 4;
-	req_access_txt = null
+	dir = 4
 	},
 /turf/unsimulated/floor/black/side{
 	dir = 8

--- a/assets/maps/prefabs/space/prefab_drug_den.dmm
+++ b/assets/maps/prefabs/space/prefab_drug_den.dmm
@@ -883,8 +883,7 @@
 /area/prefab/drug_den/party)
 "VU" = (
 /obj/machinery/vending/kitchen{
-	freestuff = 1;
-	req_access_txt = null
+	freestuff = 1
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/prefab/drug_den)

--- a/assets/maps/prefabs/space/prefab_von_ricken.dmm
+++ b/assets/maps/prefabs/space/prefab_von_ricken.dmm
@@ -1170,9 +1170,7 @@
 /area/prefab/von_ricken)
 "NE" = (
 /obj/decal/cleanable/dirt/jen,
-/obj/storage/secure/closet/fridge{
-	req_access_txt = "29"
-	},
+/obj/storage/secure/closet/fridge,
 /obj/random_item_spawner/organs/bloody/one_to_three,
 /turf/simulated/floor/black,
 /area/prefab/von_ricken)

--- a/assets/maps/prefabs/underwater/manta/prefab_water_mantamining.dmm
+++ b/assets/maps/prefabs/underwater/manta/prefab_water_mantamining.dmm
@@ -101,7 +101,7 @@
 "ap" = (
 /obj/machinery/computer/announcement{
 	name = "Communications Office Announcement Computer";
-	req_access_txt = ""
+	req_access = null
 	},
 /turf/simulated/floor,
 /area/prefab/tunnelsnake)

--- a/assets/maps/prefabs/underwater/nadir_safe/prefab_water_sketchy.dmm
+++ b/assets/maps/prefabs/underwater/nadir_safe/prefab_water_sketchy.dmm
@@ -416,9 +416,9 @@
 /area/prefab/sea_sketch)
 "bQ" = (
 /obj/machinery/door/airlock/pyro/classic{
-	dir = 4;
-	req_access_txt = "12"
+	dir = 4
 	},
+/obj/mapping_helper/access/maint,
 /turf/simulated/floor/plating,
 /area/prefab/sea_sketch)
 "bR" = (

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_strangeprison.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_strangeprison.dmm
@@ -293,16 +293,13 @@
 "bc" = (
 /obj/machinery/door/airlock/pyro/security/alt{
 	dir = 4;
-	name = "Security";
-	req_access_txt = "1"
+	name = "Security"
 	},
 /obj/mapping_helper/access/security,
 /turf/simulated/floor/red,
 /area/prefab/sea_prison)
 "bd" = (
-/obj/machinery/door/airlock/pyro/security/alt{
-	req_access_txt = "1"
-	},
+/obj/machinery/door/airlock/pyro/security/alt,
 /obj/mapping_helper/access/security,
 /turf/simulated/floor/red,
 /area/prefab/sea_prison)
@@ -355,9 +352,7 @@
 	},
 /area/prefab/sea_prison)
 "bo" = (
-/obj/machinery/door/airlock/pyro/security/alt{
-	req_access_txt = "1"
-	},
+/obj/machinery/door/airlock/pyro/security/alt,
 /obj/mapping_helper/access/security,
 /turf/simulated/floor,
 /area/prefab/sea_prison)
@@ -402,8 +397,7 @@
 "bw" = (
 /obj/machinery/door/airlock/pyro/security/alt{
 	dir = 4;
-	name = "Security";
-	req_access_txt = "1"
+	name = "Security"
 	},
 /obj/mapping_helper/access/security,
 /turf/simulated/floor,

--- a/assets/maps/random_rooms/3x5/beestro.dmm
+++ b/assets/maps/random_rooms/3x5/beestro.dmm
@@ -92,8 +92,7 @@
 /area/dmm_suite/clear_area)
 "U" = (
 /obj/machinery/door/window/eastright{
-	name = "Beestro Bar Door";
-	req_access_txt = null
+	name = "Beestro Bar Door"
 	},
 /obj/critter/domestic_bee/chef,
 /turf/simulated/bar,

--- a/assets/maps/shuttles/west/small/donut2_syndicate.dmm
+++ b/assets/maps/shuttles/west/small/donut2_syndicate.dmm
@@ -3,8 +3,7 @@
 /obj/machinery/door/airlock/pyro/reinforced/syndicate{
 	dir = 4;
 	name = "reinforced internal airlock";
-	opacity = 0;
-	req_access_txt = null
+	opacity = 0
 	},
 /obj/mapping_helper/access/medical,
 /turf/unsimulated/floor/red,
@@ -180,8 +179,7 @@
 /obj/machinery/door/airlock/pyro/reinforced/syndicate{
 	dir = 4;
 	name = "reinforced internal airlock";
-	opacity = 0;
-	req_access_txt = null
+	opacity = 0
 	},
 /obj/mapping_helper/access/heads,
 /turf/unsimulated/floor/red,
@@ -190,8 +188,7 @@
 /obj/machinery/door/airlock/pyro/reinforced/syndicate{
 	dir = 4;
 	name = "reinforced internal airlock";
-	opacity = 0;
-	req_access_txt = null
+	opacity = 0
 	},
 /obj/mapping_helper/access/security,
 /turf/unsimulated/floor/red,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes all req_access_txt defines from all /assets/maps

Only resulting change is the fridge in von ricken is no longer robotics access, though this probably isn't a huge change.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Code quality.