### PR TITLE
Syndicate pipebomb now show the pipebombs icon at the antag tab at round end

### DIFF
--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -769,6 +769,7 @@ Contains:
 	bomb_strength = 32
 
 /obj/item/assembly/timer_ignite_pipebomb/mini_syndicate
+	icon_state = "Pipe_Wired_Syndicate"
 	pipebomb_path = /obj/item/pipebomb/bomb/miniature_syndicate
 
 //////////////////////////////////handmade shotgun shells//////////////////////////////////


### PR DESCRIPTION
[Bug][Game Objects]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes it so that, at round end, syndicate pipebombs show their respective icon in the summary tab, as shown here:

![grafik](https://github.com/user-attachments/assets/fa184da7-9f84-490e-b6b1-78554767ba7e)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Someone mentioned to me in the discord that the icon is currently broken. As far as i know, not a bug report regarding this was opened so far.