### PR TITLE
Make assemblies, suicide vests and mousetrap rollers respect contraband level of their components

### DIFF
--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -398,7 +398,7 @@ Contains:
 	src.target = null
 	src.target_item_prefix = null
 	src.w_class = max(src.trigger.w_class, src.applier.w_class)
-	src.contraband = max(src.trigger.contraband, checked_item.applier.contraband)
+	src.contraband = max(src.trigger.contraband, src.applier.contraband)
 	SEND_SIGNAL(src.trigger, COMSIG_ITEM_ASSEMBLY_ITEM_SETUP, src, null, FALSE)
 	SEND_SIGNAL(src.applier, COMSIG_ITEM_ASSEMBLY_ITEM_SETUP, src, null, FALSE)
 	src.UpdateIcon()


### PR DESCRIPTION
[Bug][Game Objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes it so that the contraband level of assemblies, suicide vests and mousetrap rollers is set to the highest contraband level of items in the assembly

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Pipebomb assemblies currently dont have a contraband level. I don't think that's a good idea to have.


```changelog
(u)Lord_Earthfire
(+)Assemblies, mousetrap rollers and suicide vests have the contraband level of their highest contraband component.
```
