### PR TITLE
Fix cogwip/kappa.dmm formatting

### DIFF
--- a/maps/cogwip/kappa.dmm
+++ b/maps/cogwip/kappa.dmm
@@ -241,16 +241,14 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 4;
-
+	dir = 4
 	},
 /turf/space/cavern,
 /area/space)
 "aV" = (
 /obj/structure/girder/reinforced,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 10;
-
+	dir = 10
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/space)
@@ -281,8 +279,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 4;
-
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating,
 /area/space)
@@ -296,22 +293,19 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 4;
-
+	dir = 4
 	},
 /turf/simulated/floor/airless/engine/caution/north,
 /area/space)
 "bb" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 4;
-
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/space)
 "bc" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 4;
-
+	dir = 4
 	},
 /obj/pool/perspective{
 	tag = "icon-pool (WEST)";
@@ -580,15 +574,13 @@
 /area/space)
 "bT" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6;
-
+	dir = 6
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10;
-
+	dir = 10
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -623,12 +615,10 @@
 /area/space)
 "cb" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
-
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6;
-
+	dir = 6
 	},
 /obj/fluid_spawner{
 	amount = 2700
@@ -649,12 +639,10 @@
 /area/space)
 "ce" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9;
-
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10;
-
+	dir = 10
 	},
 /obj/fluid_spawner{
 	amount = 2700
@@ -688,15 +676,13 @@
 /area/space)
 "ck" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
-
+	dir = 5
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "cl" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9;
-
+	dir = 9
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -884,8 +870,7 @@
 "cP" = (
 /obj/machinery/door/airlock/pyro,
 /obj/cable{
-	icon_state = "1-2";
-
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/door/firedoor/pyro,
@@ -1808,15 +1793,13 @@
 "fH" = (
 /obj/mesh/catwalk,
 /obj/machinery/atmospherics/pipe/manifold{
-	dir = 1;
-
+	dir = 1
 	},
 /turf/simulated/floor/airless/plating,
 /area/space)
 "fI" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 4;
-
+	dir = 4
 	},
 /turf/simulated/wall/auto/asteroid/comet/ice_dense,
 /area/space)
@@ -1826,8 +1809,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 10;
-
+	dir = 10
 	},
 /turf/space/cavern,
 /area/space)
@@ -1892,8 +1874,7 @@
 "fT" = (
 /obj/mesh/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/overfloor{
-	dir = 4;
-
+	dir = 4
 	},
 /turf/simulated/floor/airless/plating,
 /area/space)
@@ -1903,8 +1884,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 1;
-
+	dir = 1
 	},
 /turf/space/cavern,
 /area/space)
@@ -1916,15 +1896,13 @@
 /area/space)
 "fW" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
-	dir = 6;
-
+	dir = 6
 	},
 /turf/simulated/floor,
 /area/space)
 "fX" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
-	dir = 10;
-
+	dir = 10
 	},
 /turf/simulated/floor,
 /area/space)
@@ -1967,8 +1945,7 @@
 "ge" = (
 /obj/structure/girder/reinforced,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 5;
-
+	dir = 5
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/space)
@@ -1981,8 +1958,7 @@
 /area/space)
 "gg" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
-	dir = 1;
-
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/space)
@@ -2048,15 +2024,13 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 1;
-
+	dir = 1
 	},
 /turf/simulated/floor/airless/plating,
 /area/space)
 "gp" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
-	dir = 1;
-
+	dir = 1
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2065,12 +2039,10 @@
 /area/space)
 "gr" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6;
-
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
-	dir = 1;
-
+	dir = 1
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2088,16 +2060,14 @@
 "gt" = (
 /obj/mapping_helper/wingrille_spawn/reinforced/full,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 6;
-
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/space)
 "gu" = (
 /obj/mapping_helper/wingrille_spawn/reinforced/full,
 /obj/machinery/atmospherics/pipe/manifold{
-	dir = 4;
-
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/space)
@@ -2109,19 +2079,16 @@
 /area/space)
 "gw" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10;
-
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6;
-
+	dir = 6
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "gx" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4;
-
+	dir = 4
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2183,12 +2150,10 @@
 /area/space)
 "gF" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6;
-
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10;
-
+	dir = 10
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2238,12 +2203,10 @@
 /area/space)
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10;
-
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
-	dir = 1;
-
+	dir = 1
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -2959,19 +2922,16 @@
 /area/space)
 "iT" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
-
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6;
-
+	dir = 6
 	},
 /obj/fluid_spawner{
 	amount = 2700
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor{
-	dir = 5;
-
+	dir = 5
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3352,8 +3312,7 @@
 	},
 /obj/disposalpipe/trunk/east,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 1;
-
+	dir = 1
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3529,8 +3488,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 1;
-
+	dir = 1
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3541,8 +3499,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 1;
-
+	dir = 1
 	},
 /turf/simulated/floor/pool,
 /area/space)
@@ -3553,56 +3510,47 @@
 	},
 /obj/disposalpipe/trunk/west,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 1;
-
+	dir = 1
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "kw" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9;
-
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10;
-
+	dir = 10
 	},
 /obj/fluid_spawner{
 	amount = 2700
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
-	dir = 9;
-
+	dir = 9
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "kx" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9;
-
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
-
+	dir = 5
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "ky" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4;
-
+	dir = 4
 	},
 /turf/simulated/floor/pool,
 /area/space)
 "kz" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5;
-
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9;
-
+	dir = 9
 	},
 /turf/simulated/floor/pool,
 /area/space)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix formatting on maps/cogwip/kappa.dmm pipe direction varedits

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Figured out why every minor kappa change resulted in a bunch of line changes, the formatting is wrong on the varedits.
