### PR TITLE
Add more ATMS to neon

### DIFF
--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -13602,6 +13602,9 @@
 /obj/stool/chair{
 	dir = 8
 	},
+/obj/submachine/ATM{
+	pixel_y = -20
+	},
 /turf/unsimulated/floor/green/side{
 	dir = 6
 	},
@@ -20784,6 +20787,9 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/vertical,
+/obj/submachine/ATM{
+	pixel_x = -32
+	},
 /turf/simulated/floor/bluegreen/side{
 	dir = 8
 	},
@@ -29397,6 +29403,9 @@
 /area/station/maintenance/inner/central)
 "ulG" = (
 /obj/disposalpipe/segment/horizontal,
+/obj/submachine/ATM{
+	pixel_y = -20
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING]
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds 3 more ATMS to neon: One at arrivals, one outside QM and one outside the bar.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Neon currently only has three Atms, and the only one on the station itself is in the brig.
This makes it easier to withdraw and deposit spacebux and credits on neon.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cindertroy
(+)Added 3 more ATMs to Neon
```
