### PR TITLE
Security labelling changes

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -147,9 +147,6 @@
 			if (length(tracklist))
 				var/obj/item/pinpointer/secweapons/P = new(src.loc)
 				P.track(tracklist)
-				if(!islist(P.name_suffixes))
-					//Name_suffixes wasn't a list, but it is now.
-					P.name_suffixes = list()
 				P.name_suffix("([usr.real_name])")
 				P.UpdateName()
 				usr.put_in_hand_or_eject(P)

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -147,6 +147,13 @@
 			if (length(tracklist))
 				var/obj/item/pinpointer/secweapons/P = new(src.loc)
 				P.track(tracklist)
+				if(!islist(P.name_suffixes))
+					//Name_suffixes wasn't a list, but it is now.
+					P.name_suffixes = list()
+				P.name_suffix("([usr.real_name])")
+				P.UpdateName()
+				usr.put_in_hand_or_eject(P)
+
 
 	accepted_token(var/token)
 		if (istype(token, /obj/item/requisition_token/security/assistant))

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -607,9 +607,6 @@ Equip items from body traits.
 				R.fields["mind"] = src.mind
 				D.root.add_file(R)
 
-				if(!islist(D.name_suffixes))
-					//Name_suffixes wasn't a list, but it is now.
-					D.name_suffixes = list()
 				D.name_suffix("([src.real_name])")
 				D.UpdateName()
 

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -607,7 +607,11 @@ Equip items from body traits.
 				R.fields["mind"] = src.mind
 				D.root.add_file(R)
 
-				D.name = "data disk - '[src.real_name]'"
+				if(!islist(D.name_suffixes))
+					//Name_suffixes wasn't a list, but it is now.
+					D.name_suffixes = list()
+				D.name_suffix("([src.real_name])")
+				D.UpdateName()
 
 			if(JOB.badge)
 				var/obj/item/clothing/suit/security_badge/badge = new JOB.badge(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Security pinpointers will now be vended with a label of the user's name, same as would happen by using a hand labeler.
Security pinpointers will attempt to be put in the user's hand
Security disks now use a label instead of changing the name


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
QoL for security to make them less reliant on having a hand labeler in their department.
Buff for antags by allowing them to remove the labels from disks to potentially muddle up which disk belongs to who.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Security pinpointers and disks now come labelled with the owner's name, this label can be removed with a hand labeler.
```
