### PR TITLE
Lower thirst penalties

### DIFF
--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -237,7 +237,7 @@
 		icon_state = "stam-"
 		duration = INFINITE_STATUS
 		maxDuration = null
-		change = -5
+		change = -2.5
 
 	staminaregen/cursed
 		id = "weakcurse"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lowers the penalty for thirst from  -5 to -2.5.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While tending to motives is encouraged on RP, sometimes there are shifts just chaotic enough that you can't get at a drink for some reason or another. 
Stamina is currently the most important combat number in the game, and thirst halves your regeneration, doubling the time you spend stamina stunned, on top of the invisible, secretly massive penalty to melee damage. 
It's disproportionate to the goal of motives, incentivising roleplay. Even a -2 penalty will encourage roleplay, but not annihilate people who are unable to find time to engage with it.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(+)Thirst's stamina penalty has been halved.
```
