### PR TITLE
use butcherable defines consistently

### DIFF
--- a/code/datums/gauntlet/crittergauntlet.dm
+++ b/code/datums/gauntlet/crittergauntlet.dm
@@ -1025,12 +1025,13 @@ var/global/datum/arena/gauntletController/gauntlet_controller = new()
 			if(iscritter(mob_or_critter))
 				var/obj/critter/C = mob_or_critter
 				C.health *= health_multiplier
+				C.butcherable = BUTCHER_NOT_ALLOWED
 				C.aggressive = 1
 				C.defensive = 1
 				C.opensdoors = OBJ_CRITTER_OPENS_DOORS_NONE
 			else if (isliving(mob_or_critter))
 				var/mob/living/critter/C = mob_or_critter
-				C.butcherable = FALSE
+				C.butcherable = BUTCHER_NOT_ALLOWED
 				C.health *= health_multiplier //for critters that don't user health holders
 				C.faction = list(FACTION_GUANTLET)
 				for(var/damage_key in C.healthlist) //for critters that do

--- a/code/mob/living/critter/maneater.dm
+++ b/code/mob/living/critter/maneater.dm
@@ -35,7 +35,7 @@
 	icon_state = "maneater"
 	icon_state_dead = "maneater-dead"
 	custom_gib_handler = /proc/vegetablegibs
-	butcherable = TRUE
+	butcherable = BUTCHER_ALLOWED
 	meat_type = /obj/item/reagent_containers/food/snacks/ingredient/meat/synthmeat
 	skinresult = /obj/item/reagent_containers/food/snacks/plant/lettuce
 	custom_vomit_type = /obj/decal/cleanable/blood

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -3726,7 +3726,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	base_move_delay = 6
 	base_walk_delay = 8
 	var/slime_chance = 22
-	butcherable = TRUE
+	butcherable = BUTCHER_ALLOWED
 	name_the_meat = FALSE
 	meat_type = /obj/item/reagent_containers/food/snacks/ingredient/meat/lesserSlug
 	player_can_spawn_with_pet = TRUE
@@ -4737,7 +4737,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	icon_state_dead = "lavacrab-dead"
 	density = TRUE
 	anchored = ANCHORED
-	butcherable = FALSE
+	butcherable = BUTCHER_NOT_ALLOWED
 	health_burn_vuln = 0.1
 	health_brute_vuln = 0.5
 	death_text = "%src% flops over dead!"
@@ -5039,7 +5039,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	health_burn = 10
 	flags = NOSPLASH | TABLEPASS
 	generic = FALSE
-	butcherable = FALSE
+	butcherable = BUTCHER_NOT_ALLOWED
 	no_stamina_stuns = TRUE
 	has_genes = FALSE
 

--- a/code/modules/ranch/chicken.dm
+++ b/code/modules/ranch/chicken.dm
@@ -42,7 +42,7 @@ All other chickens in this file are non-secret. Please be respectful.
 
 	is_npc = 0
 
-	butcherable = 1
+	butcherable = BUTCHER_ALLOWED
 	butcher_time = 0.2 SECONDS
 	meat_type = /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget
 

--- a/code/modules/ranch/sheep.dm
+++ b/code/modules/ranch/sheep.dm
@@ -17,7 +17,7 @@
 	can_disarm = 1
 	can_help = 1
 
-	butcherable = 1
+	butcherable = BUTCHER_ALLOWED
 	butcher_time = 0.2 SECONDS
 	meat_type = /obj/item/reagent_containers/food/snacks/ingredient/meat/sheep
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[code quality]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
use `BUTCHER_*` defines for the `butcherable` variable on objcritters/mobcritters

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
code quality