### PR TITLE
Show killswitch timer while deployed

### DIFF
--- a/code/datums/hud/shell.dm
+++ b/code/datums/hud/shell.dm
@@ -1,4 +1,4 @@
-/datum/hud/shell
+/datum/hud/silicon/shell
 	var/atom/movable/screen/hud/tool1
 	var/atom/movable/screen/hud/tool2
 	var/atom/movable/screen/hud/tool3
@@ -45,6 +45,7 @@
 		update_active_tool()
 		update_tools()
 		update_tool_selector()
+		update_health()
 
 	disposing()
 		qdel(src.tool1)
@@ -256,7 +257,7 @@
 
 /mob/living/silicon/hivebot
 	updateStatusUi()
-		if(src.hud && istype(src.hud, /datum/hud/shell))
-			var/datum/hud/shell/H = src.hud
+		if(src.hud && istype(src.hud, /datum/hud/silicon/shell))
+			var/datum/hud/silicon/shell/H = src.hud
 			H.update_status_effects()
 		return

--- a/code/datums/hud/silicon.dm
+++ b/code/datums/hud/silicon.dm
@@ -15,8 +15,21 @@
 		killswitch.invisibility = INVIS_ALWAYS
 
 	proc/update_health()
-		if (silicon.killswitch)
-			var/timeleft = round((silicon.killswitch_at - TIME)/10, 1)
+		var/mob/living/silicon/killswitch_mob = silicon
+		if (isrobot(killswitch_mob))
+			var/mob/living/silicon/robot/robot = killswitch_mob
+			if (robot.mainframe)
+				var/mob/living/silicon/ai/ai = robot.mainframe
+				if (ai.killswitch)
+					killswitch_mob = ai
+		else if (isshell(killswitch_mob))
+			var/mob/living/silicon/hivebot/eyebot/eyebot = killswitch_mob
+			if (eyebot.mainframe)
+				var/mob/living/silicon/ai/ai = eyebot.mainframe
+				if (ai.killswitch)
+					killswitch_mob = ai
+		if (killswitch_mob.killswitch)
+			var/timeleft = round((killswitch_mob.killswitch_at - TIME)/10, 1)
 			timeleft = "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
 
 			killswitch.invisibility = INVIS_NONE

--- a/code/mob/living/life/hud.dm
+++ b/code/mob/living/life/hud.dm
@@ -15,6 +15,7 @@
 			robot_owner.hud.update_environment()
 
 		if (hivebot_owner)
+			hivebot_owner.hud.update_health()
 			hivebot_owner.hud.update_charge()
 			hivebot_owner.hud.update_pulling()
 			if (ticker?.mode && istype(ticker.mode, /datum/game_mode/construction))

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -15,7 +15,7 @@
 	var/module_active = null
 	var/list/module_states = list(null,null,null)
 
-	var/datum/hud/shell/hud
+	var/datum/hud/silicon/shell/hud
 
 	var/obj/item/device/radio/radio = null
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[silicons][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Repath hivebot hud to be under silicon hud for the killswitch timer shared code
* add conditionals to the killswitch update health code that check if your robot or shell are linked to a mainframe, and if so, use the mainframe mob as the basis of whether or not to show the killswitch timer

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It should be very clear that you're on a killswitch timer and how long you have left when playing AI, regardless of if you're deployed or not.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)AI units see their killswitch timer when deployed to cyborg or eyebot shells
```
