### PR TITLE
Fixes Tommy Guillaume figurine spelling error.

### DIFF
--- a/code/modules/items/gimmick/figurine.dm
+++ b/code/modules/items/gimmick/figurine.dm
@@ -1086,8 +1086,8 @@ ABSTRACT_TYPE(/datum/figure_info/patreon)
 		icon_state = "vaughnguy"
 		ckey = "tamedevil"
 	laticauda
-		name = "\improper Tommy Guilaume"
-		icon_state = "tommyguilaume"
+		name = "\improper Tommy Guillaume"
+		icon_state = "tommyguillaume"
 		ckey = "laticauda"
 
 /obj/item/item_box/figure_capsule


### PR DESCRIPTION
[SPRITE]
[OBJECTS]
## About the PR 
Makes Tommy Guillaume figurine visible.

## Why's this needed? 
Would really expect ones figurine to be visible.


## Changelog 

```changelog
(u)EmeraldCrow
(+)Fixes Tommy Guillaume figurine.
```
