### PR TITLE
Atlas req_access_txt pass

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1168,8 +1168,7 @@
 "aeH" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
-	name = "Hydroponics";
-	req_access_txt = "35"
+	name = "Hydroponics"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -8933,8 +8932,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external{
-	name = "Burn Chamber";
-	req_access_txt = "40"
+	name = "Burn Chamber"
 	},
 /obj/mapping_helper/access/engineering_engine,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -10584,9 +10582,9 @@
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
-	id = "chapel";
-	req_access_txt = "1"
+	id = "chapel"
 	},
+/obj/mapping_helper/access/chapel_office,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
@@ -13172,8 +13170,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass{
-	name = "Kitchen";
-	req_access_txt = "35"
+	name = "Kitchen"
 	},
 /obj/mapping_helper/access/kitchen,
 /obj/mapping_helper/access/bar,
@@ -18882,15 +18879,14 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/hop)
 "piv" = (
-/obj/machinery/door/airlock/pyro/alt{
-	req_access_txt = "25|28"
-	},
+/obj/machinery/door/airlock/pyro/alt,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/access/kitchen,
+/obj/mapping_helper/access/bar,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "pjh" = (
@@ -19590,8 +19586,7 @@
 /area/station/maintenance/southeast)
 "qxs" = (
 /obj/machinery/door/airlock/pyro/glass{
-	name = "Crematorium";
-	req_access_txt = "33"
+	name = "Crematorium"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -19805,7 +19800,6 @@
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Kitchen";
-	req_access_txt = "35";
 	dir = 4
 	},
 /obj/mapping_helper/firedoor_spawn,
@@ -21335,8 +21329,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external{
-	name = "Burn Chamber";
-	req_access_txt = "40"
+	name = "Burn Chamber"
 	},
 /obj/mapping_helper/access/engineering_engine,
 /obj/forcefield/energyshield/perma/doorlink{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove all req_access_txt varedits from Atlas, placing access spawners if required, minor access changes below:
- Chapel ejector Security access > Chapel office access
- Remove erroneous Hydro/Chem access from kitchen airlocks


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
req_access_txt must go, it is a crime against good code.
