### PR TITLE
Spawned material pieces take on name of material automatically

### DIFF
--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -14,7 +14,8 @@
 	New()
 		..()
 		setup_material()
-		_update_stack_appearance()
+		if (material)
+			name = "[mat_changename ? material.getName() : ""] [initial(src.name)]"
 
 	proc/setup_material()
 		.=0

--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -14,6 +14,7 @@
 	New()
 		..()
 		setup_material()
+		_update_stack_appearance()
 
 	proc/setup_material()
 		.=0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes dropped material pieces take on the name of the material when spawned.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the drops from the nanite mining event show as "bar" or "scrap" instead of "neutronium bar" or "plutonium 239 scrap"