### PR TITLE
change DegradeFromCenter mining generation to use ReplaceWith

### DIFF
--- a/code/modules/mining/mining_encounters.dm
+++ b/code/modules/mining/mining_encounters.dm
@@ -593,8 +593,8 @@
 	var/current_range = 0
 	var/list/generated_turfs = list()
 
-	var/turf/simulated/wall/auto/asteroid/A
-	A = new base_rock(locate(center.x, center.y, center.z),0)
+	var/turf/simulated/wall/auto/asteroid/A = locate(center.x, center.y, center.z)
+	A.ReplaceWith(base_rock)
 	generated_turfs += A
 	var/turf/simulated/wall/auto/asteroid/B
 
@@ -611,7 +611,8 @@
 					continue
 				if (area_restriction && S.loc.type != area_restriction)
 					continue
-				B = new base_rock(locate(S.x, S.y, S.z),0)
+				B = locate(S.x, S.y, S.z)
+				B.ReplaceWith(base_rock)
 				generated_turfs += B
 
 	return generated_turfs


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[runtime][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
instead of spawning new asteroid turfs with `new` use `ReplaceWith`. all the other generation types use ReplaceWith, not sure why this one isn't and it worked as expected during testing.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
reduce runtimes while testing mining changes.