### PR TITLE
Add and tweak some antagonist wiki links

### DIFF
--- a/code/modules/antagonists/changeling/changeling_critter.dm
+++ b/code/modules/antagonists/changeling/changeling_critter.dm
@@ -3,7 +3,7 @@ ABSTRACT_TYPE(/datum/antagonist/subordinate/changeling_critter)
 	remove_on_death = TRUE
 	remove_on_clone = TRUE
 	antagonist_icon = "changeling"
-	wiki_link = "https://wiki.ss13.co/Changeling"
+	wiki_link = "https://wiki.ss13.co/Changeling#The_Hivemind"
 	var/critter_type = null
 	var/datum/abilityHolder/changeling/master_ability_holder
 

--- a/code/modules/antagonists/conspirator/conspirator.dm
+++ b/code/modules/antagonists/conspirator/conspirator.dm
@@ -1,7 +1,7 @@
 /datum/antagonist/conspirator
 	id = ROLE_CONSPIRATOR
 	display_name = "conspirator"
-
+	wiki_link = "https://wiki.ss13.co/Conspirator"
 	var/static/list/datum/mind/conspirators
 	var/static/datum/objective/conspiracy/conspirator_objective
 	var/static/meeting_point

--- a/code/modules/antagonists/eldritch_madness/broken.dm
+++ b/code/modules/antagonists/eldritch_madness/broken.dm
@@ -3,6 +3,7 @@
 	id = ROLE_BROKEN
 	remove_on_death = TRUE
 	remove_on_clone = TRUE //just to be sure
+	wiki_link = "https://wiki.ss13.co/Broken"
 	var/static/shared_objective_text = null
 
 /datum/antagonist/broken/announce()

--- a/code/modules/antagonists/salvager/salvager.dm
+++ b/code/modules/antagonists/salvager/salvager.dm
@@ -3,6 +3,7 @@
 	display_name = ROLE_SALVAGER
 	antagonist_icon = "salvager"
 	uses_pref_name = FALSE
+	wiki_link = "https://wiki.ss13.co/Salvager"
 
 	var/static/starting_freq = null
 	var/salvager_points

--- a/code/modules/antagonists/slasher/slasher.dm
+++ b/code/modules/antagonists/slasher/slasher.dm
@@ -2,3 +2,4 @@
 	id = ROLE_SLASHER
 	display_name = "slasher"
 	mob_path = /mob/living/carbon/human/slasher
+	wiki_link = "https://wiki.ss13.co/The_Slasher"

--- a/code/modules/antagonists/traitor/mindhack.dm
+++ b/code/modules/antagonists/traitor/mindhack.dm
@@ -3,6 +3,7 @@
 	display_name = "mindhack"
 	antagonist_icon = "mindhack"
 	remove_on_death = TRUE
+	wiki_link = "https://wiki.ss13.co/Mindhack_Rules"
 
 	is_compatible_with(datum/mind/mind)
 		return isliving(mind.current)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][gamemodes]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add links for: Conspirator, Broken, Salvager, Slasher, Mindhack wiki pages
Tweak link for: Changeling Limb-critters (point to the limbs section of the changeling page)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
wiki link feature good, link more antags to more things