### PR TITLE
Fix some pod engines causing hyperspeed pods

### DIFF
--- a/code/modules/transport/pods/engine.dm
+++ b/code/modules/transport/pods/engine.dm
@@ -36,10 +36,10 @@
 			wormholeQueued = 0
 
 	deactivate()
-		..()
-		ship.powercapacity = 0
 		if (src.active)
 			src.ship.speedmod /= src.engine_speed
+		..()
+		ship.powercapacity = 0
 		for(var/obj/item/shipcomponent/S in ship.components)
 			if(S.active)
 				S.deactivate()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][vehicles]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
the parent `deactivate` proc sets active to false, so the active check before the speedmod never occurs. moving it before the parent call fixes this

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #23247