### PR TITLE
Clear phasing event handler flag at throw end

### DIFF
--- a/code/datums/controllers/throwing_controls.dm
+++ b/code/datums/controllers/throwing_controls.dm
@@ -143,6 +143,8 @@ var/global/datum/controller/throwing/throwing_controller = new
 				break
 
 		if(end_throwing)
+			if (thr.throw_type == THROW_PHASE)
+				thing.event_handler_flags = initial(thing.event_handler_flags)
 			thrown -= thr
 			if(thr.end_throw_callback)
 				if(thr.end_throw_callback.Invoke(thr)) // pass /datum/thrown_thing, return 1 to continue the throw, might be useful!


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][admin]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
at the end of the throw, if the throw type is still throw phasing, reset the event handler flags

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
people can get stuck with noclip on if they were thrown with phasing only one tile