### PR TITLE
Stop windows from eating explosive projectiles

### DIFF
--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -516,7 +516,8 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 		logTheThing(LOG_STATION, usr, "smashes a [src] in [src.loc?.loc] ([log_loc(src)])")
 		if (src.health < (src.health_max * -0.75))
 			// You managed to destroy it so hard you ERASED it.
-			qdel(src)
+			SPAWN(0)
+				qdel(src)
 			return
 		var/atom/movable/A
 		// catastrophic event litter reduction
@@ -532,7 +533,8 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 			A = new /obj/item/rods(src.loc)
 			A.setMaterial(reinforcement)
 		playsound(src, src.shattersound, 70, 1)
-		qdel(src)
+		SPAWN(0)
+			qdel(src)
 
 	proc/update_nearby_tiles(need_rebuild, var/selfnotify = 0)
 		if(!air_master) return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
add SPAWN(0) to the window qdeling itself in its smash block so any code relying on the object existing after damage, like projectiles, can function.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If a projectile was strong enough to smash a window, the window will qdel immediately.

However, in many projectile's `on_hit` try to get the turf of the hit object after impact (i.e in `on_hit`, does `var/turf/T = get_turf(hit)`). Since it's been qdel'd, there is no turf and thus the rest of the projectile's effect was rendered moot.

This is why firing an RPG directly at a window does nothing but break the window, but hitting the wall next to it blows up properly.