### PR TITLE
Access proc cleanup

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -3911,11 +3911,11 @@ ABSTRACT_TYPE(/area/station/ai_monitored/storage/)
 			var/obj/O = A
 			if (istype(O))
 				if(access_armory in O.req_access) // Auto update access for armory stuff when it enters armory if it mismatches current auth status
-					if(src.armory_auth && !O.has_access(access_security))
+					if(src.armory_auth && !(access_security in O.req_access))
 						O.req_access += access_security
 						O.visible_message(SPAN_NOTICE("[O]'s access is automatically updated!"))
 						playsound(O, 'sound/machines/chime.ogg', 50)
-					else if (!src.armory_auth && O.has_access(access_security))
+					else if (!src.armory_auth && (access_security in O.req_access))
 						O.req_access = list(access_armory)
 						O.visible_message(SPAN_NOTICE("[O]'s access is automatically reset!"))
 						playsound(O, 'sound/machines/chime.ogg', 50)

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -119,7 +119,7 @@
  */
 /obj/proc/check_access(obj/item/I)
 	// no requirements
-	if (!src.has_access_requirements)
+	if (!src.has_access_requirements())
 		return 1
 
 	var/obj/item/card/id/ID = get_id_card(I)

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -69,7 +69,7 @@
 	if(M?.client?.holder?.ghost_interaction)
 		return 2
 	// easy out for if no access is required
-	if (src.check_access(null))
+	if (src.has_access_requirements())
 		return 1
 	if (M && ismob(M))
 		// check for admin access override
@@ -119,14 +119,7 @@
  */
 /obj/proc/check_access(obj/item/I)
 	// no requirements
-	if (!src.req_access)
-		return 1
-	// something's very wrong
-	if (!istype(src.req_access, /list))
-		return 1
-	// no requirements (also clean up src.req_access)
-	if (length(src.req_access) == 0)
-		src.req_access = null
+	if (!src.has_access_requirements)
 		return 1
 
 	var/obj/item/card/id/ID = get_id_card(I)
@@ -153,31 +146,6 @@
 		// meets all access requirements for the access group
 		if (has_access)
 			return 1
-	return 0
-
-//put in access num, check if i have that
-/obj/proc/has_access(var/acc)
-	// no requirements
-	if (!src.req_access)
-		return 1
-	// something's very wrong
-	if (!istype(src.req_access, /list))
-		return 1
-	// no requirements (also clean up src.req_access)
-	if (length(src.req_access) == 0)
-		src.req_access = null
-		return 1
-
-	for (var/req_access_group in src.req_access)
-		// access group is a list
-		if (islist(req_access_group))
-			var/list/req_access_group_list = req_access_group
-			if (acc in req_access_group_list)
-				return 1
-		// access group is a single number
-		else if (req_access_group == acc)
-			return 1
-
 	return 0
 
 /**

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -69,7 +69,7 @@
 	if(M?.client?.holder?.ghost_interaction)
 		return 2
 	// easy out for if no access is required
-	if (src.has_access_requirements())
+	if (!src.has_access_requirements())
 		return 1
 	if (M && ismob(M))
 		// check for admin access override


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cleans up unused/duplicate code in access.dm (the procs one not the defines one)
-Removes has_access proc, the only difference between "has_access(ACC)" and "ACC in thing.req_access" is that has_access erroneously returns TRUE if the thing has no access.
-Removes copied code from has_access_requirements and uses this proc in place of checking null ID with check_access, this proc is called anyway in check_access and theres no difference between calling it here vs in there


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Code quality, I accidentally used the first proc with armory updating access and it caused me a bit of a headache trying to debug it.