### PR TITLE
Fix sec headset description

### DIFF
--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -358,9 +358,9 @@
 
 	get_desc(dist, mob/user)
 		if (user.mind.is_antagonist())
-			. += SPAN_ALERT("<b>Good.</b>")
+			. += SPAN_ALERT("<b>Good.</b> ")
 		else
-			. += "Keep it safe!"
+			. += "Keep it safe! "
 		. += ..()
 /obj/item/device/radio/headset/detective
 	name = "detective's headset"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a space after the unique part of the security headset description


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #23252 
