### PR TITLE
add a bunch of status displays to Nadir

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -3476,6 +3476,9 @@
 /obj/machinery/power/data_terminal,
 /obj/table/reinforced/auto,
 /obj/machinery/computer3/generic/personal,
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_west)
 "byP" = (
@@ -10193,6 +10196,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 9
 	},
@@ -17688,6 +17694,9 @@
 	tag = ""
 	},
 /obj/shrub,
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/hallway/secondary/entry{
 	name = "Arrival Shuttle Hallway"
@@ -19049,6 +19058,9 @@
 	},
 /area/station/medical/medbay/surgery)
 "ibG" = (
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/redblack/corner{
 	dir = 1
 	},
@@ -24138,6 +24150,9 @@
 /obj/machinery/cell_charger,
 /obj/item/cell/supercell/charged,
 /obj/item/cell/supercell/charged,
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 5
 	},
@@ -26218,6 +26233,9 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},
@@ -32119,6 +32137,14 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
+"nvl" = (
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/simulated/floor/black/side{
+	dir = 4
+	},
+/area/station/hallway/primary/northeast)
 "nvD" = (
 /obj/disposalpipe/segment/mineral,
 /obj/landmark/gps_waypoint,
@@ -32481,6 +32507,9 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "nCU" = (
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/medbay/cloner)
 "nCX" = (
@@ -36415,6 +36444,13 @@
 "pnt" = (
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
+"pnu" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southeast)
 "pnP" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	req_access = null
@@ -36774,6 +36810,9 @@
 /obj/item/reagent_containers/hypospray{
 	pixel_x = 7;
 	pixel_y = 2
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
 	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/staff)
@@ -37594,6 +37633,13 @@
 	icon_state = "crewquarters";
 	name = "Warrens Hall"
 	})
+"pOy" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/southwest)
 "pPs" = (
 /obj/table/auto,
 /obj/item/dye_bottle{
@@ -38187,6 +38233,9 @@
 	})
 "qcc" = (
 /obj/reagent_dispensers/watertank/fountain,
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
 "qce" = (
@@ -45098,6 +45147,9 @@
 /area/station/medical/medbay/pharmacy)
 "tja" = (
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "tje" = (
@@ -46923,6 +46975,9 @@
 /obj/item/clothing/shoes/flippers{
 	pixel_y = -12
 	},
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
@@ -48671,6 +48726,12 @@
 /area/station/science/lobby{
 	name = "Science Lounge"
 	})
+"uNE" = (
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/northeast)
 "uNI" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
@@ -49081,6 +49142,9 @@
 	name = "autoname - SS13";
 	pixel_x = -10;
 	tag = ""
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
 	},
 /turf/simulated/floor/greenblack/corner{
 	dir = 1
@@ -94239,7 +94303,7 @@ pJi
 rnZ
 ajp
 xFO
-hcm
+pOy
 nha
 eMS
 idy
@@ -107490,7 +107554,7 @@ huI
 wTD
 auw
 lRC
-sUv
+nvl
 rJy
 sUv
 snR
@@ -111119,7 +111183,7 @@ wHl
 wHl
 wHl
 qoL
-lsj
+uNE
 jdT
 njE
 tXW
@@ -112661,7 +112725,7 @@ sSm
 ePt
 ebu
 ocD
-vEo
+pnu
 fdg
 rZb
 nlG


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
add a bunch of status displays to nadir


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
nadir only has QM status displays
Fix #23266