### PR TITLE
Changes podbay door frequency to an odd number

### DIFF
--- a/_std/packets.dm
+++ b/_std/packets.dm
@@ -71,7 +71,7 @@ proc/get_radio_connection_by_id(atom/movable/AM, id)
 #define FREQ_SECBUDDY 1089
 #define FREQ_TOUR_NAVBEACON 1443
 #define FREQ_SIGNALER 1457
-#define FREQ_DOOR_CONTROL 1142 /// pods open podbay doors with this frequency but in theory more general
+#define FREQ_DOOR_CONTROL 1143 /// pods open podbay doors with this frequency but in theory more general
 #define FREQ_MAIL_CHUTE 1475
 #define FREQ_COMM_DISH 0000 // unused for now, supposed to be for communication across comm dishes
 #define FREQ_AIR_ALARM_CONTROL 1439


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[station systems][QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes the `FREQ_DOOR_CONTROL` define from 1142 to 1143.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Parity and consistency with the other frequencies, which are all odd. Even frequencies can currently not be manually pinged due to frequency sanitization.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chasu
(+)Podbay doors now use an even frequency to communicate, allowing them to be manually targeted via packets
```
