### PR TITLE
pointblanks respect and set shoot delay

### DIFF
--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -236,7 +236,8 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 
 /obj/item/gun/proc/ShootPointBlank(atom/target, var/mob/user as mob, var/second_shot = 0)
 	if(!SEND_SIGNAL(src, COMSIG_GUN_TRY_POINTBLANK, target, user, second_shot))
-		src.shoot_point_blank(target, user, second_shot)
+		if(!ON_COOLDOWN(src, "shoot_delay", src.shoot_delay))
+			src.shoot_point_blank(target, user, second_shot)
 
 /obj/item/gun/proc/shoot_point_blank(atom/target, var/mob/user as mob, var/second_shot = 0)
 	if (!target || !user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When calling ShootPointBlank, only shoot if the gun is off cooldown.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Generally speaking most shot delays are shorter than the existing click-attack delay, so shooting e.g. a downed target is usually longer than any given weapon's shot delay for repeatedly pointblanking the same target. However, there are a few corner cases this covers for things:
* you can at shoot someone far away and then quickly point blank someone next to you
* fixes pointblanking grilles having no cooldown - Fixes #23253
