### PR TITLE
add help text for portable recharge bay

### DIFF
--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -275,6 +275,8 @@
 	var/cell_port_open = FALSE
 	///Disallows recharging of weaponry
 	var/safety_regulator = TRUE
+	HELP_MESSAGE_OVERRIDE("Use the portable recharge bay in-hand to open and close the cell compartment.\
+	<br>While open, use a large cell in-hand to place it inside, or an open hand to remove an existing cell.")
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds helptext for the portable recharge bay

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Direct, clear instructions for using it, as it's a unique item.