### PR TITLE
Adds basic botany equipment to Fortuna

### DIFF
--- a/maps/pod_wars.dmm
+++ b/maps/pod_wars.dmm
@@ -1573,6 +1573,10 @@
 	dir = 8
 	},
 /area/pod_wars/spacejunk/memorial_stats)
+"fh" = (
+/obj/machinery/plantpot,
+/turf/simulated/floor/green/side,
+/area/pod_wars/spacejunk/fstation/mess)
 "fi" = (
 /obj/disposalpipe/segment,
 /turf/unsimulated/floor/blue/corner{
@@ -3339,6 +3343,7 @@
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team1/bridge)
 "kY" = (
+/obj/machinery/gibber/output_east,
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
@@ -7253,9 +7258,14 @@
 	},
 /area/pod_wars/spacejunk/fstation/secdock)
 "xn" = (
-/obj/machinery/gibber/output_east,
-/turf/simulated/floor/green/side,
-/area/pod_wars/spacejunk/fstation/mess)
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/vending/cola/blue,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/pod_wars/spacejunk/fstation)
 "xo" = (
 /obj/deployable_turret/pod_wars/nt/activated/south,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -9100,6 +9110,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/red/side{
 	dir = 6
 	},
@@ -13211,7 +13222,7 @@
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team1/mining)
 "Qx" = (
-/obj/machinery/vending/snack,
+/obj/submachine/seed_vendor,
 /turf/simulated/floor/green/side,
 /area/pod_wars/spacejunk/fstation/mess)
 "Qy" = (
@@ -14601,6 +14612,12 @@
 	dir = 4
 	},
 /area/pod_wars/spacejunk/fstation)
+"UP" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/pod_wars/spacejunk/fstation)
 "UQ" = (
 /obj/item/organ/eye,
 /turf/simulated/wall/auto/asteroid/pod_wars,
@@ -15149,7 +15166,7 @@
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
 "WD" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/plantpot,
 /turf/simulated/floor/green/side{
 	dir = 10
 	},
@@ -15159,7 +15176,7 @@
 /turf/unsimulated/floor,
 /area/pod_wars/team1/crewlounge)
 "WF" = (
-/obj/machinery/vending/cola/blue,
+/obj/machinery/vending/hydroponics,
 /turf/simulated/floor/green/side,
 /area/pod_wars/spacejunk/fstation/mess)
 "WG" = (
@@ -74549,7 +74566,7 @@ ka
 jL
 Vz
 Uf
-Op
+fh
 ka
 Jy
 CR
@@ -74753,7 +74770,7 @@ EN
 Uf
 WF
 ka
-Jy
+xn
 SN
 aK
 JX
@@ -75155,7 +75172,7 @@ ka
 Ud
 Ok
 Uf
-xn
+Op
 Qa
 Qa
 Qa
@@ -76166,7 +76183,7 @@ GN
 sh
 hc
 ax
-lj
+UP
 lj
 pa
 Wk

--- a/maps/pod_wars.dmm
+++ b/maps/pod_wars.dmm
@@ -3343,7 +3343,7 @@
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team1/bridge)
 "kY" = (
-/obj/machinery/gibber/output_east,
+/obj/machinery/gibber/output_west,
 /turf/simulated/floor/green/side{
 	dir = 4
 	},

--- a/maps/pod_wars.dmm
+++ b/maps/pod_wars.dmm
@@ -15166,7 +15166,9 @@
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
 "WD" = (
-/obj/machinery/plantpot,
+/obj/machinery/plantpot{
+	anchored = 1
+	},
 /turf/simulated/floor/green/side{
 	dir = 10
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[game modes] [mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just adds a couple basic botany things to Fortuna's kitchen room, useful for when admins spawn Fortuna workers. Vending machines are relocated outside, can possibly be moved if hallways should be clear.

![StrongDMM_EvcEFxVv5a](https://github.com/user-attachments/assets/ef7229d9-7cfb-4a37-8c7c-5e1d2dd3b9a6)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Admins often spawn maintenance crew in for Fortuna, this just lets them cook a bit more. (Fallen soldier burgers are popular.)

