### PR TITLE
Fix canbombs detonating at the place they were build

### DIFF
--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -561,7 +561,7 @@ Contains:
 	src.UpdateIcon()
 	src.add_fingerprint(user)
 	to_combine_atom.add_fingerprint(user)
-	var/obj/item/canbomb_detonator/new_detonator = new /obj/item/canbomb_detonator(get_turf(user), src, to_combine_atom)
+	var/obj/item/canbomb_detonator/new_detonator = new /obj/item/canbomb_detonator(payload, src, to_combine_atom)
 	new_detonator.master = payload // i swear, i want to kill that master-variable sooooo bad
 	new_detonator.attachedTo = payload
 	new_detonator.builtBy = user


### PR DESCRIPTION
[Bug][Game Objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes it so that detonators for canbombs are actually placed in the canister instead on the floor

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Because this fixes #23192

Theoretically, it also fixes people able to prime a canbomb, pick up an invisible detonator, and throw it on the floor right where they want their explosion to happen (e.g. medbay)