### PR TITLE
Tweak midround salvager roll logging

### DIFF
--- a/code/modules/events/salvagers.dm
+++ b/code/modules/events/salvagers.dm
@@ -94,8 +94,8 @@
 			return
 
 		if(!admin_override && (length(candidates) < src.minimum_count) )
-			message_admins("Couldn't set up Salvager; insufficient ghosts responded ([length(candidates)], needed [src.minimum_count]). Source: [source ? "[source]" : "random"]")
-			logTheThing(LOG_ADMIN, null, "Couldn't set up Salvager; insufficient ghosts responded ([length(candidates)], needed [src.minimum_count]). Source: [source ? "[source]" : "random"]")
+			message_admins("Couldn't set up Salvager; insufficient ghosts responded (had [length(candidates)], needed [src.minimum_count]). Source: [source ? "[source]" : "random"]")
+			logTheThing(LOG_ADMIN, null, "Couldn't set up Salvager; insufficient ghosts responded (had [length(candidates)], needed [src.minimum_count]). Source: [source ? "[source]" : "random"]")
 			src.post_event()
 			return
 

--- a/code/modules/events/salvagers.dm
+++ b/code/modules/events/salvagers.dm
@@ -71,7 +71,7 @@
 		logTheThing(LOG_ADMIN, null, "Setting up [src] event. Source: [source ? "[source]" : "random"]")
 		SPAWN(0)
 			src.lock = TRUE
-			do_event(source=="spawn_antag", source)
+			do_event(source)
 
 	proc/do_event(var/source)
 		if (!src || !istype(src, /datum/random_event/major/antag/salvagers))
@@ -88,14 +88,14 @@
 		var/list/datum/mind/candidates = dead_player_list(1, src.ghost_confirmation_delay, text_messages, allow_dead_antags = 1)
 
 		if (!islist(candidates) || !length(candidates))
-			message_admins("Couldn't set Salvager; no ghosts responded. Source: [source ? "[source]" : "random"]")
+			message_admins("Couldn't set up Salvager; no ghosts responded. Source: [source ? "[source]" : "random"]")
 			logTheThing(LOG_ADMIN, null, "Couldn't set up Salvager; no ghosts responded. Source: [source ? "[source]" : "random"]")
 			src.post_event()
 			return
 
 		if(!admin_override && (length(candidates) < src.minimum_count) )
-			message_admins("Insufficient ghosts responded. Source: [source ? "[source]" : "random"]")
-			logTheThing(LOG_ADMIN, null, "Couldn't set up Salvager; Insufficient ghosts ghosts responded. Source: [source ? "[source]" : "random"]")
+			message_admins("Couldn't set up Salvager; insufficient ghosts responded ([length(candidates)], needed [src.minimum_count]). Source: [source ? "[source]" : "random"]")
+			logTheThing(LOG_ADMIN, null, "Couldn't set up Salvager; insufficient ghosts responded ([length(candidates)], needed [src.minimum_count]). Source: [source ? "[source]" : "random"]")
 			src.post_event()
 			return
 
@@ -112,8 +112,8 @@
 				attempts++
 
 			if (!(lucky_dude && istype(lucky_dude) && lucky_dude.current))
-				message_admins("Couldn't set up Salvager; candidate selection failed (had [candidates.len] candidate(s)). Source: [source ? "[source]" : "random"]")
-				logTheThing(LOG_ADMIN, null, "Couldn't set up Salvager); candidate selection failed (had [candidates.len] candidate(s)). Source: [source ? "[source]" : "random"]")
+				message_admins("Couldn't set up Salvager; candidate selection failed (had [length(candidates)] candidate(s)). Source: [source ? "[source]" : "random"]")
+				logTheThing(LOG_ADMIN, null, "Couldn't set up Salvager; candidate selection failed (had [length(candidates)] candidate(s)). Source: [source ? "[source]" : "random"]")
 				src.post_event()
 				return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[admin][gamemodes]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Tweak the logging for salvager midrounds. fixes a bug where the source would be shown as "0" and makes veribage consistent between logging and admin messages

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
clearer and more consistent logging/messaging