### PR TITLE
Whisper Maptext

### DIFF
--- a/code/modules/speech/message_modifiers/whisper.dm
+++ b/code/modules/speech/message_modifiers/whisper.dm
@@ -14,7 +14,6 @@
 /datum/message_modifier/postprocessing/whisper/process(datum/say_message/message)
 	. = message
 
-	message.flags |= SAYFLAG_NO_MAPTEXT
 	message.say_verb = message.whisper_verb
 	message.format_content_style_prefix = "<i>"
 	message.format_content_style_suffix = "</i>"


### PR DESCRIPTION
## About the PR:
Enables whisper maptext.



## Why's this needed?
By far the most requested thing in the say rework channel.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Whispers now display maptext.
```