### PR TITLE
Lawbringer works regardless of speech affects

### DIFF
--- a/code/modules/speech/modules/listen/effects/lawbringer.dm
+++ b/code/modules/speech/modules/listen/effects/lawbringer.dm
@@ -43,7 +43,7 @@
 		lawbringer.UpdateIcon()
 		return
 
-	var/text = lawbringer.sanitize_talk(message.content)
+	var/text = lawbringer.sanitize_talk(message.original_content)
 	if (!lawbringer.fingerprints_can_shoot(H))
 		if (src.valid_modes[text])
 			global.random_burn_damage(H, 50)


### PR DESCRIPTION
[GAME OBJECTS][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows the Lawbringer to work even if you are stammering, and when playing with a lizard or cow mutantrace


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Would be cool to be able to any phrase when playing with a different mutantrace.

Also would be nice to use the Lawbringer when you are stammering

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)The Lawbringer is no longer affected by speech affects or mutantrace
```
