### PR TITLE
Lawbringers check every word for mode change

### DIFF
--- a/code/modules/speech/modules/listen/effects/lawbringer.dm
+++ b/code/modules/speech/modules/listen/effects/lawbringer.dm
@@ -44,15 +44,18 @@
 		return
 
 	var/text = lawbringer.sanitize_talk(message.content)
-	if (!lawbringer.fingerprints_can_shoot(H))
-		if (src.valid_modes[text])
+	var/list/words = splittext(text, " ")
+
+	for(var/word in words)
+		if(!src.valid_modes[word])
+			continue
+		if (!lawbringer.fingerprints_can_shoot(H))
 			global.random_burn_damage(H, 50)
 			H.changeStatus("knockdown", 4 SECONDS)
 			global.elecflash(lawbringer, power = 2)
 			H.visible_message(SPAN_ALERT("[H] tries to fire [lawbringer]! The gun initiates its failsafe mode."))
-
+			return
+		lawbringer.change_mode(H, word)
+		H.update_inhands()
+		lawbringer.UpdateIcon()
 		return
-
-	lawbringer.change_mode(H, text)
-	H.update_inhands()
-	lawbringer.UpdateIcon()

--- a/code/modules/speech/modules/listen/effects/lawbringer.dm
+++ b/code/modules/speech/modules/listen/effects/lawbringer.dm
@@ -31,7 +31,7 @@
 		return
 
 	var/mob/living/carbon/human/H = message.original_speaker
-	if (lawbringer.fingerprints_can_shoot(H))
+	if (!lawbringer.fingerprints_can_shoot(H))
 		lawbringer.are_you_the_law(H, message.content)
 		return
 

--- a/code/modules/speech/modules/listen/effects/lawbringer.dm
+++ b/code/modules/speech/modules/listen/effects/lawbringer.dm
@@ -31,7 +31,7 @@
 		return
 
 	var/mob/living/carbon/human/H = message.original_speaker
-	if (lawbringer.owner_prints && (H.bioHolder.Uid != lawbringer.owner_prints))
+	if (lawbringer.fingerprints_can_shoot(H))
 		lawbringer.are_you_the_law(H, message.content)
 		return
 
@@ -49,12 +49,6 @@
 	for(var/word in words)
 		if(!src.valid_modes[word])
 			continue
-		if (!lawbringer.fingerprints_can_shoot(H))
-			global.random_burn_damage(H, 50)
-			H.changeStatus("knockdown", 4 SECONDS)
-			global.elecflash(lawbringer, power = 2)
-			H.visible_message(SPAN_ALERT("[H] tries to fire [lawbringer]! The gun initiates its failsafe mode."))
-			return
 		lawbringer.change_mode(H, word)
 		H.update_inhands()
 		lawbringer.UpdateIcon()

--- a/code/modules/speech/modules/listen/effects/lawbringer.dm
+++ b/code/modules/speech/modules/listen/effects/lawbringer.dm
@@ -25,6 +25,8 @@
 	var/obj/item/gun/energy/lawbringer/lawbringer = src.parent_tree.listener_parent
 	if (!istype(lawbringer) || !ismob(message.original_speaker))
 		return
+	if (lawbringer.loc != message.original_speaker)
+		return
 
 	if (!ishuman(message.original_speaker))
 		lawbringer.are_you_the_law(message.original_speaker, message.content)

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1537,7 +1537,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 	//Are you really the law? takes the mob as speaker, and the text spoken, sanitizes it. If you say "i am the law" and you in fact are NOT the law, it's gonna blow. Moved out of the switch statement because it that switch is only gonna run if the owner speaks
 	proc/are_you_the_law(mob/M as mob, text)
 		text = sanitize_talk(text)
-		if (findtext(text, "iamthelaw"))
+		if (findtext(text, "i am the law"))
 			//you must be holding/wearing the weapon
 			//this check makes it so that someone can't stun you, stand on top of you and say "I am the law" to kill you
 			if (src in M.contents)
@@ -1612,7 +1612,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 	//just remove all capitalization and non-letter characters
 	proc/sanitize_talk(var/msg)
 		//find all characters that are not letters and remove em
-		var/regex/r = regex("\[^a-z\]+", "g")
+		var/regex/r = regex("\[^a-z\\s\]+", "g")
 		msg = lowertext(msg)
 		msg = r.Replace(msg, "")
 		return msg

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1609,9 +1609,9 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 				indicator_display.color = "#000000"				//default, should never reach. make it black
 			src.overlays += indicator_display
 
-	//just remove all capitalization and non-letter characters
+	//just remove all capitalization and non-letter, non-space characters
 	proc/sanitize_talk(var/msg)
-		//find all characters that are not letters and remove em
+		//find all characters that are not letters or whitespace and remove em
 		var/regex/r = regex("\[^a-z\\s\]+", "g")
 		msg = lowertext(msg)
 		msg = r.Replace(msg, "")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lawbringers will now check every word in a spoken message rather than it only working if the entire message is a valid one, prioritising the first one in a message if there are multiple.
![image](https://github.com/user-attachments/assets/c64c3c31-5c3b-4cad-a48e-30899a141847)
Also fixes a bug where lawbringers would always change mode even when their loc was not the user.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it would be really funny to say "I'm gonna get you CLOWN!!!" and have the lawbringer change to clown mode, or say "Lawbringer, activate ASSAULT laser.". May result in accidental mode changes for example if still being held while saying "You are under arrest for assault" Then it will end up on High Power, but this is funny.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Lawbringers now check every word in a message for mode selection rather than the entire message.
```
