### PR TITLE
Tweak nanite balance

### DIFF
--- a/code/modules/telescience/telescope/telescopeMisc.dm
+++ b/code/modules/telescience/telescope/telescopeMisc.dm
@@ -232,10 +232,17 @@ TYPEINFO(/obj/machinery/lrteleporter)
 	current_projectile = new/datum/projectile/laser/drill/cutter
 	droploot = null
 	smashes_shit = FALSE
+	/// how many times has this nanite swarm reassembled
+	var/generation = 1
 	var/rare_metal_drop_chance = 5
 	var/rare_metal_drop_path = /obj/item/material_piece/iridiumalloy
 
+	ai_think()
+		if (dying) return
+		. = ..()
+
 	ChaseAttack(atom/M)
+		if(dying) return
 		if(target && !attacking)
 			attacking = 1
 			src.visible_message(SPAN_ALERT("<b>[src]</b> floats towards [M]!"))
@@ -247,6 +254,7 @@ TYPEINFO(/obj/machinery/lrteleporter)
 		return
 
 	CritterAttack(atom/M)
+		if(dying) return
 		if(target && !attacking)
 			attacking = 1
 			//playsound(src.loc, 'sound/machines/whistlebeep.ogg', 55, 1)
@@ -264,11 +272,16 @@ TYPEINFO(/obj/machinery/lrteleporter)
 		return
 
 	CritterDeath()
-		if(prob(33) && alive && !dying)
+		if(dying) return
+		src.visible_message(SPAN_ALERT("<b>[src]</b> collapses into a pile of dust!"))
+		if(prob(50/src.generation) && alive && !dying)
 			src.visible_message(SPAN_ALERT("<b>[src]</b> begins to reassemble!"))
 			var/turf/T = src.loc
+			var/current_generation = src.generation
 			SPAWN(5 SECONDS)
-				new/obj/critter/gunbot/drone/buzzdrone/naniteswarm(T)
+				var/obj/critter/gunbot/drone/buzzdrone/naniteswarm/swarm  = new(T)
+				swarm.generation = current_generation + 1
+
 				if(src)
 					qdel(src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][critters]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When nanites are dying, they will no longer attack or start chasing you.
Nanites have "generations", each generation has a slightly lower chance of reforming into nanites again
The baseline reform rate is now 50%, which is divided by the generation count (e.g. 50% at gen 1, 25% at gen 2, 50/3 ~17% at gen 3, etc.)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Now that nanites are more common, they feel a little too strong. This doesn't lower their direct damage, but tweaks two aspects that feel the most unfair:
1. They can attack when they are a little dust pile
2. You can theoretically get infinite spawns. while it'll be more common to get a second, it'll be less common to have e.g. 6 of them spawn off one nanite spawn.