### PR TITLE
"Default Laws" option in set fake laws

### DIFF
--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -562,19 +562,25 @@ var/global/list/module_editors = list()
 
 /mob/living/silicon/proc/set_fake_laws()
 	#define FAKE_LAW_LIMIT 12
-	var/law_base_choice = tgui_input_list(usr,"Which lawset would you like to use as a base for your new fake laws?", "Fake Laws", list("Real Laws", "Fake Laws"))
+	var/fake_lawset_choices = list ("Real Laws", "Fake Laws", "Default Laws")
+	var/law_base_choice = tgui_input_list(usr,"Which lawset would you like to use as a base for your new fake laws?", "Fake Laws", fake_lawset_choices)
 	if (!law_base_choice)
 		return
 	var/law_base = ""
-	if(law_base_choice == "Real Laws")
-		if(src.law_rack_connection)
-			law_base = src.law_rack_connection.format_for_logs("\n")
-		else
-			law_base = ""
-	else if(law_base_choice == "Fake Laws")
-		for(var/fake_law in src.fake_laws)
-			// this is just the default input for the user, so it should be fine
-			law_base += "[html_decode(fake_law)]\n"
+	switch(law_base_choice)
+		if("Real Laws")
+			if(src.law_rack_connection)
+				law_base = src.law_rack_connection.format_for_logs("\n")
+			else
+				law_base = ""
+		if("Fake Laws")
+			for(var/fake_law in src.fake_laws)
+				// this is just the default input for the user, so it should be fine
+				law_base += "[html_decode(fake_law)]\n"
+		if("Default Laws")
+			law_base += "1: [/obj/item/aiModule/asimov1::lawText]\n"
+			law_base += "2: [/obj/item/aiModule/asimov2::lawText]\n"
+			law_base += "3: [/obj/item/aiModule/asimov3::lawText]\n"
 
 	var/raw_law_text = tgui_input_text(usr, "Please enter the fake laws you would like to be able to state via the State Fake Laws command! Each line is one law.", "Fake Laws", law_base, multiline = TRUE)
 	if(!raw_law_text)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds "Default Laws" option when setting fake laws


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sometimes you want to state a minor edit to standard laws while your actual laws differ wildly from the default, this lets you get the default laws with a single selection without needing to copypaste them from somewhere


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Silicons can now select the default lawset as the base when setting their fake laws.
```
