### PR TITLE
Detgadget hat works regardless of speech affects

### DIFF
--- a/code/modules/speech/modules/listen/effects/detgadget.dm
+++ b/code/modules/speech/modules/listen/effects/detgadget.dm
@@ -6,12 +6,12 @@
 	if (!istype(hat) || !ismob(message.speaker))
 		return
 
-	var/phrase_location = findtext(message.content, hat.phrase)
+	var/phrase_location = findtext(message.original_content, hat.phrase)
 	if (!phrase_location)
 		return
 
 	var/mob/M = message.speaker
-	var/gadget = copytext(message.content, phrase_location + length(hat.phrase))
+	var/gadget = copytext(message.original_content, phrase_location + length(hat.phrase))
 	gadget = replacetext(gadget, " ", "")
 
 	for (var/name in hat.items)


### PR DESCRIPTION
[GAME OBJECTS][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows the detgadget hat to work regardless of speech affects like drunk speech or mutantrace


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Would be cool, also using the detdaget hat while drinking tons of alcohol would be epic


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)The Detgadget hat works regardless of speech affects like drunk speech
```
