### PR TITLE
Change up wizard Empower spell

### DIFF
--- a/code/modules/antagonists/wizard/abilities/mutate.dm
+++ b/code/modules/antagonists/wizard/abilities/mutate.dm
@@ -3,7 +3,7 @@
 	desc = "Temporarily superpowers your body and grants a burst of strength."
 	icon_state = "mutate"
 	targeted = 0
-	cooldown = 30 SECONDS
+	cooldown = 35 SECONDS
 	requires_robes = 1
 	offensive = 1
 	voice_grim = 'sound/voice/wizard/MutateGrim.ogg'
@@ -25,10 +25,10 @@
 			holder.owner.bioHolder.AddEffect("hulk", 0, 0, 0, 1)
 		APPLY_ATOM_PROPERTY(holder.owner, PROP_MOB_PASSIVE_WRESTLE, "empower")
 		APPLY_ATOM_PROPERTY(holder.owner, PROP_MOB_STAMINA_REGEN_BONUS, "empower", 5)
-		src.holder.owner.deStatus("knockdown")
-		var/SPtime = 9 SECONDS
+		src.holder.owner.delStatus("knockdown")
+		var/SPtime = 10 SECONDS
 		if (holder.owner.wizard_spellpower(src))
-			SPtime = 15 SECONDS
+			SPtime = 20 SECONDS
 		else
 			boutput(holder.owner, SPAN_ALERT("Your spell doesn't last as long without a staff to focus it!"))
 		SPAWN(SPtime)

--- a/code/modules/antagonists/wizard/abilities/mutate.dm
+++ b/code/modules/antagonists/wizard/abilities/mutate.dm
@@ -1,9 +1,9 @@
 /datum/targetable/spell/mutate
 	name = "Empower"
-	desc = "Temporarily superpowers your body."
+	desc = "Temporarily superpowers your body and grants a burst of strength."
 	icon_state = "mutate"
 	targeted = 0
-	cooldown = 400
+	cooldown = 30 SECONDS
 	requires_robes = 1
 	offensive = 1
 	voice_grim = 'sound/voice/wizard/MutateGrim.ogg'
@@ -25,9 +25,10 @@
 			holder.owner.bioHolder.AddEffect("hulk", 0, 0, 0, 1)
 		APPLY_ATOM_PROPERTY(holder.owner, PROP_MOB_PASSIVE_WRESTLE, "empower")
 		APPLY_ATOM_PROPERTY(holder.owner, PROP_MOB_STAMINA_REGEN_BONUS, "empower", 5)
-		var/SPtime = 150
+		src.holder.owner.deStatus("knockdown")
+		var/SPtime = 9 SECONDS
 		if (holder.owner.wizard_spellpower(src))
-			SPtime = 300
+			SPtime = 15 SECONDS
 		else
 			boutput(holder.owner, SPAN_ALERT("Your spell doesn't last as long without a staff to focus it!"))
 		SPAWN(SPtime)

--- a/code/modules/antagonists/wizard/abilities/mutate.dm
+++ b/code/modules/antagonists/wizard/abilities/mutate.dm
@@ -3,7 +3,7 @@
 	desc = "Temporarily superpowers your body and grants a burst of strength."
 	icon_state = "mutate"
 	targeted = 0
-	cooldown = 35 SECONDS
+	cooldown = 30 SECONDS
 	requires_robes = 1
 	offensive = 1
 	voice_grim = 'sound/voice/wizard/MutateGrim.ogg'
@@ -26,9 +26,9 @@
 		APPLY_ATOM_PROPERTY(holder.owner, PROP_MOB_PASSIVE_WRESTLE, "empower")
 		APPLY_ATOM_PROPERTY(holder.owner, PROP_MOB_STAMINA_REGEN_BONUS, "empower", 5)
 		src.holder.owner.delStatus("knockdown")
-		var/SPtime = 10 SECONDS
+		var/SPtime = 9 SECONDS
 		if (holder.owner.wizard_spellpower(src))
-			SPtime = 20 SECONDS
+			SPtime = 15 SECONDS
 		else
 			boutput(holder.owner, SPAN_ALERT("Your spell doesn't last as long without a staff to focus it!"))
 		SPAWN(SPtime)

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -1612,7 +1612,7 @@ ABSTRACT_TYPE(/datum/SWFuplinkspell)
 /datum/SWFuplinkspell/empower
 	name = "Empower"
 	eqtype = "Utility"
-	desc = "This spell causes you to turn into a hulk, and gain passive wrestling powers for a short while."
+	desc = "This spell removes stuns on use, causes you to turn into a hulk, and gain passive wrestling powers for a short while."
 	assoc_spell = /datum/targetable/spell/mutate
 
 /datum/SWFuplinkspell/summongolem


### PR DESCRIPTION
[GAME MODES][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the following changes:
-Reduces Empower spell duration/CD to 15s/30s from 30s/45s
-Empower removes stun knockdowns on use


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Empower is meant to be a temporary burst of strength. However, 30 seconds feels too long in that you can't really play around it, and it can be combined with other offensive spells already

Also adds some utility in a get out of stuns buff


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)Wizard empower spell duration and CD reduced to 15s/30s from 30s/45s. It now also removes knockdown status effect on use.
```
