### PR TITLE
Change wizard forcewalls to 20 second duration

### DIFF
--- a/code/modules/antagonists/wizard/abilities/forcewall.dm
+++ b/code/modules/antagonists/wizard/abilities/forcewall.dm
@@ -40,7 +40,7 @@
 			if (holder.owner.wizard_spellpower(src)) forcefield4 =  new /obj/forcefield(locate(holder.owner.x,holder.owner.y + 2,holder.owner.z))
 			if (holder.owner.wizard_spellpower(src)) forcefield5 =  new /obj/forcefield(locate(holder.owner.x,holder.owner.y - 2,holder.owner.z))
 
-		SPAWN(30 SECONDS)
+		SPAWN(20 SECONDS)
 			qdel(forcefield1)
 			qdel(forcefield2)
 			qdel(forcefield3)


### PR DESCRIPTION
[GAME MODES][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes wizard forcewall duration from 30 to 20 seconds


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently they have a longer duration than cooldown, meaning they can stay in a spot indefinitely

Change makes a small window where the crew can get past, unless the wizard is paying mind to it and may need to use a spell too


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(+)Wizard forcewall duration changed from 30 -> 20 seconds
```
