### PR TITLE
Add "Fired" as valid word for lawbringer hotshot

### DIFF
--- a/code/modules/speech/modules/listen/effects/lawbringer.dm
+++ b/code/modules/speech/modules/listen/effects/lawbringer.dm
@@ -11,6 +11,7 @@
 		"sleepshot" = TRUE,
 		"hotshot" = TRUE,
 		"incendiary" = TRUE,
+		"fired" = TRUE,
 		"assault" = TRUE,
 		"highpower" = TRUE,
 		"bigshot" = TRUE,

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1505,7 +1505,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 				if (sound)
 					playsound(M, 'sound/vox/sleep.ogg', 50)
 				src.toggle_recoil(FALSE)
-			if ("hotshot","incendiary")
+			if ("hotshot","incendiary","fired")
 				set_current_projectile(projectiles["hotshot"])
 				current_projectile.cost = 60
 				item_state = "lawg-hotshot"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds "Fired" as a valid word to activate the lawbringer's hotshot mode.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
And now the true purpose of #23319 is revealed. "You are FIRED." _**HOT**_

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)"Fired" is now a valid word for the lawbringer's hotshot mode. Go terminate those contracts!
```
