### PR TITLE
Stop flock encounter invincible door from showing as broken

### DIFF
--- a/code/modules/mining/mining_encounter_objects.dm
+++ b/code/modules/mining/mining_encounter_objects.dm
@@ -72,6 +72,9 @@
 				var/obj/flock_encounter_pedestal/pedestal = src.pedestals[i]
 				pedestal.toggle(null, TRUE)
 
+	take_damage(amount, mob/user)
+		return // stop showing as broken
+
 	disposing()
 		..()
 		src.pedestals = null

--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -80,7 +80,8 @@ TYPEINFO(/turf/simulated/floor/feather)
 	off()
 	icon_state = "floor-broken"
 	broken = TRUE
-	src.flock.all_owned_tiles -= src
+	if (src.flock)
+		src.flock.all_owned_tiles -= src
 	for (var/mob/living/critter/flock/drone/flockdrone in src.contents)
 		if (flockdrone.floorrunning)
 			flockdrone.end_floorrunning()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
overwrite take damage on the flock mining encounter puzzle door to prevent it from using the broken sprite

also fixes a flock runtime i found while testing explosives on the door (the flock turf got removed)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bad player feedback; makes them think it's possible to break down when it is in fact not.