### PR TITLE
Give intercoms maptext

### DIFF
--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -18,6 +18,7 @@ TYPEINFO(/obj/item/device/radio/intercom)
 	desc = "A wall-mounted radio intercom, used to communicate with the specified frequency. Usually turned off except during emergencies."
 	hardened = 0
 	use_speech_bubble = TRUE
+	forced_maptext = TRUE
 
 	HELP_MESSAGE_OVERRIDE("Stand next to an intercom and use the prefix <B> :in </B> to speak directly into it.")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Intercoms now have maptext.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Much, much easier to use and hopefully more noticeable so people turn them off when they're not using them instead of just letting the spam clog up the chat and make it impossible to use.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Intercoms now use maptext.
```
