### PR TITLE
Fix Cyborg Radios

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -49,9 +49,7 @@ TYPEINFO(/mob/living/silicon/robot)
 	var/module_active = null
 	var/list/module_states = list(null,null,null)
 
-	var/obj/item/device/radio/headset/default_radio = null // radio used when there's no module radio
 	var/obj/item/device/radio/headset/radio = null
-	var/obj/item/device/radio/headset/ai_radio = null // Radio used for when this is an AI-controlled shell.
 	var/obj/item/device/radio_upgrade/radio_upgrade = null // Used for syndicate robots
 	var/obj/item/instrument/scream_instrument = null
 	var/scream_note = 1 //! Either a string note or an index of the sound to play (instruments are weird)
@@ -226,15 +224,7 @@ TYPEINFO(/mob/living/silicon/robot)
 
 			src.botcard.registered = "Cyborg"
 			src.botcard.assignment = "Cyborg"
-			src.default_radio = new /obj/item/device/radio/headset(src)
-			if (src.shell)
-				src.ai_radio = new /obj/item/device/radio/headset/command/ai(src)
-				src.radio = src.ai_radio
-			else
-				src.radio = src.default_radio
-				// Do not apply the radio upgrade to AI shells
-				src.apply_radio_upgrade()
-			src.ears = src.radio
+			src.update_radio(/obj/item/device/radio/headset)
 			src.camera = new /obj/machinery/camera(src)
 			src.camera.c_tag = src.real_name
 			src.camera.network = CAMERA_NETWORK_ROBOTS
@@ -1289,11 +1279,7 @@ TYPEINFO(/mob/living/silicon/robot)
 				src.part_head.ai_interface = I
 				I.set_loc(src.part_head)
 				if (!(src in available_ai_shells))
-					if(isnull(src.ai_radio))
-						src.ai_radio = new /obj/item/device/radio/headset/command/ai(src)
-					src.radio = src.ai_radio
-					src.ears = src.radio
-					src.radio.set_loc(src)
+					src.update_radio(/obj/item/device/radio/headset/command/ai)
 					available_ai_shells += src
 					src.real_name = "AI Cyborg Shell [copytext("\ref[src]", 6, 11)]"
 					src.name = src.real_name
@@ -1539,21 +1525,13 @@ TYPEINFO(/mob/living/silicon/robot)
 						UPGR.upgrade_deactivate(src)
 
 					user.put_in_hand_or_drop(src.part_head.ai_interface)
-					src.radio = src.default_radio
-					if (src.module && istype(src.module.radio))
-						src.default_radio.toggle_speaker(FALSE)
-						src.radio = src.module.radio
-					else
-						src.default_radio.toggle_speaker(TRUE)
-
-					src.ears = src.radio
-					src.apply_radio_upgrade()
-					src.radio.set_loc(src)
 					src.part_head.ai_interface = null
-					if(src.ai_radio)
-						qdel(src.ai_radio)
-						src.ai_radio = null
 					src.shell = 0
+
+					if (src.module.radio_type)
+						src.update_radio(src.module.radio_type)
+					else
+						src.update_radio(/obj/item/device/radio/headset)
 
 					if (mainframe)
 						mainframe.return_to(src)
@@ -1892,16 +1870,6 @@ TYPEINFO(/mob/living/silicon/robot)
 		else
 			return null
 
-	proc/apply_radio_upgrade()
-		if(!istype(src.radio_upgrade))
-			return
-		// Remove it from the previous radio if applicable
-		var/obj/item/device/radio/headset/previous_radio = src.radio_upgrade.loc
-		if (istype(previous_radio))
-			previous_radio.remove_radio_upgrade()
-		if (istype(src.radio)) // Might be null when the robot is activated
-			src.radio.install_radio_upgrade(src.radio_upgrade)
-
 	add_radio_upgrade(var/obj/item/device/radio_upgrade/upgrade)
 		src.radio_upgrade = upgrade
 		src.apply_radio_upgrade()
@@ -1917,6 +1885,31 @@ TYPEINFO(/mob/living/silicon/robot)
 //////////////////////////
 // Robot-specific Procs //
 //////////////////////////
+
+	proc/update_radio(radio_path)
+		if (src.shell)
+			if (!istype(src.radio, /obj/item/device/radio/headset/command/ai))
+				radio_path = /obj/item/device/radio/headset/command/ai
+			else
+				return
+
+		if (!radio_path)
+			return
+
+		QDEL_NULL(src.radio)
+		src.radio = new radio_path(src)
+		src.ears = src.radio
+		src.apply_radio_upgrade()
+
+	proc/apply_radio_upgrade()
+		if(!istype(src.radio_upgrade))
+			return
+		// Remove it from the previous radio if applicable
+		var/obj/item/device/radio/headset/previous_radio = src.radio_upgrade.loc
+		if (istype(previous_radio))
+			previous_radio.remove_radio_upgrade()
+		if (istype(src.radio)) // Might be null when the robot is activated
+			src.radio.install_radio_upgrade(src.radio_upgrade)
 
 	proc/equip_slot(var/i, var/obj/item/tool)
 		src.module_states[i] = tool
@@ -1991,19 +1984,12 @@ TYPEINFO(/mob/living/silicon/robot)
 		src.update_appearance()
 		hud.update_module()
 		hud.module_added()
-		if(istype(RM.radio))
-			if (src.shell)
-				if(isnull(src.ai_radio))
-					src.ai_radio = new /obj/item/device/radio/headset/command/ai(src)
-				src.radio = src.ai_radio
-			else
-				src.radio.toggle_speaker(FALSE)
-				src.radio = RM.radio
+		if(ispath(RM.radio_type))
+			if (!src.shell)
 				src.internal_pda.mailgroups = RM.mailgroups
 				src.internal_pda.alertgroups = RM.alertgroups
-				src.apply_radio_upgrade()
-			src.ears = src.radio
-			src.radio.set_loc(src)
+
+			src.update_radio(RM.radio_type)
 
 	proc/remove_module()
 		if(!istype(src.module))
@@ -2014,19 +2000,13 @@ TYPEINFO(/mob/living/silicon/robot)
 		uneq_all()
 		src.module = null
 		hud.module_removed()
-		if(istype(src.radio) && src.radio != src.default_radio)
-			src.radio.set_loc(RM)
-			if (src.shell)
-				if(isnull(src.ai_radio))
-					src.ai_radio = new /obj/item/device/radio/headset/command/ai(src)
-				src.radio = src.ai_radio
-			else
-				src.radio = src.default_radio
-				src.radio.toggle_speaker(TRUE)
+		if(ispath(RM.radio_type))
+			if (!src.shell)
 				src.internal_pda.mailgroups = initial(src.internal_pda.mailgroups)
 				src.internal_pda.alertgroups = initial(src.internal_pda.alertgroups)
-				src.apply_radio_upgrade()
-			src.ears = src.radio
+
+			src.update_radio(/obj/item/device/radio/headset)
+
 		return RM
 
 	proc/activated(obj/item/O)

--- a/code/modules/robotics/robot/module/parent.dm
+++ b/code/modules/robotics/robot/module/parent.dm
@@ -16,7 +16,6 @@ ADMIN_INTERACT_PROCS(/obj/item/robot_module, proc/admin_add_tool, proc/admin_rem
 	var/included_tools = /datum/robot/module_tool_creator/recursive/module/common
 	var/included_cosmetic = null
 	var/radio_type = null
-	var/obj/item/device/radio/headset/radio = null
 	var/list/mailgroups = list(MGO_SILICON, MGD_PARTY)
 	var/list/alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_DEATH)
 
@@ -28,9 +27,6 @@ ADMIN_INTERACT_PROCS(/obj/item/robot_module, proc/admin_add_tool, proc/admin_rem
 
 	if (ispath(src.included_cosmetic, /datum/robot_cosmetic))
 		src.cosmetic_mods = new included_cosmetic(src)
-
-	if (src.radio_type != null)
-		src.radio = new src.radio_type(src)
 
 // handle various ways of adding tools to the module
 /obj/item/robot_module/proc/add_contents(adding_contents)

--- a/code/modules/speech/modules/listen/inputs/shared_input_format_modules/ears.dm
+++ b/code/modules/speech/modules/listen/inputs/shared_input_format_modules/ears.dm
@@ -20,6 +20,9 @@
 	else if (isAI(message.original_speaker))
 		job_title = "AI"
 
+	else if (isshell(message.original_speaker))
+		job_title = "Shell"
+
 	else if (isrobot(message.original_speaker))
 		job_title = "Cyborg"
 


### PR DESCRIPTION
[Bug]


## About The PR:
Instead of retaining up to three different radios in their body, cyborgs may now only carry a single radio at a time.

This should have no effect on standard behaviour as they could only ever use a single radio at any given time.

Fixes #23333, fixes #23363, fixes #23371, and fixes #23375.