### PR TITLE
Cogmap1 req_access_txt pass

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -1305,7 +1305,7 @@
 	beacon_freq = 1443;
 	desc = "A PR-4 Robuddy. These are pretty old, you didn't know there were any still around!  This one has a little name tag on the front labeled 'Murray'";
 	name = "Murray";
-	req_access_txt = ""
+	req_access = null
 	},
 /obj/machinery/navbeacon/tour/cog1/tour20,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -6849,8 +6849,7 @@
 /obj/table/auto,
 /obj/machinery/cashreg,
 /obj/machinery/door/window/eastleft{
-	name = "Tool Storage";
-	req_access_txt = "12"
+	name = "Tool Storage"
 	},
 /turf/simulated/floor,
 /area/station/storage/auxillary{
@@ -6859,13 +6858,13 @@
 "aAN" = (
 /obj/table/auto,
 /obj/machinery/door/window/westleft{
-	name = "Hydroponics Lobby";
-	req_access_txt = "35"
+	name = "Hydroponics Lobby"
 	},
 /obj/machinery/cashreg,
 /obj/disposalpipe/segment/produce{
 	dir = 4
 	},
+/obj/mapping_helper/access/hydro,
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aAO" = (
@@ -7213,8 +7212,7 @@
 	pixel_y = 7
 	},
 /obj/machinery/door/window/southleft{
-	name = "Tool Storage";
-	req_access_txt = "12"
+	name = "Tool Storage"
 	},
 /obj/item/device/gps{
 	pixel_x = 7;
@@ -7267,13 +7265,13 @@
 /obj/table/auto,
 /obj/disposalpipe/segment,
 /obj/machinery/door/window/southright{
-	name = "Hydroponics Lobby";
-	req_access_txt = "35"
+	name = "Hydroponics Lobby"
 	},
 /obj/item/hand_labeler,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/mapping_helper/access/hydro,
 /turf/simulated/floor/green,
 /area/station/hydroponics/lobby)
 "aCm" = (
@@ -9620,12 +9618,12 @@
 	},
 /obj/machinery/door/window/westright{
 	dir = 1;
-	name = "Medical Booth";
-	req_access_txt = "5"
+	name = "Medical Booth"
 	},
 /obj/window/reinforced{
 	dir = 4
 	},
+/obj/mapping_helper/access/medical,
 /turf/simulated/floor/blue/side,
 /area/station/medical/medbooth)
 "aJO" = (
@@ -9868,12 +9866,12 @@
 	dir = 2
 	},
 /obj/machinery/door/window/eastleft{
-	name = "Security Office";
-	req_access_txt = "1"
+	name = "Security Office"
 	},
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
+/obj/mapping_helper/access/security,
 /turf/simulated/floor/red,
 /area/station/security/secwing)
 "aKx" = (
@@ -39938,9 +39936,7 @@
 /obj/item/device/radio/intercom/botany{
 	dir = 1
 	},
-/obj/storage/cart/hotdog{
-	req_access_txt = "28"
-	},
+/obj/storage/cart/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,
 /obj/item/reagent_containers/food/snacks/hotdog,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes all req_access_txt varedits from Cogmap 1 and replaces them with access spawners
Minor access change on tool storage windows by botany from maint access > none, the main door has no access so the windows also shouldn't.
Minor access change on the cash payment devices on these windows that will allow anyone with access to these windows to remove registered owners on these cash registers, but this is how it is on other maps and even other areas on cogmap1 (cargo and mechlab do it like this)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Code Quality. Mappinghelpers should be used over varedits.
