### PR TITLE
Pods use packets to open hangars.

### DIFF
--- a/code/modules/transport/pods/communications.dm
+++ b/code/modules/transport/pods/communications.dm
@@ -147,14 +147,12 @@ TYPEINFO(/obj/item/device/radio/intercom/ship)
 
 		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, signal)
 
-	proc/open_hangar(mob/user as mob)
-		var/pass = input(user, "Please enter panel access number.", "Access Number") as text
-		pass = copytext(html_encode(pass), 1, 32)
+	proc/open_hangar(mob/user as mob, var/pass)
 		if(!pass)
 			return
 
 		var/datum/signal/newsignal = get_free_signal()
-		newsignal.data["command"] = "open door"
+		newsignal.data["command"] = "toggle_door"
 		if (com)
 			newsignal.data["access_type"] = jointext(com.access_type,";")
 		newsignal.data["doorpass"] = pass

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -1796,7 +1796,7 @@
 	else
 		boutput(usr, SPAN_ALERT("Uh-oh you aren't in a ship! Report this."))
 
-/obj/machinery/vehicle/proc/open_hangar()
+/obj/machinery/vehicle/proc/open_hangar(var/pass)
 	if(is_incapacitated(usr))
 		boutput(usr, SPAN_ALERT("Not when you are incapacitated."))
 		return
@@ -1804,7 +1804,7 @@
 		var/obj/machinery/vehicle/ship = usr.loc
 		if(ship.com_system)
 			if(ship.com_system.active)
-				ship.com_system.rc_ship.open_hangar(usr)
+				ship.com_system.rc_ship.open_hangar(usr, pass)
 			else
 				boutput(usr, "[ship.ship_message("SYSTEM OFFLINE")]")
 		else

--- a/code/obj/machinery/door/door_control.dm
+++ b/code/obj/machinery/door/door_control.dm
@@ -1206,7 +1206,7 @@ ABSTRACT_TYPE(/obj/machinery/activation_button)
 		boutput(user, SPAN_NOTICE("The password is \[[src.pass]\]"))
 		return
 
-	proc/open_door()
+	proc/toggle_door()
 		if(src.status & (NOPOWER|BROKEN))
 			return
 		src.use_power(5)
@@ -1236,16 +1236,7 @@ ABSTRACT_TYPE(/obj/machinery/activation_button)
 				return
 
 			if(signal.data["doorpass"] == src.pass)
-				if(src.status & (NOPOWER|BROKEN))
-					return
-				src.use_power(5)
-
-				for(var/obj/machinery/door/poddoor/M in by_type[/obj/machinery/door])
-					if (M.id == src.id)
-						if (M.density)
-							M.open()
-						else
-							M.close()
+				toggle_door()
 			return
 		////////reset pass
 		if(signal.data["command"] =="reset door pass")

--- a/code/obj/machinery/door/door_control.dm
+++ b/code/obj/machinery/door/door_control.dm
@@ -1191,20 +1191,7 @@ ABSTRACT_TYPE(/obj/machinery/activation_button)
 		if(GET_DIST(usr, src) < 16)
 			if(istype(usr.loc, /obj/machinery/vehicle))
 				var/obj/machinery/vehicle/V = usr.loc
-				if (!V.com_system)
-					boutput(usr, SPAN_ALERT("Your pod has no comms system installed!"))
-					return ..()
-				if (!V.com_system.active)
-					boutput(usr, SPAN_ALERT("Your communications array isn't on!"))
-					return ..()
-				if (!access_type)
-					open_door()
-				else
-					if(V.com_system.access_type.Find(src.access_type))
-						open_door()
-					else
-						boutput(usr, SPAN_ALERT("Access denied. Comms system not recognized."))
-						return ..()
+				V.open_hangar(pass)
 			return ..()
 
 	attack_ai(mob/user as mob)
@@ -1237,7 +1224,7 @@ ABSTRACT_TYPE(/obj/machinery/activation_button)
 		if(..())
 			return
 		//////Open Door
-		if(signal.data["command"] =="open door")
+		if(signal.data["command"] =="toggle_door")
 			if(!signal.data["doorpass"])
 				return
 			if(!signal.data["access_type"])


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[vehicles][game objects][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes the way that remote door control devices (the ones in pod hangars that can be clicked from a pod to open the hangar) open hangars to use the pod's communication system's ship radio control device's `toggle_hangar` proc, which uses packets.
- Pod-related procs named "open_door" or "open_hangar", etc. have all been renamed to "toggle_hangar_door".
- Clicking on a remote door control device while in a pod now calls the pod's `toggle_hangar_door` proc, which handles all the neccessary checks and passes the control device's `pass` variable on to the actual radio control device via its , which then sends the packets.
- This PR also removes the user input from the door control device's toggle_hangar_door, as it was unused and inaccessible.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Although pod hangars are technically packet-compatible, packets aren't used anymore, since the manual opening mechanic (entering a passcode and such) is no longer used/accessible. This PR aims to establish consistency with other packet-compatible machinery by implementing the already existing packet functionality, as well as to make it easier for packet nerds to find out how pod hangars use packets.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chasu
(+)Pod-to-hangar communication is now packet-based
```
