### PR TITLE
Local auth temporary PR

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -82,7 +82,7 @@
 	var/proc_logging = 0
 #endif
 
-	// authenticate = 0
+	authenticate = 0
 	// comment out the line below when debugging locally to enable the options & messages menu
 	control_freak = 1
 
@@ -359,6 +359,11 @@
 	//admins and mentors can enter a server through player caps.
 	var/admin_status = init_admin()
 	if (admin_status == 1)
+		var/ircmsg[] = new()
+		ircmsg["key"] =  src.key
+		ircmsg["name"] = src.ckey
+		ircmsg["msg"] = "Logged in as an Administrator"
+		ircbot.export_async("admin", ircmsg)
 		boutput(src, "<span class='ooc adminooc'>You are an admin! Time for crime.</span>")
 	else if (admin_status == 2)
 		boutput(src, "<span class='ooc adminooc'>You are possibly an admin! Please complete the Goonhub Auth process.</span>")

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -922,7 +922,7 @@ TYPEINFO(/mob)
 #ifdef SHUT_UP_AND_GIVE_ME_MEDAL_STUFF
 	return TRUE
 #else
-	return src.mind.get_player().has_medal(medal)
+	return FALSE
 #endif
 
 /mob/verb/list_medals()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[DNM]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Temporarily enables local authentication while the Byond hub is down again.
Remake of #19128 because the branch is gone and the code has changed slightly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Byond hub down, no-one can log in.
