### PR TITLE
Showing off an item includes overlays

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -2006,7 +2006,13 @@
 			src.pixel_x_offset = -src.pixel_x_offset
 			src.pixel_x_hand_offset = -src.pixel_x_hand_offset
 
-		var/image/overlay = src.item.SafeGetOverlayImage("showoff_overlay", src.item.icon, src.item.icon_state, MOB_LAYER + 0.1, src.pixel_x_offset, src.pixel_y_offset)
+		var/icon/flatIcon = getFlatIcon(src.item)
+
+		var/image/overlay = new /image
+		overlay.icon = flatIcon
+		overlay.pixel_x = src.pixel_x_offset
+		overlay.pixel_y = src.pixel_y_offset
+
 		var/image/hand_overlay = src.item.SafeGetOverlayImage("showoff_hand_overlay", 'icons/effects/effects.dmi', hand_icon_state, MOB_LAYER + 0.11, src.pixel_x_hand_offset, src.pixel_y_hand_offset, color=user.get_fingertip_color())
 
 		src.user.UpdateOverlays(overlay, "showoff_overlay")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Showing off an item now shows any overlays the item has, such as covered in blood


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Showing off an item should show how it looks, rather than just base icon state
