### PR TITLE
Add large produce satchels to botany requisition rewards

### DIFF
--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -839,22 +839,20 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 		var/randm = rand(1, 100)
 		if (randm > 50)
 			quant = 2
-			if (prob(30))
-				src.item_rewarders += new /datum/rc_itemreward/plant_cartridge
 		else if (randm > 5)
 			quant = 1
 		else
 			quant = 3
 			src.payout += 8000
-			src.item_rewarders += new /datum/rc_itemreward/plant_cartridge
 
 		for (var/i = 1; i <= quant; i++)
 			src.rc_entries += GetFruitOrVegEntry()
 		src.item_rewarders += new /datum/rc_itemreward/large_satchel
 		if(prob(30))
 			src.item_rewarders += new /datum/rc_itemreward/strange_seed
-		else
+		else if (prob(60))
 			src.item_rewarders += new /datum/rc_itemreward/tumbleweed
+
 		..()
 
 	proc/GetFruitOrVegEntry()

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -850,6 +850,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 
 		for (var/i = 1; i <= quant; i++)
 			src.rc_entries += GetFruitOrVegEntry()
+		src.item_rewarders += new /datum/rc_itemreward/large_satchel
 		if(prob(30))
 			src.item_rewarders += new /datum/rc_itemreward/strange_seed
 		else

--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -539,8 +539,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 	name = "large produce satchel"
 
 	build_reward()
-		var satchel = new /obj/item/satchel/hydro/large
-		return satchel
+		return new /obj/item/satchel/hydro/large
 
 /datum/rc_itemreward/tumbleweed
 	name = "aggressive plant specimen"

--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -513,15 +513,6 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 		..()*/
 
 
-
-
-/datum/rc_itemreward/plant_cartridge
-	name = "Hydroponics restock cartridge"
-
-	build_reward()
-		var/cart = new /obj/item/vending/restock_cartridge/hydroponics
-		return cart
-
 /datum/rc_itemreward/strange_seed
 	name = "strange seed"
 

--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -398,7 +398,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 		src.item_rewarders += new /datum/rc_itemreward/large_satchel
 		if(prob(probability))
 			src.item_rewarders += new /datum/rc_itemreward/strange_seed
-		else
+		else if (prob(probability))
 			src.item_rewarders += new /datum/rc_itemreward/tumbleweed
 
 /datum/rc_entry/item/mutated_produce

--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -395,6 +395,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 		..()
 
 	proc/AddReward(var/probability)
+		src.item_rewarders += new /datum/rc_itemreward/large_satchel
 		if(prob(probability))
 			src.item_rewarders += new /datum/rc_itemreward/strange_seed
 		else
@@ -533,6 +534,13 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 		for (var/i in 1 to src.count)
 			seed_list += new /obj/item/seed/alien
 		return seed_list
+
+/datum/rc_itemreward/large_satchel
+	name = "large produce satchel"
+
+	build_reward()
+		var satchel = new /obj/item/satchel/hydro/large
+		return satchel
 
 /datum/rc_itemreward/tumbleweed
 	name = "aggressive plant specimen"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label [Hydroponics][balance] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds large produce satchels as guaranteed rewards for botany requisitions.

Makes other rewards slightly less guaranteed in exchange. Removes the plant cartridge reward. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Botany requisition rewards are rather lacklustre; strange seeds can be obtained easier elsewhere, tumbleweeds - while cool - aren't particularly sought after, and plant cartridges are nigh-insulting. Large produce satchels are in the code, but as far as I can tell they're unavailable ingame. This distributes them in a somewhat limited capacity such that regular satchels aren't obsolete, gives more incentive for botany to cooperate with cargo and makes botany req rewards a bit more interesting. 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Egregorious
(+)Botany requisitions now reward large produce satchels. 
```
