### PR TITLE
Add a min Failure Chance to the Zip Gun

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -566,7 +566,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 				qdel(src)
 			return
 		if(ammo?.amount_left && current_projectile.power)
-			failure_chance = clamp(round(current_projectile.power/2 - 9), 0, 33)
+			failure_chance = clamp(round(current_projectile.power/2 - 9), 4, 33)
 		if(canshoot(user) && prob(failure_chance)) // Empty zip guns had a chance of blowing up. Stupid (Convair880).
 			failured = 1
 			if(prob(failure_chance))	// Sometimes the failure is obvious

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -513,7 +513,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	contraband = 6
 	ammo_cats = list(AMMO_PISTOL_ALL, AMMO_REVOLVER_ALL, AMMO_SMG_9MM, AMMO_TRANQ_ALL, AMMO_RIFLE_308, AMMO_AUTO_308, AMMO_AUTO_556, AMMO_CASELESS_G11, AMMO_FLECHETTE, AMMO_STAPLE)
 	max_ammo_capacity = 2
-	var/failure_chance = 6
+	var/failure_chance = 4 // Set on shoot(), but 4 is the minimum for all projectiles
 	var/failured = 0
 	default_magazine = /obj/item/ammo/bullets/staples
 	icon_recoil_cap = 30


### PR DESCRIPTION
[BALANCE] [OBJECTS]
## About the PR
Makes the minimum failure chance for the Zip Gun 4%, this chance does two things:
- Stun Rounds now can blow up the Zip Gun.
- .22 is now slightly less safe. From 2% Failure Chance to 4%.
4% is an inbetween of the previous default chance - 6% - and the lowest chance you can get which is 2% with the .22 ammo from hacked General Fabricators.

## Why's this needed?
The Zip Gun currently can be used without much issue with the Detective's .38 Stun Loaders, which is fairly plentiful if you can scan or hack a SecTech. The slight nerf to .22 is a side-effect, but I feel it won't effect much and this slapped together piece of shit (positive) could blow up slightly more anyway.

## Changelog
```changelog
(u)444explorer
(+)The Zip Gun is now able to break with Stun Rounds at a 4% chance. .22 Ammo has also been bumped to break the gun at 4%.
```
