### PR TITLE
Traders buy the same items throughout an entire shift

### DIFF
--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -247,7 +247,7 @@
 					T.hidden = 0
 					T.current_message = pick(T.dialogue_greet)
 					T.patience = rand(T.base_patience[1],T.base_patience[2])
-					T.set_up_goods()
+					T.set_up_goods(FALSE)
 			else
 				if (prob(T.chance_leave))
 					T.hidden = 1

--- a/code/modules/economy/traders/trader.dm
+++ b/code/modules/economy/traders/trader.dm
@@ -99,10 +99,10 @@
 		src.patience = rand(src.base_patience[1],src.base_patience[2])
 		src.set_up_goods()
 
-	proc/set_up_goods()
+	proc/set_up_goods(var/should_reset_buylist = TRUE)
 		// This is called in New and also when the trader comes back from being away for a while
 		// It basically clears out and rejumbles their commodity lists to keep things fresh
-		src.goods_buy = new/list()
+		if (should_reset_buylist) src.goods_buy = new/list()
 		src.goods_sell = new/list()
 		src.wipe_cart()
 
@@ -119,7 +119,7 @@
 		// Iterate over all rarities and pick the corresponding amount of items from the respective lists
 		for (var/rarity in src.rarities)
 			for (var/i in 1 to src.amount_of_items_per_rarity[rarity])
-				if(length(goods_buy_temp[rarity]) >= i)
+				if(should_reset_buylist && length(goods_buy_temp[rarity]) >= i)
 					var/buy_com = pick(goods_buy_temp[rarity])
 					var/datum/commodity/new_buy_com = new buy_com(src)
 					src.goods_buy += new_buy_com


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label[BALANCE][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Cargo trader buylists don't get randomised when they return during a market-shift.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I cannot recall a time I have seen anyone interact successfully with the trader's buylists unless it's an already guaranteed buy-item like Gragg's starstones. I think that's because there's too many layers of RNG involved to make it worth investing any time into. 

However the concept of round-specific bulk item collection is still theoretically fun and has the opportunity to incentivise crew interaction in a way that is unique enough compared to requisitions. So making the buy lists static might encourage people to interact with it more when they know that they have the whole shift with which to sell the products they collect, assuming the trader makes a return. 

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Egregorious
(+)Cargo's traders will now buy the same items throughout the entire shift. 
```
