### PR TITLE
Properly add or eject mobs that change type inside a pet carrier

### DIFF
--- a/code/obj/item/pet_carrier.dm
+++ b/code/obj/item/pet_carrier.dm
@@ -192,9 +192,14 @@
 				src.visible_message(SPAN_ALERT("[Obj] bursts out of [src]!"))
 		..()
 
-	Entered(Obj, OldLoc)
-		if(istype(Obj, /obj/item/rocko))
-			src.visible_message(SPAN_ALERT("[usr] places [Obj] into [src]."))
+	Entered(atom/movable/AM, OldLoc)
+		if(istype(AM, /obj/item/rocko))
+			src.visible_message(SPAN_ALERT("[usr] places [AM] into [src]."))
+		if (!(AM in src.carrier_occupants))
+			if(src.is_allowed_type(AM.type))
+				src.add_mob(AM)
+			else
+				AM.set_loc(get_turf(src))
 		..()
 
 	proc/is_allowed_type(type)
@@ -244,9 +249,9 @@
 	proc/add_mob(atom/movable/thing_to_add)
 		if (!thing_to_add)
 			return
+		src.carrier_occupants.Add(thing_to_add)
 		thing_to_add.set_loc(src)
 		thing_to_add.vis_flags |= src.mob_vis_flags
-		src.carrier_occupants.Add(thing_to_add)
 		src.vis_contents_proxy.vis_contents.Add(thing_to_add)
 		src.UpdateIcon()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When something enters the carrier, check if it's in the existing occupants. If it is not, and it's a type allowed in the carrier, add the mob to the carrier via add_mob; otherwise move it outside.
Shifts add_mob to store the grabbed mob in the occupants list before changing its loc to support the above logic change


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fix #23440