### PR TITLE
Fix AIs ignoring voice changers.

### DIFF
--- a/code/modules/speech/modules/listen/inputs/shared_input_format_modules/ears.dm
+++ b/code/modules/speech/modules/listen/inputs/shared_input_format_modules/ears.dm
@@ -29,9 +29,7 @@
 	else if (istype(message.original_speaker, /obj/machinery/computer))
 		job_title = "Computer"
 
-	message.speaker_to_display = message.real_ident
-
-	message.format_speaker_prefix += "<a href='byond://?src=\ref[src];action=track;heard_name=[message.real_ident]'>"
+	message.format_speaker_prefix += "<a href='byond://?src=\ref[src];action=track;heard_name=[message.speaker_to_display]'>"
 	message.format_verb_prefix = " ([job_title])</a>" + message.format_verb_prefix
 
 // I dislike implementing AI tracking here, however the alternative, performing the above formatting per listener and using `/mob/living/silicon/Topic` would incur a performance cost.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
AI listen modifier will not replace the shown speaker with the original speaker

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows voice changers to work on AIs again (probably also ling mimic voice?)
Fixes #23456

