### PR TITLE
Interdictor Unlocking

### DIFF
--- a/code/obj/machinery/interdictor.dm
+++ b/code/obj/machinery/interdictor.dm
@@ -10,7 +10,8 @@
 	density = 1
 	var/resisted = FALSE //Changes if someone is being protected from a radstorm
 	anchored = UNANCHORED
-	req_access = list(access_engineering)
+	req_access = null
+	object_flags = CAN_REPROGRAM_ACCESS
 
 	///Internal capacitor; the cell installed internally during construction, which acts as a capacitor for energy used in interdictor operation.
 	var/obj/item/cell/intcap = null
@@ -108,7 +109,7 @@
 
 	attack_hand(mob/user)
 		if(!emagged && !src.allowed(user))
-			boutput(user, SPAN_ALERT("Engineering clearance is required to operate the interdictor's locks."))
+			boutput(user, SPAN_ALERT("You are not authorised to operate the interdictor's locks."))
 			return
 		if(!ON_COOLDOWN(src, "maglocks", src.maglock_cooldown))
 			if(anchored)
@@ -188,10 +189,10 @@
 
 	// Typed variants for manual spawning or map placement
 
-	unlocked
-		req_access = null
-		name = "unlocked spatial interdictor"
-		desc = "A device that lessens or nullifies the effects of assorted stellar phenomena. A small tag indicates its access requirement has been removed."
+	ranch
+		req_access = list(access_ranch)
+		name = "ranch spatial interdictor"
+		desc = "A device that lessens or nullifies the effects of assorted stellar phenomena. Great for protecting chickens!"
 
 	nimbus
 		interdict_class = ITDR_NIMBUS

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -9610,7 +9610,7 @@
 /obj/railing/orange/reinforced{
 	dir = 8
 	},
-/obj/machinery/interdictor/unlocked,
+/obj/machinery/interdictor/ranch,
 /turf/simulated/floor/grasstodirt{
 	dir = 8
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -18080,7 +18080,7 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/west,
 /area/station/science/research_director)
 "haE" = (
-/obj/machinery/interdictor/unlocked,
+/obj/machinery/interdictor/ranch,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "hdq" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -63451,7 +63451,7 @@
 	pixel_x = -22;
 	pixel_y = 31
 	},
-/obj/machinery/interdictor/unlocked,
+/obj/machinery/interdictor/ranch,
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
 "xdS" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -13316,7 +13316,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aOr" = (
-/obj/machinery/interdictor/unlocked,
+/obj/machinery/interdictor/ranch,
 /turf/simulated/floor/grasstodirt{
 	dir = 8
 	},

--- a/maps/density2.dmm
+++ b/maps/density2.dmm
@@ -4443,7 +4443,7 @@
 /turf/simulated/floor/auto/dirt,
 /area/station/crew_quarters/garden/sunlight)
 "Ej" = (
-/obj/machinery/interdictor/unlocked,
+/obj/machinery/interdictor/ranch,
 /turf/simulated/floor/auto/grass/leafy,
 /area/station/ranch)
 "Ek" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -18277,7 +18277,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/interdictor/unlocked,
+/obj/machinery/interdictor/ranch,
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
 "dUq" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -61815,7 +61815,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch/north,
-/obj/machinery/interdictor/unlocked,
+/obj/machinery/interdictor/ranch,
 /turf/simulated/floor/grasstodirt{
 	dir = 4
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -43651,7 +43651,7 @@
 	},
 /obj/railing/orange/reinforced,
 /obj/machinery/firealarm/west,
-/obj/machinery/interdictor/unlocked,
+/obj/machinery/interdictor/ranch,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "mEW" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -9655,7 +9655,7 @@
 /area/station/hallway/primary/northeast)
 "eub" = (
 /obj/machinery/light,
-/obj/machinery/interdictor/unlocked,
+/obj/machinery/interdictor/ranch,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "euf" = (

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -29284,7 +29284,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/interdictor/unlocked,
+/obj/machinery/interdictor/ranch,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "uRQ" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -43937,7 +43937,7 @@
 /turf/simulated/floor/martian,
 /area/evilreaver/security)
 "tLt" = (
-/obj/machinery/interdictor/unlocked,
+/obj/machinery/interdictor/ranch,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "tLA" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows anyone with access to swipe their ID on an interdictor to unlock it
Changes the "unlocked" interdictor subtype to "ranch" and give it ranch access
Allows the AccessPro to reprogram Interdictors


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows engineering to give interdictors to other departments without needing to micromanage them.
Idea suggested on the forums: https://forum.ss13.co/showthread.php?tid=24153


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949 & RSOD
(*)Spatial interdictors can now be unlocked by swiping an ID with access. They can also have their access changed by the AccessPro
(+)The Interdictor in the ranch now requires ranch access.
```
