### PR TITLE
Mimics get disposal_travel

### DIFF
--- a/code/datums/abilities/critter/disposal_travel.dm
+++ b/code/datums/abilities/critter/disposal_travel.dm
@@ -51,6 +51,10 @@
 				boutput(holder.owner, SPAN_ALERT("That pipe is a mangled mess of pain!  Best to stay here for now."))
 				return TRUE
 
+			if (istype(holder.owner, /mob/living/critter/mimic/antag_spawn) && holder.owner.max_health >= 50)
+				boutput(holder.owner, SPAN_ALERT("Your disguise is too big to fit inside!")
+				return TRUE
+
 			activate()
 
 	proc/activate()

--- a/code/datums/abilities/critter/disposal_travel.dm
+++ b/code/datums/abilities/critter/disposal_travel.dm
@@ -52,7 +52,7 @@
 				return TRUE
 
 			if (istype(holder.owner, /mob/living/critter/mimic/antag_spawn) && holder.owner.max_health >= 50)
-				boutput(holder.owner, SPAN_ALERT("Your disguise is too big to fit inside!")
+				boutput(holder.owner, SPAN_ALERT("Your disguise is too big to fit inside!"))
 				return TRUE
 
 			activate()

--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -137,7 +137,10 @@
 	//same health as a firebot
 	health_brute = 25
 	health_burn = 25
-	add_abilities = list(/datum/targetable/critter/mimic, /datum/targetable/critter/tackle, /datum/targetable/critter/sting/mimic/antag_spawn)
+	add_abilities = list(/datum/targetable/critter/mimic,
+						/datum/targetable/critter/tackle,
+						/datum/targetable/critter/sting/mimic/antag_spawn
+						/datum/targetable/critter/vent_move)
 	hand_count = 2
 	var/modifier = null
 	//give them an actual hand so they can open doors etc.
@@ -156,6 +159,4 @@
 		L.max_wclass = W_CLASS_SMALL
 
 /mob/living/critter/mimic/virtual
-		add_abilities = list(/datum/targetable/critter/mimic,
-							/datum/targetable/critter/tackle,
-							/datum/targetable/vent_move)
+		add_abilities = list(/datum/targetable/critter/mimic,/datum/targetable/critter/tackle)

--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -140,7 +140,7 @@
 	add_abilities = list(/datum/targetable/critter/mimic,
 						/datum/targetable/critter/tackle,
 						/datum/targetable/critter/sting/mimic/antag_spawn,
-						/datum/targetable/critter/vent_move)
+						/datum/targetable/vent_move)
 	hand_count = 2
 	var/modifier = null
 	//give them an actual hand so they can open doors etc.

--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -139,7 +139,7 @@
 	health_burn = 25
 	add_abilities = list(/datum/targetable/critter/mimic,
 						/datum/targetable/critter/tackle,
-						/datum/targetable/critter/sting/mimic/antag_spawn
+						/datum/targetable/critter/sting/mimic/antag_spawn,
 						/datum/targetable/critter/vent_move)
 	hand_count = 2
 	var/modifier = null

--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -156,4 +156,6 @@
 		L.max_wclass = W_CLASS_SMALL
 
 /mob/living/critter/mimic/virtual
-		add_abilities = list(/datum/targetable/critter/mimic, /datum/targetable/critter/tackle)
+		add_abilities = list(/datum/targetable/critter/mimic,
+							/datum/targetable/critter/tackle,
+							/datum/targetable/vent_move)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[critters] [feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Does what it says on the tin. Mimics can only use this if they're small enough (under 50 health). 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gives mimics another way to be slippery if they don't have the option of using mimictoxin to run away (lots of people in a room/hall etc). 

Long answer: https://hackmd.io/eGzsEO2ATjCnPNd_6S9RwA

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CalliopeSoups
(+)Mimics now get disposal travel.
```
