### PR TITLE
allow actionbars to be processed in preround

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -796,6 +796,8 @@
 			if (AB.requires_equip && !(AB.the_item in the_mob.get_equipped_items())) continue
 			abilities_toadd += AB
 		if (!length(abilities_toadd)) return
+		if (!islist(the_mob.item_abilities))
+			the_mob.item_abilities = list()
 		the_mob.item_abilities |= abilities_toadd
 		the_mob.need_update_item_abilities = 1
 		the_mob.update_item_abilities()

--- a/code/datums/controllers/process/_process.dm
+++ b/code/datums/controllers/process/_process.dm
@@ -38,6 +38,9 @@
 	/// Process name
 	var/name
 
+	/// What game state should this controller start running in
+	var/minimum_game_state = GAME_STATE_PLAYING
+
 	/// This controls how often the process would run under ideal conditions.
 	/// If the process scheduler sees that the process has finished, it will wait until
 	/// this amount of time has elapsed from the start of the previous run to start the

--- a/code/datums/controllers/process/actions.dm
+++ b/code/datums/controllers/process/actions.dm
@@ -1,6 +1,7 @@
 
 /// handles timed player actions
 /datum/controller/process/actions
+	minimum_game_state = GAME_STATE_PREGAME
 	var/datum/controller/process/actions/action_controller
 
 	setup()

--- a/code/datums/controllers/process_scheduler.dm
+++ b/code/datums/controllers/process_scheduler.dm
@@ -109,6 +109,10 @@ var/global/datum/controller/processScheduler/processScheduler
 
 /datum/controller/processScheduler/proc/checkRunningProcesses()
 	for(var/datum/controller/process/p in running)
+		// only update processes needed in this game state
+		if (p.minimum_game_state < global.current_state)
+			continue
+
 		p.update()
 
 		if (isnull(p)) // Process was killed

--- a/code/datums/controllers/process_scheduler.dm
+++ b/code/datums/controllers/process_scheduler.dm
@@ -132,6 +132,10 @@ var/global/datum/controller/processScheduler/processScheduler
 		if (p.disabled || p.running || p.queued || !p.idle)
 			continue
 
+		// only queue processes needed in this game state
+		if (p.minimum_game_state < global.current_state)
+			continue
+
 		// If world.timeofday has rolled over, then we need to adjust.
 		if (TimeOfHour < last_start[p])
 			last_start[p] -= 36000

--- a/code/datums/controllers/process_scheduler.dm
+++ b/code/datums/controllers/process_scheduler.dm
@@ -109,9 +109,11 @@ var/global/datum/controller/processScheduler/processScheduler
 
 /datum/controller/processScheduler/proc/checkRunningProcesses()
 	for(var/datum/controller/process/p in running)
+		#ifndef UNIT_TESTS // unit tests are run in world/New
 		// only update processes needed in this game state
 		if (p.minimum_game_state < global.current_state)
 			continue
+		#endif
 
 		p.update()
 
@@ -136,9 +138,11 @@ var/global/datum/controller/processScheduler/processScheduler
 		if (p.disabled || p.running || p.queued || !p.idle)
 			continue
 
+		#ifndef UNIT_TESTS // unit tests are run in world/New
 		// only queue processes needed in this game state
 		if (p.minimum_game_state < global.current_state)
 			continue
+		#endif
 
 		// If world.timeofday has rolled over, then we need to adjust.
 		if (TimeOfHour < last_start[p])

--- a/code/datums/controllers/process_scheduler.dm
+++ b/code/datums/controllers/process_scheduler.dm
@@ -109,11 +109,9 @@ var/global/datum/controller/processScheduler/processScheduler
 
 /datum/controller/processScheduler/proc/checkRunningProcesses()
 	for(var/datum/controller/process/p in running)
-		#ifndef UNIT_TESTS // unit tests are run in world/New
 		// only update processes needed in this game state
 		if (p.minimum_game_state < global.current_state)
 			continue
-		#endif
 
 		p.update()
 
@@ -138,11 +136,9 @@ var/global/datum/controller/processScheduler/processScheduler
 		if (p.disabled || p.running || p.queued || !p.idle)
 			continue
 
-		#ifndef UNIT_TESTS // unit tests are run in world/New
 		// only queue processes needed in this game state
 		if (p.minimum_game_state < global.current_state)
 			continue
-		#endif
 
 		// If world.timeofday has rolled over, then we need to adjust.
 		if (TimeOfHour < last_start[p])

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -311,6 +311,9 @@ var/global/game_force_started = FALSE
 		for(var/turf/T in job_start_locations["AI"])
 			new /mob/living/silicon/ai/latejoin(T)
 
+	if(!processScheduler.isRunning)
+		processScheduler.start()
+
 	if (total_clients() >= OVERLOAD_PLAYERCOUNT)
 		world.tick_lag = OVERLOADED_WORLD_TICKLAG
 	else if (total_clients() >= SEMIOVERLOAD_PLAYERCOUNT)

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -311,9 +311,6 @@ var/global/game_force_started = FALSE
 		for(var/turf/T in job_start_locations["AI"])
 			new /mob/living/silicon/ai/latejoin(T)
 
-	if(!processScheduler.isRunning)
-		processScheduler.start()
-
 	if (total_clients() >= OVERLOAD_PLAYERCOUNT)
 		world.tick_lag = OVERLOADED_WORLD_TICKLAG
 	else if (total_clients() >= SEMIOVERLOAD_PLAYERCOUNT)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1844,7 +1844,7 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 			if (istype(I, /obj/item/clothing/glasses))
 				return TRUE
 		if (SLOT_GLOVES)
-			if ((!src.limbs.l_arm) && (!src.limbs.r_arm))
+			if ((!src.limbs?.l_arm) && (!src.limbs?.r_arm))
 				return FALSE
 			if (istype(I, /obj/item/clothing/gloves))
 				return TRUE
@@ -1861,7 +1861,7 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 				else
 					return TRUE
 		if (SLOT_SHOES)
-			if ((!src.limbs.l_leg) && (!src.limbs.r_leg))
+			if ((!src.limbs?.l_leg) && (!src.limbs?.r_leg))
 				return FALSE
 			if (istype(I, /obj/item/clothing/shoes))
 				var/obj/item/clothing/SH = I

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1785,7 +1785,7 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 			if (I.w_class <= W_CLASS_POCKET_SIZED && src.w_uniform)
 				return TRUE
 		if (SLOT_L_HAND)
-			if (src.limbs.l_arm)
+			if (src.limbs?.l_arm)
 				if (!istype(src.limbs.l_arm, /obj/item/parts/human_parts/arm) && !istype(src.limbs.l_arm, /obj/item/parts/robot_parts/arm) && !istype(src.limbs.l_arm, /obj/item/parts/artifact_parts/arm))
 					return FALSE
 				if (istype(src.limbs.l_arm, /obj/item/parts/human_parts/arm/left/item))
@@ -1798,7 +1798,7 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 						return FALSE
 				return TRUE
 		if (SLOT_R_HAND)
-			if (src.limbs.r_arm)
+			if (src.limbs?.r_arm)
 				if (!istype(src.limbs.r_arm, /obj/item/parts/human_parts/arm) && !istype(src.limbs.r_arm, /obj/item/parts/robot_parts/arm) && !istype(src.limbs.r_arm, /obj/item/parts/artifact_parts/arm))
 					return FALSE
 				if (istype(src.limbs.r_arm, /obj/item/parts/human_parts/arm/right/item))
@@ -1824,7 +1824,7 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 			if (I.c_flags & ONBACK)
 				return TRUE
 		if (SLOT_WEAR_MASK) // It's not pretty, but the mutantrace check will do for the time being (Convair880).
-			if (!src.organHolder.head)
+			if (!src.organHolder?.head)
 				return FALSE
 			if (istype(I, /obj/item/clothing/mask))
 				var/obj/item/clothing/M = I
@@ -1834,12 +1834,12 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 				else
 					return TRUE
 		if (SLOT_EARS)
-			if (!src.organHolder.head)
+			if (!src.organHolder?.head)
 				return FALSE
 			if (istype(I, /obj/item/clothing/ears) || istype(I,/obj/item/device/radio/headset))
 				return TRUE
 		if (SLOT_GLASSES)
-			if (!src.organHolder.head)
+			if (!src.organHolder?.head)
 				return FALSE
 			if (istype(I, /obj/item/clothing/glasses))
 				return TRUE
@@ -1849,7 +1849,7 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 			if (istype(I, /obj/item/clothing/gloves))
 				return TRUE
 		if (SLOT_HEAD)
-			if (!src.organHolder.head)
+			if (!src.organHolder?.head)
 				return FALSE
 			if (istype(I, /obj/item/clothing/head))
 				var/obj/item/clothing/H = I

--- a/code/modules/atmospherics/FEA_system.dm
+++ b/code/modules/atmospherics/FEA_system.dm
@@ -198,7 +198,8 @@ var/global/total_gas_mixtures = 0
 /// Do not call. Used by [/datum/controller/air_system/proc/process].
 /datum/controller/air_system/proc/process_update_tiles()
 	PROTECTED_PROC(TRUE)
-	for(var/turf/simulated/T as anything in tiles_to_update) // ZEWAKA-ATMOS SPACE + SPACE FLUID LEAKAGE
+	// TODO: figure out why/how unsimmed tiles creep into this list and re-add `as anything`
+	for(var/turf/simulated/T in tiles_to_update) // ZEWAKA-ATMOS SPACE + SPACE FLUID LEAKAGE
 		T.update_air_properties()
 	tiles_to_update.len = 0
 

--- a/code/obj/item/clothing.dm
+++ b/code/obj/item/clothing.dm
@@ -53,7 +53,7 @@ ABSTRACT_TYPE(/obj/item/clothing)
 				for (var/datum/hud/hud in H.huds)
 					if (src in hud.objects)
 						hud.remove_object(src)
-				H.hud.remove_object(src)
+				H.hud?.remove_object(src)
 		//fucky way of doing this but whatever
 		..()
 

--- a/code/world/initialization/2_New.dm
+++ b/code/world/initialization/2_New.dm
@@ -59,6 +59,3 @@
 	SPAWN(0)
 		init()
 
-#ifdef UNIT_TESTS
-	unit_tests.run_tests()
-#endif

--- a/code/world/initialization/2_New.dm
+++ b/code/world/initialization/2_New.dm
@@ -59,3 +59,6 @@
 	SPAWN(0)
 		init()
 
+#ifdef UNIT_TESTS
+	unit_tests.run_tests()
+#endif

--- a/code/world/initialization/3_init.dm
+++ b/code/world/initialization/3_init.dm
@@ -264,7 +264,9 @@
 
 	lincolnshire = new
 
-
+#ifdef UNIT_TESTS
+	unit_tests.run_tests()
+#endif
 #ifdef PREFAB_CHECKING
 	placeAllPrefabs()
 #endif

--- a/code/world/initialization/3_init.dm
+++ b/code/world/initialization/3_init.dm
@@ -264,10 +264,6 @@
 
 	lincolnshire = new
 
-#ifdef UNIT_TESTS
-	SPAWN (1)
-		unit_tests.run_tests()
-#endif
 #ifdef PREFAB_CHECKING
 	placeAllPrefabs()
 #endif

--- a/code/world/initialization/3_init.dm
+++ b/code/world/initialization/3_init.dm
@@ -265,7 +265,8 @@
 	lincolnshire = new
 
 #ifdef UNIT_TESTS
-	unit_tests.run_tests()
+	SPAWN (1)
+		unit_tests.run_tests()
 #endif
 #ifdef PREFAB_CHECKING
 	placeAllPrefabs()

--- a/code/world/initialization/3_init.dm
+++ b/code/world/initialization/3_init.dm
@@ -248,6 +248,9 @@
 			C.restart_dreamseeker_js()
 #endif
 
+	if(!processScheduler.isRunning)
+		processScheduler.start()
+
 	Z_LOG_DEBUG("World/Init", "Init() complete")
 	TgsInitializationComplete()
 	//sleep_offline = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[internal][feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* add a minimum game state variable to processes that defaults to GAME_STATE_PLAYING
* set actions to work in GAME_STATE_PREGAME
* initialize the process scheduler at the end of `init`
* when queuing processes, skip queueing if the game state is earlier than the set game state

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
let action bars work in pre-round