### PR TITLE
DNR observers can see AI laws by examining law rack

### DIFF
--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -207,6 +207,14 @@
 		else
 			. += "It's about to collapse!"
 
+		if (isobserver(user))
+			. += "<br>"
+			if(user.mind.get_player()?.dnr)
+				. += "Current Laws:<br>"
+				. += src.format_for_logs()
+			else
+				. += SPAN_ALERT("You must enable DNR to see the current laws.")
+
 	blob_act(power)
 		changeHealth(-power*0.15,"blob")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][silicons]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
when an observer and DNR, you can see the AI laws on a lawrack by examining it
if you are an observer and not DNR, you get a note saying you need to be DNR to see the laws.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
more natural way to view AI laws as an observer in addition to the dedicated verb