### PR TITLE
Automated Arrest proc

### DIFF
--- a/code/WorkInProgress/laundry.dm
+++ b/code/WorkInProgress/laundry.dm
@@ -110,13 +110,8 @@ TYPEINFO(/obj/submachine/laundry_machine)
 						newcash.set_loc(src)
 					//Money laundering is a crime!
 					var/mob/living/carbon/human/criminal = src.activator
-					if (ishuman(criminal) && seen_by_camera(criminal))
-						var/perpname = criminal.name
-						var/datum/db_record/sec_record = data_core.security.find_record("name", perpname)
-						if(sec_record  && sec_record["criminal"] != ARREST_STATE_ARREST)
-							sec_record["criminal"] = ARREST_STATE_ARREST
-							sec_record["mi_crim"] = "Money laundering."
-							criminal.update_arrest_icon()
+					if(criminal)
+						criminal.apply_automated_arrest("Money laundering.")
 			src.activator = null
 			src.cycle = POST
 			src.cycle_current = 0

--- a/code/WorkInProgress/zamu_mail.dm
+++ b/code/WorkInProgress/zamu_mail.dm
@@ -186,17 +186,9 @@
 
 		// I TOLD YOU IT WAS ILLEGAL!!!
 		// I WARNED YOU DOG!!!
-		if (ishuman(owner) && seen_by_camera(owner))
-			var/perpname = owner.name
-			if (owner:wear_id && owner:wear_id:registered)
-				perpname = owner:wear_id:registered
-
-			var/datum/db_record/sec_record = data_core.security.find_record("name", perpname)
-			if(sec_record && sec_record["criminal"] != ARREST_STATE_ARREST)
-				sec_record["criminal"] = ARREST_STATE_ARREST
-				sec_record["mi_crim"] = "Mail fraud."
-				var/mob/living/carbon/human/H = owner
-				H.update_arrest_icon()
+		var/mob/living/carbon/human/H = owner
+		if(istype(H))
+			H.apply_automated_arrest("Mail fraud.")
 
 
 /obj/decal/cleanable/mail_fraud

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -2223,12 +2223,8 @@
 						dab_id.dab_count++
 						dab_id.tooltip_rebuild = 1
 					src.add_karma(-4)
-					if(!dab_id && locate(/obj/machinery/bot/secbot/beepsky) in view(7, get_turf(src)))
-						var/datum/db_record/sec_record = data_core.security.find_record("name", src.name)
-						if(sec_record && sec_record["criminal"] != ARREST_STATE_ARREST)
-							sec_record["criminal"] = ARREST_STATE_ARREST
-							sec_record["mi_crim"] = "Public dabbing."
-							src.update_arrest_icon()
+					if(!dab_id)
+						src.apply_automated_arrest("Public dabbing.")
 
 					if(src.reagents) src.reagents.add_reagent("dabs",5)
 

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -295,18 +295,10 @@ datum
 				if(!istype(holder) || !istype(holder.my_atom) || !ishuman(holder.my_atom))
 					return
 				var/mob/living/carbon/human/H = holder.my_atom
-				if(seen_by_camera(H))
-					// determine the name of the perp (goes by ID if wearing one)
-					var/perpname = H.name
-					if(H:wear_id && H:wear_id:registered)
-						perpname = H:wear_id:registered
-					var/datum/db_record/gen_record = data_core.general.find_record("name", perpname)
-					var/datum/db_record/sec_record = data_core.security.find_record("name", perpname)
-					// Yes. Its 21. This is Space America. That is canon now.
-					if(gen_record && sec_record && text2num(gen_record["age"]) < 21 && sec_record["criminal"] != ARREST_STATE_ARREST)
-						sec_record["criminal"] = ARREST_STATE_ARREST
-						sec_record["mi_crim"] = "Underage drinking."
-						H.update_arrest_icon()
+				var/datum/db_record/gen_record = data_core.general.find_record("name", H.name)
+				// Yes. Its 21. This is Space America. That is canon now.
+				if(gen_record && text2num(gen_record["age"]) < 21)
+					H.apply_automated_arrest("Underage drinking.")
 
 		fooddrink/alcoholic/hard_punch
 			name = "hard punch"

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -359,11 +359,7 @@ Custom Books
 				return
 
 			jerk.traitHolder?.addTrait("wasitsomethingisaid")
-
-			var/datum/db_record/S = data_core.security.find_record("id", jerk.datacore_id)
-			S?["criminal"] = ARREST_STATE_ARREST
-			S?["mi_crim"] = "Reading highly-confidential private information."
-			jerk.update_arrest_icon()
+			jerk.apply_automated_arrest("Reading highly-confidential private information.", requires_camera_seen = FALSE, use_visible_name = FALSE)
 		else
 			return list("It appears to be heavily encrypted information.")
 

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -1082,13 +1082,11 @@ TYPEINFO(/obj/item/clothing/head/that/gold)
 			playsound(src.loc, 'sound/vox/crime.ogg', 100, 1)
 
 		// Guess what? you wear the hat, you go to jail. Easy Peasy.
-		var/datum/db_record/S = data_core.security.find_record("id", user.datacore_id)
-		S?["criminal"] = ARREST_STATE_ARREST
-		S?["ma_crim"] = pick("Being unstoppable","Swagging out so hard","Stylin on \'em","Puttin\' in work")
-		S?["ma_crim_d"] = pick("Convicted Badass, to the bone.","Certified Turbonerd, home-grown.","Absolute Salad.","King of crimes, Queen of Flexxin\'")
+		var/reason = pick("Being unstoppable","Swagging out so hard","Stylin on \'em","Puttin\' in work")
+		var/details = pick("Convicted Badass, to the bone.","Certified Turbonerd, home-grown.","Absolute Salad.","King of crimes, Queen of Flexxin\'")
 		var/mob/living/carbon/human/H = user
-		if (istype(H))
-			H.update_arrest_icon()
+		if(istype(H))
+			H.apply_automated_arrest(reason,details,TRUE,FALSE,FALSE)
 
 	custom_suicide = 1
 	suicide_in_hand = 0

--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -312,11 +312,10 @@
 				src.visible_message("<b>[src] is obliterated! Was it worth it?</b>")
 				user.shock(user, 2501, stun_multiplier = 1,  ignore_gloves = 1)
 
-				var/mob/living/carbon/clown = user
+				var/mob/living/carbon/human/clown = user
 				if(istype(clown))
-					var/datum/db_record/S = data_core.security.find_record("id", clown.datacore_id)
-					S?["criminal"] = "*Arrest*"
-					S?["mi_crim"] = "Making a very irritating announcement."
+					//Computer is normally offcams and the clown normally has mask on + ID in computer so visible name will be Unknown
+					clown.apply_automated_arrest("Making a very irritating announcement.", requires_camera_seen = FALSE, use_visible_name = FALSE)
 
 					clown.update_burning(15) // placed here since update_burning is only for mob/living
 				if(src.ID)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the many places the arrest status is set automatically (Mail fraud, Underage drinking, etc) into one proc on humans
Aligns all these to require camera coverage and blame a disguise if the user is wearing one, with the following exceptions:
- Syndicate hat does not require camera coverage and will use real name
- Reading beepsky's diary does not require camera coverage and will use real name

Will conflict with #23495 (WITHOUT MERGE CONFLICT!!!), either of us will update for the other just don't merge both at the same time!!!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These are set in many places and actually don't properly update arrest icons for anyone with matching name.
Automated arrests are inconsistent in needing camera coverage or using visible name vs disguise.