### PR TITLE
Fix wheelchair Help-Swap bug

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -743,6 +743,11 @@ TYPEINFO(/mob)
 				src.set_loc(newloc)
 				tmob.set_loc(oldloc)
 
+				if(tmob.buckled)
+					tmob.buckled.set_loc(oldloc)
+				if(src.buckled)
+					src.buckled.set_loc(newloc)
+
 				if (istype(tmob.loc, /turf/space))
 					logTheThing(LOG_COMBAT, src, "trades places with (Help Intent) [constructTarget(tmob,"combat")], pushing them into space.")
 				else if (locate(/atom/movable/hotspot) in tmob.loc)

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -1208,7 +1208,8 @@ TYPEINFO(/obj/stool/chair/comfy/wheelchair)
 
 	set_loc(newloc)
 		. = ..()
-		unbuckle()
+		if(src.buckled_guy?.loc != src.loc)
+			unbuckle()
 
 /* ======================================================= */
 /* -------------------- Dining Chairs -------------------- */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
After swapping places with someone set whatever you or they were buckled to to their new loc
Only unbuckle someone from a wheelchair when changing loc when the new loc is not the same as the rider


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes being able to swap with someone in a wheelchair but not with their chair, causing them to move out of their chair but remain buckled (More people should play wheelchair by the way, its fun and this bug would've been caught sooner!)