### PR TITLE
Mobs are put back down when juggle failing

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2568,8 +2568,6 @@ Tries to put an item in an available backpack, belt storage, pocket, or hand slo
 	if (!src.juggling())
 		return
 	src.visible_message(SPAN_ALERT("<b>[src]</b> drops everything [he_or_she(src)] [were_or_was(src)] juggling!"))
-	for (var/mob/M in src.juggling)
-		src.remove_juggle(M)
 	for (var/atom/movable/A in src.juggling)
 		src.remove_juggle(A)
 		if(istype(A, /obj/item/device/light)) //i hate this

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2568,6 +2568,8 @@ Tries to put an item in an available backpack, belt storage, pocket, or hand slo
 	if (!src.juggling())
 		return
 	src.visible_message(SPAN_ALERT("<b>[src]</b> drops everything [he_or_she(src)] [were_or_was(src)] juggling!"))
+	for (var/mob/M in src.juggling)
+		src.remove_juggle(M)
 	for (var/atom/movable/A in src.juggling)
 		src.remove_juggle(A)
 		if(istype(A, /obj/item/device/light)) //i hate this
@@ -2603,6 +2605,8 @@ Tries to put an item in an available backpack, belt storage, pocket, or hand slo
 	logTheThing(LOG_STATION, src, "drops the items they were juggling")
 
 /mob/living/carbon/human/proc/remove_juggle(atom/movable/thing)
+	if (ismob(thing)) // prevents nullspacing if admins do a goofy
+		thing.loc = src.loc
 	UnregisterSignal(thing, COMSIG_MOVABLE_SET_LOC)
 	thing.layer = initial(thing.layer)
 	src.juggle_dummy.vis_contents -= thing


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug fix]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
You can't juggle mobs usually but sometimes admins allow for it, this PR fixes #23293 by putting a mob check into drop_juggle.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Juggling shouldn't send you to the shadow realm.



