### PR TITLE
Get client fix for AI mainframes

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -91,7 +91,7 @@ datum/mind
 			Z_LOG_ERROR("Mind/TransferTo", "Tried to transfer mind [(current ? "of mob " + key_name(current) : src)] to qdel'd mob [new_character].")
 			CRASH("Tried to transfer mind [identify_object(src)] to qdel'd mob [identify_object(new_character)].")
 
-		if (new_character.client)
+		if (new_character.get_client() && (new_character.get_client() != current.get_client()))
 			if (current)
 				boutput(current, "<h3 class='alert'>You were about to be transferred into another body, but that body was occupied!</h3>")
 				var/errmsg = "Tried to transfer mind of mob [identify_object(current)] to mob with an existing client [identify_object(new_character)]"

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -3482,3 +3482,6 @@ TYPEINFO(/mob)
 
 /mob/proc/frostburn_temp()
 	return src.base_body_temp - (src.temp_tolerance * 4)
+
+/mob/proc/get_client() //AIs can have no client var while still having a client
+	return src.client

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -623,6 +623,9 @@ TYPEINFO(/mob/dead/observer)
 	if(QDELETED(corpse) || corpse.loc == null)
 		tgui_alert(src, "You don't have a corpse! If you're very sure you do, and this seems wrong, make a bug report!", "No corpse")
 		return
+	if(corpse.get_client())
+		tgui_alert(src, "Someone else is already in your corpse! If this seems wrong, make a bug report!", "Corpse taken")
+		return
 	if(src.client && src.client.holder && src.client.holder.state == 2)
 		var/rank = src.client.holder.rank
 		src.client.clear_admin_verbs()

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2807,3 +2807,10 @@ proc/get_mobs_trackable_by_AI()
 		src.job = "AI"
 		if (src.mind)
 			src.mind.assigned_role = "AI"
+
+/mob/living/silicon/ai/get_client() //AIs can have no client var while still having a client
+	if(src.deployed_shell?.client)
+		return src.deployed_shell.client
+	else if(src.eyecam?.client)
+		return src.eyecam.client
+	return ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a /mob/proc/get_client() proc that returns the mob's client, AI cores override this by returning the client of their eye or deployed shell as while deployed AI.client is null.
Use the above proc to check if a mind can be transferred to a body, preventing a client being put into an AI core while that AI is off in their eye or shell.
Also check get_client() before returning to a corpse.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
AIs can have multiple mobs while their main mob has no client, allowing return to corpse and other AI mindbreaking shenanigans
Fixes #22705 and probably other AI-based client bugs

