### PR TITLE
Flip welding mask up

### DIFF
--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -725,6 +725,9 @@ TYPEINFO(/obj/item/clothing/head/helmet/camera)
 				if (src.up)
 					src.flip_down(source, silent=TRUE)
 					boutput(source, SPAN_HINT("You nod, dropping the welding mask over your face."))
+				else
+					src.flip_up(source, silent=TRUE)
+					boutput(source, SPAN_HINT("You nod, raising the welding mask off your face."))
 
 	proc/obscure(mob/user)
 		user.addOverlayComposition(/datum/overlayComposition/weldingmask)

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -722,6 +722,8 @@ TYPEINFO(/obj/item/clothing/head/helmet/camera)
 	proc/emote_handler(mob/source, var/emote)
 		switch(emote)
 			if ("nod")
+				if (ON_COOLDOWN(src, "weldingmask_nod", 1 SECOND))
+					return
 				if (src.up)
 					src.flip_down(source, silent=TRUE)
 					boutput(source, SPAN_HINT("You nod, dropping the welding mask over your face."))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [PLAYER ACTIONS] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This allows to flip the welding mask up and down on a 1 second cooldown.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
QoL


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kaan
(+)Nods now push a welding mask back on your head.
```
