### PR TITLE
Department Jobban check uses job category

### DIFF
--- a/code/modules/admin/jobban.dm
+++ b/code/modules/admin/jobban.dm
@@ -74,15 +74,15 @@
 				return TRUE
 
 		if(cache.Find("Engineering Department"))
-			if(J.job_category = JOB_ENGINEERING || istype(J, /datum/job/command/chief_engineer))
+			if(J.job_category == JOB_ENGINEERING || istype(J, /datum/job/command/chief_engineer))
 				return TRUE
 
 		if(cache.Find("Security Department") || cache.Find("Security Officer"))
-			if(J.job_category = JOB_SECURITY || istype(J, /datum/job/command/head_of_security))
+			if(J.job_category == JOB_SECURITY || istype(J, /datum/job/command/head_of_security))
 				return TRUE
 
 		if(cache.Find("Heads of Staff"))
-			if(J.job_category = JOB_COMMAND)
+			if(J.job_category == JOB_COMMAND)
 				return TRUE
 
 	if(cache.Find("Ghostdrone"))

--- a/code/modules/admin/jobban.dm
+++ b/code/modules/admin/jobban.dm
@@ -65,9 +65,9 @@
 		cache = jobban_get_for_player(M)
 
 	var/datum/job/J = find_job_in_controller_by_string(rank)
-	if (J?.no_jobban_from_this_job)
-		return FALSE
 	if(J)
+		if (J.no_jobban_from_this_job)
+			return FALSE
 
 		if(cache.Find("Everything Except Assistant"))
 			if(!istype(J, /datum/job/civilian/staff_assistant))

--- a/code/modules/admin/jobban.dm
+++ b/code/modules/admin/jobban.dm
@@ -67,24 +67,23 @@
 	var/datum/job/J = find_job_in_controller_by_string(rank)
 	if (J?.no_jobban_from_this_job)
 		return FALSE
+	if(J)
 
+		if(cache.Find("Everything Except Assistant"))
+			if(!istype(J, /datum/job/civilian/staff_assistant))
+				return TRUE
 
+		if(cache.Find("Engineering Department"))
+			if(J.job_category = JOB_ENGINEERING || istype(J, /datum/job/command/chief_engineer))
+				return TRUE
 
-	if(cache.Find("Everything Except Assistant"))
-		if(rank != "Staff Assistant" && rank != "Technical Assistant" && rank != "Medical Assistant")
-			return TRUE
+		if(cache.Find("Security Department") || cache.Find("Security Officer"))
+			if(J.job_category = JOB_SECURITY || istype(J, /datum/job/command/head_of_security))
+				return TRUE
 
-	if(cache.Find("Engineering Department"))
-		if(rank in list("Mining Supervisor","Engineer","Atmospheric Technician","Miner"))
-			return TRUE
-
-	if(cache.Find("Security Department") || cache.Find("Security Officer"))
-		if(rank in list("Security Officer","Security Assistant","Vice Officer","Detective"))
-			return TRUE
-
-	if(cache.Find("Heads of Staff"))
-		if(rank in list("Captain","Head of Personnel","Head of Security","Chief Engineer","Research Director","Medical Director"))
-			return TRUE
+		if(cache.Find("Heads of Staff"))
+			if(J.job_category = JOB_COMMAND)
+				return TRUE
 
 	if(cache.Find("Ghostdrone"))
 		if(rank in list("Ghostdrone","Remy","Bumblespider","Crow"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes jobban_isbanned check for department categories to use job_category and an istype for their department head.
Resulting changes:

- Add QM and Technical trainee and CE to Engineering Department
- Take Mining supervisor and Atmostech from Engineering Department
- Add Technical assistant and Medical assistant to "Everything but assistant" (these are trainees now and assistant means staffie)
- Take Vice Officer from security department (job's gone)
- Add HoS to security department (will probably never actually come into play but its still a sec job)
- Add Comms Officer to Heads of Staff (not that its seen with manta gone)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There are lots of lists of job strings everywhere, most of which are outdated, these should use category or type checks instead