### PR TITLE
Hidden mimics can't be shoved around 

### DIFF
--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -102,6 +102,7 @@
 		if (src.is_hiding)
 			return
 		src.is_hiding = TRUE
+		src.density = 0
 		qdel(src.name_tag)
 		src.name_tag = null
 		src.UpdateIcon()
@@ -113,6 +114,7 @@
 		if(!src.is_hiding)
 			return
 		src.is_hiding = FALSE
+		src.density = 1
 		src.name_tag = new()
 		src.update_name_tag()
 		src.vis_contents += src.name_tag

--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -101,7 +101,7 @@
 			return
 		if (src.is_hiding)
 			return
-		if (src.max_health > 50)
+		if (src.max_health >= 50)
 			src.density = 0
 		src.is_hiding = TRUE
 		qdel(src.name_tag)

--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -27,6 +27,7 @@
 	var/is_hiding = FALSE
 	///The last time our disguise was interrupted
 	var/last_disturbed = INFINITY
+	var/obj/current_disguise = null
 	///Time taken to hide if we sit still (Life interval dependent)
 	var/rehide_time = 5 SECONDS
 	var/pixel_amount = null
@@ -74,6 +75,7 @@
 		if (base_return)
 			src.dir_locked = FALSE
 			src.base_form = TRUE
+			src.current_disguise = null
 			src.appearance = /mob/living/critter/mimic/
 			src.stop_hiding()
 		else
@@ -81,6 +83,7 @@
 			var/pixels = null
 			src.dir_locked = TRUE
 			src.base_form = FALSE
+			src.current_disguise = target
 			src.appearance = target
 			src.dir = target.dir
 			src.invisibility = initial(src.invisibility)
@@ -101,8 +104,7 @@
 			return
 		if (src.is_hiding)
 			return
-		if (src.max_health >= 50)
-			src.density = 0
+		src.density = src.current_disguise.density
 		src.is_hiding = TRUE
 		qdel(src.name_tag)
 		src.name_tag = null

--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -101,8 +101,9 @@
 			return
 		if (src.is_hiding)
 			return
+		if (src.max_health > 50)
+			src.density = 0
 		src.is_hiding = TRUE
-		src.density = 0
 		qdel(src.name_tag)
 		src.name_tag = null
 		src.UpdateIcon()

--- a/code/mob/living/critter/mimic.dm
+++ b/code/mob/living/critter/mimic.dm
@@ -27,7 +27,7 @@
 	var/is_hiding = FALSE
 	///The last time our disguise was interrupted
 	var/last_disturbed = INFINITY
-	var/obj/current_disguise = null
+	var/hide_density = null
 	///Time taken to hide if we sit still (Life interval dependent)
 	var/rehide_time = 5 SECONDS
 	var/pixel_amount = null
@@ -75,7 +75,7 @@
 		if (base_return)
 			src.dir_locked = FALSE
 			src.base_form = TRUE
-			src.current_disguise = null
+			src.hide_density = 1
 			src.appearance = /mob/living/critter/mimic/
 			src.stop_hiding()
 		else
@@ -83,7 +83,7 @@
 			var/pixels = null
 			src.dir_locked = TRUE
 			src.base_form = FALSE
-			src.current_disguise = target
+			src.hide_density = target.density
 			src.appearance = target
 			src.dir = target.dir
 			src.invisibility = initial(src.invisibility)
@@ -104,7 +104,7 @@
 			return
 		if (src.is_hiding)
 			return
-		src.density = src.current_disguise.density
+		src.density = src.hide_density
 		src.is_hiding = TRUE
 		qdel(src.name_tag)
 		src.name_tag = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[critters] [balance] [qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Basic PR has the mimic copy its disguise's density when hiding.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mimics don't have a way to hop onto a table or anything so they're usually hiding on the ground, being able to just stumble into them and reveal them is a bit easy.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CalliopeSoups
(+)Mimics copy the density of their disguise while hiding, letting people walk over you as most items.
```
