### PR TITLE
Unique name for burning commol root requisitions

### DIFF
--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -466,6 +466,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 		if (typepath == /obj/item/reagent_containers/food/snacks/mushroom/cloak) name = "cloaked panellus mushroom"
 		else if (typepath == /obj/item/reagent_containers/food/snacks/mushroom/amanita) name = "amanita mushroom"
 		else if (typepath == /obj/item/reagent_containers/food/snacks/plant/tomato/incendiary) name = "volatile tomato"
+		else if (typepath == /obj/item/plant/herb/commol/burning) name = "warm commol root"
 
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label [bug] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Burning commol roots are referred to as 'warm commol roots' in requisition contracts.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

All commol mutation products are generically named 'commol root'. The requisitions should refer to them uniquely so as to not cause confusion. 

"Warm" instead of "burning" because 'warm' is included in the item description, which I think might make the distinction more obvious for non-botanists. 

fixes #23550
