### PR TITLE
More accurate directions

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -294,7 +294,7 @@
 
 	shoot(atom/target, var/mob/user, var/pointblank = FALSE, params)
 		if((..() && istype(user.loc, /turf/space) || user.no_gravity) && src.has_space_pushback)
-			user.inertia_dir = get_dir(target, user)
+			user.inertia_dir = get_dir_accurate(target, user)
 			step(user, user.inertia_dir)
 
 	arm38

--- a/code/mob/dead.dm
+++ b/code/mob/dead.dm
@@ -59,7 +59,7 @@ TYPEINFO(/mob/dead)
 		..()
 	else
 		if (GET_DIST(src, target) > 0)
-			src.set_dir(get_dir(src, target))
+			src.set_dir(get_dir_accurate(src, target))
 		src.examine_verb(target)
 
 /mob/dead/process_move(keys)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -982,7 +982,7 @@
 	u_equip(I)
 
 	if (GET_DIST(src, target) > 0)
-		src.set_dir(get_dir(src, target))
+		src.set_dir(get_dir_accurate(src, target, FALSE)) // Face the throwing direction
 
 	//actually throw it!
 	if (I)
@@ -990,7 +990,7 @@
 		I.layer = initial(I.layer)
 		var/yeet = 0 // what the fuck am I doing
 		var/yeet_change_mod = yeet_chance
-		var/throw_dir = get_dir(src, target)
+		var/throw_dir = get_dir_accurate(src, target)
 		if(src.mind)
 			if(src.mind.karma >= 50) //karma karma karma karma karma khamelion
 				yeet_change_mod *= 1
@@ -1012,7 +1012,7 @@
 			// Added log_reagents() call for drinking glasses. Also the location (Convair880).
 			logTheThing(LOG_COMBAT, src, "throws [I] [I.is_open_container() ? "[log_reagents(I)] " : ""][dir2text(throw_dir)] at [log_loc(src)].")
 		if (istype(src.loc, /turf/space) || src.no_gravity) //they're in space, move em one space in the opposite direction
-			src.inertia_dir = get_dir(target, src) // Float opposite direction from throw
+			src.inertia_dir = get_dir_accurate(target, src) // Float opposite direction from throw
 			step(src, inertia_dir)
 		if ((istype(I.loc, /turf/space) || I.no_gravity)  && ismob(I))
 			var/mob/M = I
@@ -3069,7 +3069,7 @@ Tries to put an item in an available backpack, belt storage, pocket, or hand slo
 			#endif
 
 			if(AM.throwforce >= 40)
-				src.throw_at(get_edge_target_turf(src,get_dir(AM, src)), 10, 1)
+				src.throw_at(get_edge_target_turf(src,get_dir_accurate(AM, src)), 10, 1)
 				src.changeStatus("stunned", 3 SECONDS)
 
 		else
@@ -3096,7 +3096,7 @@ Tries to put an item in an available backpack, belt storage, pocket, or hand slo
 		#endif
 
 		if(AM.throwforce >= 40)
-			src.throw_at(get_edge_target_turf(src, get_dir(AM, src)), 10, 1)
+			src.throw_at(get_edge_target_turf(src, get_dir_accurate(AM, src)), 10, 1)
 			src.changeStatus("stunned", 3 SECONDS)
 
 /// Goes through all the things that can be recolored and updates their colors

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -511,7 +511,7 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 			// Added log_reagents() call for drinking glasses. Also the location (Convair880).
 			logTheThing(LOG_COMBAT, src, "throws [I] [I.is_open_container() ? "[log_reagents(I)] " : ""][dir2text(throw_dir)] at [log_loc(src)].")
 		if (istype(src.loc, /turf/space) || src.no_gravity) //they're in space, move em one space in the opposite direction
-			src.inertia_dir = get_dir(target, src) // Float opposite direction from throw
+			src.inertia_dir = get_dir_accurate(target, src) // Float opposite direction from throw
 			step(src, inertia_dir)
 		if ((istype(I.loc, /turf/space) || I.no_gravity) && ismob(I))
 			var/mob/M = I

--- a/code/mob/living/intangible/ai-camera.dm
+++ b/code/mob/living/intangible/ai-camera.dm
@@ -209,7 +209,7 @@ TYPEINFO(/mob/living/intangible/aieye)
 				src.set_loc(target)
 
 			if (GET_DIST(src, target) > 0)
-				src.set_dir(get_dir(src, target))
+				src.set_dir(get_dir_accurate(src, target, FALSE)) // Eye faces target when interacting
 
 			if(in_ai_range)
 				target.attack_ai(src, params, location, control)

--- a/code/modules/chemistry/tools/extinguisher.dm
+++ b/code/modules/chemistry/tools/extinguisher.dm
@@ -180,7 +180,7 @@ var/global/list/extinguisher_blacklist_melt = list("acid",
 
 		playsound(src, 'sound/effects/spray.ogg', 30, TRUE, -3)
 
-		var/direction = get_dir(src,target)
+		var/direction = get_dir_accurate(src,target)
 
 		var/turf/T = get_turf(target)
 		var/turf/T1 = get_step(T,turn(direction, 90))
@@ -210,11 +210,12 @@ var/global/list/extinguisher_blacklist_melt = list("acid",
 				var/turf/my_target = pick(the_targets)
 				W.spray_at(my_target, R, try_connect_fluid = 1)
 
+		// Propel user in opposite direction
 		if (istype(user.loc, /turf/space))
-			user.inertia_dir = get_dir(target, user)
+			user.inertia_dir = get_dir_accurate(target, user)
 			step(user, user.inertia_dir)
 		else if( user.buckled && !user.buckled.anchored )
-			var/wooshdir = get_dir( target, user )
+			var/wooshdir = get_dir_accurate( target, user )
 			SPAWN(0)
 				for( var/i = 1, (user?.buckled && !user.buckled.anchored && i <= rand(3,5)), i++ )
 					step( user.buckled, wooshdir )

--- a/code/modules/interface/mob_input.dm
+++ b/code/modules/interface/mob_input.dm
@@ -97,14 +97,8 @@
 	//circumvented by some rude hack in client.dm; uncomment if hack ceases to exist
 	//if (istype(target, /atom/movable/screen/ability))
 	//	target:clicked(params)
-	if (GET_DIST(src, target) > 0)
-		if(src.can_turn())
-			set_dir(get_dir(src, target))
-			if(dir & (dir-1))
-				if (dir & EAST)
-					set_dir(EAST)
-				else if (dir & WEST)
-					set_dir(WEST)
+	if (GET_DIST(src, target) > 0 && src.can_turn())
+		set_dir(get_dir_accurate(src, target, FALSE)) // Face the direction of the target
 
 /**
  * This proc is called when a mob double clicks on something with the left mouse button.

--- a/code/modules/items/specials/ItemSpecials.dm
+++ b/code/modules/items/specials/ItemSpecials.dm
@@ -38,27 +38,26 @@
 				return NORTHEAST
 	return NORTH
 
-/proc/get_dir_accurate(var/atom/source, var/atom/target) // Get the closest direction rather than prioritizing a certain axis
+/// Get the closest direction to the target rather than prioritizing a certain axis
+/proc/get_dir_accurate(var/atom/source, var/atom/target, var/intercardinal = TRUE)
 	if(!source || !target)
 		CRASH("Invalid Params for get_dir_accurate: Source:[identify_object(source)] Target:[identify_object(target)]")
 	var/dir_angle = get_angle(source, target)
+	if(!intercardinal) // Only care about N,S,E, and W
+		switch(dir_angle)
+			if(45 to 135) return EAST
+			if(135 to 181, -181 to -135) return SOUTH
+			if(-135 to -45) return WEST
+			else return NORTH
 	switch(dir_angle)
-		if(22.5 to 67.5)
-			return NORTHEAST
-		if(67.5 to 112.5)
-			return EAST
-		if(112.5 to 157.5)
-			return SOUTHEAST
-		if(157.5 to 181, -181 to -157.5)
-			return SOUTH
-		if(-67.5 to -22.5)
-			return NORTHWEST
-		if(-112.5 to -67.5)
-			return WEST
-		if(-157.5 to -112.5)
-			return SOUTHWEST
-		else
-			return NORTH
+		if(22.5 to 67.5) return NORTHEAST
+		if(67.5 to 112.5) return EAST
+		if(112.5 to 157.5) return SOUTHEAST
+		if(157.5 to 181, -181 to -157.5) return SOUTH
+		if(-67.5 to -22.5) return NORTHWEST
+		if(-112.5 to -67.5) return WEST
+		if(-157.5 to -112.5) return SOUTHWEST
+		else return NORTH
 
 /proc/get_dir_pixel(var/atom/source, var/atom/target, params) //Get_dir using pixel coordinates of mouse
 	var/dx = (target.x - source.x) * 32

--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -329,13 +329,11 @@ toxic - poisons
 	var/strong = FALSE
 
 	on_pointblank(var/obj/projectile/P, var/mob/living/M)
-		// var/dir = angle2dir(angle)
-		M.throw_at(get_edge_target_turf(M, get_dir(P, M)),7,1, throw_type = THROW_GUNIMPACT)
+		M.throw_at(get_edge_target_turf(M, get_dir_accurate(P, M)),7,1, throw_type = THROW_GUNIMPACT)
 
-		//When it hits a mob or such should anything special happen
+	//When it hits a mob or such should anything special happen
 	on_hit(atom/hit, angle, var/obj/projectile/O)
-		// var/dir = angle2dir(angle)
-		var/dir = get_dir(O.shooter, hit)
+		var/dir = get_dir_accurate(O.shooter, hit)
 		var/pow = O.power
 		if (isliving(hit))
 			O.die()

--- a/code/obj/item/basketball.dm
+++ b/code/obj/item/basketball.dm
@@ -227,7 +227,6 @@
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 		if (!mounted && GET_DIST(src, target) == 1)
 			if (isturf(target) && target.density)
-				//if (get_dir(src,target) == NORTH || get_dir(src,target) == EAST || get_dir(src,target) == SOUTH || get_dir(src,target) == WEST)
 				if (get_dir(src,target) in cardinal)
 					src.visible_message(SPAN_NOTICE("<b>[user] mounts [src] on [target].</b>"))
 					user.drop_item()

--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -246,7 +246,7 @@ TYPEINFO(/obj/item/device/gps)
 			icon_state = "gps-off"
 			return
 
-		src.set_dir(get_dir(src,tracking_target))
+		src.set_dir(get_dir_accurate(src,tracking_target))
 		if (GET_DIST(src,tracking_target) == 0)
 			icon_state = "gps-direct"
 		else

--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -83,7 +83,7 @@ A Flamethrower in various states of assembly
 			return TRUE
 
 	log_shoot(mob/user, turf/T, obj/projectile/P)
-		logTheThing(LOG_COMBAT, user, "fires \a [src] ([lit ? "lit, " : ""][MODE_TO_STRING(mode)]) from [log_loc(user)], vector: ([T.x - user.x], [T.y - user.y]), dir: <I>[dir2text(get_dir(user, T))]</I>, reagents: [log_reagents(src.fueltank)] with chamber volume [amt_chem]")
+		logTheThing(LOG_COMBAT, user, "fires \a [src] ([lit ? "lit, " : ""][MODE_TO_STRING(mode)]) from [log_loc(user)], vector: ([T.x - user.x], [T.y - user.y]), dir: <I>[dir2text(get_dir_accurate(user, T))]</I>, reagents: [log_reagents(src.fueltank)] with chamber volume [amt_chem]")
 
 	/// allow refilling the fuel tank by simply clicking the reagent dispensers
 	afterattack(atom/target, mob/user, flag)

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -452,7 +452,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	return 0
 
 /obj/item/gun/proc/log_shoot(mob/user, turf/T, obj/projectile/P)
-	logTheThing(LOG_COMBAT, user, "fires \a [src] from [log_loc(user)], vector: ([T.x - user.x], [T.y - user.y]), dir: <I>[dir2text(get_dir(user, T))]</I>, projectile: <I>[P.name]</I>[P.proj_data && P.proj_data.type ? ", [P.proj_data.type]" : null]")
+	logTheThing(LOG_COMBAT, user, "fires \a [src] from [log_loc(user)], vector: ([T.x - user.x], [T.y - user.y]), dir: <I>[dir2text(get_dir_accurate(user, T))]</I>, projectile: <I>[P.name]</I>[P.proj_data && P.proj_data.type ? ", [P.proj_data.type]" : null]")
 
 /obj/item/gun/examine()
 	if (src.artifact)

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -215,8 +215,8 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 				FLICK(flick_state, src)
 
 		if(..() && istype(user.loc, /turf/space) || user.no_gravity)
-			user.inertia_dir = get_dir(target, user)
-			step(user, user.inertia_dir)
+			user.inertia_dir = get_dir_accurate(target, user)
+			step(user, user.inertia_dir) // Propel user in opposite direction
 
 	proc/eject_magazine(mob/user)
 		if (src.ammo.amount_left <= 0)


### PR DESCRIPTION
[player actions][qol]

## About the PR
- Replace a number of usages of the get_dir() proc (which prioritizes diagonals) with get_dir_accurate()

## Why's this needed?
- Controls and inertia more accurately reflect player inputs

## Changelog
```changelog
(u)LorrMaster
(+)Controls and inertia directions more accurately reflect player inputs
```
