### PR TITLE
SKIP_CAMERA_COVERAGE always treats things as on-camera

### DIFF
--- a/code/mob/living/intangible/ai-camera.dm
+++ b/code/mob/living/intangible/ai-camera.dm
@@ -521,8 +521,7 @@ TYPEINFO(/mob/living/intangible/aieye)
 		src.observing = null
 
 	examine_verb(atom/A as mob|obj|turf in view(,usr))
-		var/turf/T = get_turf(A)
-		if (!length(T.camera_coverage_emitters))
+		if (!seen_by_camera(A))
 			return
 		. = ..()
 

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2450,9 +2450,7 @@ proc/get_mobs_trackable_by_AI()
 			continue
 		if (M == usr)
 			continue
-
-		var/turf/T = get_turf(M)
-		if(!T.camera_coverage_emitters || !length(T.camera_coverage_emitters))
+		if(!seen_by_camera(M))
 			continue
 
 		var/name = M.name

--- a/code/mob/living/silicon/ai/camera_handling.dm
+++ b/code/mob/living/silicon/ai/camera_handling.dm
@@ -196,8 +196,7 @@
 		#ifndef UPSCALED_MAP
 		if(!failedToTrack) //We don't have a premature failure
 			failedToTrack = 1 //Assume failure
-			var/turf/T = get_turf(tracking)
-			if (T.camera_coverage_emitters && length(T.camera_coverage_emitters))
+			if (seen_by_camera(tracking))
 				failedToTrack = 0
 		#endif
 

--- a/code/mob/living/silicon/ai/holograms.dm
+++ b/code/mob/living/silicon/ai/holograms.dm
@@ -63,7 +63,7 @@
 			src.show_text("Your mainframe was unable relay this command that far away!", "red")
 			return
 
-		if (!istype(T) || length(T?.camera_coverage_emitters) == 0)
+		if (!istype(T) || !seen_by_camera(T))
 			boutput(eyecam, "No camera available to project a hologram from.")
 			return
 

--- a/code/modules/camera/network.dm
+++ b/code/modules/camera/network.dm
@@ -110,11 +110,11 @@
 
 /// Return true if atom is a turf or on a turf with camera coverage
 /proc/seen_by_camera(var/atom/atom)
+	if(isarea(atom) || !atom)
+		return FALSE
 	#ifdef SKIP_CAMERA_COVERAGE
 	return TRUE
 	#endif
-	if(isarea(atom))
-		return
 	var/turf/T = atom
 	if(!istype(T))
 		T = get_turf(atom)

--- a/code/modules/camera/network.dm
+++ b/code/modules/camera/network.dm
@@ -112,6 +112,8 @@
 /proc/seen_by_camera(var/atom/atom)
 	if(isarea(atom) || !atom)
 		return FALSE
+	if(!isturf(atom.loc))
+		return FALSE
 	#ifdef SKIP_CAMERA_COVERAGE
 	return TRUE
 	#endif

--- a/code/modules/camera/network.dm
+++ b/code/modules/camera/network.dm
@@ -108,7 +108,14 @@
 				candidate.vars[rec_var] = C
 				C.addToReferrers(candidate)
 
-/// Return true if mob is on a turf with camera coverage
-/proc/seen_by_camera(var/mob/M)
-	var/turf/T = get_turf(M)
+/// Return true if atom is a turf or on a turf with camera coverage
+/proc/seen_by_camera(var/atom/atom)
+	#ifdef SKIP_CAMERA_COVERAGE
+	return TRUE
+	#endif
+	if(isarea(atom))
+		return
+	var/turf/T = atom
+	if(!istype(T))
+		T = get_turf(atom)
 	. = (T.camera_coverage_emitters && length(T.camera_coverage_emitters))

--- a/code/modules/interface/input.dm
+++ b/code/modules/interface/input.dm
@@ -180,7 +180,7 @@ var/list/dirty_keystates = list()
 		if (src.mob.mob_flags & SEE_THRU_CAMERAS)
 			if(isturf(object))
 				var/turf/T = object
-				if (!length(T.camera_coverage_emitters))
+				if (!seen_by_camera(T))
 					return
 				else
 					if (parameters["right"])

--- a/code/obj/item/device/pda2/bot_control.dm
+++ b/code/obj/item/device/pda2/bot_control.dm
@@ -131,7 +131,7 @@
 		var/turf/summon_turf = get_turf(PDA)
 		if (isAIeye(usr))
 			summon_turf = get_turf(usr)
-			if (!(summon_turf.camera_coverage_emitters && length(summon_turf.camera_coverage_emitters)))
+			if (!seen_by_camera(summon_turf))
 				summon_turf = get_turf(PDA)
 
 		if(href_list["active"])
@@ -162,7 +162,7 @@
 				var/turf/summon_location = get_turf(usr) // summon_turf is already used
 				if((BOUNDS_DIST(get_turf(usr), get_turf(src.master)) == 0) || isAIeye(usr))
 					if(guardthis == "Here")
-						if(isAIeye(usr) && (summon_location.camera_coverage_emitters && length(summon_location.camera_coverage_emitters))) // God damn AI eyes
+						if(isAIeye(usr) && seen_by_camera(summon_location)) // God damn AI eyes
 							guardthis = get_area(get_turf(usr))
 						else
 							guardthis = get_area(get_turf(src.master))

--- a/code/obj/item/device/pda2/portable_machinery_control.dm
+++ b/code/obj/item/device/pda2/portable_machinery_control.dm
@@ -197,7 +197,7 @@
 				var/turf/our_loc = get_turf(PDA)
 				if (isAIeye(usr))
 					our_loc = get_turf(usr)
-					if (!(our_loc.camera_coverage_emitters && length(our_loc.camera_coverage_emitters)))
+					if (!seen_by_camera(our_loc))
 						boutput(usr, SPAN_ALERT("This area is not within your range of influence."))
 						return
 

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -870,7 +870,7 @@ Code:
 
 		if (isAIeye(usr))
 			var/turf/eye_loc = get_turf(usr)
-			if (length(eye_loc.camera_coverage_emitters))
+			if (seen_by_camera(eye_loc))
 				an_area = get_area(eye_loc)
 
 		signal.data["message"] = "***CRISIS ALERT*** Location: [an_area ? an_area.name : "nowhere"]!"

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -292,7 +292,7 @@ proc/reachable_in_n_steps(turf/from, turf/target, n_steps, use_gas_cross=FALSE)
 	. = list()
 
 	var/turf/T = get_turf(center)
-	if(length(T?.camera_coverage_emitters))
+	if(seen_by_camera(T))
 		for_by_tcl(theAI, /mob/living/silicon/ai)
 			if (theAI.deployed_to_eyecam)
 				var/mob/living/intangible/aieye/AIeye = theAI.eyecam


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Expand seen_by_camera() proc to accept any non-area atom and replace all camera coverage emitter checks for something being "on cams" with this global proc. This proc will always return TRUE if SKIP_CAMERA_COVERAGE is defined, treating everything as on-camera.
If an atom's loc is not a turf seen_by_camera will always return false as they're in a locker or something (possibly change to check loc's vis_contents in future for vehicles and the like)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If there's no camera network setup as the AI will see EVERYTHING as on-cam but any ability checking somethings on camera such as: summoning bots, examining things, tracking mobs, or placing holograms will fail so will other things that rely on camera coverage such as apply_automated_arrest.

