### PR TITLE
adds a slag shovel to donut 3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -9901,6 +9901,10 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
+/obj/item/slag_shovel{
+	pixel_x = 11;
+	pixel_y = 11
+	},
 /turf/simulated/floor/black/grime,
 /area/station/quartermaster/refinery)
 "cQy" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a slag shovel to the donut 3 refinery.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mainly consistency with all the other maps. Since #23264 got merged, people have been trying to dig more. Usually, the slag shovel is the only one around, but donut 3 is still missing one.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
