### PR TITLE
Fixes broken floor tiles in the Donut 2 bar

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -43013,7 +43013,7 @@
 	icon_state = "line1"
 	},
 /obj/mapping_helper/access/bar,
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/catering)
 "ssc" = (
 /obj/cable{

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -15816,7 +15816,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/table/reinforced/auto,
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/kitchen)
 "cwM" = (
 /obj/machinery/light_switch/south,
@@ -26351,7 +26351,7 @@
 /obj/machinery/light/small/floor,
 /obj/mapping_helper/firedoor_spawn,
 /obj/table/reinforced/auto,
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/kitchen)
 "iNJ" = (
 /obj/table/wood/auto,
@@ -34015,7 +34015,7 @@
 	dir = 8
 	},
 /obj/mapping_helper/firedoor_spawn,
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/kitchen)
 "nnN" = (
 /obj/cable{
@@ -45742,7 +45742,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/table/reinforced/auto,
-/turf/simulated/bar,
+/turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/kitchen)
 "tXu" = (
 /obj/machinery/atmospherics/binary/valve{


### PR DESCRIPTION
[bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Several floor tiles in the donut 2  bar are the wrong type, and can't be crowbarred or changed by the floor designer. This fixes that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is the bane of bartenders trying to redecorate. and bugs are pretty bad i guess.



