### PR TITLE
RoleControl only allows prioritizing jobs listed in the latejoin menu

### DIFF
--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -1065,69 +1065,11 @@ var/datum/job_controller/job_controls
 	logTheThing(LOG_DIARY, usr, "created special job [JOB.name]", "admin")
 	return JOB
 
-/// Search by job name for a ob datum from the set of jobs available for joining in the current round
+/// Searches all jobs in the controller by name, including special and hidden jobs, to find a match
 ///
-/// Returns the matching /datum/job, or null if it doesn't exist
+/// Returns the matching `/datum/job`, or `null` if there are no matches.
 ///
 /// Parameters:
-///
-/// job_name - string (default null): The job name to search for
-///
-/// staple_only - boolean (default FALSE): Only search staple jobs
-///
-/// soft - boolean (default FALSE): Do not log search misses
-///
-/// case_sensitive - boolean (default TRUE): match search string case exactly
-///
-/proc/find_available_job_by_string(job_name, staple_only = FALSE, soft = TRUE, case_sensitive = TRUE)
-	RETURN_TYPE(/datum/job)
-	if (!job_name || !istext(job_name))
-		logTheThing(LOG_DEBUG, null, "<b>Job Controller:</b> Attempt to find job with bad string '[job_name]' in controller detected")
-		return null
-
-	var/list/excluded_strings = list("Special Respawn","Custom Names","Everything Except Assistant",
-	"Engineering Department","Security Department","Heads of Staff", "Pod_Wars", "Syndicate", "Construction Worker", "MODE", "Ghostdrone", "Animal")
-	#ifndef MAP_OVERRIDE_MANTA
-	excluded_strings += "Communications Officer"
-	#endif
-	if (job_name in excluded_strings)
-		return null
-
-	var/list/results = list()
-	for (var/datum/job/J in job_controls.staple_jobs)
-		if (J.no_late_join)
-			continue
-		if (J.limit == 0)
-			continue
-		if (J.match_to_string(job_name, case_sensitive))
-			results += J
-
-	if (!staple_only)
-		for(var/datum/job/special/J in job_controls.special_jobs)
-			if (J.no_late_join)
-				continue
-			if (J.limit == 0)
-				continue
-			if (J.match_to_string(job_name, case_sensitive))
-				results += J
-
-		for(var/datum/job/created/J in job_controls.special_jobs)
-			if (J.no_late_join)
-				continue
-			if (J.limit == 0)
-				continue
-			if (J.match_to_string(job_name, case_sensitive))
-				results += J
-
-	if(length(results) == 1)
-		return results[1]
-	else if(length(results) > 1)
-		stack_trace("Multiple jobs share the name '[job_name]'!")
-		return results[1]
-	if (!soft)
-		logTheThing(LOG_DEBUG, null, "No job found with name '[job_name]'!")
-
-/// Searches all jobs in the controller by name, including special and hidden jobs, to find a match
 ///
 /// string - string (default ""): The job name to search for
 ///
@@ -1137,8 +1079,9 @@ var/datum/job_controller/job_controls
 ///
 /// case_sensitive - boolean (default TRUE): match search string case exactly
 ///
+/// latejoin_available - boolean (default: FALSE): Only list jobs that can currently be late-joined
 ///
-/proc/find_job_in_controller_by_string(var/string, var/staple_only = 0, var/soft = FALSE, var/case_sensitive = TRUE)
+/proc/find_job_in_controller_by_string(var/string, var/staple_only = 0, var/soft = FALSE, var/case_sensitive = TRUE, var/latejoin_available = FALSE)
 	RETURN_TYPE(/datum/job)
 	if (!string || !istext(string))
 		logTheThing(LOG_DEBUG, null, "<b>Job Controller:</b> Attempt to find job with bad string '[string]' in controller detected")
@@ -1152,15 +1095,26 @@ var/datum/job_controller/job_controls
 		return null
 	var/list/results = list()
 	for (var/datum/job/J in job_controls.staple_jobs)
+		if (latejoin_available)
+			if (J.no_late_join)
+				continue
+			if (J.limit == 0)
+				continue
 		if (J.match_to_string(string, case_sensitive))
 			results += J
 	if (!staple_only)
 		for (var/datum/job/J in job_controls.special_jobs)
+			if (latejoin_available)
+				if (J.no_late_join)
+					continue
+				if (J.limit == 0)
+					continue
 			if (J.match_to_string(string, case_sensitive))
 				results += J
-		for (var/datum/job/J in job_controls.hidden_jobs)
-			if (J.match_to_string(string, case_sensitive))
-				results += J
+		if (!latejoin_available)
+			for (var/datum/job/J in job_controls.hidden_jobs)
+				if (J.match_to_string(string, case_sensitive))
+					results += J
 	if(length(results) == 1)
 		return results[1]
 	else if(length(results) > 1)

--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -1079,9 +1079,9 @@ var/datum/job_controller/job_controls
 ///
 /// case_sensitive - boolean (default TRUE): match search string case exactly
 ///
-/// latejoin_available - boolean (default: FALSE): Only list jobs that can currently be late-joined
+/// latejoin_only - boolean (default: FALSE): Only list jobs that can currently be late-joined
 ///
-/proc/find_job_in_controller_by_string(var/string, var/staple_only = 0, var/soft = FALSE, var/case_sensitive = TRUE, var/latejoin_available = FALSE)
+/proc/find_job_in_controller_by_string(var/string, var/staple_only = 0, var/soft = FALSE, var/case_sensitive = TRUE, var/latejoin_only = FALSE)
 	RETURN_TYPE(/datum/job)
 	if (!string || !istext(string))
 		logTheThing(LOG_DEBUG, null, "<b>Job Controller:</b> Attempt to find job with bad string '[string]' in controller detected")
@@ -1095,7 +1095,7 @@ var/datum/job_controller/job_controls
 		return null
 	var/list/results = list()
 	for (var/datum/job/J in job_controls.staple_jobs)
-		if (latejoin_available)
+		if (latejoin_only)
 			if (J.no_late_join)
 				continue
 			if (J.limit == 0)
@@ -1104,14 +1104,14 @@ var/datum/job_controller/job_controls
 			results += J
 	if (!staple_only)
 		for (var/datum/job/J in job_controls.special_jobs)
-			if (latejoin_available)
+			if (latejoin_only)
 				if (J.no_late_join)
 					continue
 				if (J.limit == 0)
 					continue
 			if (J.match_to_string(string, case_sensitive))
 				results += J
-		if (!latejoin_available)
+		if (!latejoin_only)
 			for (var/datum/job/J in job_controls.hidden_jobs)
 				if (J.match_to_string(string, case_sensitive))
 					results += J

--- a/code/modules/networks/computer3/job_controls.dm
+++ b/code/modules/networks/computer3/job_controls.dm
@@ -48,7 +48,7 @@ var/datum/job/priority_job = null
 					global.priority_job = null
 					src.print_text("Cleared priority job listing.")
 					return
-				var/datum/job/job = find_available_job_by_string(job_name, soft = TRUE, case_sensitive = FALSE)
+				var/datum/job/job = find_job_in_controller_by_string(job_name, soft = TRUE, case_sensitive = FALSE, latejoin_available = TRUE)
 				if (!job)
 					src.print_text("Error: unable to identify role with name \[[job_name]\]")
 					return
@@ -58,7 +58,7 @@ var/datum/job/priority_job = null
 
 			if ("info")
 				var/job_name = command_list.Join(" ") //all later arguments are assumed to just be parts of the job name
-				var/datum/job/job = find_available_job_by_string(job_name, soft = TRUE, case_sensitive = FALSE)
+				var/datum/job/job = find_job_in_controller_by_string(job_name, soft = TRUE, case_sensitive = FALSE, latejoin_available = TRUE)
 				if (!job)
 					src.print_text("Error: unable to identify role with name \[[job_name]\]")
 					return

--- a/code/modules/networks/computer3/job_controls.dm
+++ b/code/modules/networks/computer3/job_controls.dm
@@ -48,7 +48,7 @@ var/datum/job/priority_job = null
 					global.priority_job = null
 					src.print_text("Cleared priority job listing.")
 					return
-				var/datum/job/job = find_job_in_controller_by_string(job_name, soft = TRUE, case_sensitive = FALSE, latejoin_available = TRUE)
+				var/datum/job/job = find_job_in_controller_by_string(job_name, soft = TRUE, case_sensitive = FALSE, latejoin_only= TRUE)
 				if (!job)
 					src.print_text("Error: unable to identify role with name \[[job_name]\]")
 					return
@@ -58,7 +58,7 @@ var/datum/job/priority_job = null
 
 			if ("info")
 				var/job_name = command_list.Join(" ") //all later arguments are assumed to just be parts of the job name
-				var/datum/job/job = find_job_in_controller_by_string(job_name, soft = TRUE, case_sensitive = FALSE, latejoin_available = TRUE)
+				var/datum/job/job = find_job_in_controller_by_string(job_name, soft = TRUE, case_sensitive = FALSE, latejoin_only = TRUE)
 				if (!job)
 					src.print_text("Error: unable to identify role with name \[[job_name]\]")
 					return

--- a/code/modules/networks/computer3/job_controls.dm
+++ b/code/modules/networks/computer3/job_controls.dm
@@ -48,7 +48,7 @@ var/datum/job/priority_job = null
 					global.priority_job = null
 					src.print_text("Cleared priority job listing.")
 					return
-				var/datum/job/job = find_job_in_controller_by_string(job_name, soft = TRUE, case_sensitive = FALSE)
+				var/datum/job/job = find_available_job_by_string(job_name, soft = TRUE, case_sensitive = FALSE)
 				if (!job)
 					src.print_text("Error: unable to identify role with name \[[job_name]\]")
 					return
@@ -58,7 +58,7 @@ var/datum/job/priority_job = null
 
 			if ("info")
 				var/job_name = command_list.Join(" ") //all later arguments are assumed to just be parts of the job name
-				var/datum/job/job = find_job_in_controller_by_string(job_name, soft = TRUE, case_sensitive = FALSE)
+				var/datum/job/job = find_available_job_by_string(job_name, soft = TRUE, case_sensitive = FALSE)
 				if (!job)
 					src.print_text("Error: unable to identify role with name \[[job_name]\]")
 					return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][station systems]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a parameter to the proc that finds jobs by string to limit it to jobs that show up in the late join menu.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
RoleControl lets you prioritize *any* valid job name, including hidden jobs, like "Discount Godzilla" or "Junior Syndicate Agent" right now. This also stops you from prioritizing daily jobs that don't match the current day, like trying to get Tourists on a Monday.