### PR TITLE
Adjust tick lag logic

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -480,9 +480,11 @@ var/global/game_force_started = FALSE
 				var/cpu_low = ((world.cpu <= TICKLAG_CPU_MIN) && (pred_cpu_low < TICKLAG_CPU_MAX))
 
 				if (cpu_over_high || cpu_over_predicted)
-					++highCpuCount
+					if (highCpuCount < TICKLAG_INCREASE_THRESHOLD)
+						++highCpuCount
 				else if (cpu_low)
-					--highCpuCount
+					if (highCpuCount > -TICKLAG_DECREASE_THRESHOLD)
+						--highCpuCount
 
 				// Map-CPU counters
 				var/map_over_high = (world.map_cpu >= TICKLAG_MAPCPU_MAX)
@@ -490,9 +492,11 @@ var/global/game_force_started = FALSE
 				var/map_low = ((world.map_cpu <= TICKLAG_MAPCPU_MIN) && (pred_map_low < TICKLAG_MAPCPU_MAX))
 
 				if (map_over_high || map_over_predicted)
-					++highMapCpuCount
+					if (highMapCpuCount < TICKLAG_INCREASE_THRESHOLD)
+						++highMapCpuCount
 				else if (map_low)
-					--highMapCpuCount
+					if (highMapCpuCount > -TICKLAG_DECREASE_THRESHOLD)
+						--highMapCpuCount
 
 				// adjust the tick_lag, if needed
 				var/dilated_tick_lag

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -477,17 +477,17 @@ var/global/game_force_started = FALSE
 				var/pred_map_high  = world.map_cpu * (world.tick_lag / next_higher_tl)
 				var/pred_map_low   = world.map_cpu * (world.tick_lag / next_lower_tl)
 
-				if (world.cpu >= TICKLAG_CPU_MAX)
-					if (pred_cpu_high >= TICKLAG_CPU_MAX && highCpuCount < TICKLAG_INCREASE_THRESHOLD)
+				if ((world.cpu >= TICKLAG_CPU_MAX) && (pred_cpu_high >= TICKLAG_CPU_MAX))
+					if (highCpuCount < TICKLAG_INCREASE_THRESHOLD)
 						highCpuCount++
-				else if (world.cpu <= TICKLAG_CPU_MIN)
-					if (pred_cpu_low < TICKLAG_CPU_MAX && highCpuCount > -TICKLAG_DECREASE_THRESHOLD)
+				else if ((world.cpu <= TICKLAG_CPU_MIN) && (pred_cpu_low < TICKLAG_CPU_MAX))
+					if (highCpuCount > -TICKLAG_DECREASE_THRESHOLD)
 						highCpuCount--
-				if (world.map_cpu >= TICKLAG_MAPCPU_MAX)
-					if (pred_map_high >= TICKLAG_MAPCPU_MAX && highMapCpuCount < TICKLAG_INCREASE_THRESHOLD)
+				if ((world.map_cpu >= TICKLAG_MAPCPU_MAX) && (pred_map_high >= TICKLAG_MAPCPU_MAX))
+					if (highMapCpuCount < TICKLAG_INCREASE_THRESHOLD)
 						highMapCpuCount++
-				else if (world.map_cpu <= TICKLAG_MAPCPU_MIN)
-					if (pred_map_low < TICKLAG_MAPCPU_MAX && highMapCpuCount > -TICKLAG_DECREASE_THRESHOLD)
+				else if ((world.map_cpu <= TICKLAG_MAPCPU_MIN) && (pred_map_low < TICKLAG_MAPCPU_MAX))
+					if (highMapCpuCount > -TICKLAG_DECREASE_THRESHOLD)
 						highMapCpuCount--
 
 				// adjust the tick_lag, if needed

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -471,21 +471,28 @@ var/global/game_force_started = FALSE
 
 				// Pre-compute the next lower tick-lag and what CPU would look like
 				var/next_lower_tick_lag = max(world.tick_lag - TICKLAG_DILATION_DEC, timeDilationLowerBound)
-				var/pred_cpu_low  = world.cpu     * (world.tick_lag / next_lower_tick_lag)
-				var/pred_map_low  = world.map_cpu * (world.tick_lag / next_lower_tick_lag)
+				var/pred_cpu_low = world.cpu * (world.tick_lag / next_lower_tick_lag)
+				var/pred_map_low = world.map_cpu * (world.tick_lag / next_lower_tick_lag)
 
-				if (world.cpu >= TICKLAG_CPU_MAX)
-					if (highCpuCount < TICKLAG_INCREASE_THRESHOLD)
-						highCpuCount++
-				else if ((world.cpu <= TICKLAG_CPU_MIN) && (pred_cpu_low < TICKLAG_CPU_MAX))
-					if (highCpuCount > -TICKLAG_DECREASE_THRESHOLD)
-						highCpuCount--
-				if (world.map_cpu >= TICKLAG_MAPCPU_MAX)
-					if (highMapCpuCount < TICKLAG_INCREASE_THRESHOLD)
-						highMapCpuCount++
-				else if ((world.map_cpu <= TICKLAG_MAPCPU_MIN) && (pred_map_low < TICKLAG_MAPCPU_MAX))
-					if (highMapCpuCount > -TICKLAG_DECREASE_THRESHOLD)
-						highMapCpuCount--
+				// CPU counters
+				var/cpu_over_high = (world.cpu >= TICKLAG_CPU_MAX)
+				var/cpu_over_predicted = ((pred_cpu_low >= TICKLAG_CPU_MAX) && (highCpuCount < 0))
+				var/cpu_low = ((world.cpu <= TICKLAG_CPU_MIN) && (pred_cpu_low < TICKLAG_CPU_MAX))
+
+				if (cpu_over_high || cpu_over_predicted)
+					++highCpuCount
+				else if (cpu_low)
+					--highCpuCount
+
+				// Map-CPU counters
+				var/map_over_high = (world.map_cpu >= TICKLAG_MAPCPU_MAX)
+				var/map_over_predicted = ((pred_map_low >= TICKLAG_MAPCPU_MAX) && (highMapCpuCount < 0))
+				var/map_low = ((world.map_cpu <= TICKLAG_MAPCPU_MIN) && (pred_map_low < TICKLAG_MAPCPU_MAX))
+
+				if (map_over_high || map_over_predicted)
+					++highMapCpuCount
+				else if (map_low)
+					--highMapCpuCount
 
 				// adjust the tick_lag, if needed
 				var/dilated_tick_lag

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -469,21 +469,18 @@ var/global/game_force_started = FALSE
 			if (world.time > last_try_dilate + TICKLAG_DILATE_INTERVAL) //interval separate from the process loop. maybe consider moving this for cleanup later (its own process loop with diff. interval?)
 				last_try_dilate = world.time
 
-				var/next_higher_tl = min(world.tick_lag + TICKLAG_DILATION_INC, timeDilationUpperBound)
-				var/next_lower_tl  = max(world.tick_lag - TICKLAG_DILATION_DEC, timeDilationLowerBound)
+				// Pre-compute the next lower tick-lag and what CPU would look like
+				var/next_lower_tl = max(world.tick_lag - TICKLAG_DILATION_DEC, timeDilationLowerBound)
+				var/pred_cpu_low  = world.cpu     * (world.tick_lag / next_lower_tl)
+				var/pred_map_low  = world.map_cpu * (world.tick_lag / next_lower_tl)
 
-				var/pred_cpu_high  = world.cpu     * (world.tick_lag / next_higher_tl)
-				var/pred_cpu_low   = world.cpu     * (world.tick_lag / next_lower_tl)
-				var/pred_map_high  = world.map_cpu * (world.tick_lag / next_higher_tl)
-				var/pred_map_low   = world.map_cpu * (world.tick_lag / next_lower_tl)
-
-				if ((world.cpu >= TICKLAG_CPU_MAX) && (pred_cpu_high >= TICKLAG_CPU_MAX))
+				if (world.cpu >= TICKLAG_CPU_MAX)
 					if (highCpuCount < TICKLAG_INCREASE_THRESHOLD)
 						highCpuCount++
 				else if ((world.cpu <= TICKLAG_CPU_MIN) && (pred_cpu_low < TICKLAG_CPU_MAX))
 					if (highCpuCount > -TICKLAG_DECREASE_THRESHOLD)
 						highCpuCount--
-				if ((world.map_cpu >= TICKLAG_MAPCPU_MAX) && (pred_map_high >= TICKLAG_MAPCPU_MAX))
+				if (world.map_cpu >= TICKLAG_MAPCPU_MAX)
 					if (highMapCpuCount < TICKLAG_INCREASE_THRESHOLD)
 						highMapCpuCount++
 				else if ((world.map_cpu <= TICKLAG_MAPCPU_MIN) && (pred_map_low < TICKLAG_MAPCPU_MAX))

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -477,7 +477,7 @@ var/global/game_force_started = FALSE
 				// CPU counters
 				var/cpu_over_high = (world.cpu >= TICKLAG_CPU_MAX)
 				var/cpu_over_predicted = ((pred_cpu_low >= TICKLAG_CPU_MAX) && (highCpuCount < 0))
-				var/cpu_low = ((world.cpu <= TICKLAG_CPU_MIN) && (pred_cpu_low < TICKLAG_CPU_MAX))
+				var/cpu_low = (((world.cpu <= TICKLAG_CPU_MIN) && (pred_cpu_low < TICKLAG_CPU_MAX)) || ((world.cpu <= TICKLAG_CPU_MIN) && (highCpuCount > 0)))
 
 				if (cpu_over_high || cpu_over_predicted)
 					if (highCpuCount < TICKLAG_INCREASE_THRESHOLD)
@@ -489,7 +489,7 @@ var/global/game_force_started = FALSE
 				// Map-CPU counters
 				var/map_over_high = (world.map_cpu >= TICKLAG_MAPCPU_MAX)
 				var/map_over_predicted = ((pred_map_low >= TICKLAG_MAPCPU_MAX) && (highMapCpuCount < 0))
-				var/map_low = ((world.map_cpu <= TICKLAG_MAPCPU_MIN) && (pred_map_low < TICKLAG_MAPCPU_MAX))
+				var/map_low = (((world.map_cpu <= TICKLAG_MAPCPU_MIN) && (pred_map_low < TICKLAG_MAPCPU_MAX)) || ((world.map_cpu <= TICKLAG_MAPCPU_MIN) && (highMapCpuCount > 0)))
 
 				if (map_over_high || map_over_predicted)
 					if (highMapCpuCount < TICKLAG_INCREASE_THRESHOLD)

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -497,7 +497,6 @@ var/global/game_force_started = FALSE
 				else if (max(highCpuCount, highMapCpuCount) <= -TICKLAG_DECREASE_THRESHOLD)
 					dilated_tick_lag = round(max(world.tick_lag - TICKLAG_DILATION_DEC, timeDilationLowerBound), min(TICKLAG_DILATION_INC, TICKLAG_DILATION_DEC))
 
-
 				// only set the value if it changed! earlier iteration of this was
 				// setting world.tick_lag very often, which caused instability with
 				// the networking. do not spam change world.tick_lag! you will regret it!

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -489,7 +489,13 @@ var/global/game_force_started = FALSE
 				if (max(highCpuCount, highMapCpuCount) >= TICKLAG_INCREASE_THRESHOLD)
 					dilated_tick_lag = round(min(world.tick_lag + TICKLAG_DILATION_INC,	timeDilationUpperBound), min(TICKLAG_DILATION_INC, TICKLAG_DILATION_DEC))
 				else if (max(highCpuCount, highMapCpuCount) <= -TICKLAG_DECREASE_THRESHOLD)
-					dilated_tick_lag = round(max(world.tick_lag - TICKLAG_DILATION_DEC, timeDilationLowerBound), min(TICKLAG_DILATION_INC, TICKLAG_DILATION_DEC))
+					var/next_tick_lag = round(max(world.tick_lag - TICKLAG_DILATION_DEC, timeDilationLowerBound), min(TICKLAG_DILATION_INC, TICKLAG_DILATION_DEC))
+					// Predict CPU usage if we lowered ticklag
+					var/predicted_cpu = world.cpu * (world.tick_lag / next_tick_lag)
+					// only lower tick lag if the predicted cpu is lower than the upperbound to re-raise it to prevent oscillating ticklag values
+					if (predicted_cpu < TICKLAG_CPU_MAX)
+						dilated_tick_lag = next_tick_lag
+
 
 				// only set the value if it changed! earlier iteration of this was
 				// setting world.tick_lag very often, which caused instability with

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -470,9 +470,9 @@ var/global/game_force_started = FALSE
 				last_try_dilate = world.time
 
 				// Pre-compute the next lower tick-lag and what CPU would look like
-				var/next_lower_tl = max(world.tick_lag - TICKLAG_DILATION_DEC, timeDilationLowerBound)
-				var/pred_cpu_low  = world.cpu     * (world.tick_lag / next_lower_tl)
-				var/pred_map_low  = world.map_cpu * (world.tick_lag / next_lower_tl)
+				var/next_lower_tick_lag = max(world.tick_lag - TICKLAG_DILATION_DEC, timeDilationLowerBound)
+				var/pred_cpu_low  = world.cpu     * (world.tick_lag / next_lower_tick_lag)
+				var/pred_map_low  = world.map_cpu * (world.tick_lag / next_lower_tick_lag)
 
 				if (world.cpu >= TICKLAG_CPU_MAX)
 					if (highCpuCount < TICKLAG_INCREASE_THRESHOLD)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Initial world.tick_lag | next_tick_lag | CPU Multiplier | New world.cpu Threshold (Original: 70%)
-- | -- | -- | --
0.8 | 0.6 | 0.8 / 0.6 ≈ 1.3333 | 90 / 1.3333 ≈ 67.5%
0.6 | 0.4 | 0.6 / 0.4 = 1.5 | 90 / 1.5 = 60.0%
0.4 | 0.2 | 0.4 / 0.2 = 2.0 | 90 / 2.0 = 45.0%

* Makes lowering of ticklag a bit less aggressive than it is currently. In the current system the ticklag will attempt to lower whenever server CPU is below 70%, however if the CPU is higher than the above thresholds the resulting new CPU usage will be above 90%, instantly beginning the process to re-raise the ticklag
* CPU predictions above 90% will allow the ticklag counters to raise, but only up to 0. Any further will require actual high cpu at the current tick lag tier.
* CPU below 70% will allow tack lag counters to lower from values above 0, but lowering to -10 to trigger a tick lag change will also require the predicted cpu to be low enough as well. Combined with the above change this should prevent tick lag from drifting needlessly when otherwise running at a stable time dilation

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mostly to address the issue of servers bouncing between 0.2 and 0.4

The frequent oscillation between 0.2 and 0.4 has resulted in many players reporting lag that's being caused by the over aggressive attempts to lower tick lag on the server leaving them with a degraded experience.