### PR TITLE
You must use an aggressive grab to move with someone already in an aggressive grab

### DIFF
--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -311,9 +311,24 @@
 								src.remove_pulling()
 								//hud.update_pulling() // FIXME
 							else
-								pulling += src.pulling
+								var/can_pull = TRUE
+								if (ismob(src.pulling))
+									var/mob/M = src.pulling
+									for(var/obj/item/grab/grab_grabbed_by in M.grabbed_by)
+										if (grab_grabbed_by.assailant != src && grab_grabbed_by.state > GRAB_PASSIVE)
+											can_pull = FALSE
+											src.remove_pulling()
+											break
+								if (can_pull)
+									pulling += src.pulling
 						for (var/obj/item/grab/G in src.equipped_list(check_for_magtractor = 0))
-							pulling += G.affecting
+							var/can_pull = TRUE
+							for(var/obj/item/grab/grab_grabbed_by in G.affecting.grabbed_by)
+								if (grab_grabbed_by.assailant != src && grab_grabbed_by.state > G.state)
+									can_pull = FALSE
+									break
+							if (can_pull)
+								pulling += G.affecting
 
 						for (var/atom/movable/A in pulling)
 							if (GET_DIST(src, A) == 0) // if we're moving onto the same tile as what we're pulling, don't pull


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][player actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When moving with a grab or pull, check if the target is in someone else's aggressive grab. If so, only move them if your grab is stronger than a passive grab.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Very easy to save people from someone being eaten by a abom changeling with pulls/passive grabs, when eating them requires an aggressive grab. 

This prevents silicons from pulling people out of aggressive grabs entirely.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)You must use an aggressive grab to pull people away from aggressive grabs.
```
