### PR TITLE
Fixes typo in Cyber Incompatible record listing

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1167,7 +1167,7 @@ TYPEINFO(/datum/trait/partyanimal)
 	icon_state = "cyber_incompatible"
 	points = 1
 	disability_type = TRAIT_DISABILITY_MAJOR
-	disability_name = "Cybernetics Incompatable"
+	disability_name = "Cybernetics Incompatibility"
 	disability_desc = "Patient is incompatible with all forms of cybernetic augmentation, including cyborgification."
 
 	onAdd(mob/owner)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This fixes a typo in cybernetics incompatibility's name in medical records, and rewords it slightly to be in line with how other traits are displayed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Typos bad!



