### PR TITLE
Infinity Dragon's Beard Fix

### DIFF
--- a/code/modules/cooking/food_and_drink/candy.dm
+++ b/code/modules/cooking/food_and_drink/candy.dm
@@ -829,6 +829,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy/wrapped_candy/taffy
 				src.desc = "A loop of dragon's beard candy that has been folded into uncountable microscopic strands."
 				src.real_name = "infinity-fold dragon's beard candy loop"
 				src.eat_message = "[src] immediately dissolves in your mouth."
+				if (src.reagents.total_volume + 3 > src.reagents.maximum_volume)
+					src.reagents.remove_any(3) // we need space for the msg
 				src.reagents.add_reagent("enriched_msg", 3)
 
 /obj/item/reagent_containers/food/snacks/candy/dragons_beard/infinity
@@ -839,6 +841,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy/wrapped_candy/taffy
 
 	New()
 		..()
+		if (src.reagents.total_volume + 3 > src.reagents.maximum_volume)
+			src.reagents.remove_any(3) // we need space for the msg
 		src.reagents.add_reagent("enriched_msg", 3)
 
 /obj/item/reagent_containers/food/snacks/candy/dragons_beard_cut

--- a/code/modules/cooking/food_and_drink/candy.dm
+++ b/code/modules/cooking/food_and_drink/candy.dm
@@ -839,12 +839,6 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy/wrapped_candy/taffy
 	icon_state = "dragonsbeard-loopinf"
 	folds = 32
 
-	New()
-		..()
-		if (src.reagents.total_volume + 3 > src.reagents.maximum_volume)
-			src.reagents.remove_any(3) // we need space for the msg
-		src.reagents.add_reagent("enriched_msg", 3)
-
 /obj/item/reagent_containers/food/snacks/candy/dragons_beard_cut
 	name = "dragon's beard candy"
 	desc = "A piece of dragon's beard candy."


### PR DESCRIPTION
[BUG] [OBJECTS] [CATERING]

## About the PR
Makes sure that the dragons beard infinity candy always has space for the enriched msg by removing some if its full
also removes the unnessacary add reagent in new() as it updates itself anyway

## Why's this needed?
buge fix