### PR TITLE
Table Construction QoL Improvements

### DIFF
--- a/_std/defines/obj.dm
+++ b/_std/defines/obj.dm
@@ -11,6 +11,8 @@
 #define HAS_DIRECTIONAL_BLOCKING (1<<3)
 /// prevents ghost critter interaction. On obj so it can cover machinery, items etc...
 #define NO_GHOSTCRITTER (1<<4)
+/// allows for tables to be built under items they normally wouldn't be able to be built under, such as microwaves and personal computers
+#define NO_BLOCK_TABLE (1<<5)
 
 /// At which alpha do opague objects become see-through?
 #define MATERIAL_ALPHA_OPACITY 190

--- a/code/modules/cooking/microwave.dm
+++ b/code/modules/cooking/microwave.dm
@@ -53,6 +53,7 @@ TYPEINFO(/obj/machinery/microwave)
 	var/obj/item/reagent_containers/food/snacks/being_cooked = null
 	/// Single non food item that can be added to the microwave
 	var/obj/item/extra_item
+	object_flags = NO_BLOCK_TABLE
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH
 	var/emagged = FALSE
 

--- a/code/modules/cooking/mixer.dm
+++ b/code/modules/cooking/mixer.dm
@@ -18,6 +18,7 @@ TYPEINFO(/obj/machinery/mixer)
 	density = 1
 	anchored = ANCHORED
 	flags = TGUI_INTERACTIVE
+	object_flags = NO_BLOCK_TABLE
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 
 	var/image/blender_off

--- a/code/modules/disposals/disposal.dm
+++ b/code/modules/disposals/disposal.dm
@@ -1586,6 +1586,7 @@ TYPEINFO(/obj/item/reagent_containers/food/snacks/einstein_loaf)
 	anchored = ANCHORED
 	density = 1
 	weldable = FALSE
+	object_flags = NO_BLOCK_TABLE
 	var/turf/stuff_chucking_target
 	HELP_MESSAGE_OVERRIDE("The smart disposal outlet cannot be detached by welding.")
 
@@ -1653,6 +1654,7 @@ TYPEINFO(/obj/item/reagent_containers/food/snacks/einstein_loaf)
 	name = "filter disposal outlet"
 	desc = "A disposal outlet with a little sensor in it, to allow it to filter out unwanted things from the system."
 	icon_state = "unblockoutlet"
+	object_flags = NO_BLOCK_TABLE
 	var/turf/stuff_chucking_target
 	var/list/allowed_types = list()
 
@@ -2038,6 +2040,7 @@ TYPEINFO(/obj/disposaloutlet)
 	icon_state = "outlet"
 	density = 1
 	anchored = ANCHORED
+	object_flags = NO_BLOCK_TABLE
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_SCREWDRIVER
 	var/active = 0
 	var/turf/target	// this will be where the output objects are 'thrown' to.

--- a/code/modules/networks/computer3/buildandrepair.dm
+++ b/code/modules/networks/computer3/buildandrepair.dm
@@ -49,6 +49,7 @@ TYPEINFO(/obj/item/motherboard)
 		max_peripherals = 3
 		metal_given = 3
 		glass_needed = 1
+		object_flags = NO_BLOCK_TABLE
 
 
 	azungarcomputer_upper

--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -58,6 +58,7 @@
 			setup_starting_peripheral1 = /obj/item/peripheral/network/powernet_card/terminal
 			setup_starting_peripheral2 = /obj/item/peripheral/sound_card
 			setup_starting_program = /datum/computer/file/terminal_program/email
+			object_flags = NO_BLOCK_TABLE
 
 			personel_alt
 				icon_state = "old_alt"

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1702,6 +1702,7 @@ TYPEINFO(/obj/machinery/networked/printer)
 	desc = "A networked printer.  It's designed to print."
 	anchored = ANCHORED
 	density = 1
+	object_flags = NO_BLOCK_TABLE
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WIRECUTTERS | DECON_MULTITOOL | DECON_DESTRUCT
 	icon_state = "printer0"
 	device_tag = "PNET_PRINTDEVC"
@@ -2179,6 +2180,7 @@ TYPEINFO(/obj/machinery/networked/printer)
 	anchored = ANCHORED
 	density = 1
 	icon_state = "scanner0"
+	object_flags = NO_BLOCK_TABLE
 	deconstruct_flags = DECON_DESTRUCT
 	//device_tag = "PNET_SCANDEVC"
 	var/scanning = 0 //Are we scanning RIGHT NOW?

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -4779,6 +4779,7 @@ TYPEINFO(/obj/machinery/guardbot_dock)
 	icon_state = "tour"
 	pixel_y = 8
 	var/obj/machinery/bot/guardbot/linked_bot = null
+	object_flags = NO_BLOCK_TABLE
 
 	New()
 		..()

--- a/code/obj/item/device/mic_amp_etc.dm
+++ b/code/obj/item/device/mic_amp_etc.dm
@@ -94,6 +94,7 @@ TYPEINFO(/obj/loudspeaker)
 	icon_state = "loudspeaker"
 	anchored = ANCHORED
 	density = 1
+	object_flags = NO_BLOCK_TABLE
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_MULTITOOL
 
 	New()

--- a/code/obj/item/misc_junk.dm
+++ b/code/obj/item/misc_junk.dm
@@ -481,6 +481,7 @@ TYPEINFO(/obj/item/reagent_containers/vape)
 	density = 1
 	icon = 'icons/obj/wrestlingbell.dmi'
 	icon_state = "wrestlingbell"
+	object_flags = NO_BLOCK_TABLE
 	deconstruct_flags = DECON_WRENCH
 	var/last_ring = 0
 

--- a/code/obj/item/table_rack_parts.dm
+++ b/code/obj/item/table_rack_parts.dm
@@ -669,7 +669,7 @@ TYPEINFO(/obj/item/furniture_parts/woodenstool)
 
 			var/obj/blocker
 			for (var/obj/O in target_turf)
-				if (O.density)
+				if (O.density && !(HAS_FLAG(O.object_flags, HAS_DIRECTIONAL_BLOCKING) || (ispath(parts.furniture_type, /obj/table) && HAS_FLAG(O.object_flags, NO_BLOCK_TABLE))))
 					blocker = O
 					break
 

--- a/code/obj/machinery/espresso.dm
+++ b/code/obj/machinery/espresso.dm
@@ -13,6 +13,7 @@ TYPEINFO(/obj/machinery/espresso_machine)
 	anchored = ANCHORED
 	flags = NOSPLASH | TGUI_INTERACTIVE
 	event_handler_flags = NO_MOUSEDROP_QOL
+	object_flags = NO_BLOCK_TABLE
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS
 	var/cupslimit = 2
 	var/cupsinside = 0
@@ -190,6 +191,7 @@ TYPEINFO(/obj/machinery/coffeemaker)
 	density = 1
 	anchored = ANCHORED
 	flags = NOSPLASH
+	object_flags = NO_BLOCK_TABLE
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS
 	var/carafe_name = "coffee carafe"
 	var/image/image_top = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature][actions][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a "NO_BLOCK_TABLE" flag to a couple of object types which usually spawn on tables (such as personal computers and wrestling bells). Parts-based furniture construction will ignore blockages from objects with directional blocking and, if the furniture item in question is a table, objects with the new NO_BLOCK_TABLE flag.

The following items have been given the NO_BLOCK_TABLE flag and can thus now have tables constructed under them:
KitchenHelper food mixers
Loudspeakers
Disposal outlets
Personal computers (and their frames)
Espresso machines
Coffee machines
Tourbot consoles
Wrestling bells
Printers
Scanners


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, should a table or rack on the same tile as a thindow be deconstructed, it will be unnecessarily difficult to rebuild said table/rack without also removing the thindow. This PR also solves a similar case with items which spawn on tables - most notably personal computers - preventing broken tables from being rebuilt under them.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)nova2053
(+)Tables, racks, and other items which use a similar construction method can now be constructed on the same tile as thindows, sliding glass doors, and other objects with directional blocking.
(+)Tables can now be constructed under a couple more objects, such as microwaves, espresso machines, and more. See PR page for full list.
```
