### PR TITLE
Tweaks cogmap2's engine wiring

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -20990,9 +20990,6 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/obj/cable/orange{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "bne" = (
@@ -21937,16 +21934,13 @@
 	dir = 5
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/caution/corner/ne,
 /area/station/engine/hotloop)
 "bpU" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
-	},
-/obj/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs{
 	dir = 8
@@ -22487,6 +22481,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "corner_east"
@@ -22509,10 +22506,7 @@
 "brN" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
@@ -22582,12 +22576,6 @@
 	name = "Combustion Chamber Heat Shield";
 	pixel_x = -20;
 	pixel_y = 26
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
@@ -23050,14 +23038,13 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
 	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
 	pixel_x = -24
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
@@ -24307,20 +24294,20 @@
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bxn" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/inner)
-"bxo" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
+/obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/caution/south,
+/area/station/engine/inner)
+"bxo" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
@@ -24329,9 +24316,6 @@
 	dir = 4
 	},
 /obj/machinery/light_switch/north,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bxq" = (
@@ -24343,9 +24327,6 @@
 	pixel_y = 21
 	},
 /obj/machinery/meter,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bxr" = (
@@ -24353,10 +24334,7 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/west,
 /area/station/engine/inner)
@@ -24364,8 +24342,8 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/cable/orange{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/caution/east,
 /area/station/engine/inner)
@@ -24378,16 +24356,10 @@
 	pixel_y = 21
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bxv" = (
 /obj/table/reinforced/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/item/sheet/steel/fullstack,
 /obj/random_item_spawner/tools,
 /turf/simulated/floor/plating,
@@ -24395,18 +24367,12 @@
 "bxw" = (
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/tools,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/item/sheet/steel/reinforced/fullstack,
 /obj/item/sheet/steel/reinforced/fullstack,
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bxx" = (
 /obj/table/reinforced/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/item/sheet/glass/fullstack,
 /obj/item/sheet/glass/fullstack,
 /obj/item/sheet/glass/reinforced/fullstack,
@@ -24420,47 +24386,36 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bxz" = (
 /obj/storage/closet/fire,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bxA" = (
 /obj/decal/cleanable/cobweb2,
 /obj/storage/closet/fire,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bxB" = (
-/obj/decal/poster/wallsign/fire,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/engine/gas)
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "bxC" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/binary/valve{
+	dir = 4;
+	name = "hot auxillary valve"
 	},
-/obj/decal/stripe_caution,
-/turf/simulated/floor,
-/area/station/engine/gas)
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "bxD" = (
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
@@ -24938,13 +24893,16 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/caution/corner/nw,
 /area/station/engine/inner)
 "byZ" = (
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
@@ -24956,6 +24914,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
+	},
+/obj/cable{
+	icon_state = "5-8"
 	},
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
@@ -24980,6 +24941,9 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-9"
+	},
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
 	},
@@ -24988,6 +24952,9 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/inner)
 "bzg" = (
@@ -24995,7 +24962,10 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/caution/north{
 	dir = 1
@@ -25005,20 +24975,23 @@
 /obj/disposalpipe/junction{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
 	},
 /area/station/engine/inner)
 "bzi" = (
 /obj/decal/poster/wallsign/hazard_hotloop,
-/obj/cable/orange{
-	icon_state = "1-2"
-	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
 "bzj" = (
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
@@ -26723,6 +26696,9 @@
 /area/station/hallway/primary/west)
 "bEf" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/stairs{
 	dir = 1
 	},
@@ -26734,6 +26710,9 @@
 	pixel_y = 21
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bEl" = (
@@ -29554,6 +29533,9 @@
 /area/station/hallway/primary/east)
 "bLA" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/stairs,
 /area/station/engine/inner)
 "bLC" = (
@@ -29561,6 +29543,9 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bLG" = (
@@ -31195,6 +31180,9 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/caution/north{
 	dir = 8
 	},
@@ -31203,6 +31191,9 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /obj/disposalpipe/segment/transport{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/north{
 	dir = 8
@@ -31215,6 +31206,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
 	},
@@ -31225,6 +31219,9 @@
 	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/inner)
@@ -31238,6 +31235,9 @@
 	},
 /obj/machinery/light_switch/north,
 /obj/decal/stripe_caution,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/routing/engine)
 "bQF" = (
@@ -31764,30 +31764,21 @@
 /area/station/engine/inner)
 "bSa" = (
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/west,
 /area/station/engine/inner)
 "bSc" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/caution/east,
 /area/station/engine/inner)
 "bSd" = (
 /obj/machinery/light/small,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bSe" = (
 /obj/table/reinforced/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/item/sheet/steel/fullstack,
 /obj/item/sheet/steel/fullstack,
 /obj/random_item_spawner/tools,
@@ -31797,21 +31788,12 @@
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/tools,
 /obj/item/reagent_containers/food/drinks/fueltank,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/item/sheet/steel/reinforced/fullstack,
 /obj/item/sheet/steel/reinforced/fullstack,
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bSg" = (
 /obj/table/reinforced/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/item/sheet/glass/fullstack,
 /obj/item/sheet/glass/reinforced/fullstack,
 /obj/item/storage/belt/utility,
@@ -31821,33 +31803,18 @@
 "bSh" = (
 /obj/machinery/light/small,
 /obj/machinery/portable_atmospherics/canister/empty,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bSi" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/portable_atmospherics/canister/empty,
-/obj/cable{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bSj" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating/scorched,
 /area/station/engine/inner)
 "bSk" = (
 /obj/decal/poster/wallsign/fire,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/engine)
 "bSl" = (
@@ -31857,11 +31824,16 @@
 /turf/simulated/floor/grime,
 /area/station/routing/engine)
 "bSm" = (
-/obj/cable{
-	icon_state = "2-8"
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
-/turf/simulated/floor/grime,
-/area/station/routing/engine)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/caution/northsouth{
+	dir = 1
+	},
+/area/station/engine/inner)
 "bSn" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/grime,
@@ -54054,9 +54026,6 @@
 	level = 2
 	},
 /obj/machinery/light,
-/obj/cable/orange{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "dPz" = (
@@ -54144,12 +54113,15 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
 "dSM" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/binary/valve{
 	name = "combustion chamber bypass valve";
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
@@ -54207,8 +54179,8 @@
 /area/station/ai_monitored/storage/eva)
 "dVS" = (
 /obj/machinery/light,
-/obj/cable/orange{
-	icon_state = "1-2"
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
@@ -54252,6 +54224,9 @@
 	},
 /obj/cable/orange{
 	icon_state = "0-2"
+	},
+/obj/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/inner)
@@ -54714,6 +54689,22 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/engine/storage)
+"eAe" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "engine_observation";
+	name = "Observation Shutter";
+	opacity = 0
+	},
+/obj/cable/orange,
+/obj/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engine/inner)
 "eAi" = (
 /obj/table/auto,
 /obj/random_item_spawner/med_tool,
@@ -56183,6 +56174,9 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/north,
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/grime,
 /area/station/routing/engine)
 "gdq" = (
@@ -57066,9 +57060,6 @@
 "gVq" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
-	},
-/obj/cable/orange{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -58049,9 +58040,6 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/cable/orange{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "hNZ" = (
@@ -58804,9 +58792,6 @@
 "isV" = (
 /obj/cable/orange{
 	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/inner)
@@ -61090,6 +61075,9 @@
 /obj/cable/orange{
 	icon_state = "0-2"
 	},
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/core)
 "ksF" = (
@@ -61354,10 +61342,7 @@
 	dir = 4
 	},
 /obj/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/inner)
@@ -61792,9 +61777,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/southwest)
 "kYu" = (
-/obj/cable/orange{
-	icon_state = "0-2"
-	},
 /obj/machinery/computer/power_monitor/smes{
 	dir = 8;
 	name = "Engine Output Monitoring"
@@ -61803,6 +61785,9 @@
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
+	},
+/obj/cable/orange{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -61826,6 +61811,9 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/engineering,
 /obj/decal/stripe_delivery,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/routing/engine)
 "kZS" = (
@@ -63661,9 +63649,6 @@
 /obj/cable/orange{
 	icon_state = "0-2"
 	},
-/obj/cable/orange{
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/core)
 "mIX" = (
@@ -63888,6 +63873,9 @@
 	opacity = 0
 	},
 /obj/cable/orange,
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/core)
 "mSd" = (
@@ -65142,7 +65130,7 @@
 /area/station/crew_quarters/hop)
 "odN" = (
 /obj/cable/orange{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -65800,6 +65788,9 @@
 	icon_state = "1-2"
 	},
 /obj/decal/stripe_caution,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/inner)
 "oMp" = (
@@ -67911,6 +67902,9 @@
 	icon_state = "1-2"
 	},
 /obj/decal/stripe_caution,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/inner)
 "qNE" = (
@@ -68526,6 +68520,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai)
+"rlv" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grime,
+/area/station/engine/gas)
 "rlM" = (
 /obj/machinery/door/poddoor/pyro/shutters{
 	density = 0;
@@ -68738,6 +68741,12 @@
 /mob/living/critter/small_animal/cockroach,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"rwq" = (
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "rxl" = (
 /obj/decal/poster/wallsign/stencil/right/r{
 	pixel_x = 16
@@ -69747,6 +69756,10 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/fitness)
+"sAV" = (
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "sBM" = (
 /obj/disposalpipe/segment/morgue{
 	icon_state = "pipe-c"
@@ -71354,9 +71367,6 @@
 	icon_state = "4-8"
 	},
 /obj/cable/orange{
-	icon_state = "0-4"
-	},
-/obj/cable/orange{
 	icon_state = "0-8"
 	},
 /obj/cable/orange,
@@ -71743,6 +71753,9 @@
 /obj/cable/orange{
 	icon_state = "0-8"
 	},
+/obj/cable/orange{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/inner)
 "uAV" = (
@@ -71883,6 +71896,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hangar/qm)
+"uIC" = (
+/turf/simulated/floor/grime,
+/area/station/routing/engine)
 "uIO" = (
 /obj/mesh/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -72180,11 +72196,14 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "uVo" = (
-/obj/cable/orange{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
 	},
-/turf/simulated/floor/orangeblack,
-/area/station/engine/hotloop)
+/obj/cable{
+	icon_state = "6-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "uVv" = (
 /obj/machinery/light/small/floor,
 /obj/decal/stripe_delivery,
@@ -73073,6 +73092,12 @@
 /obj/effects/background_objects/iudicium,
 /turf/space,
 /area/space)
+"vVK" = (
+/obj/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "vWj" = (
 /obj/mesh/grille/steel,
 /turf/simulated/floor/grime,
@@ -73173,6 +73198,9 @@
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/engineering_atmos,
 /obj/decal/stripe_delivery,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/gas)
 "waT" = (
@@ -73415,6 +73443,9 @@
 /area/station/maintenance/outer/ne)
 "wrQ" = (
 /obj/machinery/firealarm/east,
+/obj/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "wsg" = (
@@ -111345,7 +111376,7 @@ jOa
 lTm
 jOa
 dYf
-nEr
+eAe
 llT
 byT
 tgp
@@ -111647,7 +111678,7 @@ bGa
 fyt
 bJU
 bLA
-dRH
+sAV
 bOV
 byT
 bRS
@@ -112548,11 +112579,11 @@ bxj
 byV
 wtr
 gVq
-bGc
+rwq
 bGc
 gXp
 bGc
-bGc
+rwq
 gVq
 wtr
 bQp
@@ -112849,12 +112880,12 @@ bij
 pZD
 byV
 liE
-osT
-bGc
+bxC
+rwq
 bGc
 gXp
 bGc
-bGc
+rwq
 osT
 liE
 bQp
@@ -113156,7 +113187,7 @@ odN
 rLc
 xMN
 rLc
-odN
+vVK
 dOT
 bAF
 bQq
@@ -113752,7 +113783,7 @@ bpO
 wcb
 hZe
 bvn
-bxn
+bxo
 byY
 rfU
 bCu
@@ -114658,7 +114689,7 @@ bpS
 brK
 bty
 bvn
-bxo
+uVo
 bzb
 vGY
 snV
@@ -115565,7 +115596,7 @@ brN
 btB
 sli
 bxr
-bze
+bxn
 bAL
 bCz
 eat
@@ -115863,7 +115894,7 @@ blq
 bmK
 bor
 dSM
-hJM
+bxB
 dVS
 bzi
 kFD
@@ -116165,7 +116196,7 @@ bjK
 bon
 bos
 bpW
-uVo
+hJM
 wrQ
 yfP
 bxt
@@ -116481,7 +116512,7 @@ bKd
 bLN
 bCy
 bPf
-bQv
+bSm
 bSd
 bTC
 bVn
@@ -116783,7 +116814,7 @@ bGo
 bEv
 bCy
 bAL
-bQv
+bSm
 bSe
 bTC
 bVo
@@ -117387,7 +117418,7 @@ bKf
 bLP
 bCy
 bAL
-bQv
+bSm
 bSg
 bTE
 bVq
@@ -117689,7 +117720,7 @@ bKg
 bLQ
 bCy
 oVL
-bQv
+bSm
 bSh
 bTC
 bVr
@@ -118293,7 +118324,7 @@ bKi
 bLS
 bCy
 bPi
-bQv
+bSm
 bSj
 bTC
 eEu
@@ -118584,7 +118615,7 @@ bqd
 sEs
 btJ
 box
-bxB
+btJ
 waK
 bAQ
 bCD
@@ -118886,7 +118917,7 @@ bqe
 brY
 btK
 bvo
-bxC
+btK
 bzj
 bAQ
 bCE
@@ -118898,7 +118929,7 @@ bLT
 heG
 bPj
 bQD
-bSl
+uIC
 bTI
 bVv
 bWY
@@ -119189,7 +119220,7 @@ brZ
 brZ
 bvp
 bxD
-bzk
+rlv
 bAQ
 sna
 bED
@@ -119200,7 +119231,7 @@ bLU
 tdV
 bPj
 gdf
-bSm
+bWZ
 bTJ
 bVw
 bWZ

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -23046,6 +23046,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "btE" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping] [qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Basic PR that shuffles some wires around so that they don't cover heat pipes fully. Not sure if this needs a changelog, let me know if not.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cog2's engine sets on fire a lot. I asked around about it and it turns out pipe breaches can be difficult to spot because a lot of wires layer over the pipes. 


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CalliopeSoups
(+)Cogmap 2's engine has less heat pipe covering wires.
```
