### PR TITLE
Portable pumps will now shut off when ejecting a tank.

### DIFF
--- a/code/modules/atmospherics/portable/pump.dm
+++ b/code/modules/atmospherics/portable/pump.dm
@@ -168,7 +168,7 @@ TYPEINFO(/obj/machinery/portable_atmospherics/pump)
 				. = TRUE
 		if("eject-tank")
 			src.eject_tank()
-			src.on = FALSE
+			src.turn_off()
 			. = TRUE
 
 /obj/machinery/portable_atmospherics/pump/suicide(var/mob/living/carbon/human/user)

--- a/code/modules/atmospherics/portable/pump.dm
+++ b/code/modules/atmospherics/portable/pump.dm
@@ -9,7 +9,7 @@ TYPEINFO(/obj/machinery/portable_atmospherics/pump)
 	dir = NORTH //so it spawns with the fan side showing
 	density = 1
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER
-	var/on = 0
+	var/on = FALSE
 	var/direction_out = 0 //0 = siphoning, 1 = releasing
 	var/target_pressure = 100
 	var/image/tank_hatch
@@ -168,6 +168,7 @@ TYPEINFO(/obj/machinery/portable_atmospherics/pump)
 				. = TRUE
 		if("eject-tank")
 			src.eject_tank()
+			src.on = FALSE
 			. = TRUE
 
 /obj/machinery/portable_atmospherics/pump/suicide(var/mob/living/carbon/human/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the behavior of portable atmos pumps (the blue things) to automatically turn off when they eject tanks.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is a QOL fix change that makes the behavior of portable pumps match the behavior of the larger gas canisters, which automatically close when you eject the tank. Its weird that their behaviors don't match and this often results in unintended plasma floods.
