### PR TITLE
Synth Leg Absorbtion

### DIFF
--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -907,11 +907,46 @@
 	easy_attach = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_PLANT)
+	var/datum/fluid_group/absorbing_group = null //! Used to tell when the fluid has changed to reduce message spam
 
 	New(var/atom/holder)
 		if (holder != null)
 			set_loc(holder)
 		..()
+
+	on_life()
+		. = ..()
+		if(!src.holder)
+			return
+		var/turf/T = get_turf(src.holder)
+		if(!T.active_liquid?.group?.reagents)
+			src.absorbing_group = null
+			return
+		if(!prob(30) || !ishuman(src.holder))
+			return
+		var/mob/living/carbon/human/H = src.holder
+		if(HAS_FLAG(H.wear_suit?.c_flags, SPACEWEAR) || HAS_FLAG(H.w_uniform?.c_flags, SPACEWEAR))
+			return // Can't absorb through space suit
+		else if(H.shoes)
+			if(T.active_liquid.my_depth_level >= depth_levels[2])
+				// Absorb through shoes if legs are submerged
+				absorb_reagents(T.active_liquid, 5)
+		else
+			absorb_reagents(T.active_liquid, 5)
+
+	proc/absorb_reagents(var/obj/fluid/fluid, var/absorbtion_rate)
+		var/datum/reagents/R = fluid.group.reagents
+		if(!R.total_volume)
+			return
+		if(fluid.group != src.absorbing_group)
+			var/tasteMessage = SPAN_NOTICE("[R.get_taste_string(src.holder)]")
+			src.holder.visible_message(SPAN_NOTICE("[src.holder]'s [src] begins to absorb the fluid from [src]."),"[SPAN_NOTICE("You begin to absorb the fluid from [src].")]\n[tasteMessage]", group = "[src.holder]_drink_messages")
+			src.absorbing_group = fluid.group
+		R.reaction(src.holder, INGEST, clamp(R.total_volume, CHEM_EPSILON, min(absorbtion_rate, (src.holder.reagents?.maximum_volume - src.holder.reagents?.total_volume))))
+		R.trans_to(src.holder, min(R.total_volume, absorbtion_rate))
+		playsound(src.holder.loc,'sound/items/drink.ogg', rand(10,20), 1)
+		eat_twitch(src.holder)
+
 
 /obj/item/parts/human_parts/leg/right/synth
 	name = "synthetic right leg"
@@ -927,12 +962,45 @@
 	easy_attach = TRUE
 	limb_is_unnatural = TRUE
 	kind_of_limb = (LIMB_PLANT)
+	var/datum/fluid_group/absorbing_group = null //! Used to tell when the fluid has changed to reduce message spam
 
 	New(var/atom/holder)
 		if (holder != null)
 			set_loc(holder)
 		..()
 
+	on_life()
+		. = ..()
+		if(!src.holder)
+			return
+		var/turf/T = get_turf(src.holder)
+		if(!T.active_liquid?.group?.reagents)
+			src.absorbing_group = null
+			return
+		if(!prob(30) || !ishuman(src.holder))
+			return
+		var/mob/living/carbon/human/H = src.holder
+		if(HAS_FLAG(H.wear_suit?.c_flags, SPACEWEAR) || HAS_FLAG(H.w_uniform?.c_flags, SPACEWEAR))
+			return // Can't absorb through space suit
+		else if(H.shoes)
+			if(T.active_liquid.my_depth_level >= depth_levels[2])
+				// Absorb through shoes if legs are submerged
+				absorb_reagents(T.active_liquid, 5)
+		else
+			absorb_reagents(T.active_liquid, 5)
+
+	proc/absorb_reagents(var/obj/fluid/fluid, var/absorbtion_rate)
+		var/datum/reagents/R = fluid.group.reagents
+		if(!R.total_volume)
+			return
+		if(fluid.group != src.absorbing_group)
+			var/tasteMessage = SPAN_NOTICE("[R.get_taste_string(src.holder)]")
+			src.holder.visible_message(SPAN_NOTICE("[src.holder]'s [src] begins to absorb the fluid from [src]."),"[SPAN_NOTICE("You begin to absorb the fluid from [src].")]\n[tasteMessage]", group = "[src.holder]_drink_messages")
+			src.absorbing_group = fluid.group
+		R.reaction(src.holder, INGEST, clamp(R.total_volume, CHEM_EPSILON, min(absorbtion_rate, (src.holder.reagents?.maximum_volume - src.holder.reagents?.total_volume))))
+		R.trans_to(src.holder, min(R.total_volume, absorbtion_rate))
+		playsound(src.holder.loc,'sound/items/drink.ogg', rand(10,20), 1)
+		eat_twitch(src.holder)
 
 /obj/item/parts/human_parts/arm/left/synth/bloom
 	desc = "A left arm. Looks like a rope composed of vines. There's some little flowers on it."

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -439,18 +439,17 @@
 			if(prob(30))
 				absorb_reagents(T.active_liquid.group, absorbtion_rate)
 			return
-		else if(T.active_liquid.my_depth_level < 2)
-			// Fluid not deep enough to absorb through shoes/suit
+		if(T.active_liquid.my_depth_level < 2)
+			return // Fluid not deep enough to absorb through shoes/suit
+
+		// Less likely to absorb based on chem protection
+		var/chem_prot = clamp(GET_ATOM_PROPERTY(H, PROP_MOB_CHEMPROT), 0, 40)
+		if(chem_prot >= 40)
 			return
-		else
-			// Less likely to absorb based on chem protection
-			var/chem_prot = clamp(GET_ATOM_PROPERTY(H, PROP_MOB_CHEMPROT), 0, 40)
-			if(chem_prot >= 40)
-				return
-			var/absorb_prob = (30 - (chem_prot / 2))
-			if(!prob(absorb_prob))
-				return
-			absorb_reagents(T.active_liquid.group, absorbtion_rate)
+		var/absorb_prob = (30 - (chem_prot / 2))
+		if(!prob(absorb_prob))
+			return
+		absorb_reagents(T.active_liquid.group, absorbtion_rate)
 
 	proc/absorb_reagents(var/datum/fluid_group/fluids, var/absorbtion_rate)
 		var/datum/reagents/R = fluids.reagents


### PR DESCRIPTION
[hydroponics][feature][add to wiki]

## About the PR 
- Synth & kudzu legs will now passively "drink" reagents from fluid puddles while you stand on them. This counts as ingesting them.
- The effect can be avoided in fluids below depth level 2 by wearing shoes.
- The absorption frequency scales down with chem protection, being negated entirely at 40%.

## Why's this needed? 
- Thematic effect to differentiate plant legs

## Changelog 
```changelog
(u)LorrMaster
(*)Synth legs will now passively absorb reagents. Shoes prevent the effect in shallow fluids. An additional chem protection of 40% prevents it while submerged.
```
