### PR TITLE
Puts the bar juicer in the bartender tallcloset

### DIFF
--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -947,7 +947,8 @@ ADMIN_INTERACT_PROCS(/obj/storage/secure/closet, proc/break_open)
 	req_access = list(access_bar)
 	spawn_contents = list(/obj/item/gun/russianrevolver,\
 	/obj/item/reagent_containers/food/drinks/bottle/vintage,\
-	/obj/item/storage/box/glassbox)
+	/obj/item/storage/box/glassbox,\
+	/obj/item/reagent_containers/food/drinks/juicer)
 
 /obj/storage/secure/closet/civilian/chaplain
 	name = "\improper Religious supplies locker"

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -5167,7 +5167,6 @@
 /area/station/crew_quarters/catering)
 "ard" = (
 /obj/table/auto,
-/obj/item/reagent_containers/food/drinks/juicer,
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -48283,7 +48283,6 @@
 /area/station/maintenance/northwest)
 "vwb" = (
 /obj/storage/secure/closet/civilian/bartender,
-/obj/item/reagent_containers/food/drinks/juicer,
 /obj/item/storage/box/donkpocket_kit{
 	pixel_x = -7;
 	pixel_y = 4

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -39365,10 +39365,6 @@
 /area/station/engine/inner)
 "lYc" = (
 /obj/table/auto,
-/obj/item/reagent_containers/food/drinks/juicer{
-	pixel_x = -4;
-	pixel_y = 10
-	},
 /obj/item/swingsignfolded,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -30549,7 +30549,6 @@
 /area/station/hangar/engine)
 "dFj" = (
 /obj/rack,
-/obj/item/reagent_containers/food/drinks/juicer,
 /obj/item/swingsignfolded,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1427,7 +1427,7 @@
 /area/station/hallway/primary/northeast)
 "aEY" = (
 /obj/machinery/manufacturer/general{
-	free_resources = list(/obj/item/material_piece/steel = 1, /obj/item/material_piece/copper = 1, /obj/item/material_piece/glass = 1)
+	free_resources = list(/obj/item/material_piece/steel=1,/obj/item/material_piece/copper=1,/obj/item/material_piece/glass=1)
 	},
 /turf/simulated/floor/black,
 /area/station/storage/emergencyinternals)
@@ -9087,7 +9087,7 @@
 /area/shuttle/arrival/station)
 "eez" = (
 /obj/machinery/manufacturer/general{
-	free_resources = list(/obj/item/material_piece/steel = 1, /obj/item/material_piece/copper = 1, /obj/item/material_piece/glass = 1)
+	free_resources = list(/obj/item/material_piece/steel=1,/obj/item/material_piece/copper=1,/obj/item/material_piece/glass=1)
 	},
 /turf/simulated/floor/plating,
 /area/pasiphae/maint)
@@ -40981,9 +40981,6 @@
 	pixel_x = -12
 	},
 /obj/rack,
-/obj/item/reagent_containers/food/drinks/juicer{
-	pixel_y = 5
-	},
 /obj/item/storage/box/fruit_wedges,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
@@ -44867,7 +44864,7 @@
 	pixel_y = 1
 	},
 /obj/machinery/manufacturer/uniform{
-	free_resources = list(/obj/item/material_piece/cloth/cottonfabric = 5)
+	free_resources = list(/obj/item/material_piece/cloth/cottonfabric=5)
 	},
 /turf/simulated/floor/blueblack{
 	dir = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label --[Catering][qol]>

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Puts the juice-o-matic in the bartender tallcloset (not to be confused with wall closet), so that it can be on every map without people having to headache about it in the future. Also removes the juicers that were laying out since they'll be in the closet.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
it's actually a decently useful tool-- even though it does the same things the reagent extractor does,, it's portability and ease of use set it apart. it was only on like half the maps. Shoutout to the person who mhelped about this yesterday!