### PR TITLE
Balance AEX shell pricing

### DIFF
--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -755,7 +755,7 @@ datum/commodity/drugs/sell/poppies
 	comname = "12ga AEX ammo"
 	comtype = /obj/item/ammo/bullets/aex
 	desc = "12 gauge ammo marked 12ga AEX Large Wildlife Dispersal Cartridge. Huh."
-	price = PAY_EMBEZZLED
+	price = PAY_EMBEZZLED * 2.5
 
 /datum/commodity/contraband/flare
 	comname = "12ga Flare Shells"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR  Doubles the base price of AEX rounds for balancing<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
[Balance]


## Why's this needed? Aex rounds are incredibly overpowered and stupidly cheap<!-- Describe why you think this should be added to the game. -->



## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bobbis Dobbis
(+)AEX shell price now 2.5x the original for balancing.
```
