### PR TITLE
Make mobs in small_animal able to go through flaps freely.

### DIFF
--- a/code/modules/economy/supply_misc.dm
+++ b/code/modules/economy/supply_misc.dm
@@ -110,7 +110,7 @@ TYPEINFO(/obj/strip_door)
 				return TRUE
 			else if (isintangible(A))
 				return TRUE
-			else if (istype(A,/mob/living/critter/changeling/handspider) || istype(A,/mob/living/critter/changeling/eyespider))
+			else if (istype(A,/mob/living/critter/changeling/handspider) || istype(A,/mob/living/critter/changeling/eyespider) || istype(A,/mob/living/critter/small_animal))
 				return TRUE
 			else if (isdead(M))
 				return TRUE
@@ -128,6 +128,8 @@ TYPEINFO(/obj/strip_door)
 			return
 		if (isliving(A))
 			var/mob/living/M = A
+			if (istype(A,/mob/living/critter/small_animal))
+				A.layer = src.layer - 0.01
 			var/density = src.flap_material.hasProperty("density") ? src.flap_material.getProperty("density") : 3
 			M.changeStatus("slowed", 2 SECONDS, density * 2)
 		src.flap_material.triggerOnEntered(src, A)
@@ -137,6 +139,8 @@ TYPEINFO(/obj/strip_door)
 		..()
 		if (isliving(A))
 			var/mob/living/M = A
+			if (istype(A,/mob/living/critter/small_animal))
+				A.layer = MOB_LAYER
 			M.delStatus("slowed")
 
 	ex_act(severity)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR This makes it so any small critter (mainly ghost critters, but anything in the small_critter catagory will be affected by this.) will be capable of moving through flaps, but will still be slowed when doing so.<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
[Balance]


## Why's this needed? it makes no sense at all how critters are not able to do this, due to being small they should not have to crawl to go past them.<!-- Describe why you think this should be added to the game. -->



## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bobbis Dobbis
(+)Small Critters are now able to freely move past flaps, but will still be slowed.
```
