### PR TITLE
Washing machines don't trap you forever after being thrown in

### DIFF
--- a/code/WorkInProgress/laundry.dm
+++ b/code/WorkInProgress/laundry.dm
@@ -259,7 +259,13 @@ TYPEINFO(/obj/submachine/laundry_machine)
 			logTheThing(LOG_COMBAT, M, "is thrown into a [src.name] at [log_loc(src)].")
 			M.set_loc(src)
 			src.open = 0
-			UpdateIcon()
+			src.on = 1
+			src.occupant = M
+			src.cycle = PRE
+			src.cycle_max = CYCLE_TIME_MOB_INSIDE
+			src.UpdateIcon()
+			if (!processing_items.Find(src))
+				processing_items.Add(src)
 	else
 		return ..()
 

--- a/code/WorkInProgress/laundry.dm
+++ b/code/WorkInProgress/laundry.dm
@@ -258,17 +258,27 @@ TYPEINFO(/obj/submachine/laundry_machine)
 			M.visible_message(SPAN_ALERT("<B>[M] gets tossed into the washing machine!</B>"))
 			logTheThing(LOG_COMBAT, M, "is thrown into a [src.name] at [log_loc(src)].")
 			M.set_loc(src)
-			src.open = 0
-			src.on = 1
+			M.changeStatus("knockdown", 1.5 SECONDS)
 			src.occupant = M
+			src.open = 0
 			src.cycle = PRE
-			src.cycle_max = CYCLE_TIME_MOB_INSIDE
-			src.UpdateIcon()
+			cycle_max = CYCLE_TIME_MOB_INSIDE
 			if (!processing_items.Find(src))
 				processing_items.Add(src)
+			UpdateIcon()
 	else
 		return ..()
 
+/obj/submachine/laundry_machine/relaymove(mob/user as mob)
+	if (src.occupant == user)
+		if (!can_act(user))
+			return
+		user.set_loc(src.loc)
+		src.occupant = null
+		src.open = 1
+		src.UpdateIcon()
+		cycle_max = CYCLE_TIME
+		playsound(src, 'sound/machines/click.ogg', 50)
 
 /obj/submachine/laundry_machine/attack_hand(mob/user)
 	if (!can_act(user))

--- a/code/WorkInProgress/laundry.dm
+++ b/code/WorkInProgress/laundry.dm
@@ -270,7 +270,7 @@ TYPEINFO(/obj/submachine/laundry_machine)
 		return ..()
 
 /obj/submachine/laundry_machine/relaymove(mob/user as mob)
-	if (src.occupant == user)
+	if (src.occupant == user && !src.on)
 		if (!can_act(user))
 			return
 		user.set_loc(src.loc)

--- a/code/WorkInProgress/laundry.dm
+++ b/code/WorkInProgress/laundry.dm
@@ -361,16 +361,17 @@ TYPEINFO(/obj/submachine/laundry_machine)
 					src.unload()
 					src.cycle = PRE
 		if("cycle")
-			if (!occupant) //You cant turn it on or off if someone is inside to prevent people getting stuck inside
-				src.on = !src.on
-				. = TRUE
-				src.visible_message("[usr] switches [src] [src.on ? "on" : "off"].")
-				src.activator = usr
-				if (src.on)
-					src.cycle = PRE
-					src.open = 0
-					if (!(src in processing_items))
-						processing_items.Add(src)
+			if (src.occupant)
+				src.cycle_max = CYCLE_TIME_MOB_INSIDE
+			src.on = !src.on
+			. = TRUE
+			src.visible_message("[usr] switches [src] [src.on ? "on" : "off"].")
+			src.activator = usr
+			if (src.on)
+				src.cycle = PRE
+				src.open = 0
+				if (!(src in processing_items))
+					processing_items.Add(src)
 	src.UpdateIcon()
 
 /obj/submachine/laundry_machine/Click(location, control, params)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug fix] [game objects] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #23666

This DOES pretty much make throwing people inside objectively better than stuffing them in. I could make being thrown in do less damage, possibly.

Edit: Thrown people can escape by moving around after a second and a bit. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I left an antag in a washing machine not knowing it was like this and came back to them SSD. I'm going to hell



