### PR TITLE
Loose singularity rebalance

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -2142,8 +2142,16 @@ ABSTRACT_TYPE(/datum/projectile/bullet/homing/rocket)
 	on_hit(atom/hit, dirflag)
 		var/obj/machinery/the_singularity/S = hit
 		if(istype(S))
-			new /obj/whitehole(S.loc, 0 SECONDS, 30 SECONDS)
-			qdel(S)
+			if (S.radius > 3)
+				S.shrink()
+				new /obj/effects/magicspark(S.loc)
+				SPAWN(3 SECONDS)
+					if(S)
+						S.shrink()
+						new /obj/effects/magicspark(S.loc)
+			else
+				new /obj/whitehole(S.loc, 0 SECONDS, 30 SECONDS)
+				qdel(S)
 		else
 			new /obj/effects/rendersparks(hit.loc)
 			if(ishuman(hit))

--- a/code/obj/effects/misc.dm
+++ b/code/obj/effects/misc.dm
@@ -53,3 +53,16 @@
 	pixel_x = 0
 	pixel_y = 0
 	layer = EFFECTS_LAYER_4
+
+/obj/effects/magicspark
+	name = "magic spark"
+	anchored = ANCHORED_ALWAYS
+	icon = 'icons/effects/160x160.dmi'
+	icon_state = "magicspark"
+	layer = EFFECTS_LAYER_4
+
+	New()
+		. = ..()
+		src.pixel_x -= 80
+		src.pixel_y -= 80
+		SPAWN(2.5 SECONDS) qdel(src)

--- a/code/obj/effects/misc.dm
+++ b/code/obj/effects/misc.dm
@@ -60,6 +60,7 @@
 	icon = 'icons/effects/160x160.dmi'
 	icon_state = "magicspark"
 	layer = EFFECTS_LAYER_4
+	plane = PLANE_DEFAULT_NOWARP
 
 	New()
 		. = ..()

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -201,7 +201,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	STOP_TRACKING_CAT(TR_CAT_GHOST_OBSERVABLES)
 	. = ..()
 
-/obj/machinery/the_singularity/process(mult)
+/obj/machinery/the_singularity/process()
 	var/turf/T = get_turf(src)
 	if(isrestrictedz(T?.z) && !src.restricted_z_allowed)
 		src.visible_message(SPAN_NOTICE("Something about this place makes [src] wither and implode."))
@@ -228,7 +228,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 
 	if (active == 1)
 		move()
-		SPAWN(2 SECONDS * mult) // slowing this baby down a little -drsingh // smooth movement
+		SPAWN(2 SECONDS) // slowing this baby down a little -drsingh // smoother movement
 			move()
 
 			var/recapture_prob = clamp(25-(radius**2) , 0, 25)
@@ -291,7 +291,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 		var/next_dir = pick(alldirs)
 		if (!src.target_turf)
 			src.target_turf = get_random_station_turf()
-		if (src.target_turf_counter)
+		if (src.target_turf_counter > 0)
 			src.target_turf_counter--
 			next_dir = get_dir_accurate(src, src.target_turf)
 		else

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -289,21 +289,23 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	if (selfmove)
 		var/list/vector = src.calc_direction()
 		var/next_dir = pick(alldirs)
-		if (!src.target_turf)
-			src.target_turf = get_random_station_turf()
-		if (src.target_turf_counter > 0)
-			src.target_turf_counter--
-			next_dir = get_dir_accurate(src, src.target_turf)
-		else
-			if (prob(20))
+
+		if (src.target_turf_counter <= 0)
+			if (prob(20)) // drift towards a random station turf for a few steps
 				src.target_turf = get_random_station_turf()
 				src.target_turf_counter = rand(3,7)
+		else
+			if (!src.target_turf)
+				src.target_turf = get_random_station_turf()
+			src.target_turf_counter--
+			next_dir = get_dir_accurate(src, src.target_turf)
 
 		var/vector_length = (vector[1] ** 2 + vector[2] ** 2) ** (1/2)
 		if (prob(vector_length * 400)) //scale the chance to move in the direction of resultant force by the strength of that force
 			var/angle = arctan(vector[2], vector[1])
 			next_dir = angle2dir(angle)
 
+		// don't cross containment fields
 		for (var/dist = max(0,radius-1), dist <= radius+1, dist++)
 			var/turf/checkloc = get_ranged_target_turf(src.get_center(), next_dir, dist)
 			if (locate(/obj/machinery/containment_field) in checkloc)

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -157,8 +157,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/the_singularitygen, proc/activate)
 
 	/// Targeted turf when loose
 	var/turf/target_turf
-	///
-	var/target_turf_counter
+	/// How many steps we'll continue to walk towards the target turf before rerolling
+	var/target_turf_counter = 0
 
 #ifdef SINGULARITY_TIME
 /*

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -155,6 +155,10 @@ ADMIN_INTERACT_PROCS(/obj/machinery/the_singularitygen, proc/activate)
 	var/gib_mobs = 0 //! if it should call gib on mobs
 	var/list/obj/succ_cache
 
+	/// Targeted turf when loose
+	var/turf/target_turf
+	///
+	var/target_turf_counter
 
 #ifdef SINGULARITY_TIME
 /*
@@ -197,7 +201,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	STOP_TRACKING_CAT(TR_CAT_GHOST_OBSERVABLES)
 	. = ..()
 
-/obj/machinery/the_singularity/process()
+/obj/machinery/the_singularity/process(mult)
 	var/turf/T = get_turf(src)
 	if(isrestrictedz(T?.z) && !src.restricted_z_allowed)
 		src.visible_message(SPAN_NOTICE("Something about this place makes [src] wither and implode."))
@@ -224,7 +228,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 
 	if (active == 1)
 		move()
-		SPAWN(1.1 SECONDS) // slowing this baby down a little -drsingh
+		SPAWN(2 SECONDS * mult) // slowing this baby down a little -drsingh // smooth movement
 			move()
 
 			var/recapture_prob = clamp(25-(radius**2) , 0, 25)
@@ -284,18 +288,28 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 
 	if (selfmove)
 		var/list/vector = src.calc_direction()
-		var/dir = pick(cardinal)
+		var/next_dir = pick(alldirs)
+		if (!src.target_turf)
+			src.target_turf = get_random_station_turf()
+		if (src.target_turf_counter)
+			src.target_turf_counter--
+			next_dir = get_dir_accurate(src, src.target_turf)
+		else
+			if (prob(20))
+				src.target_turf = get_random_station_turf()
+				src.target_turf_counter = rand(3,7)
+
 		var/vector_length = (vector[1] ** 2 + vector[2] ** 2) ** (1/2)
 		if (prob(vector_length * 400)) //scale the chance to move in the direction of resultant force by the strength of that force
 			var/angle = arctan(vector[2], vector[1])
-			dir = angle2dir(angle)
+			next_dir = angle2dir(angle)
 
 		for (var/dist = max(0,radius-1), dist <= radius+1, dist++)
-			var/turf/checkloc = get_ranged_target_turf(src.get_center(), dir, dist)
+			var/turf/checkloc = get_ranged_target_turf(src.get_center(), next_dir, dist)
 			if (locate(/obj/machinery/containment_field) in checkloc)
 				return
 
-		step(src, dir)
+		step(src, next_dir)
 
 ///Returns a 2D vector representing the resultant force acting on the singulo by all gravity wells, scaled by their distance
 /obj/machinery/the_singularity/proc/calc_direction()
@@ -483,6 +497,11 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 			return ..()
 	else
 		return ..()
+
+/obj/machinery/the_singularity/proc/shrink()
+	radius--
+	SafeScaleAnim((radius-0.5)/(radius+0.5),(radius-0.5)/(radius+0.5), anim_time=3 SECONDS, anim_easing=CUBIC_EASING|EASE_OUT)
+	grav_pull = min((radius+1)*3, grav_pull)
 
 /obj/machinery/the_singularity/proc/grow()
 	if(radius<maxradius)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Anti-singularity buster changes
  * Hitting a singularity with 3 or less radius will create a white hole (as before)
  * Hitting a larger singularity than that will cause the singularity to shrink by two radius, with an accompying visual effect
* Singularity movment changes
  * Singularities now move slightly more smoothly (e.g. from 4/5.1/8/9.1 to 4/6/8/10)
  * Singularities can move diagonally
  * Singularities will switch between stepping in random directions and taking steps towards a random station turf

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
make loose singularities a little more dangerous to the station and less binary

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Anti-singularity buster shots will shrink large singularities. Small singularities will explode into white holes.
(+)Loose singularities are more likely to drift towards station tiles.
```