### PR TITLE
Modify lawbringer voice activation to register commands that consist over more than a single word

### DIFF
--- a/code/modules/speech/modules/listen/effects/lawbringer.dm
+++ b/code/modules/speech/modules/listen/effects/lawbringer.dm
@@ -1,25 +1,25 @@
 /datum/listen_module/effect/lawbringer
 	id = LISTEN_EFFECT_LAWBRINGER
 	var/list/valid_modes = list(
-		"detain" = TRUE,
-		"execute" = TRUE,
-		"exterminate" = TRUE,
-		"cluwneshot" = TRUE,
-		"smokeshot" = TRUE,
-		"fog" = TRUE,
-		"knockout" = TRUE,
-		"sleepshot" = TRUE,
-		"hotshot" = TRUE,
-		"incendiary" = TRUE,
-		"fired" = TRUE,
-		"assault" = TRUE,
-		"highpower" = TRUE,
-		"bigshot" = TRUE,
-		"clownshot" = TRUE,
-		"clown" = TRUE,
-		"pulse" = TRUE,
-		"push" = TRUE,
-		"throw" = TRUE,
+		"detain",
+		"execute",
+		"exterminate",
+		"cluwneshot",
+		"smokeshot",
+		"fog",
+		"knockout",
+		"sleepshot",
+		"hotshot",
+		"incendiary",
+		"fired",
+		"assault",
+		"high power",
+		"bigshot",
+		"clownshot",
+		"clown",
+		"pulse",
+		"push",
+		"throw",
 	)
 
 /datum/listen_module/effect/lawbringer/process(datum/say_message/message)
@@ -47,12 +47,11 @@
 		return
 
 	var/text = lawbringer.sanitize_talk(message.content)
-	var/list/words = splittext(text, " ")
 
-	for(var/word in words)
-		if(!src.valid_modes[word])
+	for(var/valid_mode in valid_modes)
+		if(!findtext(text, valid_mode))
 			continue
-		lawbringer.change_mode(H, word)
+		lawbringer.change_mode(H, valid_mode)
 		H.update_inhands()
 		lawbringer.UpdateIcon()
 		return

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1541,7 +1541,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 				if (sound)
 					playsound(M, 'sound/vox/hot.ogg', 50)
 				src.toggle_recoil(TRUE)
-			if ("assault","highpower", "bigshot")
+			if ("assault","high power", "bigshot")
 				set_current_projectile(projectiles["assault"])
 				current_projectile.cost = 170
 				item_state = "lawg-bigshot"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This modifies the vocal command functionality of the lawbringer to allow it to register commands consisting of more than just a single word.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Less confusion, and less wondering why "high power" doesn't work, as it brings the lawbringer back to matching its instruction pamphlet and previous functionality


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Avanth
(+)The lawbringer can now understand multiple words again.
```
