### PR TITLE
Make Ghost critters immune to food poisoning

### DIFF
--- a/code/modules/medical/diseases/food_poisoning.dm
+++ b/code/modules/medical/diseases/food_poisoning.dm
@@ -9,6 +9,9 @@
 /datum/ailment/disease/food_poisoning/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)
 	if (..())
 		return
+	if(istype(affected_mob,/mob/living/critter/small_animal))
+		affected_mob.cure_disease(D)
+		return
 	switch(D.stage)
 		if(1)
 			if(probmult(5))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance]
## About the PR This PR makes all mobs in small_animals unable to get food poisoning. <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->



## Why's this needed? animals should be able to eat raw meat without getting ill, if ghost critters can eat ant covered food and not take damage, it would make sense for them to not get ill from food poisoning.  <!-- Describe why you think this should be added to the game. -->



## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bobbis dobbis
(+)Small animals are no longer affected by food poisoning.
```
