### PR TITLE
Pipes encased in walls have increased fatigue pressure

### DIFF
--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -26,7 +26,15 @@
 	initial_icon_state = icon_state
 
 /obj/machinery/atmospherics/pipe/proc/effective_fatigue_pressure()
-	return src.fatigue_pressure * ((src.material?.getProperty("density") ** 2) || 1)
+	var/output = src.fatigue_pressure * ((src.material?.getProperty("density") ** 2) || 1)
+	var/turf/pipe_location = get_turf(src)
+	//pipes encased by walls get a bonus in fatigue pressure equal to the density of the material times 5, times 10 for reinforced walls. So pipes that lay bare should be the main weak point of the engine.
+	if(istype(pipe_location, /turf/simulated/wall))
+		var/turf/simulated/wall/wall_location = pipe_location
+		output *= ((wall_location.material?.getProperty("density") * 5) || 1)
+		if(istype(pipe_location, /turf/simulated/wall/auto/reinforced))
+			output *= 2
+	return output
 
 /// Returns list of coordinates to start and stop welding animation.
 /obj/machinery/atmospherics/pipe/proc/get_welding_positions()


### PR DESCRIPTION
[Feature][atmospherics]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes it so that pipes in walls benefit from massively increased fatigue pressure. A pipe in a normal wall will have its fatigue pressure increased by 5 times wall-density, while it is double that for reinforced walls

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

In the discussion about the TEG (https://forum.ss13.co/showthread.php?tid=24227), which has sparked due to the fix of the abuse of manifolds, the idea of doing additional reinforcement of pipes was mentioned and appreciated from multiple sides.

This PR tries two things: giving an additional way to reinforce pipes while also removing some need to add unbreakable pipes via mapping for normal burns.

Many pipes in walls have been made indestructable due to being encased in walls. By giving them a higher fatigue pressure at baseline, we guarantee that these pipes will only break at the point where all exposed pipes have already broken. This enables mappers to design future TEG's with less magical immune pipes.

Also, this gives engineers a way to sacrifice space in their engine for resiliance. By encasing pipes in walls, they will be able to further strenghten the walls. This also makes the welding-pattern easier: By only being able to wall off certain pipe segments, some pipes will try to burst earlier than others, putting the focus on less pipes. Of course, you are at fault if you use that to just pump the numbers higher and i will have no pity on your pipes blowing up.

This change e.g. enables bohrum plated, in reinforced bohrum walls set pipes with ghc to have a fatigue pressure of up to 2,16e12 kpa.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(*)Atmospheric pipes in walls have their fatigue pressure increased by 5 times the walls material density. Double the value for reinforced walls.
```
