### PR TITLE
Fix custom pies naming themselves after chicken eggs

### DIFF
--- a/code/modules/cooking/cookingrecipes.dm
+++ b/code/modules/cooking/cookingrecipes.dm
@@ -1572,11 +1572,11 @@ ABSTRACT_TYPE(/datum/cookingrecipe/oven/burger)
 		var/found2 = 0
 		for (var/obj/item/T in ourCooker.contents)
 
-			if (T.type == ingredients[1] && !found1)
+			if (!found1 && istype(T, ingredients[1]))
 				found1 = TRUE
 				continue
 
-			if (T.type == ingredients[2] && !found2)
+			if (!found2 && istype( T, ingredients[2]))
 				found2 = TRUE
 				continue
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label [bug][catering]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The custom pie recipe now performs a typecheck of its ingredients to determine what is part of its recipe and what is a filling, rather than checking for strict equality. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

If you made custom pies with any non-generic egg, the custom pies would have 'egg' as part of its name. For instance a knife pie would be called a "knifeegg pie". It should just be a knife pie unless additional eggs are added. 
