### PR TITLE
Adds HoS access to customs lacking security access

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -21586,6 +21586,7 @@
 	},
 /obj/mapping_helper/access/head_of_personnel,
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/hos,
 /turf/simulated/floor/black,
 /area/station/bridge/customs)
 "jzL" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -17922,6 +17922,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/access/security,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -1327,6 +1327,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	req_access = null
 	},
+/obj/mapping_helper/access/hos,
 /turf/simulated/floor/plating/jen,
 /area/station/bridge/customs)
 "arc" = (

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -26897,6 +26897,7 @@
 	enter_id = "hop";
 	name = "Bridge"
 	},
+/obj/mapping_helper/access/hos,
 /turf/simulated/floor/blue,
 /area/station/bridge/customs)
 "tjm" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -45433,6 +45433,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
+/obj/mapping_helper/access/hos,
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "green2"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives HoS' access to customs without security access.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sometimes the only ID computer is in customs on a map, which can make for fustrating HoP-less shifts when the HoS has ID access anyway. I'm assuming not giving all of sec access when customs isn't integrated with sec is a map by map design choice so I'm doing HoS access instead of letting sec flood in there every time AI calls a AA rat out.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cheekybrdy
(+)All Customs are accessible by the HoS now.
```
