### PR TITLE
Make gas flow scanner mech scannable.

### DIFF
--- a/code/obj/machinery/meter.dm
+++ b/code/obj/machinery/meter.dm
@@ -10,12 +10,18 @@
 	var/id
 	var/noiselimiter = 0
 
+TYPEINFO(/obj/machinery/meter)
+	mats = 1
+
 /obj/machinery/meter/New()
 	..()
-	SPAWN(1 SECOND)
-		src.target = locate(/obj/machinery/atmospherics/pipe) in loc
+	src.attach_to_pipe()
 	MAKE_SENDER_RADIO_PACKET_COMPONENT(null, null, frequency)
 	AddComponent(/datum/component/mechanics_holder)
+
+/obj/machinery/meter/proc/attach_to_pipe()
+	SPAWN(1 SECOND)
+		src.target = locate(/obj/machinery/atmospherics/pipe) in loc
 
 /obj/machinery/meter/process()
 	if(!target)
@@ -85,6 +91,14 @@
 			. += "The sensor error light is blinking."
 	else
 		. += "The connect error light is blinking."
+
+/obj/machinery/meter/was_built_from_frame()
+	. = ..()
+	src.attach_to_pipe()
+
+/obj/machinery/meter/was_deconstructed_to_frame(mob/user)
+	. = ..()
+	src.target = null
 
 
 /obj/machinery/meter/attack_hand(mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[ATMOSPHERICS][FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This change makes the meters over atmos pipes mechscannable. This will allow anyone to scan and deploy a meter over an atmos pipe to measure its content.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Constructable atmos is the new hot thing and a lot of the new pipe machinery is packet controllable, but theres no way to get any information about whats in the pipes. This change only involved a slight tweak to the existing meter logic. This opens the door for some fully automated atmos based monstrosities.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)KakoLookiyam
(+) Gas flow meters are now mechscannable and deployable..
```
