### PR TITLE
Makes secured assemblies splashable

### DIFF
--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -352,6 +352,7 @@ Contains:
 		src.add_fingerprint(user)
 		src.UpdateIcon()
 		src.last_armer = user
+		flags ^= NOSPLASH
 		return
 	..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QoL][Game objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows for reagent splashing on finished assemblies by toggling the (by default active) NOSPLASH flag when securing an assembly.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The NOSPLASH flag was probably put there to avoid accidentially splashing your hellmix all over your new assembly when trying to add it, but since finished assemblies can't have any items added to them, it'd make sense for them to act like other items again.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chasu
(+)Secured assemblies can now be splashed with reagents, such as glue.
```
