### PR TITLE
Fix Non-standard radio frequencies hearing 145.9

### DIFF
--- a/code/obj/flock/structure/relay.dm
+++ b/code/obj/flock/structure/relay.dm
@@ -198,7 +198,7 @@ TYPEINFO(/obj/flock_structure/relay)
 			wearer.show_text("A final scream of horrific static bursts from your radio, destroying it!", "red")
 			wearer.apply_sonic_stun(3, 6, 60, 0, 0, rand(1, 3), rand(1, 3))
 		radio.bricked = TRUE
-		radio.frequency = rand(R_FREQ_MINIMUM, 10000)
+		radio.set_frequency(rand(R_FREQ_MINIMUM, 10000))
 		radio.secure_frequencies = list()
 		radio.set_secure_frequencies()
 		no_more_radios = TRUE

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -555,7 +555,7 @@
 	New()
 		..()
 		SPAWN(1 SECOND)
-			src.frequency = R_FREQ_SYNDICATE // let's see if this stops rounds from being ruined every fucking time
+			src.set_frequency(R_FREQ_SYNDICATE) // let's see if this stops rounds from being ruined every fucking time
 
 	leader
 		icon_override = "syndieboss"
@@ -623,7 +623,7 @@
 	New()
 		..()
 		SPAWN(1 SECOND)
-			src.frequency = R_FREQ_PIRATE
+			src.set_frequency(R_FREQ_PIRATE)
 
 	first_mate
 		icon_override = "pirate_first_mate"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes everywhere a headset's frequency is set to use .set_frequency()

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The radio's packet needs to be updated so this should be called instead to prevent headsets hearing 145.9 without it selected
@Mister-Moriarty had a different solution in mind but when I tried that each radio transmission would occur 4 times so I'll leave that change for now.
