### PR TITLE
AI shell gender is last possessing mainframe's

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1821,6 +1821,7 @@ or don't if it uses a custom topopen overlay
 	src.deployed_shell = target_shell
 	src.mind.transfer_to(target_shell)
 	src.deployed_shell.ensure_listen_tree().AddListenInput(LISTEN_INPUT_EARS_AI)
+	target_shell.gender = src.gender
 
 /mob/living/silicon/ai/verb/toggle_lock()
 	set category = "AI Commands"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When deploying to an AI shell set its gender to the mainframe's


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #23720