### PR TITLE
adds help text for railings

### DIFF
--- a/code/obj/railing.dm
+++ b/code/obj/railing.dm
@@ -1,6 +1,7 @@
 /obj/railing
 	name = "railing"
 	desc = "Two sets of bars shooting onward with the sole goal of blocking you off. They can't stop you from vaulting over them though!"
+	HELP_MESSAGE_OVERRIDE("")
 	anchored = ANCHORED
 	density = 1
 	icon = 'icons/obj/objects.dmi'
@@ -57,6 +58,16 @@
 				var/datum/material/M = getMaterial("steel")
 				R.setMaterial(M)
 		qdel(src)
+
+	get_help_message(dist, mob/user)
+		. = ..()
+		if (src.broken)
+			. += "You can use a <b>welding tool</b> to remove this broken railing."
+		else
+			if (src.is_reinforced)
+				. += "You can use <b>wirecutters</b> to remove the reinforcement from this railing, or a <b>welding tool</b> to deconstruct it."
+			else
+				. += "You can use <b>metal rods</b> to reinforce this railing, or a <b>welding tool</b> to deconstruct it."
 
 	ex_act(severity)
 		switch(severity)


### PR DESCRIPTION
[QoL][Player Actions]

## About the PR
Give help text when lookingat raillings. it is simole.


## Why's this needed? 
make sense, can be confuising.
also, 
![image](https://github.com/user-attachments/assets/47db2333-1c3a-44c2-8aee-d4f2a08c178a)
:>
