### PR TITLE
Fix all turfs being "off cams"

### DIFF
--- a/code/modules/camera/network.dm
+++ b/code/modules/camera/network.dm
@@ -112,7 +112,7 @@
 /proc/seen_by_camera(var/atom/atom)
 	if(isarea(atom) || !atom)
 		return FALSE
-	if(!isturf(atom.loc))
+	if(!isturf(atom) && !isturf(atom.loc)) //Not on a turf, probably in a locker or something
 		return FALSE
 	#ifdef SKIP_CAMERA_COVERAGE
 	return TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Only check if somethings on a turf if that thing isn't a turf. turfs can't be in lockers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #23731
Fixes all turfs being considered in lockers and "offcams".
