### PR TITLE
Throw EMAG to emag things

### DIFF
--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -46,6 +46,12 @@ TYPEINFO(/obj/item/card/emag)
 	attack()	//Fucking attack messages up in this joint.
 		return
 
+	throw_impact(atom/hit_atom, datum/thrown_thing/thr)
+		..()
+		if(hit_atom && thr)
+			hit_atom.emag_act(thr.thrown_by, src)
+		return
+
 /obj/item/card/emag/attack_self(mob/user as mob)
 	if(ON_COOLDOWN(user, "showoff_item", SHOWOFF_COOLDOWN))
 		return


### PR DESCRIPTION
[game objects][feature]

## About the PR
- Atoms hit by a thrown EMAG get emagged.

## Why's this needed?
- Might open up some interesting strategies. At the very least it should be funny.

## Testing
![Screenshot 2025-06-04 215236](https://github.com/user-attachments/assets/89328971-c230-4de5-b994-4a7943edfe41)
![Screenshot 2025-06-04 215400](https://github.com/user-attachments/assets/82bd18aa-0f76-4811-85a2-8076c5473ce2)

## Changelog
```changelog
(u)LorrMaster
(+)Throwing an EMAG at things will now emag them.
```
