### PR TITLE
Satchels only auto-fill with produce from harvests, ignore seeds

### DIFF
--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -869,17 +869,13 @@ TYPEINFO(/obj/machinery/plantpot)
 	// This proc is where the harvesting actually happens. Again it shouldn't need tweaking
 	// with since i've tried to account for most special circumstances that might come up.
 	if(!user) return
-	var/satchelpick = 0
 	if(SA)
 		if(length(SA.contents) >= SA.maxitems)
 			boutput(user, SPAN_ALERT("Your satchel is already full! Free some space up first."))
 			return
 		else
-			satchelpick = input(user, "What do you want to harvest into the satchel?", "[src.name]", 0) in list("Everything","Produce Only","Seeds Only","Never Mind")
-			if(!HYPcheck_if_harvestable() || satchelpick == "Never Mind")
+			if(!HYPcheck_if_harvestable())
 				return
-			if(satchelpick == "Everything")
-				satchelpick = null
 	// it's okay if we don't have a satchel at all since it'll just harvest by hand instead
 	var/datum/plant/growing = src.current
 	var/datum/plantgenes/DNA = src.plantgenes
@@ -1138,8 +1134,6 @@ TYPEINFO(/obj/machinery/plantpot)
 
 		// At this point all the harvested items are inside the plant pot, and this is the
 		// part where we decide where they're going and get them out.
-		var/seeds_only = satchelpick == "Seeds Only"
-		var/produce_only = satchelpick == "Produce Only"
 		if(SA)
 			// If we're putting stuff in a satchel, this is where we do it.
 			for(var/obj/item/I in src.contents)
@@ -1147,11 +1141,9 @@ TYPEINFO(/obj/machinery/plantpot)
 					boutput(user, SPAN_ALERT("Your satchel is full! You dump the rest on the floor."))
 					break
 				if(istype(I,/obj/item/seed/))
-					if(SA.check_valid_content(I) && (!satchelpick || seeds_only))
-						I.set_loc(SA)
-						I.add_fingerprint(user)
+					continue
 				else
-					if(SA.check_valid_content(I) && (!satchelpick || produce_only))
+					if(SA.check_valid_content(I))
 						I.set_loc(SA)
 						I.add_fingerprint(user)
 			SA.UpdateIcon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label [qol][hydroponics]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Produce satchels no longer have a popup option to harvest seeds or produce. Using them on a harvestable plant will instead  automatically harvest and place produce in satchel and dump the seed packet on the floor. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Even before seed packets, I found the option to harvest seeds directly into the satchel was very rarely used. The mechanic feels practically obsolete now that there aren't multiple seed items per harvest. The popup is annoying and is entirely counter-productive to the qol that auto-filling satchels directly from harvests intends to confer. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

I'm not sure screenshots are useful for this because it's like trying to prove a negative.

Tested multiple harvests with an empty satchel; until satchel became full, after satchel was full, before plant was ready to harvest and after plant had died. 
![Screenshot 2025-06-05 080451](https://github.com/user-attachments/assets/ea663354-ec5c-4c49-bac6-7f3c306696bd)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Egregorious
(+)Harvesting plants with a produce satchel now auto-fills it with produce directly and ignores the seed packet, instead of demanding input.
```
