### PR TITLE
Options to change what satchels auto-fill with when harvesting

### DIFF
--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -264,7 +264,7 @@
 		var/harvest_what = HARVEST_ONLY_PRODUCE
 
 		HELP_MESSAGE_OVERRIDE({"Click on it to pull out a random item, or click on it with <b>Grab Intent</b> to search for a specific item.
-		 	Click on it with <b>Disarm Intent</b> to change what you fill it with when harvesting."})
+		 	Use a pen on it to change what you fill it with when harvesting."})
 
 		New()
 			..()

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -1,3 +1,7 @@
+#define HARVEST_ONLY_PRODUCE 1
+#define HARVEST_ONLY_SEEDS 2
+#define HARVEST_BOTH 3
+
 /obj/item/satchel
 	name = "satchel"
 	desc = "A leather satchel for holding things."
@@ -256,6 +260,11 @@
 		icon_state = "hydrosatchel"
 		item_state = "hydrosatchel"
 		itemstring = "items of produce"
+		var/list/harvesting_strings = list(HARVEST_ONLY_PRODUCE = "produce", HARVEST_ONLY_SEEDS = "seeds", HARVEST_BOTH = "seeds and produce",)
+		var/harvest_what = HARVEST_ONLY_PRODUCE
+
+		HELP_MESSAGE_OVERRIDE({"Click on it to pull out a random item, or click on it with <b>Grab Intent</b> to search for a specific item.
+		 	Click on it with <b>Disarm Intent</b> to change what you fill it with when harvesting."})
 
 		New()
 			..()
@@ -279,6 +288,23 @@
 				var/obj/item/seed/template_seed = template
 				. = (inserted_seed.planttype?.type == template_seed.planttype?.type) && \
 					(inserted_seed.plantgenes.mutation?.type == template_seed.plantgenes.mutation?.type)
+
+		attack_hand(mob/user)
+			if (src.loc == user && user.a_intent == INTENT_DISARM)
+				if(harvest_what == HARVEST_ONLY_PRODUCE)
+					boutput(user, SPAN_ALERT("You will fill [src] with seeds when harvesting."))
+					harvest_what = HARVEST_ONLY_SEEDS
+				else if (harvest_what == HARVEST_ONLY_SEEDS)
+					boutput(user, SPAN_ALERT("You will fill [src] with seeds and produce when harvesting."))
+					harvest_what = HARVEST_BOTH
+				else if (harvest_what == HARVEST_BOTH)
+					boutput(user, SPAN_ALERT("You will fill [src] with produce when harvesting."))
+					harvest_what = HARVEST_ONLY_PRODUCE
+				return
+			else return ..()
+
+		get_desc()
+			return "It contains [src.contents.len]/[src.maxitems] [src.itemstring]. The autofibre label reads \"[harvesting_strings[harvest_what]]\"."
 
 		large
 			name = "large produce satchel"

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -289,22 +289,22 @@
 				. = (inserted_seed.planttype?.type == template_seed.planttype?.type) && \
 					(inserted_seed.plantgenes.mutation?.type == template_seed.plantgenes.mutation?.type)
 
-		attack_hand(mob/user)
-			if (src.loc == user && user.a_intent == INTENT_DISARM)
+		attackby(obj/item/W, mob/user)
+			if (src.loc == user && istype(W, /obj/item/pen))
 				if(harvest_what == HARVEST_ONLY_PRODUCE)
-					boutput(user, SPAN_ALERT("You will fill [src] with seeds when harvesting."))
+					boutput(user, SPAN_ALERT("You scribble on the label that you'll fill [src] with seeds when harvesting."))
 					harvest_what = HARVEST_ONLY_SEEDS
 				else if (harvest_what == HARVEST_ONLY_SEEDS)
-					boutput(user, SPAN_ALERT("You will fill [src] with seeds and produce when harvesting."))
+					boutput(user, SPAN_ALERT("You scribble on the label that you'll fill [src] with seeds and produce when harvesting."))
 					harvest_what = HARVEST_BOTH
 				else if (harvest_what == HARVEST_BOTH)
-					boutput(user, SPAN_ALERT("You will fill [src] with produce when harvesting."))
+					boutput(user, SPAN_ALERT("You scribble on the label that you'll fill [src] with produce when harvesting."))
 					harvest_what = HARVEST_ONLY_PRODUCE
 				return
-			else return ..()
+			. = ..()
 
 		get_desc()
-			return "It contains [src.contents.len]/[src.maxitems] [src.itemstring]. The autofibre label reads \"[harvesting_strings[harvest_what]]\"."
+			return "It contains [src.contents.len]/[src.maxitems] [src.itemstring]. A small label in the lining reads \"[harvesting_strings[harvest_what]]\"."
 
 		large
 			name = "large produce satchel"

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -292,13 +292,13 @@
 		attackby(obj/item/W, mob/user)
 			if (src.loc == user && istype(W, /obj/item/pen))
 				if(harvest_what == HARVEST_ONLY_PRODUCE)
-					boutput(user, SPAN_ALERT("You scribble on the label that you'll fill [src] with seeds when harvesting."))
+					boutput(user, SPAN_NOTICE("You scribble on the label that you'll fill [src] with seeds when harvesting."))
 					harvest_what = HARVEST_ONLY_SEEDS
 				else if (harvest_what == HARVEST_ONLY_SEEDS)
-					boutput(user, SPAN_ALERT("You scribble on the label that you'll fill [src] with seeds and produce when harvesting."))
+					boutput(user, SPAN_NOTICE("You scribble on the label that you'll fill [src] with seeds and produce when harvesting."))
 					harvest_what = HARVEST_BOTH
 				else if (harvest_what == HARVEST_BOTH)
-					boutput(user, SPAN_ALERT("You scribble on the label that you'll fill [src] with produce when harvesting."))
+					boutput(user, SPAN_NOTICE("You scribble on the label that you'll fill [src] with produce when harvesting."))
 					harvest_what = HARVEST_ONLY_PRODUCE
 				return
 			. = ..()

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -869,17 +869,18 @@ TYPEINFO(/obj/machinery/plantpot)
 	// This proc is where the harvesting actually happens. Again it shouldn't need tweaking
 	// with since i've tried to account for most special circumstances that might come up.
 	if(!user) return
-	var/satchelpick = 0
+	var/fill_seeds = 0
+	var/fill_produce = 0
 	if(SA)
+		var/obj/item/satchel/hydro/produce_satchel = SA
+		if (produce_satchel)
+			var/satchelpick = 0
+			satchelpick = produce_satchel.harvest_what
+			fill_seeds = satchelpick == HARVEST_ONLY_SEEDS || satchelpick == HARVEST_BOTH
+			fill_produce = satchelpick == HARVEST_ONLY_PRODUCE || satchelpick == HARVEST_BOTH
 		if(length(SA.contents) >= SA.maxitems)
 			boutput(user, SPAN_ALERT("Your satchel is already full! Free some space up first."))
 			return
-		else
-			satchelpick = input(user, "What do you want to harvest into the satchel?", "[src.name]", 0) in list("Everything","Produce Only","Seeds Only","Never Mind")
-			if(!HYPcheck_if_harvestable() || satchelpick == "Never Mind")
-				return
-			if(satchelpick == "Everything")
-				satchelpick = null
 	// it's okay if we don't have a satchel at all since it'll just harvest by hand instead
 	var/datum/plant/growing = src.current
 	var/datum/plantgenes/DNA = src.plantgenes
@@ -1138,8 +1139,6 @@ TYPEINFO(/obj/machinery/plantpot)
 
 		// At this point all the harvested items are inside the plant pot, and this is the
 		// part where we decide where they're going and get them out.
-		var/seeds_only = satchelpick == "Seeds Only"
-		var/produce_only = satchelpick == "Produce Only"
 		if(SA)
 			// If we're putting stuff in a satchel, this is where we do it.
 			for(var/obj/item/I in src.contents)
@@ -1147,11 +1146,11 @@ TYPEINFO(/obj/machinery/plantpot)
 					boutput(user, SPAN_ALERT("Your satchel is full! You dump the rest on the floor."))
 					break
 				if(istype(I,/obj/item/seed/))
-					if(SA.check_valid_content(I) && (!satchelpick || seeds_only))
+					if(fill_seeds && SA.check_valid_content(I))
 						I.set_loc(SA)
 						I.add_fingerprint(user)
 				else
-					if(SA.check_valid_content(I) && (!satchelpick || produce_only))
+					if(fill_produce && SA.check_valid_content(I))
 						I.set_loc(SA)
 						I.add_fingerprint(user)
 			SA.UpdateIcon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label [qol][hydroponics][add to wiki]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Alternative to #23745. I thought a different PR is in order because it's a very different implementation.

Produce satchels no longer have a popup option to harvest seeds or produce. They now have an internal value to determine what they auto-fill with, which can be cycled through by using a pen on them. Options are 'produce', 'seeds', and 'seeds and produce'. It defaults to produce-only. Satchels can be inspected to check what they're currently set to. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The popup menu for quick-filling a satchel while harvesting completely subverts the point of the quick-fill mechanic by being annoying and tedious. This lets people still have access to all the auto-filling options, but front-loads the decision making so it's easy to spam. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested multiple harvests with an empty satchel, full satchel, before plant was ready to harvest and after plant had died with each of the options.
![Screenshot 2025-06-06 094708](https://github.com/user-attachments/assets/d6b5b466-2534-454e-8ff2-40049742060a)


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Egregorious
(+)Use a pen on a produce satchel to change what it will auto-fill with when harvesting plants.
```
