### PR TITLE
Replace pug woof cooldown with stamina cost

### DIFF
--- a/_std/defines/stamina.dm
+++ b/_std/defines/stamina.dm
@@ -82,6 +82,7 @@
 
 /// How much farting costs. I am not even kidding.
 #define STAMINA_DEFAULT_FART_COST 1
+#define STAMINA_DEFAULT_WOOF_COST 15
 
 #define USE_STAMINA_DISORIENT //use the new stamina based stun disorient system thingy
 

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -2290,15 +2290,14 @@
 					return
 				else
 					src.remove_stamina(STAMINA_DEFAULT_WOOF_COST)
-					if (src.get_stamina() > 0)
+					if (src.get_stamina() > 0 && !GET_COOLDOWN(src, "pug_woof_wheeze"))
 						message = "<b>[src]</b> woofs!"
 						playsound(src.loc, 'sound/voice/urf.ogg', 60, channel=VOLUME_CHANNEL_EMOTE)
 					else
-						if (!ON_COOLDOWN(src, "pug_woof_wheeze", 2 SECONDS))
-							message = "[src] wheezes"
-							playsound(src.loc, 'sound/voice/pug_wheeze.ogg', 60, channel=VOLUME_CHANNEL_EMOTE)
+						if (!ON_COOLDOWN(src, "pug_woof_wheeze", 3 SECONDS))
 							src.take_oxygen_deprivation(STAMINA_DEFAULT_WOOF_COST)
 							src.changeStatus("knockdown", 4 SECONDS)
+							return src.emote("wheeze", voluntary, emoteTarget, dead_check) //tail recursion, geddit?
 			else
 				if (voluntary)
 					src.show_text("Unusable emote '[act]'. 'Me help' for a list.", "blue")

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -2289,9 +2289,16 @@
 					src.say("Woof.")
 					return
 				else
-					message = "<b>[src]</b> woofs!"
-					if (src.emote_check(voluntary, 1 SECOND))
+					src.remove_stamina(STAMINA_DEFAULT_WOOF_COST)
+					if (src.get_stamina() > 0)
+						message = "<b>[src]</b> woofs!"
 						playsound(src.loc, 'sound/voice/urf.ogg', 60, channel=VOLUME_CHANNEL_EMOTE)
+					else
+						if (!ON_COOLDOWN(src, "pug_woof_wheeze", 2 SECONDS))
+							message = "[src] wheezes"
+							playsound(src.loc, 'sound/voice/pug_wheeze.ogg', 60, channel=VOLUME_CHANNEL_EMOTE)
+							src.take_oxygen_deprivation(STAMINA_DEFAULT_WOOF_COST)
+							src.changeStatus("knockdown", 4 SECONDS)
 			else
 				if (voluntary)
 					src.show_text("Unusable emote '[act]'. 'Me help' for a list.", "blue")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reverts b89dd61 and replaces it with a stamina cost, if you try to woof while on negative stamina you fall over and take oxygen damage.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People like to spam the woof emote but it can get annoying when there's no end to it, adding a stamina cost still lets people have the funny barkarbkarkbarkbrrk but with the caveat that you will fall over if you choose to spam it for too long.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

![image](https://github.com/user-attachments/assets/6bc180e1-4e17-409d-ba55-97e057f5ac6f)
Me in shallow crit from excessive woofing
## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Pug woof once again has no cooldown but now has a stamina cost and will cause you to fall over wheezing if used too much.
```
