### PR TITLE
Fix overriden mindhack removal

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -925,6 +925,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		if(!src.inactive) //If this isn't the implant currently mindhacking the owner don't remove antag status
 			M.delStatus("mindhack")
 			M.mind?.remove_antagonist(ROLE_MINDHACK, ANTAGONIST_REMOVAL_SOURCE_SURGERY)
+		src.inactive = FALSE //Set back to normal incase its used again
 		return
 
 	proc/add_orders(var/orders)

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -893,6 +893,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			H.show_text("<b>You resist [implant_hacker]'s attempt to mindhack you!</b>", "red")
 			logTheThing(LOG_COMBAT, H, "resists [constructTarget(implant_hacker,"combat")]'s attempt to mindhack them at [log_loc(H)].")
 			return FALSE
+		return TRUE
 
 	implanted(var/mob/M, var/mob/I)
 		..()
@@ -904,8 +905,11 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		M.changeStatus("knockdown", 10 SECONDS)
 
 		//Remove any existing mindhack statuses and override existing implants
-		for (var/obj/item/implant/mindhack/MS in M.implant)
-			MS.override()
+		var/mob/living/carbon/human/H = M
+		H.mind?.remove_antagonist(ROLE_MINDHACK, ANTAGONIST_REMOVAL_SOURCE_OVERRIDE)
+		for (var/obj/item/implant/mindhack/MS in H.implant)
+			if(MS != src)
+				MS.inactive = TRUE
 
 		if(M == I)
 			boutput(M, SPAN_ALERT("You feel utterly strengthened in your resolve! You are the most important person in the universe!"))
@@ -929,15 +933,6 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		src.custom_orders = copytext(sanitize(html_encode(orders)), 1, MAX_MESSAGE_LEN)
 		if (!(copytext(src.custom_orders, -1) in list(".", "?", "!")))
 			src.custom_orders += "!"
-
-	proc/override(var/orders)
-		if(src.inactive)
-			return FALSE
-		var/mob/living/carbon/human/H = src.implanted
-		if(!istype(H))
-			return FALSE
-		H.mind?.remove_antagonist(ROLE_MINDHACK, ANTAGONIST_REMOVAL_SOURCE_OVERRIDE)
-		src.inactive = TRUE
 
 /obj/item/implant/mindhack/super
 	name = "mindhack DELUXE implant"

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -910,7 +910,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		for (var/obj/item/implant/mindhack/MS in H.implant)
 			if(MS != src)
 				MS.inactive = TRUE
-		src.inactive = TRUE
+		src.inactive = FALSE
 
 		if(M == I)
 			boutput(M, SPAN_ALERT("You feel utterly strengthened in your resolve! You are the most important person in the universe!"))

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -910,6 +910,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		for (var/obj/item/implant/mindhack/MS in H.implant)
 			if(MS != src)
 				MS.inactive = TRUE
+		src.inactive = TRUE
 
 		if(M == I)
 			boutput(M, SPAN_ALERT("You feel utterly strengthened in your resolve! You are the most important person in the universe!"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes mindhack status being removed on the removal of an implant that has been overriden
Also move deluxe implant back up to with the regular one instead of marionette separating them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The first surgically remove implant is always the oldest one (at least in testing) meaning the newer, actually active implant is disabled despite still being present in the player, only the most recently implanted mindhack implant will be considered "active" and remove the antag status on implant removal.

Fixes #23766

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested with commenting out the client check and giving a dummy a mind. 
Before: Antag status is removed on the first implant surgically removed.
After: Antag status is removed on the most recently implanted implant being removed.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

