### PR TITLE
Organise keylabeler mappings by category

### DIFF
--- a/.github/keylabeler.yml
+++ b/.github/keylabeler.yml
@@ -9,6 +9,7 @@ caseSensitive: false
 
 # Explicit keyword mappings to labels. Form of match:label. Required.
 labelMappings:
+# Priority
     "[BUG - CRITICAL]": p-critical
     "[CRITICAL]": p-critical
     "[BUG - MAJOR]": p-major
@@ -17,14 +18,12 @@ labelMappings:
     "[MINOR]": p-minor
     "[BUG - TRIVIAL]": p-trivial
     "[TRIVIAL]": p-trivial
+# Category
     "[BUG]": c-bug
     "[FIX]": c-bug
     "[BUGFIX]": c-bug
     "fixes #": c-bug
     "[RUNTIME]": c-runtime
-    "[INPUT WANTED]": e-input-wanted
-    "[INPUT]": e-input-wanted
-    "[FEEDBACK]": e-input-wanted
     "[ENHANCEMENT]": c-feature
     "[FEATURE]": c-feature
     "[FEAT]": c-feature
@@ -40,18 +39,23 @@ labelMappings:
     "[REMOVAL]": c-removal
     "[REVERT]": c-revert
     "[REWORK]": c-rework
+# Extra
+    "[INPUT WANTED]": e-input-wanted
+    "[INPUT]": e-input-wanted
+    "[FEEDBACK]": e-input-wanted
+    "[EASY]": e-good-first-issue
+    "[GFI]": e-good-first-issue
+    "[GOOD FIRST ISSUE]": e-good-first-issue
+    "[WIKI]": e-add-to-wiki
+    "[ADD TO WIKI]": e-add-to-wiki
+    "[CONTEST]": e-contest
+# Area
     "[SECRET]": a-secret
     "[TGUI]": a-ui
     "[UI]": a-ui
     "[TOOLS]": a-tooling
     "[TOOLING]": a-tooling
-    "[EASY]": e-good-first-issue
-    "[GFI]": e-good-first-issue
-    "[GOOD FIRST ISSUE]": e-good-first-issue
     "[MEDAL]": a-medal
-    "[WIKI]": e-add-to-wiki
-    "[ADD TO WIKI]": e-add-to-wiki
-    "[CONTEST]": e-contest
     "[ADMIN]": a-admin
     "[AI]": a-ai
     "[API]": a-api


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Organises keylabeler to be by category with comments separating the sections (I hope this works in YML, haven't touched it much), it mostly already was i just shifted a couple around

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Easier to add/remove more labels when they're organised

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Testing is if the keylabeler doesn't explode :D
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
