### PR TITLE
Fix Nuclear Authentication teams

### DIFF
--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -268,7 +268,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 				return
 
 			var/timer_modifier = 0
-			if (isnukeop(user))
+			if (istrainedsyndie(user))
 				timer_modifier = -src.timer_modifier_disk
 				user.visible_message(SPAN_ALERT("<b>[user]</b> inserts [W.name], shortening the bomb's timer by [src.timer_modifier_disk / 10] seconds!"))
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the isnukeop() check for determining if the auth disk should add or remove time to istrainedsyndie(), making the following antagonists remove nuke time rather than add it: Nukeop gunbot, Traitor, Sleeper, Generic agents and Omnitraitors

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #23773
Allows traitors that rolled micronuke in their surplus to auth it to decrease the timer

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested as the following roles with a /event nuclear bomb:
None - Timer increased
Traitor - Timer decreased
Gunbot - Timer decreased
Headrev - Timer increased


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Any trained syndicate operative (ones that can open the listening post) will now remove time when putting the auth disk in a nuclear bomb, rather than just nukeops.
```
