### PR TITLE
moves senior description to grow_old to prevent exponential descriptions

### DIFF
--- a/code/modules/ranch/ranch_critter_base.dm
+++ b/code/modules/ranch/ranch_critter_base.dm
@@ -207,11 +207,6 @@
 		if(!can_lie && !isdead(src))
 			can_lie = 1
 
-	get_desc(dist, mob/user)
-		. = ..()
-		if (src.stage == RANCH_STAGE_SENIOR)
-			desc += "This animal looks rather old and probably won't be able to produce anything."
-
 	reduce_lifeprocess_on_death()
 		. = ..()
 		remove_lifeprocess(/datum/lifeprocess/ranch/age)
@@ -236,6 +231,7 @@
 
 	proc/grow_old()
 		stage = RANCH_STAGE_SENIOR
+		desc += "This animal looks rather old and probably won't be able to produce anything."
 		return
 
 	proc/die_of_old_age()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
title
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes a fuck up, += in get_desc kept adding to the description every time someone looked at it.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
