### PR TITLE
Fix list inputs on component data input form

### DIFF
--- a/_std/lists.dm
+++ b/_std/lists.dm
@@ -112,6 +112,15 @@
 	for(var/key in key_list)
 		. |= key_list[key]
 
+///Flattens a keyed list into just its keys, discarding values
+/proc/flatten_list_to_keys(list/key_list)
+	RETURN_TYPE(/list)
+	if(!islist(key_list))
+		return null
+	. = list()
+	for(var/key in key_list)
+		. |= key
+
 ///Make a normal list an associative one
 /proc/make_associative(list/flat_list)
 	RETURN_TYPE(/alist)

--- a/code/datums/components/equipment_fault.dm
+++ b/code/datums/components/equipment_fault.dm
@@ -578,9 +578,13 @@ TYPEINFO(/datum/component/equipment_fault/messy)
 
 /datum/component/equipment_fault/messy/Initialize(tool_flags, cleanables)
 	. = ..()
-	if (!islist(cleanables))
-		return COMPONENT_INCOMPATIBLE
-	src.cleanable_types = cleanables
+	if (cleanables)
+		if (ispath(cleanables, /obj/decal/cleanable))
+			src.cleanable_types = list(cleanables)
+		else if (islist(cleanables))
+			src.cleanable_types = cleanables
+		else
+			return COMPONENT_INCOMPATIBLE
 
 /datum/component/equipment_fault/messy/ef_process(obj/machinery/M, mult)
 	src.ef_perform_fault(M)

--- a/code/modules/admin/debug.dm
+++ b/code/modules/admin/debug.dm
@@ -306,7 +306,11 @@ var/global/debug_messages = 0
 		//supplied lists have a different interface with a `list` var and `value` being the currently selected list item
 		//confusing!!
 		if (customization[ARG_INFO_TYPE] == DATA_INPUT_LIST_PROVIDED)
-			.["options"][customization[ARG_INFO_NAME]]["list"] = flatten_list_to_keys(customization[ARG_INFO_DEFAULT])
+			var/list/key_list = list()
+			for (var/key in customization[ARG_INFO_DEFAULT])
+				key_list += "[key]" //stringify here to prevent encoding issues with letting the frontend do it
+			.["options"][customization[ARG_INFO_NAME]]["list"] = key_list
+			.["options"][customization[ARG_INFO_NAME]]["value"] = src.listargs[customization[ARG_INFO_NAME]]
 		//normal variable
 		.["options"][customization[ARG_INFO_NAME]]["value"] = src.listargs[customization[ARG_INFO_NAME]]
 
@@ -344,7 +348,16 @@ var/global/debug_messages = 0
 					listargs[params["name"]] = target
 					. = TRUE
 					break;
-
+		if ("modify_list_value")
+			for(var/customization in initialization_args)
+				if(params["name"]==customization[ARG_INFO_NAME] \
+				&& params["type"]==customization[ARG_INFO_TYPE])
+					//go through the actual values and compare their stringified value to the one we got from the frontend
+					//so we don't end up returning a string instead of a type for instance
+					for (var/list_option in customization[ARG_INFO_DEFAULT])
+						if (strip_illegal_characters("[list_option]") == params["value"])
+							src.listargs[params["name"]] = list_option
+							return TRUE
 		if("activate")
 			closed = TRUE
 			ui.close()

--- a/code/modules/admin/debug.dm
+++ b/code/modules/admin/debug.dm
@@ -233,6 +233,7 @@ var/global/debug_messages = 0
 
 /datum/proccall_editor
 	var/atom/movable/target
+	/// The current key value state of the arguments we want to return
 	var/list/listargs
 	var/list/initialization_args
 	/// Boolean field describing if the tgui_color_picker was closed by the user.
@@ -242,7 +243,7 @@ var/global/debug_messages = 0
 	..()
 	src.target = target
 	initialization_args = init_args
-	src.listargs = list()
+	src.setup_listargs()
 
 /datum/proccall_editor/disposing()
 	src.target = null
@@ -272,36 +273,42 @@ var/global/debug_messages = 0
 	. = ..()
 	closed = TRUE
 
-
-/datum/proccall_editor/ui_static_data(mob/user)
-	. = ui_data()
-	.["name"] = "Variables"
+///Set up the default values stored in listargs before we open the interface
+/datum/proccall_editor/proc/setup_listargs()
+	src.listargs = list()
 	for(var/customization in initialization_args)
-		.["options"][customization[ARG_INFO_NAME]] += list(
-			"type" = customization[ARG_INFO_TYPE],
-			"description" = customization[ARG_INFO_DESC])
 		if(length(customization) >= ARG_INFO_DEFAULT)
-			.["options"][customization[ARG_INFO_NAME]]["value"] = customization[ARG_INFO_DEFAULT]
-			src.listargs[customization[ARG_INFO_NAME]] = customization[ARG_INFO_DEFAULT]
+			if (customization[ARG_INFO_TYPE] == DATA_INPUT_LIST_PROVIDED)
+				var/list/supplied_list = customization[ARG_INFO_DEFAULT]
+				src.listargs[customization[ARG_INFO_NAME]] = supplied_list[1]
+			else
+				src.listargs[customization[ARG_INFO_NAME]] = customization[ARG_INFO_DEFAULT]
 		else
-			.["options"][customization[ARG_INFO_NAME]]["value"] = null
+			src.listargs[customization[ARG_INFO_NAME]] = null
 
-/datum/proccall_editor/ui_data()
+/datum/proccall_editor/ui_data(mob/user)
 	. = list()
+	.["name"] = "Variables"
 	.["options"] = list()
 	for(var/customization in initialization_args)
 		.["options"][customization[ARG_INFO_NAME]] += list(
 			"type" = customization[ARG_INFO_TYPE],
-			"description" = customization[ARG_INFO_DESC],
-			"value" = src.listargs[customization[ARG_INFO_NAME]]
-		)
+			"description" = customization[ARG_INFO_DESC])
+
+		//show coordinates as well as actual value
 		if(customization[ARG_INFO_TYPE] == DATA_INPUT_REFPICKER)
 			var/atom/target = src.listargs[customization[ARG_INFO_NAME]]
 			if(isatom(target))
 				.["options"][customization[ARG_INFO_NAME]]["value"] = "([target.x],[target.y],[target.z]) [target]"
 			else
 				.["options"][customization[ARG_INFO_NAME]]["value"] = "null"
-
+			continue
+		//supplied lists have a different interface with a `list` var and `value` being the currently selected list item
+		//confusing!!
+		if (customization[ARG_INFO_TYPE] == DATA_INPUT_LIST_PROVIDED)
+			.["options"][customization[ARG_INFO_NAME]]["list"] = flatten_list_to_keys(customization[ARG_INFO_DEFAULT])
+		//normal variable
+		.["options"][customization[ARG_INFO_NAME]]["value"] = src.listargs[customization[ARG_INFO_NAME]]
 
 /datum/proccall_editor/ui_act(action, list/params, datum/tgui/ui)
 	USR_ADMIN_ONLY

--- a/code/modules/tgui/tgui_input_list.dm
+++ b/code/modules/tgui/tgui_input_list.dm
@@ -100,11 +100,8 @@
 	src.start_with_search = start_with_search == "auto" ? length(items) > 10 : start_with_search
 	src.capitalize = capitalize
 
-	// Gets rid of illegal characters
-	var/static/regex/whitelistedWords = regex(@{"([^\u0020-\u8000]+)"})
-
 	for(var/i in items)
-		var/string_key = allowIllegal ? i : whitelistedWords.Replace("[i]", "")
+		var/string_key = allowIllegal ? i : strip_illegal_characters(i)
 
 		src.items += string_key
 		src.items_map[string_key] = i

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -359,6 +359,11 @@ proc/castRay(var/atom/A, var/Angle, var/Distance) //Adapted from some forum stuf
 	// 	index = findtext(t, ">")
 	. = html_encode(t)
 
+///Strip out weird illegal characters that TGUI discards anyway, see `\improper` and other Byond lunacy
+/proc/strip_illegal_characters(text)
+	var/static/regex/whitelistedWords = regex(@{"([^\u0020-\u8000]+)"})
+	return whitelistedWords.Replace("[text]", "")
+
 ///Cleans up data passed in from network packets for display so it doesn't mess with formatting
 /proc/tidy_net_data(var/t)
 	. = isnum(t) ? t : strip_html(t)

--- a/tgui/packages/tgui/interfaces/common/DataInput.tsx
+++ b/tgui/packages/tgui/interfaces/common/DataInput.tsx
@@ -115,7 +115,7 @@ const DataInputListEntry = (props) => {
           selected={item === value}
           color="transparent"
           onClick={() =>
-            act('modify_value', {
+            act('modify_list_value', {
               name: name,
               value: item,
               type: type,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactors the `/datum/proccall_editor` data entry form to allow for `DATA_INPUT_LIST_PROVIDED` to work properly.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some components use this and it doesn't work right now, also I want to use this form for things like admin add antag options.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

![image](https://github.com/user-attachments/assets/5dcae1d0-abcf-433c-b198-196116bb3c58)
(ignore the fact that the tool flags are still extremely cursed)
