### PR TITLE
Makes hotspot burn-application more generic

### DIFF
--- a/code/modules/atmospherics/FEA_fire.dm
+++ b/code/modules/atmospherics/FEA_fire.dm
@@ -261,8 +261,7 @@
 /atom/movable/hotspot/proc/update_status_effect(mob/living/target)
 	var/clamped_temp = clamp(temperature, FIRE_MINIMUM_TEMPERATURE_TO_EXIST, maximum_status_temp)
 	var/t = (clamped_temp - FIRE_MINIMUM_TEMPERATURE_TO_EXIST) / (maximum_status_temp - FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
-	var burn = lerp(min_status_duration, max_status_duration, t)
-	target.update_burning(burn)
+	target.update_burning(lerp(min_status_duration, max_status_duration, t))
 
 
 /atom/movable/hotspot/ex_act()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label[bug][status effects] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Replaces burning-duration update calcs with a generic proc that lerps between a minimum and maximum burn duration based on temperature. Applies 30 seconds of burning at 373 kelvin, and 55 seconds of burning at 5000 kelvin.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Previous code was more difficult to maintain, and partially bugged. It invariably set burning to 55 seconds when stepped into, despite burning application for remaining within fire being a fraction of that; this keeps both methods of application more consistent.

Personally I might suggest crossing-into-fire being less intense, considering the number of activations scales with player movement and can thus trigger more often. However since noone was complaining while it was maxed out, that might be rocking the boat unnecessarily. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested with the vega flamethrower and fireball for stepping into chemfires (chemfires never reach past the first process() deletion checks unless there is also a gasfire present and thus won't ever passively burn). Plasma fire for stepping into and remaining within gasfires. 

Before:
![Screenshot 2025-06-09 122624](https://github.com/user-attachments/assets/b42bfe2b-6593-4c6e-86ea-e9ec4f236e6d)
After: 
![Screenshot 2025-06-10 211823](https://github.com/user-attachments/assets/06418477-3a03-4e6a-b256-d3bc7cd573c1)


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Egregorious
(+)The burn-duration recieved from stepping into fires properly scales with the fire's temperature.
```
