### PR TITLE
Add next_click limit to Telekinesis

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -799,6 +799,10 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 	//Click-drag tk stuff.
 /obj/item/proc/click_drag_tk(atom/over_object, src_location, over_location, over_control, params)
 	if(!src.anchored)
+		if(ismob(usr))
+			if (world.time < usr.next_click)
+				return
+			usr.next_click = world.time + max(src.click_delay, src.combat_click_delay)
 		if (iswraith(usr))
 			var/mob/living/intangible/wraith/W = usr
 			//Basically so poltergeists need to be close to an object to send it flying far...


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Telekinesis will respect user next_click. 
An expansion on #4817 to also ensure items follow expected combat delays. 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ensures consistent behavior of various items/equipment when used.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Evaluated behavior with various items.
Evaluated behavior does not impact other aspects such as ghost_interaction
