### PR TITLE
Fix Nadir elevator moving almanac

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -7218,9 +7218,6 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/storage)
 "doE" = (
-/obj/decal/poster/miners_almanac{
-	pixel_y = 28
-	},
 /turf/simulated/floor/engine/caution/corner{
 	dir = 8
 	},
@@ -35932,7 +35929,12 @@
 /obj/machinery/door_control{
 	id = "nadir_minetop";
 	name = "Loading Door Control";
-	pixel_y = 24
+	pixel_y = 24;
+	pixel_x = 8
+	},
+/obj/decal/poster/miners_almanac{
+	pixel_y = 28;
+	pixel_x = -6
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the nadir miners almanac to the main room from above the elevator

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #23771, don't map stuff onto elevators.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![image](https://github.com/user-attachments/assets/9453e143-c8df-4c45-b31c-0b7bf416b66c)