### PR TITLE
Makes mechcomp teleport projectiles no longer destroyable by the mineral magnet

### DIFF
--- a/_std/defines/atom.dm
+++ b/_std/defines/atom.dm
@@ -61,6 +61,7 @@
 #define MOVE_NOCLIP 				(1 << 9)
 /// Atom won't get warped to z5 via floor holes on underwater maps
 #define IMMUNE_TRENCH_WARP			(1 << 10)
+#define IMMUNE_MINERAL_MAGNET		(1 << 11)
 
 
 //THROW flags (what kind of throw, we can have ddifferent kinds of throws ok)

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -793,6 +793,8 @@ ABSTRACT_TYPE(/datum/projectile/special)
 		src.starting_turf = get_turf(P)
 		src.eye_glider = new(get_turf(P))
 		src.eye_glider.flags |= UNCRUSHABLE
+		src.eye_glider.event_handler_flags |= IMMUNE_MINERAL_MAGNET
+		P.event_handler_flags |= IMMUNE_MINERAL_MAGNET
 		src.eye_glider.anchored = ANCHORED_ALWAYS
 		for (var/mob/M in P.contents)
 			if(M.client)

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -159,7 +159,7 @@
 		var/turf/origin = get_turf(src)
 		for (var/turf/T in block(origin, locate(origin.x + width - 1, origin.y + height - 1, origin.z)))
 			for (var/obj/O in T)
-				if (!(O.type in mining_controls.magnet_do_not_erase) && !istype(O, /obj/magnet_target_marker))
+				if (!(O.type in mining_controls.magnet_do_not_erase) && !istype(O, /obj/magnet_target_marker) && !HAS_FLAG(O.event_handler_flags, IMMUNE_MINERAL_MAGNET))
 					qdel(O)
 			T.ClearAllOverlays()
 			for (var/mob/living/L in T)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->[BUG][game objects]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes https://github.com/goonstation/goonstation/issues/23793 by adding a new event_handler flag `IMMUNE_MINERAL_MAGNET`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The mineral magnet is one of the few things in this game that can destroy any child in the `/obj` path and would probably need this flag sooner or later.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
First I reproduced the bug by setting the mechcomp warp projectile speed to 1, and setting up a mechcomp teleporter above and below the mineral magnet area. Confirmed the projectile was being deleted when the purple walls went up.

Made changes, then made the same teleport setup. Confirmed these cases worked as expected.:
1. The visible projectile isn't destroyed.
2. When inside the projectile, it still functions like normal and the mob isn't destroyed.
3. Other objects (tested a toolbox, gps, and a locker) are still destroyed as normal in the magnet.

Screenshot of the setup:
![image](https://github.com/user-attachments/assets/a4c05656-f18c-46be-848c-656f8b70a541)
