### PR TITLE
Maneater devouring people now notifies ghosts

### DIFF
--- a/code/datums/abilities/critter/maneater_devour.dm
+++ b/code/datums/abilities/critter/maneater_devour.dm
@@ -49,6 +49,8 @@
 		ownerMob.visible_message(SPAN_ALERT("<B>[ownerMob] hungrily devours [target]!</B>"))
 		playsound(ownerMob.loc, 'sound/voice/burp_alien.ogg', 50, 1)
 		logTheThing(LOG_COMBAT, ownerMob, "devours [constructTarget(target,"combat")] whole at [log_loc(owner)].")
+		var/where_text =  get_ghost_where_text(owner)
+		message_ghosts("<b>[target.name]</b> was devoured whole by a Maneater at [where_text])].")
 		//if we got a maneater as a user, we store it because of its unique behaviour
 		var/mob/living/critter/plant/maneater/eating_maneater = null
 		if (istype(ownerMob, /mob/living/critter/plant/maneater))

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -681,10 +681,7 @@
 
 	if (src.mind) // I think this is kinda important (Convair880).
 		if (src.mind.ckey && !inafterlife(src))
-			var/turf/where = get_turf(src)
-			var/where_text = "Unknown (?, ?, ?)"
-			if (where)
-				where_text = "<b>[where.loc]</b> [showCoords(where.x, where.y, where.z, ghostjump=TRUE)]"
+			var/where_text =  get_ghost_where_text(src)
 
 			message_ghosts("<b>[src.name]</b> has died in ([where_text]).")
 #ifdef DATALOGGER

--- a/code/obj/rocko.dm
+++ b/code/obj/rocko.dm
@@ -34,10 +34,7 @@
 		STOP_TRACKING_CAT(TR_CAT_PETS)
 		STOP_TRACKING_CAT(TR_CAT_GHOST_OBSERVABLES)
 
-		var/turf/where = get_turf(src)
-		var/where_text = "Unknown (?, ?, ?)"
-		if (where)
-			where_text = "<b>[where.loc]</b> [showCoords(where.x, where.y, where.z, ghostjump=TRUE)]"
+		var/where_text = get_ghost_where_text(src)
 		message_ghosts("<b>[src.name]</b> has died in ([where_text]).")
 		..()
 

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2566,6 +2566,12 @@ proc/total_cross(turf/T, atom/movable/mover)
 
 var/atom/movable/abstract_say_source/deadchat/deadchat_announcer = new()
 
+/proc/get_ghost_where_text(atom/X)
+	var/turf/where = get_turf(X)
+	. = "Unknown (?, ?, ?)"
+	if (where)
+		. = "<b>[where.loc]</b> [showCoords(where.x, where.y, where.z, ghostjump=TRUE)]"
+
 /proc/message_ghosts(message, show_wraith = FALSE)
 	var/list/mob/living/intangible/wraith/wraiths = list()
 	for (var/datum/antagonist/antagonist_datum as anything in global.get_all_antagonists(ROLE_WRAITH))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label [BUG][critters]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes: https://github.com/goonstation/goonstation/issues/23770. Adds a `message_ghosts` for maneater devouring players that says "[player] was devoured whole by a Maneater at [location]"

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More interesting and bespoke ghost messages keep the game engaging for those removed from the round.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spanwed a maneater and an assistant. Confirmed that a ghost message did not appear when the assistant was devoured.

After changes, spawned a maneater and an assistant. Confirmed that the ghost message showed up.

![image](https://github.com/user-attachments/assets/975427cc-74f2-4ac3-94a1-ac1c59db52aa)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

