### PR TITLE
Fix local JS errors on 515 builds

### DIFF
--- a/browserassets/src/js/chui/chui.js
+++ b/browserassets/src/js/chui/chui.js
@@ -48,7 +48,7 @@ chui.bycall = function (method, data) {
 	data = data || {};
 	data._cact = method;
 	const Http = new XMLHttpRequest();
-	Http.open("GET", "byond://?src=" + chui.window + "&" + $.param(data));
+	Http.open("GET", "?src=" + chui.window + "&" + $.param(data));
 	Http.send();
 };
 
@@ -305,7 +305,7 @@ chui.fadeIn = function () {
 						pos: x - 40 * neg + "," + (y - 40 * neg),
 					});
 				},
-			},
+			}
 		);
 	}, 1000);
 };
@@ -330,7 +330,7 @@ chui.fadeOut = function () {
 				});
 			},
 			complete: chui.close,
-		},
+		}
 	);
 };
 

--- a/browserassets/src/js/processScheduler.js
+++ b/browserassets/src/js/processScheduler.js
@@ -98,7 +98,7 @@
 
 		// Remove existing sticky header if present.
 		var existingSticky = document.getElementById(
-			containerId + "-sticky-header",
+			containerId + "-sticky-header"
 		);
 		if (existingSticky) {
 			existingSticky.parentNode.removeChild(existingSticky);
@@ -287,7 +287,7 @@
 			var sortingState = { column: index, direction: newDir };
 			localStorage.setItem(
 				"tableSorting_" + table.parentNode.id,
-				JSON.stringify(sortingState),
+				JSON.stringify(sortingState)
 			);
 		}
 		updateStickyHeaderState(table, table.parentNode.id);

--- a/browserassets/src/js/telescope.js
+++ b/browserassets/src/js/telescope.js
@@ -297,7 +297,7 @@ function redrawCanvas() {
 			currP.y * scalar[1],
 			currP.size * scalar[0],
 			0,
-			2 * Math.PI,
+			2 * Math.PI
 		);
 		context.stroke();
 		currP.size = Math.min(currP.size + currP.growSpeed, currP.maxSize);
@@ -316,7 +316,7 @@ function redrawCanvas() {
 			curr.y,
 			curr.currentSize,
 			lerpColor(curr.fromColor, curr.color, prc),
-			prc * (adj * 2),
+			prc * (adj * 2)
 		);
 	}
 
@@ -331,7 +331,7 @@ function redrawCanvas() {
 	if (prcReady == 1)
 		cooldownProps.barOpacity = Math.max(
 			cooldownProps.barOpacity - cooldownProps.barFadeSpeed,
-			0,
+			0
 		);
 
 	if (glitchProps.glitching) {
@@ -388,7 +388,7 @@ function easeInOutQuad(
 	currentIteration,
 	startValue,
 	changeInValue,
-	totalIterations,
+	totalIterations
 ) {
 	if ((currentIteration /= totalIterations / 2) < 1) {
 		return (
@@ -405,7 +405,7 @@ function easeInOutCubic(
 	currentIteration,
 	startValue,
 	changeInValue,
-	totalIterations,
+	totalIterations
 ) {
 	if ((currentIteration /= totalIterations / 2) < 1) {
 		return (changeInValue / 2) * Math.pow(currentIteration, 3) + startValue;
@@ -419,7 +419,7 @@ function easeInOutCirc(
 	currentIteration,
 	startValue,
 	changeInValue,
-	totalIterations,
+	totalIterations
 ) {
 	if ((currentIteration /= totalIterations / 2) < 1) {
 		return (

--- a/browserassets/src/js/tooltip.js
+++ b/browserassets/src/js/tooltip.js
@@ -211,7 +211,7 @@ var tooltip = {
 				tooltip.params = $.parseJSON(params);
 			} catch (e) {
 				triggerError(
-					"(position params) JSON parse error for: " + params + ". " + e,
+					"(position params) JSON parse error for: " + params + ". " + e
 				);
 				return;
 			}
@@ -275,7 +275,7 @@ var tooltip = {
 					"Manually adjusted leftOffset by " +
 						manualOffsetX +
 						" amount. Real pixel offset value: " +
-						manualOffsetX * resizeRatioX,
+						manualOffsetX * resizeRatioX
 				);
 			}
 			if (tooltip.options.offset.hasOwnProperty("y")) {
@@ -285,7 +285,7 @@ var tooltip = {
 					"Manually adjusted topOffset by " +
 						manualOffsetY +
 						" amount. Real pixel offset value: " +
-						manualOffsetY * resizeRatioY,
+						manualOffsetY * resizeRatioY
 				);
 			}
 		}
@@ -296,10 +296,10 @@ var tooltip = {
 
 		//Calculate where on the screen the popup should appear (below the hovered tile)
 		var posX = Math.round(
-			(left - 1) * realIconSizeX + leftOffset + tooltip.padding,
+			(left - 1) * realIconSizeX + leftOffset + tooltip.padding
 		); //-1 to position at the left of the target tile
 		var posY = Math.round(
-			(tilesShownY - top + 1) * realIconSizeY + topOffset + tooltip.padding,
+			(tilesShownY - top + 1) * realIconSizeY + topOffset + tooltip.padding
 		); //+1 to position at the bottom of the target tile
 
 		var docWidth = 0,
@@ -336,7 +336,7 @@ var tooltip = {
 		//Apply our sizing
 		tooltip.$wrap.attr(
 			"style",
-			"width: " + docWidth + "px; height: " + docHeight + "px;",
+			"width: " + docWidth + "px; height: " + docHeight + "px;"
 		);
 
 		//Handle special flags
@@ -414,7 +414,7 @@ var tooltip = {
 				". PosX: " +
 				posX +
 				". PosY: " +
-				posY,
+				posY
 		);
 		tooltip.show(docWidth, docHeight, posX, posY);
 	},
@@ -455,14 +455,14 @@ var tooltip = {
 
 		try {
 			tooltip.mapOffsets = $.parseJSON(
-				map[tooltip.getMapControlFor("helper") + ".saved-params"],
+				map[tooltip.getMapControlFor("helper") + ".saved-params"]
 			);
 		} catch (e) {
 			triggerError(
 				"(updateCallback helper saved-params) JSON parse error for: " +
 					map[tooltip.getMapControlFor("helper") + ".saved-params"] +
 					". " +
-					e,
+					e
 			);
 			return;
 		}
@@ -481,7 +481,7 @@ var tooltip = {
 				". theme: " +
 				tooltip.options.theme +
 				". interrupt: " +
-				tooltip.interrupt,
+				tooltip.interrupt
 		);
 
 		//Some reset stuff to avoid fringe issues with sizing
@@ -494,7 +494,7 @@ var tooltip = {
 
 		tooltip.$docBody.attr(
 			"class",
-			tooltip.options.theme + (tooltip.pinned ? " pinned" : ""),
+			tooltip.options.theme + (tooltip.pinned ? " pinned" : "")
 		);
 		tooltip.$wrap.attr("style", "");
 		tooltip.changeContent(tooltip.options.title, tooltip.options.content); //calls position, which calls show
@@ -505,7 +505,7 @@ var tooltip = {
 			tooltip.params = $.parseJSON(params);
 		} catch (e) {
 			triggerError(
-				"(update params) JSON parse error for: " + params + ". " + e,
+				"(update params) JSON parse error for: " + params + ". " + e
 			);
 			return;
 		}
@@ -515,7 +515,7 @@ var tooltip = {
 				tooltip.params.init.screen,
 				tooltip.params.init.iconSize,
 				tooltip.params.init.window,
-				tooltip.params.init.map,
+				tooltip.params.init.map
 			);
 		}
 
@@ -523,7 +523,7 @@ var tooltip = {
 			tooltip.options = $.parseJSON(options);
 		} catch (e) {
 			triggerError(
-				"(update options) JSON parse error for: " + options + ". " + e,
+				"(update options) JSON parse error for: " + options + ". " + e
 			);
 			return;
 		}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][internals]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Removes commas before closing parentheticals in JS files. trident no like
* remove `byond://` from the `XMLHttpRequest` call, which was also causing problems. this isn't used directly in the telescope.js file so with everything *else* moved to non-chui, I believe the 516 compatibility concern is avoided?

Supercedes #23336

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Multiple JS errors on local 515 builds are annoying
Tooltips don't work on 515 local

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested local builds with both latest 515 and latest 516
* Quantum telescope (516 looks busted still, but no JS errors and works; known issue)
* Trader dialog 
* Process scheduler UI (`Main-Loop-Context` command)