### PR TITLE
Prevents hemochromia from showing up as unknown

### DIFF
--- a/code/modules/medical/genetics/baseBioeffect.dm
+++ b/code/modules/medical/genetics/baseBioeffect.dm
@@ -155,6 +155,9 @@ ABSTRACT_TYPE(/datum/bioEffect)
 	proc/onPowerChange(oldval, newval)
 		return
 
+	proc/onResearched()
+		return
+
 	onVarChanged(variable, oldval, newval)
 		. = ..()
 		if(variable == "power")

--- a/code/modules/medical/genetics/bioEffects/hemochromia.dm
+++ b/code/modules/medical/genetics/bioEffects/hemochromia.dm
@@ -67,6 +67,13 @@
 			holder.RemoveEffect(src.id)
 			holder.RemovePoolEffect(src)
 
+	onResearched()
+		for (var/hemochromia in concrete_typesof(/datum/bioEffect/hemochromia))
+			var/datum/bioEffect/BE = new hemochromia
+			var/datum/bioEffect/GBE = BE.global_instance
+			GBE.research_level = max(GBE.research_level, EFFECT_RESEARCH_DONE)
+
+
 ABSTRACT_TYPE(/datum/bioEffect/hemochromia)
 
 /datum/bioEffect/hemochromia

--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -480,6 +480,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 		if (grant_research)
 			if (global_BE.research_level < EFFECT_RESEARCH_DONE)
 				genResearch.mutations_researched++
+				global_BE.onResearched()
 			global_BE.research_level = max(global_BE.research_level, EFFECT_RESEARCH_ACTIVATED)
 
 		if(E.get_global_instance() == E)

--- a/code/modules/medical/genetics/geneticsResearch.dm
+++ b/code/modules/medical/genetics/geneticsResearch.dm
@@ -217,6 +217,7 @@ var/datum/geneticsResearchManager/genResearch = new()
 		if (global_instance.research_level < EFFECT_RESEARCH_DONE)
 			global_instance.research_level = max(global_instance.research_level, EFFECT_RESEARCH_DONE)
 			genResearch.mutations_researched++
+			global_instance.onResearched()
 		..()
 
 // TIER ONE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR causes the Hemochromia Type-U gene to unlock all of its variants when researched, allowing them to show up on gene scanners and analyzers when activated.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #8718 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![image](https://github.com/user-attachments/assets/332b6c62-e1a4-447d-8ee2-9e78b08d730c)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)Researching the hemochromia gene also researches all of its variants.
```
