### PR TITLE
Closes #23430 - Spy Stickers No Longer Possess Speakers

### DIFF
--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -604,7 +604,7 @@
 /obj/item/device/radio/spy
 	name = "spy radio"
 	desc = "Spy radio housed in a sticker. Wait, how are you reading this?"
-	initial_speaker_enabled = FALSE
+	has_speaker = FALSE
 	hardened = FALSE
 
 /obj/item/device/radio/spy/det_only


### PR DESCRIPTION
[QoL]


## About The PR:
Spy stickers no longer possess speakers; this makes them more intuitive to use and prevents players from clogging up the chat window by accidently enabling the speakers before placing the sticker.
Closes #23430.


## Testing:
![image](https://github.com/user-attachments/assets/b84e9e36-f8d1-45fe-a3c5-567b6b5ad375)