### PR TITLE
Commaster properly clears data when restarted

### DIFF
--- a/code/modules/networks/computer3/communication.dm
+++ b/code/modules/networks/computer3/communication.dm
@@ -34,6 +34,7 @@
 
 		src.reply_wait = -1
 
+		menu = MENU_MAIN
 		src.print_shuttle_status()
 		src.print_intro_text()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR modifies the Commaster program to properly enter `MENU_MAIN` when opened, clearing any incomplete commands from the previous session and starting fresh.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #12994, Fixes #14873, Fixes #23564

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

To test, the following procedure was done:

* The Commaster program was opened
* The Transmit command was given, and the program was immediately exited
* Commaster was reopened again, and the Transmit command was sent a second time

On master, this resulted in the previous transmit command going through with the title 'transmit'. On the fixed branch, the program opened a fresh transmit command, as intended.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
