### PR TITLE
Destroying a compact sleeper/port-a-medbay properly removes its internal console

### DIFF
--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -690,7 +690,7 @@ TYPEINFO(/obj/machinery/sleeper/port_a_medbay)
 
 	disposing()
 		STOP_TRACKING_CAT(TR_CAT_PORTABLE_MACHINERY)
-		qdel(our_console)
+		QDEL_NULL(our_console)
 		..()
 
 
@@ -775,7 +775,7 @@ TYPEINFO(/obj/machinery/sleeper/port_a_medbay)
 		our_console.our_sleeper = src
 
 	disposing()
-		qdel(our_console)
+		QDEL_NULL(our_console)
 		..()
 
 	attack_hand(mob/user)

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -690,6 +690,7 @@ TYPEINFO(/obj/machinery/sleeper/port_a_medbay)
 
 	disposing()
 		STOP_TRACKING_CAT(TR_CAT_PORTABLE_MACHINERY)
+		qdel(our_console)
 		..()
 
 
@@ -772,6 +773,10 @@ TYPEINFO(/obj/machinery/sleeper/port_a_medbay)
 		..()
 		our_console = new /obj/machinery/sleep_console/compact (src)
 		our_console.our_sleeper = src
+
+	disposing()
+		qdel(our_console)
+		..()
 
 	attack_hand(mob/user)
 		if (our_console)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR deletes the internal console of the compact sleeper and port-a-medbay when they're disposed instead of leaving it on the ground.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #19102 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Bug was confirmed by calling `ex_act(2)` on a Port-A-Medbay repeatedly. After fix was implemented, it was tested by repeating the same process multiple times.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

