### PR TITLE
Fix `args` keyword being used as a var in one unit test

### DIFF
--- a/code/modules/unit_tests/rand.dm
+++ b/code/modules/unit_tests/rand.dm
@@ -17,28 +17,28 @@
 		deterministic_check(/datum/xor_rand_generator/proc/xor_randf, list(0,100), 100, 3, 0xB00)
 		deterministic_check(/datum/xor_rand_generator/proc/xor_rand, list(0,100), 100, 3, 0xDEAD)
 
-/datum/unit_test/xor_rand/proc/distribution_check(delegate, args, iterations)
+/datum/unit_test/xor_rand/proc/distribution_check(delegate, call_args, iterations)
 	var/result
 	var/sum
 	var/list/distro = list()
 	var/list/sub_distro = list()
-	var/range = args
-	if(!length(args))
+	var/range = call_args
+	if(!length(call_args))
 		range = list(0,1)
 	var/expected_mean = ((range[2]-range[1])/2)
 	var/sum_sqrs
 
 	for(var/i in 1 to iterations)
 		if(delegate)
-			result = call(R, delegate)(arglist(args))
+			result = call(R, delegate)(arglist(call_args))
 		else
-			if(length(args))
-				result = rand(args[1],args[2])
+			if(length(call_args))
+				result = rand(call_args[1],call_args[2])
 			else
 				result = rand()
 
 		var/bucket_val = result
-		if(!length(args))
+		if(!length(call_args))
 			bucket_val *= 100
 		sum += result
 		sum_sqrs += (result-expected_mean)**2
@@ -61,7 +61,7 @@
 	TEST_ASSERT(cv >= 0.51, "Test Coefficient of variation is within tolerance. [delegate] [cv] >= 0.51")
 	TEST_ASSERT(cv <= 0.65, "Test Coefficient of variation is within tolerance. [delegate] [cv] <= 0.65")
 
-/datum/unit_test/xor_rand/proc/deterministic_check(delegate, args, iterations, attempts, seed)
+/datum/unit_test/xor_rand/proc/deterministic_check(delegate, call_args, iterations, attempts, seed)
 	var/list/first_iteration = list()
 	var/list/this_result
 
@@ -70,9 +70,9 @@
 		R.seed = seed
 		for(var/j in 1 to iterations)
 			if(i == 1)
-				first_iteration += call(R, delegate)(arglist(args))
+				first_iteration += call(R, delegate)(arglist(call_args))
 			else
-				this_result = call(R, delegate)(arglist(args))
+				this_result = call(R, delegate)(arglist(call_args))
 				TEST_ASSERT(first_iteration[j] == this_result, "Test calculations is the same. Index:[j] [first_iteration[j]] == [this_result]")
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
swaps `args` to `call_args` in a proc def in a unit test

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
`args` has special meaning in DM, overriding by using it as a var name can cause unusual behaviour. 
OpenDream will (soon) report instances of this as a `SoftReservedKeyword` error.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

CI will test it
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->


