### PR TITLE
Fix bad HoS access merge

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -185,12 +185,9 @@
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_maxsec, access_brig, access_securitylockers,
 						access_forensics_lockers, access_armory, access_ticket, access_tox, access_tox_storage, access_chemistry, access_medical,
 						access_morgue, access_change_ids, access_eva, access_heads, access_medical_lockers, access_medlab,
-						access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
 						access_crematorium, access_kitchen, access_robotics, access_cargo, access_money,
 						access_research, access_dwaine_superuser, access_hydro, access_ranch, access_ai_upload,
 						access_tech_storage, access_maint_tunnels, access_bar, access_janitor, access_fine_small, access_fine_large,
-						access_crematorium, access_kitchen, access_robotics, access_cargo, access_money,
-						access_research, access_dwaine_superuser, access_hydro, access_ranch, access_ai_upload,
 						access_engineering, access_teleporter, access_engineering_engine, access_engineering_control,
 						access_mining, access_pathology, access_researchfoyer, access_chapel_office, access_telesci,
 						access_engineering_storage, access_engineering_mechanic)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes duplicated access lines on HoS accesses caused by bad merge

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These lines are duplicate due to a bad upstream merge after fining access and shouldn't be here
https://github.com/goonstation/goonstation/pull/23200/commits/25e28050ec38f0deeb6cb7dd944e4cc2293e96f1

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![image](https://github.com/user-attachments/assets/178d2a28-8cf7-4fa8-8829-fa1c4251f2e7)
Access unchanged