### PR TITLE
Fix `usr` being used as a proc arg in portagene

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -152,8 +152,8 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //------------ Unit Test Framework ------------//
 
-#define UNIT_TESTS
-#define UNIT_TESTS_RUN_TILL_COMPLETION // Bypass 10 Second Limit
+//#define UNIT_TESTS
+//#define UNIT_TESTS_RUN_TILL_COMPLETION // Bypass 10 Second Limit
 //#define UNIT_TEST_TYPES /datum/unit_test/explosion_test, /datum/unit_test/deletion_regressions // Only run tests of these types - comma separated list of types
 
 #ifdef CI_RUNTIME_CHECKING

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -152,8 +152,8 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //------------ Unit Test Framework ------------//
 
-//#define UNIT_TESTS
-//#define UNIT_TESTS_RUN_TILL_COMPLETION // Bypass 10 Second Limit
+#define UNIT_TESTS
+#define UNIT_TESTS_RUN_TILL_COMPLETION // Bypass 10 Second Limit
 //#define UNIT_TEST_TYPES /datum/unit_test/explosion_test, /datum/unit_test/deletion_regressions // Only run tests of these types - comma separated list of types
 
 #ifdef CI_RUNTIME_CHECKING

--- a/code/modules/medical/genetics/portagene.dm
+++ b/code/modules/medical/genetics/portagene.dm
@@ -64,15 +64,15 @@
 			logTheThing(LOG_STATION, usr, "sets [src.name]'s home turf to [log_loc(src.homeloc)].")
 		return
 
-	relaymove(mob/usr as mob, dir)
-		if (!isalive(usr))
+	relaymove(mob/user as mob, dir)
+		if (!isalive(user))
 			return
 		if (src.locked)
-			boutput(usr, SPAN_ALERT("<b>The scanner door is locked!</b>"))
+			boutput(user, SPAN_ALERT("<b>The scanner door is locked!</b>"))
 			return
 
 		src.go_out()
-		add_fingerprint(usr)
+		add_fingerprint(user)
 		playsound(src.loc, 'sound/machines/sleeper_open.ogg', 50, 1)
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
renames a proc arg from `usr` to `user`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
`usr` has special meaning in DM, overriding by using it as a var name can cause unusual behaviour.
OpenDream will (soon) report instances of this as a SoftReservedKeyword error.
