### PR TITLE
Fix `usr` being used as proc arg in grenades

### DIFF
--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1081,12 +1081,12 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 				message_admins("Grenade ([src]) primed at [log_loc(src)] by [key_name(user)].")
 			logTheThing(LOG_COMBAT, user, "primes a grenade ([src.type]) at [log_loc(user)].")
 
-	proc/arm(mob/usr as mob)
+	proc/arm(mob/user as mob)
 
-		usr.show_message(SPAN_ALERT("<B>You have armed the [src.name]!"))
-		for(var/mob/O in viewers(usr))
+		user.show_message(SPAN_ALERT("<B>You have armed the [src.name]!"))
+		for(var/mob/O in viewers(user))
 			if (O.client)
-				O.show_message(SPAN_ALERT("<B>[usr] has armed the [src.name]! Run!</B>"), 1)
+				O.show_message(SPAN_ALERT("<B>[user] has armed the [src.name]! Run!</B>"), 1)
 
 		if (icon_state_armed)
 			icon_state = icon_state_armed


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
renames a proc arg from `usr` to `user`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
`usr` has special meaning in DM, overriding by using it as a var name can cause unusual behaviour.
OpenDream will (soon) report instances of this as a SoftReservedKeyword error.
https://github.com/OpenDreamProject/OpenDream/pull/2307
