### PR TITLE
Fix `usr` being used as a proc arg in vape

### DIFF
--- a/code/obj/item/misc_junk.dm
+++ b/code/obj/item/misc_junk.dm
@@ -381,12 +381,12 @@ TYPEINFO(/obj/item/reagent_containers/vape)
 			src.emagged = 1
 		return 1
 
-	attackby(obj/item/reagent_containers/ecig_refill_cartridge/E, mob/usr) //you may call this redundantly overdoing it. I say fuck you
+	attackby(obj/item/reagent_containers/ecig_refill_cartridge/E, mob/user) //you may call this redundantly overdoing it. I say fuck you
 		if (istype(E, /obj/item/reagent_containers/ecig_refill_cartridge))
 			if (!E.reagents.total_volume)
-				usr.show_text("\The [src] is empty.", "red")
+				user.show_text("\The [src] is empty.", "red")
 				return
-			usr.show_text("You refill the [src] with the cartridge.", "red")
+			user.show_text("You refill the [src] with the cartridge.", "red")
 			E.reagents.trans_to(src, 50)
 			src.reagents.add_reagent("nicotine", 50)
 			qdel(E) //this technically implies that vapes infinitely eat these refills. I say the catriges are made of pure nicotine and are slowly absorbed


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
renames a proc arg from `usr` to `user`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
`usr` has special meaning in DM, overriding by using it as a var name can cause unusual behaviour.
OpenDream will (soon) report instances of this as a SoftReservedKeyword error.
https://github.com/OpenDreamProject/OpenDream/pull/2307
