### PR TITLE
Fix Cog1 TEG pipe rupturability

### DIFF
--- a/assets/maps/engine_rooms/cogmap/TEG_100.dmm
+++ b/assets/maps/engine_rooms/cogmap/TEG_100.dmm
@@ -73,7 +73,6 @@
 /area/station/engine/core)
 "eq" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	can_rupture = 0;
 	dir = 6
 	},
 /obj/machinery/meter{
@@ -210,7 +209,6 @@
 /area/station/engine/core)
 "lQ" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
 	dir = 10
 	},
 /obj/machinery/meter{
@@ -337,7 +335,6 @@
 /area/station/engine/inner)
 "vv" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
 	dir = 9
 	},
 /obj/cable{
@@ -349,9 +346,7 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "vN" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0
-	},
+/obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	name = "Core Access";
 	req_access = null
@@ -418,9 +413,7 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "yZ" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	can_rupture = 0
-	},
+/obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	name = "Core Access";
 	req_access = null
@@ -491,7 +484,6 @@
 /area/station/engine/inner)
 "Cv" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
 	dir = 1
 	},
 /obj/machinery/power/stats_meter{
@@ -663,7 +655,6 @@
 	pixel_y = 20
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	can_rupture = 0;
 	dir = 10
 	},
 /obj/cable{
@@ -701,7 +692,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
 	dir = 6
 	},
 /obj/cable{

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -19410,7 +19410,9 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/engine)
 "bqq" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0
+	},
 /obj/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
@@ -19419,7 +19421,9 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/engine)
 "bqs" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/engine)
 "bqt" = (
@@ -19938,7 +19942,8 @@
 /area/station/routing/eva)
 "btv" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
+	dir = 4;
+	can_rupture = 0
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
@@ -20730,7 +20735,8 @@
 /area/station/engine/combustion_chamber)
 "bxJ" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 10
+	dir = 10;
+	can_rupture = 0
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
@@ -35791,7 +35797,6 @@
 /area/station/routing/sortingRoom)
 "cOb" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	can_rupture = 0;
 	dir = 5
 	},
 /turf/simulated/floor/grey,
@@ -38688,7 +38693,8 @@
 /area/station/turret_protected/Zeta)
 "eJV" = (
 /obj/machinery/atmospherics/pipe/manifold{
-	level = 2
+	level = 2;
+	can_rupture = 0
 	},
 /obj/machinery/meter,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -48486,7 +48492,9 @@
 /turf/simulated/floor/black,
 /area/station/engine/coldloop)
 "mqz" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0
+	},
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -52989,7 +52997,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "pwM" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0
+	},
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -53362,7 +53372,8 @@
 /area/space)
 "pKI" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 4
+	dir = 4;
+	can_rupture = 0
 	},
 /obj/cable,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -53481,7 +53492,8 @@
 /area/station/engine/storage)
 "pTf" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 4
+	dir = 4;
+	can_rupture = 0
 	},
 /obj/cable{
 	icon_state = "0-2"
@@ -56070,7 +56082,6 @@
 /area/station/garden/owlery)
 "rSs" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
 	dir = 6
 	},
 /turf/simulated/floor/red,
@@ -60232,7 +60243,9 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "uKI" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
 "uKK" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Does a pass on which pipes in the cog1 TEG are rupturable, making sure ones under walls and windows arent, and any others are. Specifically ignores pipes not in the engine or loop rooms, such as the purge pipes to the south, which are presumably purposefully unburstable.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #23831

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

![image](https://github.com/user-attachments/assets/2ebd841a-562f-4eae-a83d-449285ce2c04)
Pipe on floor can be rupture.
