### PR TITLE
(Hopefully) Fix gangs having no members

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -109,7 +109,7 @@
 	for(var/datum/gang/gang in src.gangs)
 		num_people_needed += min(gang.current_max_gang_members, max_member_count) - length(gang.members)
 	if(isnull(candidates))
-		candidates = get_possible_enemies(ROLE_GANG_MEMBER, num_people_needed, allow_carbon=TRUE, filter_proc=GLOBAL_PROC_REF(can_join_gangs), force_fill = FALSE)
+		candidates = get_possible_enemies(ROLE_GANG_MEMBER, num_people_needed, allow_carbon=TRUE, force_fill = FALSE)
 	var/num_people_available = min(num_people_needed, length(candidates))
 	var/people_added_per_gang = round(num_people_available / num_teams)
 	num_people_available = people_added_per_gang * num_teams
@@ -120,10 +120,6 @@
 			var/datum/mind/candidate = candidates[i++]
 			candidate.add_subordinate_antagonist(ROLE_GANG_MEMBER, master = gang.leader, silent=TRUE)
 			traitors |= candidate
-
-/proc/can_join_gangs(mob/M) //stupid frickin 515 call syntax making me make this a global grumble grumble
-	var/datum/job/job = find_job_in_controller_by_string(M.mind.assigned_role)
-	. = (!job || !job.can_be_antag(ROLE_GANG_MEMBER) || !job.can_be_antag(ROLE_GANG_LEADER))
 
 /datum/game_mode/gang/send_intercept()
 	..(src.traitors)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the filter_proc from gangwar gang member get_possible_enemies

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gangs are spawning with no members, I suspect the filter_proc functionality is broken somewhere as this is the only gamemode that uses it, get_possible_enemies already checks if they can be the role being passed to it (ROLE_GANG_MEMBER here) so this shouldn't make anyone that shouldnt be member a member.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Uh.. it builds... no way to check if this actually works on my own though. Reccomend a TM and running a gang round to see if they get members (and giving them points to make members if they get none)
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

