### PR TITLE
Fix for vent_pumps that made them not suck gases.

### DIFF
--- a/code/modules/atmospherics/machinery/unary/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/unary/vent_pump.dm
@@ -33,11 +33,17 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/New()
 	..()
-	if (src.on)
-		src.turn_on()
 	if(src.frequency)
 		src.net_id = generate_net_id(src)
 		MAKE_DEFAULT_RADIO_PACKET_COMPONENT(src.net_id, null, frequency)
+
+/obj/machinery/atmospherics/unary/vent_pump/initialize()
+	..()
+	if(src.on)
+		src.turn_on()
+	else
+		src.turn_off()
+	src.UpdateIcon()
 
 /obj/machinery/atmospherics/unary/vent_pump/proc/turn_on()
 	src.on = TRUE
@@ -138,7 +144,10 @@
 			. = TRUE
 
 		if("power_toggle")
-			src.on = !src.on
+			if (src.on)
+				src.turn_off()
+			else
+				src.turn_on()
 			. = TRUE
 
 		if("set_direction")
@@ -219,8 +228,6 @@
 			icon_state = "[hide_pipe ? "h" : "" ]in"
 	else
 		icon_state = "[hide_pipe ? "h" : "" ]off"
-		if (src.on)
-			src.turn_off()
 
 	SET_PIPE_UNDERLAY(src.node, src.dir, "long", issimplepipe(src.node) ?  src.node.color : null, hide_pipe)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][SIZE-S]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Addresses the issue [#23806](https://github.com/goonstation/goonstation/issues/23806)
1. Removed premature `turn_on()` call from `New()` that caused vents to disable themselves
2. Fixed radio toggle command to properly handle bubble absorption because yes
3. Prevented state changes during icon updates

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- Siphoning vents silently disable themselves at round start
- Radio toggle commands don't properly manage bubble components
- Some vents appear on but are functionally off

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![FR-ezgif com-optimize](https://github.com/user-attachments/assets/ae6affcc-330a-4dce-acbb-d72f1d75324b)