### PR TITLE
Blood/age cursers only affect the person who touches them

### DIFF
--- a/code/obj/artifacts/artifact_objects/curser.dm
+++ b/code/obj/artifacts/artifact_objects/curser.dm
@@ -22,6 +22,7 @@
 	examine_hint = "It is covered in very conspicuous markings."
 	// general vars
 	var/chosen_curse
+	var/affects_multiple = TRUE
 	var/list/active_cursees = list()
 	var/static/list/durations = \
 		list(BLOOD_CURSE = null, AGING_CURSE = null, NIGHTMARE_CURSE = null, MAZE_CURSE = null, DISP_CURSE = 2 MINUTES, LIGHT_CURSE = 3 MINUTES)
@@ -39,6 +40,8 @@
 	New()
 		..()
 		src.chosen_curse = pick(BLOOD_CURSE, AGING_CURSE, NIGHTMARE_CURSE, MAZE_CURSE, DISP_CURSE, LIGHT_CURSE)
+		if(chosen_curse == BLOOD_CURSE || chosen_curse == AGING_CURSE)
+			affects_multiple = FALSE
 
 	effect_touch(obj/O, mob/living/user)
 		. = ..()
@@ -60,9 +63,10 @@
 
 		logTheThing(LOG_STATION, O, "Curser artifact with effect [src.chosen_curse] activated at [log_loc(O)] by [key_name(user)]")
 
-		for (var/mob/living/carbon/human/H in range(5, O))
-			if (H != user && !isdead(H))
-				curse_candidates += H
+		if(src.affects_multiple)
+			for (var/mob/living/carbon/human/H in range(5, O))
+				if (H != user && !isdead(H))
+					curse_candidates += H
 
 		for (var/i = 1 to min(length(curse_candidates), rand(2, 5)))
 			var/candidate = pick(curse_candidates)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SCIENCE][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds the variable `affects_multiple` to curse artifacts, which is set to FALSE for blood- and aging-type cursers. Curse artifacts will only seek out additional targets if it is set to TRUE

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The blood and aging curses are disproportionately severe compared to how easy it is to get affected by them. They're extremely difficult to cure, requiring you to convince people to touch the obviously evil artifact (assuming you still have it), leave your body unclonable, and don't even have the courtesy of killing quickly. Multiple people have said that it's easier to kill and clone the poor victim rather than attempt to break the curse normally.

Normally, none of this would be a problem. Artifacts are inherently dangerous, and the crew shouldn't be randomly touching them like nothing. Having a wider variety of things for medbay to deal with is cool. However, right now it is way too easy to get cursed. Unlike any of the other deadly artifact types, you don't have to touch it, only stand within earshot of someone who does. I don't think "don't exist near random artifacts" is very practical or sensible as a preventative measure. Making the most severe versions of the curse only affect one person should make people more willing to actually engage with them instead of being overwhelmed by curse victims. At the very least, it should prevent random cases of spending the next 15 minutes dying horribly.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested this by touching spawned curse artifacts with and around target dummies with visible statuses enabled.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)Blood and aging curse artifacts now only affect the person foolish enough to touch them.
```
