### PR TITLE
Added check for Neon when generating cyborg engineer tools

### DIFF
--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -118,7 +118,7 @@
 		/obj/item/weldingtool,
 		/obj/item/rcd,
 		/obj/item/deconstructor/borg,
-		#if defined(MAP_OVERRIDE_OSHAN) || defined(MAP_OVERRIDE_NEON)
+		#ifdef HOTSPOTS_ENABLED
 			/obj/item/mining_tool/powered/shovel,
 		#endif
 		/datum/robot/module_tool_creator/item_type/amount/steel_tile,
@@ -126,7 +126,7 @@
 		/datum/robot/module_tool_creator/item_type/amount/steel_sheet,
 		/datum/robot/module_tool_creator/item_type/amount/glass_sheet,
 		/datum/robot/module_tool_creator/item_type/amount/cable_coil,
-		#if defined(MAP_OVERRIDE_OSHAN) || defined(MAP_OVERRIDE_NEON)
+		#ifdef HOTSPOTS_ENABLED
 			/datum/robot/module_tool_creator/item_type/amount/cable_coil/reinforced,
 		#endif
 		/obj/item/device/t_scanner,

--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -118,7 +118,7 @@
 		/obj/item/weldingtool,
 		/obj/item/rcd,
 		/obj/item/deconstructor/borg,
-		#ifdef MAP_OVERRIDE_OSHAN
+		#if defined(MAP_OVERRIDE_OSHAN) || defined(MAP_OVERRIDE_NEON)
 			/obj/item/mining_tool/powered/shovel,
 		#endif
 		/datum/robot/module_tool_creator/item_type/amount/steel_tile,
@@ -126,7 +126,7 @@
 		/datum/robot/module_tool_creator/item_type/amount/steel_sheet,
 		/datum/robot/module_tool_creator/item_type/amount/glass_sheet,
 		/datum/robot/module_tool_creator/item_type/amount/cable_coil,
-		#ifdef MAP_OVERRIDE_OSHAN
+		#if defined(MAP_OVERRIDE_OSHAN) || defined(MAP_OVERRIDE_NEON)
 			/datum/robot/module_tool_creator/item_type/amount/cable_coil/reinforced,
 		#endif
 		/obj/item/device/t_scanner,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[BUG][MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check for Neon when generating tools for the cyborg engineering modules to ensure they get shovels and reinforced cables like they would on Oshan.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #23853 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested via setting map overrides to both Oshan and Neon to ensure engineering modules spawn with shovel/reinforced cables. Also double checked to make sure these tools still do not spawn on the other maps to make sure I didn't bust anything.

![{6707CCCB-9ECA-4C35-A802-18C78137A739}](https://github.com/user-attachments/assets/f47af262-4c7d-43f1-b33b-d54876fbb3e5)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
