### PR TITLE
Fixes duplicate stressball message

### DIFF
--- a/code/modules/items/gimmick/plushies.dm
+++ b/code/modules/items/gimmick/plushies.dm
@@ -334,7 +334,7 @@ TYPEINFO(/obj/submachine/claw_machine)
 			boutput(user, SPAN_NOTICE(pick("Your head hurts a little less.", "You breathe a little easier.", "The pain in your chest lessens.")))
 
 	user.visible_message(SPAN_EMOTE("[user] fidgets with [src]."), group = "stress_ball")
-	boutput(user, SPAN_NOTICE("You feel [pick("a bit", "slightly", "a teeny bit", "somewhat", "surprisingly", "")] [pick("better", "more calm", "more composed", "less stressed")]."), group = "stress_ball")
+	boutput(user, SPAN_NOTICE("You feel [pick("a bit", "slightly", "a teeny bit", "somewhat", "surprisingly", "")] [pick("better", "more calm", "more composed", "less stressed")]."), group = "stress_ball_self")
 
 /obj/item/toy/plush/small/deneb
 	name = "Deneb the swan"

--- a/code/modules/items/gimmick/plushies.dm
+++ b/code/modules/items/gimmick/plushies.dm
@@ -333,8 +333,7 @@ TYPEINFO(/obj/submachine/claw_machine)
 			stressed_person.blood_volume -= rand(3,7)
 			boutput(user, SPAN_NOTICE(pick("Your head hurts a little less.", "You breathe a little easier.", "The pain in your chest lessens.")))
 
-	user.visible_message(SPAN_EMOTE("[user] fidgets with [src]."), group = "stress_ball")
-	boutput(user, SPAN_NOTICE("You feel [pick("a bit", "slightly", "a teeny bit", "somewhat", "surprisingly", "")] [pick("better", "more calm", "more composed", "less stressed")]."), group = "stress_ball_self")
+	user.visible_message(SPAN_EMOTE("[user] fidgets with [src]."), "You squeeze [src]. <br> [SPAN_NOTICE("You feel [pick("a bit", "slightly", "a teeny bit", "somewhat", "surprisingly", "")] [pick("better", "more calm", "more composed", "less stressed")].")]", group = "stress_ball")
 
 /obj/item/toy/plush/small/deneb
 	name = "Deneb the swan"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes the messages generated by `attack_hand()` on stressballs to use `message_self`, instead of having them in two separate lines.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #23872 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![image](https://github.com/user-attachments/assets/cc6ab711-a008-4f12-918e-9bf930202e58)



<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

