### PR TITLE
Remove MAP_OVERRIDE_MANTA and related defines

### DIFF
--- a/_std/mapDefines.dm
+++ b/_std/mapDefines.dm
@@ -54,12 +54,6 @@
 #define HOTSPOTS_ENABLED 1
 
 // Non rotation
-#elif defined(MAP_OVERRIDE_MANTA)
-
-#define UNDERWATER_MAP 1
-#define MOVING_SUB_MAP 1
-#define SUBMARINE_MAP 1
-
 #elif defined(MAP_OVERRIDE_DESTINY)
 
 #elif defined(MAP_OVERRIDE_HORIZON)

--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -1302,53 +1302,6 @@ var/obj/manta_speed_lever/mantaLever = null
 			command_alert("The Magnetic tether has been successfully repaired. Magnetic attachment points are online once again.", "Magnetic Tether Repaired", alert_origin = ALERT_STATION)
 			return
 
-#ifdef MOVING_SUB_MAP //Defined in the map-specific .dm configuration file.
-/datum/random_event/special/mantacommsdown
-	name = "Communications Malfunction"
-
-	event_effect(var/source)
-		..()
-		if (random_events.announce_events)
-			command_alert("Communication tower has been severely damaged aboard NSS Manta. Ships automated communication system will now attempt to re-establish signal through backup channel. We estimate this will take eight to ten minutes.", "Communications Malfunction", alert_origin = ALERT_STATION)
-			playsound_global(world, 'sound/effects/commsdown.ogg', 100)
-			sleep(rand(80,100))
-			signal_loss += 100
-			sleep(rand(4800,6000))
-			signal_loss -= 100
-
-			if (random_events.announce_events)
-				command_alert("Communication link has been established with Oshan Laboratory through backkup channel. Communications should be restored to normal aboard NSS Manta.", "Communications Restored", alert_origin = ALERT_STATION)
-			else
-				message_admins(SPAN_INTERNAL("Manta Comms event ceasing."))
-
-
-/datum/random_event/major/electricmalfunction
-	name = "Electrical Malfunction"
-
-	event_effect()
-		..()
-		var/obj/machinery/junctionbox/J = pick(by_type[/obj/machinery/junctionbox])
-		if (J.broken)
-			return
-		J.Breakdown()
-		command_alert("Certain junction boxes are malfunctioning around NSS Manta. Please seek out and repair the malfunctioning junction boxes before they lead to power outages.", "Electrical Malfunction", alert_origin = ALERT_STATION)
-
-/datum/random_event/special/namepending
-	name = "Name Pending"
-
-	event_effect()
-		..()
-		var/list/eligible = by_type[/obj/machinery/mantapropulsion].Copy()
-		for(var/i=0, i<3, i++)
-			var/obj/machinery/mantapropulsion/big/P = pick(eligible)
-			P.Breakdown()
-			eligible.Remove(P)
-			sleep(1 SECOND)
-
-		new /obj/effect/boommarker(pick_landmark(LANDMARK_BIGBOOM))
-#endif
-
-
 //-------------------------------------------- MANTA COMPATIBLE AREAS HERE --------------------------------------------
 //Also ugh, duplicate code.
 

--- a/code/area.dm
+++ b/code/area.dm
@@ -447,11 +447,7 @@ TYPEINFO(/area)
 			//if ("AI Satellite Core") sound_fx_1 = pick('sound/ambience/station/Station_SpookyAtmosphere1.ogg','sound/ambience/station/Station_SpookyAtmosphere2.ogg') // same as above
 			if ("The Blind Pig") sound_fx_1 = pick('sound/ambience/spooky/TheBlindPig.ogg','sound/ambience/spooky/TheBlindPig2.ogg')
 			if ("M. Fortuna's House of Fortune") sound_fx_1 = 'sound/ambience/spooky/MFortuna.ogg'
-			#ifdef SUBMARINE_MAP
-			else sound_fx_1 = pick(ambience_submarine)
-			#else
 			else sound_fx_1 = pick(ambience_general)
-			#endif
 
 	proc/add_light(var/obj/machinery/light/L)
 		if (!light_manager)
@@ -1326,9 +1322,6 @@ ABSTRACT_TYPE(/area/adventure)
 	name = "Derelict Space Station"
 	icon_state = "derelict"
 	occlude_foreground_parallax_layers = TRUE
-#ifdef SUBMARINE_MAP
-	force_fullbright = 1
-#endif
 #ifdef UNDERWATER_MAP
 	requires_power = FALSE
 #endif
@@ -1337,9 +1330,6 @@ ABSTRACT_TYPE(/area/adventure)
 	name = "Derelict Diner"
 	icon_state = "derelict"
 	occlude_foreground_parallax_layers = TRUE
-#ifdef SUBMARINE_MAP
-	force_fullbright = 1
-#endif
 #ifdef UNDERWATER_MAP
 	requires_power = FALSE
 #endif
@@ -1871,11 +1861,7 @@ TYPEINFO(/area/station)
 	minimaps_to_render_on = MAP_ALL
 	occlude_foreground_parallax_layers = TRUE
 	var/tmp/initial_structure_value = 0
-#ifdef MOVING_SUB_MAP
-	filler_turf = "/turf/space/fluid/manta"
-#else
 	filler_turf = null
-#endif
 
 	New()
 		..()
@@ -2393,10 +2379,6 @@ ABSTRACT_TYPE(/area/station/mining)
 	icon_state = "bridge"
 	sound_environment = 4
 	station_map_colour = MAPC_COMMAND
-#ifdef SUBMARINE_MAP
-	sound_group = "bridge"
-	sound_loop = 'sound/ambience/station/underwater/sub_bridge_ambi1.ogg'
-#endif
 
 /area/station/bridge/united_command //currently only on atlas - ET
     name = "United Command"
@@ -4507,19 +4489,11 @@ Don't try and do this in the editor nerd. ~Warc
 	do_not_irradiate = FALSE
 	sound_fx_1 = 'sound/ambience/station/Station_VocalNoise1.ogg'
 	var/initial_structure_value = 0
-#ifdef MOVING_SUB_MAP
-	filler_turf = "/turf/space/fluid/manta"
-
-	New()
-		..()
-		initial_structure_value = calculate_structure_value()
-#else
 	filler_turf = null
 
 	New()
 		..()
 		initial_structure_value = calculate_structure_value()
-#endif
 
 /area/station2/atmos
 	name = "Atmospherics"
@@ -4753,10 +4727,6 @@ area/station/hallway/starboardupperhallway
 	name = "Bridge"
 	icon_state = "bridge"
 	sound_environment = 4
-#ifdef SUBMARINE_MAP
-	sound_group = "bridge"
-	sound_loop = 'sound/ambience/station/underwater/sub_bridge_ambi1.ogg'
-#endif
 
 /area/station2/captain //Three below this one are because Manta uses specific ambience on the bridge
 	name = "Captain's Office"

--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -1076,7 +1076,7 @@ var/datum/job_controller/job_controls
 	if (!string || !istext(string))
 		logTheThing(LOG_DEBUG, null, "<b>Job Controller:</b> Attempt to find job with bad string '[string]' in controller detected")
 		return null
-	var/list/excluded_strings = list("Special Respawn","Custom Names","Everything Except Assistant", "Communications Officer",
+	var/list/excluded_strings = list("Special Respawn","Custom Names","Everything Except Assistant",
 	"Engineering Department","Security Department","Heads of Staff", "Pod_Wars", "Syndicate", "Construction Worker", "MODE", "Ghostdrone", "Animal")
 	if (string in excluded_strings)
 		return null

--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -1076,11 +1076,8 @@ var/datum/job_controller/job_controls
 	if (!string || !istext(string))
 		logTheThing(LOG_DEBUG, null, "<b>Job Controller:</b> Attempt to find job with bad string '[string]' in controller detected")
 		return null
-	var/list/excluded_strings = list("Special Respawn","Custom Names","Everything Except Assistant",
+	var/list/excluded_strings = list("Special Respawn","Custom Names","Everything Except Assistant", "Communications Officer",
 	"Engineering Department","Security Department","Heads of Staff", "Pod_Wars", "Syndicate", "Construction Worker", "MODE", "Ghostdrone", "Animal")
-	#ifndef MAP_OVERRIDE_MANTA
-	excluded_strings += "Communications Officer"
-	#endif
 	if (string in excluded_strings)
 		return null
 	var/list/results = list()

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -322,8 +322,6 @@
 				continue // Only Continue as Captain, as non-captain command staff appear both in the command section and their departmental section
 			else
 				Command.Add(entry)
-				if(rank == "Communications Officer")
-					continue
 
 		if((rank in security_jobs) || (rank in security_gimmicks))
 			if(rank in command_jobs)

--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -155,7 +155,7 @@
 	for(var/mob/living/carbon/human/player in mobs)
 		if(player.mind && !isdead(player))
 			var/role = player.mind.assigned_role
-			if(role in list("Captain", "Head of Security", "Head of Personnel", "Chief Engineer", "Research Director", "Medical Director","Communications Officer"))
+			if(role in list("Captain", "Head of Security", "Head of Personnel", "Chief Engineer", "Research Director", "Medical Director"))
 				heads += player.mind
 
 	if(length(heads) < 1)
@@ -170,7 +170,7 @@
 	for(var/mob/player in mobs)
 		if(player.mind)
 			var/role = player.mind.assigned_role
-			if(role in list("Captain", "Head of Security", "Head of Personnel", "Chief Engineer", "Research Director", "Medical Director","Communications Officer"))
+			if(role in list("Captain", "Head of Security", "Head of Personnel", "Chief Engineer", "Research Director", "Medical Director"))
 				heads += player.mind
 
 	return heads

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -324,9 +324,6 @@ ABSTRACT_TYPE(/datum/job/command)
 	announce_on_join = TRUE
 
 
-#ifdef SUBMARINE_MAP
-	slot_suit = list(/obj/item/clothing/suit/armor/hopcoat)
-#endif
 	slot_back = list(/obj/item/storage/backpack)
 	slot_belt = list(/obj/item/device/pda2/hop)
 	slot_jump = list(/obj/item/clothing/under/suit/hop)
@@ -352,11 +349,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	items_in_backpack = list(/obj/item/device/flash)
 	wiki_link = "https://wiki.ss13.co/Head_of_Security"
 
-#ifdef SUBMARINE_MAP
-	slot_jump = list(/obj/item/clothing/under/rank/head_of_security/fancy_alt)
-#else
 	slot_jump = list(/obj/item/clothing/under/rank/head_of_security)
-#endif
 	slot_suit = list(/obj/item/clothing/suit/armor/vest)
 	slot_back = list(/obj/item/storage/backpack/security)
 	slot_belt = list(/obj/item/device/pda2/hos)
@@ -471,27 +464,6 @@ ABSTRACT_TYPE(/datum/job/command)
 	slot_eyes = list(/obj/item/clothing/glasses/healthgoggles/upgraded)
 	slot_poc1 = list(/obj/item/device/pda2/medical_director)
 	items_in_backpack = list(/obj/item/device/flash)
-
-#ifdef MAP_OVERRIDE_MANTA
-/datum/job/command/comm_officer
-	name = "Communications Officer"
-	limit = 1
-	wages = PAY_IMPORTANT
-	access_string = "Communications Officer"
-	announce_on_join = TRUE
-	wiki_link = "https://wiki.ss13.co/Communications_Officer"
-
-	slot_ears = list(/obj/item/device/radio/headset/command/comm_officer)
-	slot_eyes = list(/obj/item/clothing/glasses/sunglasses)
-	slot_jump = list(/obj/item/clothing/under/rank/comm_officer)
-	slot_card = /obj/item/card/id/command
-	slot_foot = list(/obj/item/clothing/shoes/black)
-	slot_back = list(/obj/item/storage/backpack/withO2)
-	slot_belt = list(/obj/item/device/pda2/heads)
-	slot_poc1 = list(/obj/item/pen/fancy)
-	slot_head = list(/obj/item/clothing/head/sea_captain/comm_officer_hat)
-	items_in_backpack = list(/obj/item/device/camera_viewer/security, /obj/item/device/audio_log, /obj/item/device/flash)
-#endif
 
 // Security Jobs
 
@@ -1220,15 +1192,31 @@ ABSTRACT_TYPE(/datum/job/special)
 	items_in_backpack = list(/obj/item/tank/mini/oxygen,/obj/item/crowbar)
 	wiki_link = "https://wiki.ss13.co/Atmospheric_Technician"
 
+/datum/job/special/comm_officer
+	name = "Communications Officer"
+	limit = 0
+	wages = PAY_IMPORTANT
+	access_string = "Communications Officer"
+	announce_on_join = TRUE
+	wiki_link = "https://wiki.ss13.co/Communications_Officer"
+
+	slot_ears = list(/obj/item/device/radio/headset/command/comm_officer)
+	slot_eyes = list(/obj/item/clothing/glasses/sunglasses)
+	slot_jump = list(/obj/item/clothing/under/rank/comm_officer)
+	slot_card = /obj/item/card/id/command
+	slot_foot = list(/obj/item/clothing/shoes/black)
+	slot_back = list(/obj/item/storage/backpack/withO2)
+	slot_belt = list(/obj/item/device/pda2/heads)
+	slot_poc1 = list(/obj/item/pen/fancy)
+	slot_head = list(/obj/item/clothing/head/sea_captain/comm_officer_hat)
+	items_in_backpack = list(/obj/item/device/camera_viewer/security, /obj/item/device/audio_log, /obj/item/device/flash)
+
 /datum/job/special/radioshowhost
 	name = "Radio Show Host"
 	wages = PAY_TRADESMAN
 	linkcolor = CIVILIAN_LINK_COLOR
 	access_string = "Radio Show Host"
-#ifdef MAP_OVERRIDE_MANTA
-	limit = 0
-	special_spawn_location = null
-#elif defined(MAP_OVERRIDE_OSHAN)
+#if defined(MAP_OVERRIDE_OSHAN)
 	limit = 1
 	special_spawn_location = null
 #elif defined(MAP_OVERRIDE_NADIR)

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1216,7 +1216,7 @@ ABSTRACT_TYPE(/datum/job/special)
 	wages = PAY_TRADESMAN
 	linkcolor = CIVILIAN_LINK_COLOR
 	access_string = "Radio Show Host"
-#if defined(MAP_OVERRIDE_OSHAN)
+#ifdef MAP_OVERRIDE_OSHAN
 	limit = 1
 	special_spawn_location = null
 #elif defined(MAP_OVERRIDE_NADIR)

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -160,52 +160,6 @@ proc/create_fluff(datum/mind/target)
 /datum/objective/regular/steal
 	var/obj/item/steal_target
 	var/target_name
-#ifdef MAP_OVERRIDE_MANTA
-	set_up()
-		var/list/items = list("Head of Security\'s beret", "prisoner\'s beret", "DetGadget hat", "horse mask", "authentication disk",
-		"\'freeform\' AI module", "gene power module", "mainframe memory board", "yellow cake", "aurora MKII utility belt", "Head of Security\'s war medal", "Research Director\'s Diploma", "Medical Director\'s Medical License", "Head of Personnel\'s First Bill",
-		"much coveted Gooncode")
-
-		if(!countJob("Head of Security"))
-			items.Remove("Head of Security\'s beret")
-		if(!countJob("Captain"))
-			items.Remove("authentication disk")
-		if(!countJob("Chief Engineer"))
-			items.Remove("aurora MKII utility belt")
-
-		target_name = pick(items)
-		switch(target_name)
-			if("Head of Security\'s beret")
-				steal_target = /obj/item/clothing/head/hos_hat
-			if("prisoner\'s beret")
-				steal_target = /obj/item/clothing/head/beret/prisoner
-			if("DetGadget hat")
-				steal_target = /obj/item/clothing/head/det_hat/gadget
-			if("authentication disk")
-				steal_target = /obj/item/disk/data/floppy/read_only/authentication
-			if("\'freeform\' AI module")
-				steal_target = /obj/item/aiModule/freeform
-			if("gene power module")
-				steal_target = /obj/item/cloneModule/genepowermodule
-			if("mainframe memory board")
-				steal_target = /obj/item/disk/data/memcard/main2
-			if("yellow cake")
-				steal_target = /obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake
-			if("aurora MKII utility belt")
-				steal_target = /obj/item/storage/belt/utility/prepared/ceshielded
-			if("Head of Security\'s war medal")
-				steal_target = /obj/item/clothing/suit/security_badge/hosmedal
-			if("Research Director\'s Diploma")
-				steal_target = /obj/item/rddiploma
-			if("Medical Director\'s Medical License")
-				steal_target = /obj/item/mdlicense
-			if("Head of Personnel\'s First Bill")
-				steal_target = /obj/item/firstbill
-			if("much coveted Gooncode")
-				steal_target = /obj/item/toy/gooncode
-			if("horse mask")
-				steal_target = /obj/item/clothing/mask/horse_mask
-#else
 	set_up()
 		var/list/items = list("Head of Security\'s beret", "prisoner\'s beret", "DetGadget hat", "horse mask", "authentication disk",
 		"\'freeform\' AI module", "gene power module", "mainframe memory board", "yellow cake", "aurora MKII utility belt", "much coveted Gooncode", "golden crayon")
@@ -243,7 +197,6 @@ proc/create_fluff(datum/mind/target)
 				steal_target = /obj/item/clothing/mask/horse_mask
 			if("golden crayon")
 				steal_target = /obj/item/pen/crayon/golden
-#endif
 
 		explanation_text = "Steal the [target_name] and have it anywhere on you at the end of the shift."
 		return steal_target
@@ -423,22 +376,6 @@ ABSTRACT_TYPE(/datum/multigrab_target)
 
 /datum/objective/regular/bonsaitree
 	// Brought this back as a very rare gimmick objective (Convair880).
-#ifdef MAP_OVERRIDE_MANTA
-	explanation_text = "Destroy the Captain's ship in a bottle."
-
-	check_completion()
-		var/area/cap_quarters = locate(/area/station/captain)
-		var/obj/captain_bottleship/cap_ship
-
-		for (var/obj/captain_bottleship/T in cap_quarters)
-			cap_ship = T
-		if (!cap_ship)
-			return 1  // Somebody deleted it somehow, I suppose?
-		else if (cap_ship?.destroyed == 1)
-			return 1
-		else
-			return 0
-#else
 	explanation_text = "Destroy the Captain's prized bonsai tree."
 
 	check_completion()
@@ -453,7 +390,6 @@ ABSTRACT_TYPE(/datum/multigrab_target)
 			return 1
 		else
 			return 0
-#endif
 ///////////////////////////////////////////////////////////////
 // Regular objectives not currently used in current gameplay //
 ///////////////////////////////////////////////////////////////

--- a/code/datums/titlecard.dm
+++ b/code/datums/titlecard.dm
@@ -4,8 +4,6 @@
 
 	#if defined(MAP_OVERRIDE_OSHAN)
 	var/image_url = "images/titlecards/oshan_titlecard.png"
-	#elif defined(MAP_OVERRIDE_MANTA)
-	var/image_url = "images/titlecards/manta_titlecard.png"
 	#elif defined(MAP_OVERRIDE_POD_WARS)
 	var/image_url = "images/titlecards/podwars.png"
 	#else
@@ -155,10 +153,6 @@ proc/get_global_tip()
 		icon_state = "title_oshan"
 		name = "Oshan Laboratory"
 		desc = "An underwater laboratory on the planet Abzu."
-	#elif defined(MAP_OVERRIDE_MANTA)
-		icon_state = "title_manta"
-		name = "The NSS Manta"
-		desc = "Some fancy comic about the NSS Manta and its travels on the planet Abzu."
 	#endif
 	#if defined(REVERSED_MAP)
 		transform = list(-1, 0, 0, 0, 1, 0)

--- a/code/lists/jobs.dm
+++ b/code/lists/jobs.dm
@@ -87,7 +87,6 @@ var/list/command_jobs = list(
 	"Head of Personnel",
 	"Head of Security",
 	"Chief Engineer",
-	"Communications Officer",
 	/*"Clown"*/
 )
 var/list/security_jobs = list(
@@ -133,6 +132,7 @@ var/list/service_jobs = list(
 var/list/command_gimmicks = list(
 	"Head of Mining",
 	"Nanotrasen Security Consultant" /* NTSC isn't a gimmick role, but for the sake of sorting, it practically is*/,
+	"Communications Officer",
 )
 var/list/security_gimmicks = list(
 	"Vice Officer",

--- a/code/modules/antagonists/antagonist_helpers.dm
+++ b/code/modules/antagonists/antagonist_helpers.dm
@@ -89,5 +89,4 @@ proc/get_all_gangs()
 			"Chief Engineer",
 			"Research Director",
 			"Medical Director",
-			"Communications Officer",
 			)

--- a/code/modules/events/minor/pests.dm
+++ b/code/modules/events/minor/pests.dm
@@ -69,15 +69,3 @@
 					spawnamount -= 12
 					LAGCHECK(LAG_LOW)
 		logTheThing(LOG_STATION, null, "minor pest event spawned [type] at [log_loc(pestlandmark)]")
-
-#ifdef MOVING_SUB_MAP //Defined in the map-specific .dm configuration file.
-/datum/random_event/minor/electricmalfunction
-	name = "Electrical Malfunction"
-
-	event_effect()
-		..()
-		var/obj/machinery/junctionbox/J = pick(by_type[/obj/machinery/junctionbox])
-		if (J.broken)
-			return
-		J.Breakdown()
-#endif

--- a/code/modules/events/minor/trader.dm
+++ b/code/modules/events/minor/trader.dm
@@ -30,8 +30,6 @@
 			shuttle = pick("left","right","left","right","diner"); // just making the diner docking a little less common.
 #if defined(MAP_OVERRIDE_OSHAN)
 		var/docked_where = shuttle == "diner" ? "sea diner" : "station";
-#elif defined(MAP_OVERRIDE_MANTA)
-		var/docked_where = shuttle == "diner" ? "sea diner" : "station";
 #elif defined(MAP_OVERRIDE_NADIR)
 		var/docked_where = shuttle == "diner" ? "underdiner" : "station";
 #else

--- a/code/modules/fluids/fluid_commands.dm
+++ b/code/modules/fluids/fluid_commands.dm
@@ -124,9 +124,7 @@ client/proc/replace_space_exclusive()
 
 			var/turf/orig = locate(S.x, S.y, S.z)
 
-#if defined(MOVING_SUB_MAP)
-			var/turf/space/fluid/manta/T = orig.ReplaceWith(/turf/space/fluid/manta, FALSE, TRUE, FALSE, TRUE)
-#elif defined(UNDERWATER_MAP)
+#if defined(UNDERWATER_MAP)
 			var/turf/space/fluid/T = orig.ReplaceWith(/turf/space/fluid, FALSE, TRUE, FALSE, TRUE)
 #else //space map
 			var/turf/space/fluid/T = orig.ReplaceWith(/turf/space/fluid, FALSE, TRUE, FALSE, TRUE)

--- a/code/modules/fluids/fluid_commands.dm
+++ b/code/modules/fluids/fluid_commands.dm
@@ -124,11 +124,7 @@ client/proc/replace_space_exclusive()
 
 			var/turf/orig = locate(S.x, S.y, S.z)
 
-#if defined(UNDERWATER_MAP)
 			var/turf/space/fluid/T = orig.ReplaceWith(/turf/space/fluid, FALSE, TRUE, FALSE, TRUE)
-#else //space map
-			var/turf/space/fluid/T = orig.ReplaceWith(/turf/space/fluid, FALSE, TRUE, FALSE, TRUE)
-#endif
 
 #ifdef UNDERWATER_MAP
 			T.name = ocean_name

--- a/code/modules/worldgen/GenerateMining.dm
+++ b/code/modules/worldgen/GenerateMining.dm
@@ -23,8 +23,6 @@ TYPEINFO(/turf/variableTurf)
 			if (source.z == Z_LEVEL_STATION)
 				#ifdef MAP_OVERRIDE_NADIR
 				source.ReplaceWith(/turf/space/fluid/acid)
-				#elif defined(MOVING_SUB_MAP)
-				source.ReplaceWith(/turf/space/fluid/manta, FALSE, TRUE, FALSE, TRUE)
 				#else
 				source.ReplaceWith(/turf/space/fluid, FALSE, TRUE, FALSE, TRUE)
 				#endif
@@ -47,8 +45,6 @@ TYPEINFO(/turf/variableTurf/floor)
 			if (source.z == Z_LEVEL_STATION)
 				#ifdef MAP_OVERRIDE_NADIR
 				source.ReplaceWith(/turf/space/fluid/acid)
-				#elif defined(MOVING_SUB_MAP)
-				source.ReplaceWith(/turf/space/fluid/manta, FALSE, TRUE, FALSE, TRUE)
 				#else
 				source.ReplaceWith(/turf/space/fluid, FALSE, TRUE, FALSE, TRUE)
 				#endif
@@ -85,8 +81,6 @@ TYPEINFO(/turf/variableTurf/clear)
 			if (source.z == Z_LEVEL_STATION)
 				#ifdef MAP_OVERRIDE_NADIR
 				source.ReplaceWith(/turf/space/fluid/acid)
-				#elif defined(MOVING_SUB_MAP)
-				source.ReplaceWith(/turf/space/fluid/manta, FALSE, TRUE, FALSE, TRUE)
 				#else
 				source.ReplaceWith(/turf/space/fluid, FALSE, TRUE, FALSE, TRUE)
 				#endif

--- a/code/modules/worldgen/prefab/mapPrefab.dm
+++ b/code/modules/worldgen/prefab/mapPrefab.dm
@@ -173,9 +173,6 @@ proc/get_prefab_tags()
 #if defined(MAP_OVERRIDE_NADIR)
 		wanted_tags |= PREFAB_NADIR
 #endif
-#if defined(MAP_OVERRIDE_MANTA)
-		wanted_tags |= PREFAB_MANTA | PREFAB_NADIR_UNSAFE
-#endif
 	else
 		wanted_tags |= PREFAB_SPACE
 	return wanted_tags

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -468,17 +468,9 @@ TYPEINFO(/obj/item/tank/jetpack)
 	var/on = FALSE
 
 	// base_icon_state is used when updating the jetpack's icon, with "1" or "0" appended depending on if the jetpack is on or not
-	// jetpacks have special behavior on Manta, hence the overrides here
-	#if defined(MAP_OVERRIDE_MANTA)
-	icon_state = "jetpack_mag0"
-	item_state = "jetpack_mag"
-	c_flags = IS_JETPACK | ONBACK
-	var/base_icon_state = "jetpack_mag"
-	#else
 	icon_state = "jetpack0"
 	item_state = "jetpack"
 	var/base_icon_state = "jetpack"
-	#endif
 
 	New()
 		..()
@@ -500,11 +492,6 @@ TYPEINFO(/obj/item/tank/jetpack)
 		return
 
 	proc/allow_thrust(num, mob/user)
-		#if defined(MAP_OVERRIDE_MANTA)
-		if (MagneticTether != 1)
-			return 0
-		#endif
-
 		if (!(src.on))
 			return 0
 		if ((num < 0.01 || TOTAL_MOLES(src.air_contents) < num))

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -463,14 +463,10 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 		//explosion(src, src.loc, 35, 45, 55, 55)
 
 
-#ifdef MAP_OVERRIDE_MANTA
-		world.showCinematic("manta_nukies")
-#else
 		var/datum/hud/cinematic/cinematic = new
 		for (var/client/C in clients)
 			cinematic.add_client(C)
 		cinematic.play("nuke")
-#endif
 		if(istype(gamemode))
 			gamemode.nuke_detonated = 1
 			gamemode.check_win()

--- a/code/obj/machinery/shipalert.dm
+++ b/code/obj/machinery/shipalert.dm
@@ -134,11 +134,7 @@ TYPEINFO(/obj/machinery/shipalert)
 		return FALSE
 	//alert and siren
 	if (announce)
-#ifdef MAP_OVERRIDE_MANTA
-		command_alert("This is not a drill. This is not a drill. General Quarters, General Quarters. All hands man your battle stations. Crew without military training shelter in place. Set material condition '[rand(1, 100)]-[pick_string("station_name.txt", "militaryLetters")]' throughout the ship. The route of travel is forward and up to starboard, down and aft to port. Prepare for hostile contact.", "NSS Manta - General Quarters")
-#else
 		command_alert("All personnel, this is not a test. There is a confirmed, hostile threat on-board and/or near the station: [reason]. Report to your stations. Prepare for the worst.", "Alert - Condition Red", alert_origin = ALERT_STATION)
-#endif
 		playsound_global(world, soundGeneralQuarters, 100, pitch = 0.9) //lower pitch = more serious or something idk
 	//toggle on
 	shipAlertState = SHIP_ALERT_BAD

--- a/code/obj/storage/closets.dm
+++ b/code/obj/storage/closets.dm
@@ -232,7 +232,6 @@ TYPEINFO(/obj/storage/closet/coffin)
 	/obj/item/clothing/mask/breath,
 	/obj/item/clothing/under/misc/syndicate,
 	/obj/item/tank/jetpack/syndicate,
-	/obj/item/tank/jetpack,
 	/obj/item/clothing/under/misc/syndicate,
 #ifdef XMAS
 	/obj/item/clothing/head/helmet/space/santahat/noslow,

--- a/code/obj/storage/closets.dm
+++ b/code/obj/storage/closets.dm
@@ -231,11 +231,8 @@ TYPEINFO(/obj/storage/closet/coffin)
 	spawn_contents = list(
 	/obj/item/clothing/mask/breath,
 	/obj/item/clothing/under/misc/syndicate,
-#if defined(MAP_OVERRIDE_MANTA)
 	/obj/item/tank/jetpack/syndicate,
-#else
 	/obj/item/tank/jetpack,
-#endif
 	/obj/item/clothing/under/misc/syndicate,
 #ifdef XMAS
 	/obj/item/clothing/head/helmet/space/santahat/noslow,

--- a/code/world/initialization/3_init.dm
+++ b/code/world/initialization/3_init.dm
@@ -237,11 +237,6 @@
 		qdel(thing)
 	#endif
 
-#ifdef MOVING_SUB_MAP
-	Z_LOG_DEBUG("World/Init", "Making Manta start moving...")
-	mantaSetMove(moving=1, doShake=0)
-#endif
-
 #ifdef TWITCH_BOT_ALLOWED
 	for (var/client/C)
 		if (C.ckey == TWITCH_BOT_CKEY)

--- a/code/world/world.dm
+++ b/code/world/world.dm
@@ -10,9 +10,7 @@
 /world
 	mob = /mob/new_player
 
-	#ifdef MOVING_SUB_MAP //Defined in the map-specific .dm configuration file.
-	turf = /turf/space/fluid/manta
-	#elif defined(UNDERWATER_MAP)
+	#ifdef UNDERWATER_MAP
 	turf = /turf/space/fluid
 	#else
 	turf = /turf/space

--- a/maps/config/map.dm
+++ b/maps/config/map.dm
@@ -56,8 +56,6 @@
 #include "nadir.dm"
 
 // non rotation maps
-#elif defined(MAP_OVERRIDE_MANTA)
-#include "manta.dm"
 
 #elif defined(MAP_OVERRIDE_DESTINY)
 #include "destiny.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[internal][removal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove references to the following defines:
* `MAP_OVERRIDE_MANTA`
* `MOVING_SUB_MAP`
* `SUBMARINE_MAP`

Does NOT remove related objects or assets. Does remove some manta-specific events.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Code cleanup

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Compiled Oshan/Nadir/Neon local, all worked as expected.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
