### PR TITLE
Intangible's can't eat

### DIFF
--- a/code/mob/living/intangible.dm
+++ b/code/mob/living/intangible.dm
@@ -27,6 +27,8 @@ TYPEINFO(/mob/living/intangible)
 		return
 	can_strip()
 		return 0
+	can_eat()
+		return FALSE
 	can_use_hands()
 		return 0
 	is_active()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
mob/living/intangible's can_eat() will always return false

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #23880

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![image](https://github.com/user-attachments/assets/58776093-87d9-46ff-a5ff-7ef134eea06c)
![image](https://github.com/user-attachments/assets/a3dffbff-b7b7-4fe5-b1b4-04b818594f2e)

