### PR TITLE
Captain's Bonsai uses health, but only has 5hp

### DIFF
--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -518,6 +518,8 @@ TYPEINFO(/obj/shrub/syndicateplant)
 		if (inafterlife(user))
 			boutput(user, "You can't bring yourself to hurt such a beautiful thing!")
 			return
+		if(istype(W, /obj/item/sticker)) //Stickers stick to it rather than destroy
+			return
 		if (src.destroyed) return
 		if (user.mind && user.mind.assigned_role == "Captain")
 			if (issnippingtool(W))

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -472,12 +472,15 @@ TYPEINFO(/obj/shrub/syndicateplant)
 	icon = 'icons/misc/worlds.dmi'
 	icon_state = "bonsai"
 	desc = "The Captain's most prized possession. Don't touch it. Don't even look at it."
+	health = 5 //Fragile tree
 	anchored = ANCHORED
 	density = 1
 	layer = EFFECTS_LAYER_UNDER_1
 	dir = EAST
 
 	destroy()
+		if(src.destroyed)
+			return
 		src.set_dir(NORTHEAST)
 		src.destroyed = 1
 		src.set_density(0)
@@ -518,20 +521,18 @@ TYPEINFO(/obj/shrub/syndicateplant)
 		if (inafterlife(user))
 			boutput(user, "You can't bring yourself to hurt such a beautiful thing!")
 			return
-		if(istype(W, /obj/item/sticker)) //Stickers stick to it rather than destroy
-			return
-		if (src.destroyed) return
 		if (user.mind && user.mind.assigned_role == "Captain")
 			if (issnippingtool(W))
 				boutput(user, SPAN_NOTICE("You carefully and lovingly sculpt your bonsai tree."))
 			else
 				boutput(user, SPAN_ALERT("Why would you ever destroy your precious bonsai tree?"))
-		else if(isitem(W) && (user.mind && user.mind.assigned_role != "Captain"))
-			src.destroy()
+			return
+		var/was_destroyed = src.destroyed
+		. = ..()
+		if(src.destroyed && !was_destroyed)
 			boutput(user, SPAN_ALERT("I don't think the Captain is going to be too happy about this..."))
 			src.visible_message(SPAN_ALERT("<b>[user] ravages [src] with [W].</b>"))
 			src.interesting = "Inexplicably, the genetic code of the bonsai tree has the words 'fuck [user.real_name]' encoded in it over and over again."
-		return
 
 	meteorhit(obj/O as obj)
 		src.visible_message(SPAN_ALERT("<b>The meteor smashes right through [src]!</b>"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the captain's bonsai have health like every other shrub, meaning it can only be destroyed by an item that does damage.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows stickers to be stuck to the bonsai, Fixes #23341
Prevents unintended items destroying shrubs.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![image](https://github.com/user-attachments/assets/8de3251c-3b62-4ed3-804f-f3e3698b2267)
Shrub didn't break when using an ID card on it, did break when using wirecutters

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

```changelog
(u)JORJ949
(*)The Captain's Bonsai now uses health like other bushes, but is very fragile and only has 5hp!
```
