### PR TITLE
Fixes #23532 - No More Duplicate Mentormouse Pings

### DIFF
--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -331,7 +331,7 @@ var/regex/forbidden_character_regex = regex(@"[\u2028\u202a\u202b\u202c\u202d\u2
 
 		// Handle hear sounds.
 		if (src.hear_sound && !src.received_module.say_channel.suppress_hear_sound)
-			mob_listener.playsound_local_not_inworld(src.hear_sound, 55, 0.01, flags = SOUND_IGNORE_SPACE)
+			mob_listener.playsound_local_not_inworld(src.hear_sound, 55, 0.01, flags = SOUND_IGNORE_SPACE | SOUND_SKIP_OBSERVERS)
 
 	// If the speaker to display is null, use the real name of the speaker instead.
 	if (isnull(src.speaker_to_display))


### PR DESCRIPTION
[Bug]


## About The PR:
Fixes #23532.


## Testing:
Tested by mangling `/datum/say_message/proc/format_for_output` and `/mob/proc/playsound_local_not_inworld` so that sound is forcibly output even of no client is present on the target.