### PR TITLE
Harbinger summons are protected until they make their choice

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -30,9 +30,9 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //------------ OPTIONS TO GO FAST ------------//
 
-//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
+#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
 
-//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
+#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
 
 //#define SKIP_FEA_SETUP // Skip setting up atmospheric system
 //#define SKIP_Z5_SETUP // Skip generation of mining level

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -30,9 +30,9 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //------------ OPTIONS TO GO FAST ------------//
 
-#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
+//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
 
-#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
+//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
 
 //#define SKIP_FEA_SETUP // Skip setting up atmospheric system
 //#define SKIP_Z5_SETUP // Skip generation of mining level

--- a/code/datums/abilities/critter/eat_limb.dm
+++ b/code/datums/abilities/critter/eat_limb.dm
@@ -53,12 +53,22 @@
 	onStart()
 		..()
 		if (ishuman(target))
-			src.duration = 10 SECONDS
+			src.duration = 5 SECONDS
 			APPLY_ATOM_PROPERTY(user, PROP_MOB_CANTMOVE, "chomping")
 			var/mob/living/carbon/human/human = target
 			user.set_loc(human)
 			human.vis_contents += user
-			user.layer = MOB_LAYER+5
+			if (istype(tornlimb, /obj/item/parts/human_parts/leg/))
+				user.pixel_y = -13
+				if (istype(tornlimb, /obj/item/parts/human_parts/leg/left))
+					user.pixel_x = 6
+				else
+					user.pixel_x = -6
+			else if (istype(tornlimb, /obj/item/parts/human_parts/arm/left))
+				user.pixel_x = 10
+			else
+				user.pixel_x = -10
+			user.layer = MOB_LAYER+1
 			user.animate_movement = SYNC_STEPS
 		else
 			src.interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_ACTION
@@ -85,6 +95,9 @@
 		if (ishuman(target))
 			var/mob/living/carbon/human/human = target
 			human.vis_contents -= user
+			take_bleeding_damage(target, user, 10, DAMAGE_CUT, 1)
+			user.pixel_y = 0
+			user.pixel_x = 0
 			user.set_loc(get_turf(target))
 			REMOVE_ATOM_PROPERTY(user, PROP_MOB_CANTMOVE, "chomping")
 		src.gobble(target, user)

--- a/code/datums/abilities/critter/eat_limb.dm
+++ b/code/datums/abilities/critter/eat_limb.dm
@@ -30,7 +30,7 @@
 					LAZYLISTADD(randLimb, potential_limb)
 			src.torn_limb = targetHuman.limbs.get_limb(pick(randLimb))
 		if (ishuman(target) || istype(target, /obj/item/parts/human_parts))
-			src.holder.owner.visible_message(SPAN_ALERT("<b>[holder.owner] starts to gnaw at [src.torn_limb]!</b>"))
+			src.holder.owner.visible_message(SPAN_ALERT("<b>[holder.owner] leaps, latching onto and gnawing at [src.torn_limb]!</b>"))
 		else
 			return
 		actions.start(new/datum/action/bar/icon/eat_limb(target, holder.owner, src.torn_limb), holder.owner)
@@ -84,7 +84,8 @@
 			var/gib = make_cleanable(/obj/decal/cleanable/blood/gibs, get_turf(target))
 			playsound(user, 'sound/impact_sounds/Flesh_Crush_1.ogg', 60, 1)
 			eat_twitch(user)
-			random_brute_damage(target, 2)
+			random_brute_damage(target, 6)
+			take_bleeding_damage(target, user, 1, DAMAGE_CUT, 1)
 			ThrowRandom(gib, rand(2,6))
 
 	onEnd()
@@ -95,7 +96,7 @@
 		if (ishuman(target))
 			var/mob/living/carbon/human/human = target
 			human.vis_contents -= user
-			take_bleeding_damage(target, user, 10, DAMAGE_CUT, 1)
+			take_bleeding_damage(target, user, 15, DAMAGE_CUT, 1)
 			user.pixel_y = 0
 			user.pixel_x = 0
 			user.set_loc(get_turf(target))

--- a/code/modules/antagonists/wraith/critters/nascent.dm
+++ b/code/modules/antagonists/wraith/critters/nascent.dm
@@ -25,6 +25,7 @@ TYPEINFO(/mob/living/critter/wraith)
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "poltergeist-corp"
 	hand_count = 0
+	nodamage = 1
 	health_brute = 50
 	health_brute_vuln = 1
 	health_burn = 50
@@ -54,6 +55,11 @@ TYPEINFO(/mob/living/critter/wraith)
 		add_hh_flesh(src.health_brute, src.health_brute_vuln)
 		add_hh_flesh_burn(src.health_burn, src.health_burn_vuln)
 
+	attackby(var/obj/item/I, mob/user)
+		boutput(user, "[I] seems to just pass through...")
+
+	attack_hand(mob/user)
+		boutput(user, "Your hand just seems to phase through...")
 
 	death(var/gibbed)
 		if (src.master)

--- a/code/modules/antagonists/wraith/critters/nascent.dm
+++ b/code/modules/antagonists/wraith/critters/nascent.dm
@@ -21,7 +21,8 @@ TYPEINFO(/mob/living/critter/wraith)
 	name = "???"
 	real_name = "???"
 	desc = "It looks unfinished"
-	density = 1
+	density = 0
+	nodamage = 1
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "poltergeist-corp"
 	hand_count = 0
@@ -54,6 +55,11 @@ TYPEINFO(/mob/living/critter/wraith)
 		add_hh_flesh(src.health_brute, src.health_brute_vuln)
 		add_hh_flesh_burn(src.health_burn, src.health_burn_vuln)
 
+	attackby(var/obj/item/I, mob/user)
+		boutput(user, "[I] seems to just pass through...")
+
+	attack_hand(mob/user)
+		boutput(user, "Your hand just seems to phase through...")
 
 	death(var/gibbed)
 		if (src.master)

--- a/code/modules/antagonists/wraith/critters/nascent.dm
+++ b/code/modules/antagonists/wraith/critters/nascent.dm
@@ -25,7 +25,6 @@ TYPEINFO(/mob/living/critter/wraith)
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "poltergeist-corp"
 	hand_count = 0
-	nodamage = 1
 	health_brute = 50
 	health_brute_vuln = 1
 	health_burn = 50
@@ -55,11 +54,6 @@ TYPEINFO(/mob/living/critter/wraith)
 		add_hh_flesh(src.health_brute, src.health_brute_vuln)
 		add_hh_flesh_burn(src.health_burn, src.health_burn_vuln)
 
-	attackby(var/obj/item/I, mob/user)
-		boutput(user, "[I] seems to just pass through...")
-
-	attack_hand(mob/user)
-		boutput(user, "Your hand just seems to phase through...")
 
 	death(var/gibbed)
 		if (src.master)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance] [critter] [qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR simply removes the nascant wraith spawn's density and sets them to take no damage. This seems small enough to not need a changelog?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pretty much every harbinger shift I see a newbie or someone who otherwise hasn't taken harbinger summons before spawn as one, and look around like "huh? what do". Then they are immediately mauled by an angry medical director in a few hits while they read the abilities. This feels bad to watch every time, please protect them they're babies.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Doesn't need a screenshot really, tested and seems to be fine. Hit with items and empty hands.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

