### PR TITLE
Harbinger summons are protected until they make their choice

### DIFF
--- a/code/modules/antagonists/wraith/critters/nascent.dm
+++ b/code/modules/antagonists/wraith/critters/nascent.dm
@@ -25,6 +25,7 @@ TYPEINFO(/mob/living/critter/wraith)
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "poltergeist-corp"
 	hand_count = 0
+	nodamage = 1
 	health_brute = 50
 	health_brute_vuln = 1
 	health_burn = 50
@@ -54,6 +55,11 @@ TYPEINFO(/mob/living/critter/wraith)
 		add_hh_flesh(src.health_brute, src.health_brute_vuln)
 		add_hh_flesh_burn(src.health_burn, src.health_burn_vuln)
 
+	attackby(var/obj/item/I, mob/user)
+		boutput(user, "[I] seems to just pass through...")
+
+	attack_hand(mob/user)
+		boutput(user, "Your hand just seems to phase through...")
 
 	death(var/gibbed)
 		if (src.master)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance] [critter] [qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR simply removes the nascant wraith spawn's density and sets them to take no damage. This seems small enough to not need a changelog?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pretty much every harbinger shift I see a newbie or someone who otherwise hasn't taken harbinger summons before spawn as one, and look around like "huh? what do". Then they are immediately mauled by an angry medical director in a few hits while they read the abilities. This feels bad to watch every time, please protect them they're babies.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Doesn't need a screenshot really, tested and seems to be fine. Hit with items and empty hands.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

