### PR TITLE
Fix reagent dispensers being unscannable by spectro eyes/goggles

### DIFF
--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -10,6 +10,7 @@
 	icon_state = "watertank"
 	density = 1
 	anchored = UNANCHORED
+	var/rc_flags = RC_SCALE | RC_SPECTRO
 	flags = FLUID_SUBMERGE | ACCEPTS_MOUSEDROP_REAGENTS
 	object_flags = NO_GHOSTCRITTER
 	pressure_resistance = 2*ONE_ATMOSPHERE
@@ -27,7 +28,7 @@
 
 	get_desc(dist, mob/user)
 		if (dist <= 2 && reagents)
-			. += "<br>[SPAN_NOTICE("[reagents.get_description(user,RC_SCALE)]")]"
+			. += "<br>[SPAN_NOTICE("[reagents.get_description(user,src.rc_flags)]")]"
 
 	proc/smash()
 		var/turf/T = get_turf(src)
@@ -272,7 +273,7 @@ TYPEINFO(/obj/reagent_dispensers/watertank/fountain)
 	get_desc(dist, mob/user)
 		. += "There's [cup_amount] paper cup[s_es(src.cup_amount)] in [src]'s cup dispenser."
 		if (dist <= 2 && reagents)
-			. += "<br>[SPAN_NOTICE("[reagents.get_description(user,RC_SCALE)]")]"
+			. += "<br>[SPAN_NOTICE("[reagents.get_description(user, src.rc_flags)]")]"
 
 	attackby(obj/W, mob/user)
 		if (has_tank)
@@ -436,6 +437,7 @@ TYPEINFO(/obj/reagent_dispensers/watertank/fountain)
 	icon_state = "barrel-blue"
 	amount_per_transfer_from_this = 25
 	p_class = 3
+	rc_flags = RC_SCALE | RC_SPECTRO | RC_VISIBLE
 	flags = FLUID_SUBMERGE | OPENCONTAINER | ACCEPTS_MOUSEDROP_REAGENTS
 	var/base_icon_state = "barrel-blue"
 	var/funnel_active = TRUE //if TRUE, allows players pouring liquids from beakers with just one click instead of clickdrag, for convenience


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Updates the reagent container flags on reagent dispensers to be more accurate to:
- Allow reagent_dispensers to be scanned by spectroscopic eyes, goggles and borg upgrades.
- Allow seeing the colour of the contents of chemical barrel

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I see no reason these shouldn't be scannable with spectroscopic scanners when they are by reagent analyzers, and chemical barrels have the liquid visible on the side so you should be able to judge the colour on it.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Red line being removing the spectroscopic goggles
![image](https://github.com/user-attachments/assets/77c69be0-a2f6-4e63-97c4-41329bc3001b)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
