### PR TITLE
Fix Photocopied ID data having no icon

### DIFF
--- a/code/obj/machinery/photocopier.dm
+++ b/code/obj/machinery/photocopier.dm
@@ -775,7 +775,7 @@ TYPEINFO(/obj/machinery/photocopier)
 
 	proc/scan_id_data(var/obj/item/card/id/I, var/mob/user)
 		scan_setup(I, user)
-		if(I.icon_state == "gold")
+		if(I.icon_state == "id_gold")
 			src.icon_state = "scan_id_gold"
 		else
 			src.icon_state = "scan_id"
@@ -808,6 +808,7 @@ TYPEINFO(/obj/machinery/photocopier)
 		src.print_info["stamps"] = null
 		src.print_info["form_fields"] = list()
 		src.print_info["field_counter"] = 1
+		src.print_info["icon"] = 'icons/obj/writing.dmi'
 		src.print_info["icon_state"] = "paper_blank"
 		src.print_info["sizex"] = 0
 		src.print_info["sizey"] = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes photocopied ID data having no icon
Also fixes erroniously checking for the "gold" icon state which is now the "id_gold" icon state, which I missed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #23061 probably, I couldn't reproduce so it was probably this?

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![image](https://github.com/user-attachments/assets/f0ed058f-7648-4a8c-a7a2-32e270b79489)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

