### PR TITLE
Remove "slap the ass (hot)" from photocopier output text

### DIFF
--- a/code/obj/machinery/photocopier.dm
+++ b/code/obj/machinery/photocopier.dm
@@ -749,7 +749,7 @@ TYPEINFO(/obj/machinery/photocopier)
 	proc/scan_butt(var/obj/item/clothing/head/butt/B, var/mob/user)
 		scan_setup(B, user)
 		src.icon_state = "buttt"
-		boutput(user, "You slap the ass (hot) on the scan bed, close the lid, and press start...")
+		boutput(user, "You put [B] on the scan bed, close the lid, and press start...")
 		effects_scanning(B)
 		src.print_type = "butt"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes "You slap the ass (hot) on the scan bed, close the lid, and press start..." to "You put the butt on the scan bed, close the lid, and press start..."

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I don't think this text really fits in the goonstation environment, it feels really out of place.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![image](https://github.com/user-attachments/assets/a1c00c68-629e-4198-951d-1970781907cc)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
