### PR TITLE
Fix Poor syndicate operative having ammo

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2322,7 +2322,7 @@ ABSTRACT_TYPE(/datum/job/special/syndicate)
 
 /datum/job/special/syndicate/weak/no_ammo
 	name = "Poorly Equipped Junior Syndicate Operative"
-	slot_poc2 = list() //And also no ammo.
+	slot_poc1 = list() //And also no ammo.
 
 //Specialist operatives using nukie class gear
 ABSTRACT_TYPE(/datum/job/special/syndicate/specialist)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Nulls the correct pocket for the Poorly Equipped Junior Syndicate Operative so they correctly get no ammo

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I moved where the tank was to have the pouch in the left pocket like security and never swapped which pocket gets nulled on this job

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![image](https://github.com/user-attachments/assets/cb4628a5-e12d-4c1e-9ebb-3c9a95bf7b22)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

