### PR TITLE
Brain damage rework - Inoperable machinery

### DIFF
--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -21,6 +21,7 @@ TYPEINFO(/obj/machinery/chem_dispenser)
 	var/icon_base = "dispenser"
 	flags = NOSPLASH | TGUI_INTERACTIVE
 	object_flags = NO_GHOSTCRITTER
+	usable_with_brain_damage = FALSE
 	var/health = 400
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
 	var/obj/item/beaker = null

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -33,6 +33,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 	object_flags = CAN_REPROGRAM_ACCESS | NO_GHOSTCRITTER
 	netnum = -1		// set so that APCs aren't found as powernet nodes
 	text = ""
+	usable_with_brain_damage = FALSE
 	var/area/area
 	var/areastring = null
 	var/autoname_on_spawn = 0 // Area.name
@@ -568,6 +569,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 
 /obj/machinery/power/apc/attack_hand(mob/user)
 	if (!can_act(user))
+		return
+	if (src.brain_dmg_check(user))
 		return
 
 	add_fingerprint(user)

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -67,6 +67,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item)
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_MULTITOOL
 	object_flags = CAN_REPROGRAM_ACCESS | NO_GHOSTCRITTER
 	speech_verb_say = "beeps"
+	usable_with_brain_damage = FALSE
 
 	var/freestuff = 0
 	var/obj/item/card/id/scan = null
@@ -1396,6 +1397,7 @@ TYPEINFO(/obj/machinery/vending/medical)
 	light_r =1
 	light_g = 0.88
 	light_b = 0.88
+	usable_with_brain_damage = TRUE
 
 	create_products(restocked)
 		..()

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -13,6 +13,8 @@
 	var/cannot_be_stored = FALSE
 	var/move_triggered = 0
 	var/object_flags = 0
+	/// if this object can be used with high brain damage
+	var/usable_with_brain_damage = FALSE
 
 	animate_movement = 2
 //	desc = SPAN_ALERT("HI THIS OBJECT DOESN'T HAVE A DESCRIPTION MAYBE IT SHOULD???")
@@ -453,3 +455,15 @@
 		src.was_deconstructed_to_frame(user)
 		F.RegisterSignal(src, COMSIG_ATOM_ENTERED, TYPE_PROC_REF(/obj/item/electronics/frame, kickout))
 	return F
+
+/// check if the mob has high enough brain damage that they can't use this
+/obj/proc/brain_dmg_check(mob/user)
+	if (src.usable_with_brain_damage)
+		return
+	if (!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if (!H.traitHolder.getTrait("training_medical") && H.get_brain_damage() >= BRAIN_DAMAGE_MAJOR)
+		boutput(user, SPAN_ALERT("You don't have enough concentration to use \the [src]!"))
+		return TRUE
+	return

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -501,6 +501,8 @@
 /obj/item/device/pda2/attack_self(mob/user as mob)
 	if(!user.client)
 		return
+	if (src.brain_dmg_check(user))
+		return
 	if(!user.literate)
 		boutput(user, SPAN_ALERT("You don't know how to read, the screen is meaningless to you."))
 		return

--- a/code/obj/machinery.dm
+++ b/code/obj/machinery.dm
@@ -177,6 +177,8 @@
 	return src.Attackhand(user)
 
 /obj/machinery/attack_hand(mob/user)
+	if (src.brain_dmg_check(user))
+		return TRUE
 	. = ..()
 	if(status & (NOPOWER|BROKEN))
 		return 1
@@ -184,13 +186,7 @@
 		return 1
 	if(!in_interact_range(src, user) || !istype(src.loc, /turf))
 		return 1
-
 	if (user)
-		if (ishuman(user))
-			if(user.get_brain_damage() >= BRAIN_DAMAGE_MAJOR || prob(user.get_brain_damage()))
-				boutput(user, SPAN_ALERT("You are too dazed to use [src] properly."))
-				return 1
-
 		src.add_fingerprint(user)
 		interact_particle(user,src)
 	return 0

--- a/code/obj/machinery/computer.dm
+++ b/code/obj/machinery/computer.dm
@@ -4,6 +4,7 @@
 	density = 1
 	anchored = ANCHORED
 	power_usage = 250
+	usable_with_brain_damage = FALSE
 	HELP_MESSAGE_OVERRIDE(null)
 	var/datum/light/light
 	var/light_r = 1

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -31,6 +31,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 	density = TRUE
 	anchored = ANCHORED
 	power_usage = 200
+	usable_with_brain_damage = FALSE
 
 	/// req_access is used to lock out specific features and not limit deconstruction therefore DECON_NO_ACCESS is required
 	req_access = list(access_heads)
@@ -563,6 +564,8 @@ TYPEINFO(/obj/machinery/manufacturer)
 			if (!(status & NOPOWER || status & BROKEN))
 				if (src.shock(user, 33))
 					return
+		if (src.brain_dmg_check(user))
+			return
 		src.ui_interact(user)
 
 	proc/is_electrified()


### PR DESCRIPTION
[MEDICAL][FEATURE][REWORK][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reworks how brain damage interacts with machinery

Having greater than 60 brain damage no longer has a random chance to make common machinery inoperable, it is now guaranteed

In addition to machinery, APCs and PDAs are now unable to be used

Nanomeds are excluded so that you can still get mannitol

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
-Makes brain damage machine inoperability more consistent
-Adds more of a unique effect to having brain damage that you need to watch out for

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested various machinery at 75 brain damage in addition to APCs, PDAs, vending machines, nanomeds, chem dispensers, computers, and manufacturers

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(*)Major (60) brain damage now has a guaranteed chance to make common machinery inoperable, in addition to PDAs and APCs. Nanomeds are excluded.
```
