### PR TITLE
trinkets and similar items set real_name

### DIFF
--- a/code/WorkInProgress/flourish.dm
+++ b/code/WorkInProgress/flourish.dm
@@ -160,6 +160,7 @@ TYPEINFO(/datum/component/pet)
 			var/obj/item/trinket = new T(get_turf(src))
 			var/datum/db_record/R = pick(data_core.general.records)
 			trinket.name = "[R["name"]][pick_string("trinkets.txt", "modifiers")] [trinket.name]"
+			trinket.real_name = trinket.name
 			trinket.quality = rand(5,80)
 			sleep(1 SECOND)
 			qdel(src)

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -83,6 +83,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 			equip_success = 1
 			var/obj/I = new path(H.loc)
 			I.name = "[H.real_name][pick_string("trinkets.txt", "modifiers")] [I.name]"
+			I.real_name = I.name
 			I.quality = rand(5,80)
 			var/equipped = 0
 			if (H.back?.storage && H.equip_if_possible(I, SLOT_IN_BACKPACK))

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -695,6 +695,7 @@ Equip items from body traits.
 	if (trinket)
 		src.trinket = get_weakref(trinket)
 		trinket.name = "[src.real_name][pick_string("trinkets.txt", "modifiers")] [trinket.name]"
+		trinket.real_name = trinket.name
 		trinket.quality = rand(5,80)
 		trinkets_to_equip += trinket
 
@@ -702,6 +703,7 @@ Equip items from body traits.
 	if (src.traitHolder && src.traitHolder.hasTrait("smoker"))
 		var/obj/item/device/light/zippo/smoker_zippo = new(src)
 		smoker_zippo.name = "[src.real_name][pick_string("trinkets.txt", "modifiers")] [smoker_zippo.name]"
+		smoker_zippo.real_name = smoker_zippo.name
 		smoker_zippo.quality = rand(5,80)
 		trinkets_to_equip += smoker_zippo
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR sets the `real_name` of trinkets and similar items to match the personalized name of the trinket, allowing it to persist between name changes (such as from becoming blood-stained)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #23014 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![image](https://github.com/user-attachments/assets/204dc7aa-794d-404a-8563-bde6cf0d6529)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

