### PR TITLE
Fixes default iconstates for chainsaws

### DIFF
--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -19,7 +19,7 @@ TYPEINFO(/obj/item/saw)
 	icon = 'icons/obj/items/weapons.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_weapons.dmi'
 	icon_state = "c_saw_off"
-	item_state = "c_saw"
+	item_state = "c_saw-D"
 	var/base_state = "c_saw"
 	var/active = 0
 	hit_type = DAMAGE_CUT
@@ -141,7 +141,7 @@ TYPEINFO(/obj/item/saw/syndie)
 /obj/item/saw/syndie
 	name = "red chainsaw"
 	icon_state = "c_saw_s_off"
-	item_state = "c_saw_s"
+	item_state = "c_saw_s-D"
 	base_state = "c_saw_s"
 	tool_flags = TOOL_SAWING | TOOL_CHOPPING //fucks up doors. fuck doors
 	active = 0

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -48,7 +48,10 @@ TYPEINFO(/obj/item/saw)
 	active
 		active = 1
 		force = 12
+		icon_state = "c_saw"
+		item_state = "c_saw-A"
 		arm_icon = "chainsaw-A"
+
 
 		New()
 			..()
@@ -56,9 +59,6 @@ TYPEINFO(/obj/item/saw)
 
 	New()
 		..()
-		SPAWN(0.5 SECONDS)
-			if (src)
-				src.UpdateIcon()
 		BLOCK_SETUP(BLOCK_ROD)
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes the initial iconstates for chainsaws to be the correct on or off version (depending on subtype), instead of having it call `UpdateIcon` on `New`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #23940

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested by vending a chainsaw directly into hand from the vending machine. To ensure that removing the `UpdateIcon()` call from New() wouldn't break anything, I tried spawning multiple chainsaws in addition to doing limb replacements using the admin panels.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
