### PR TITLE
Fix Chem Dispenser division by zero

### DIFF
--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -1085,9 +1085,10 @@ proc/ui_describe_reagents(atom/A)
 			fabrication_tick += 1
 			if (fabrication_tick >= ticks_to_fabricate)
 				fabrication_tick = 0
-				var/reagents_per_container = flow_rate / length(connected_containers)
-				for(var/obj/container in connected_containers)
-					container.reagents.add_reagent(reagent_to_fabricate, reagents_per_container)
+				if(length(src.connected_containers))
+					var/reagents_per_container = flow_rate / length(src.connected_containers)
+					for(var/obj/container in src.connected_containers)
+						container.reagents.add_reagent(reagent_to_fabricate, reagents_per_container)
 			update_visuals()
 
 


### PR DESCRIPTION
[OBJECTS][RUNTIME]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes portable chem dispensers not try to see how many reagents to put into connected containers if there are no connected containers

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Division by zero bad!

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested by activating a chem dispenser then removing the connected beaker, before, runtimes, after, does not runtime.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

