### PR TITLE
Consistent Border Width For Announcements

### DIFF
--- a/browserassets/src/css/browserOutput.css
+++ b/browserassets/src/css/browserOutput.css
@@ -384,7 +384,7 @@ h1.alert, h2.alert {color: #000000;}
 .command_alert {color: #000; margin:0px; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif, "Twemoji", "Segoe UI Emoji"}
 div.command_alert {border: 2px solid; margin-top: 0.5em; margin-bottom: 0.5em}
 h1.command_alert {font-weight: bold; font-size: 120%; border: 0px; text-align: center; padding: 0.2em 0.5em}
-h2.command_alert {font-weight: bold; font-size: 130%; border-bottom: 4px solid ;padding: 0.2em 0.5em}
+h2.command_alert {font-weight: bold; font-size: 130%; border-bottom: 2px solid ;padding: 0.2em 0.5em}
 p.command_alert {padding: 0.4em 0.7em}
 
 div.ageneral {border-color: #86869D}


### PR DESCRIPTION
[QoL]


## About The PR:
Reduces the internal border width from 4px to 2px on the new announcements, so that it is consistent with the external borders.


## Why Is This Needed?
The original 35B announcements had consistent widths for the borders, and the extra width irks me.

Current border widths on `master`, image credit to Herb:
![image](https://github.com/user-attachments/assets/3ca3c081-29f0-467d-b2ce-0c6a78e1a846)


## Testing:
![Screenshot 2025-06-26 105741](https://github.com/user-attachments/assets/fd71fc37-be29-4a0c-98cb-0fa6b94ca6a1)