### PR TITLE
Grow your own guns

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -4029,6 +4029,25 @@
 		result_amount = 3
 		mix_phrase = "The mixture gives off a harsh odor."
 
+	gun_infusion
+		name = "Phytoballistic Infusate"
+		id = "gun_infusion"
+		result = "gun_infusion"
+		/*
+		The recipe is meant to encourage quintissential botany practices
+		- Botany's association with chemicals can best be described as "mass production", hence the quantities.
+		- Blackpowder is both a bullet chemical and a chem that is historically mass produced with the help of ingredients from botany.
+		- CLF3 is another weaponisable botany chem, but it also adds splice-requirements to the recipe.
+		- Plasma is the sci-fi space-magic chem that makes any of this even quasi-believable.
+		- Guns are made of metal.
+		- Gun distillate adds the still as part of the process.
+		- Temperature basically forces the use of Cryostylane, since this can only be made in something like a chem barrel.
+		*/
+		required_reagents = list("blackpowder" = 100, "infernite" = 100, "plasma" = 10, "iron" = 10, "gun_distillate" = 1)
+		max_temperature = 250
+		result_amount = 1
+		mix_phrase = "The mixture crystalises and then collapses in on itself, leaving behind small amount of gunmetal-grey sludge."
+
 	copper_nitrate
 		name = "Copper Nitrate"
 		id = "copper_nitrate"

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -4036,14 +4036,14 @@
 		/*
 		The recipe is meant to encourage quintissential botany practices
 		- Botany's association with chemicals can best be described as "mass production", hence the quantities.
-		- Blackpowder is both a bullet chemical and a chem that is historically mass produced with the help of ingredients from botany.
-		- CLF3 is another weaponisable botany chem, but it also adds splice-requirements to the recipe.
+		- Blackpowder is both a bullet chemical and a chem that is traditionally mass produced with the help of ingredients sourced from botany.
+		- Booster enzyme adds splice-requirements to the recipe, and acts as the 'organic' interface.
 		- Plasma is the sci-fi space-magic chem that makes any of this even quasi-believable.
-		- Guns are made of metal.
+		- Guns are made of metal, there should be metal in there somewhere.
 		- Gun distillate adds the still as part of the process.
 		- Temperature basically forces the use of Cryostylane, since this can only be made in something like a chem barrel.
 		*/
-		required_reagents = list("blackpowder" = 100, "infernite" = 100, "plasma" = 10, "iron" = 10, "gun_distillate" = 1)
+		required_reagents = list("blackpowder" = 200, "booster_enzyme" = 100, "plasma" = 10, "iron" = 10, "gun_distillate" = 1)
 		max_temperature = 250
 		result_amount = 1
 		mix_phrase = "The mixture crystalises and then collapses in on itself, leaving behind small amount of gunmetal-grey sludge."

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3194,6 +3194,22 @@ datum
 				if (DNA.cropsize > 1)
 					growth_tick.cropsize_bonus -= 0.24
 
+		gun_infusion
+			name = "Phytoballistic Infusate"
+			id = "gun_infusion"
+			description = "A largely untested compound which can be infused into plants to imbue them with ballistic properties."
+			fluid_r = 129
+			fluid_g = 133
+			fluid_b = 137
+
+		gun_distillate
+			name = "Gun Distillate"
+			id = "gun_distillate"
+			description = "The distilled essence of ranged weaponry."
+			fluid_r = 141
+			fluid_g = 145
+			fluid_b = 141
+
 		///////////////////////////
 		/// BODILY FLUIDS /////////
 		///////////////////////////

--- a/code/modules/cooking/food_and_drink/plants.dm
+++ b/code/modules/cooking/food_and_drink/plants.dm
@@ -1074,6 +1074,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 	desc = "Spooky!"
 	planttype = /datum/plant/fruit/pumpkin
 	icon_state = "pumpkin"
+	item_state = "pumpkin"
 	edible = FALSE
 	food_color = "#CC6600"
 	validforhat = 1

--- a/code/modules/hydroponics/plants.dm
+++ b/code/modules/hydroponics/plants.dm
@@ -276,6 +276,10 @@ ABSTRACT_TYPE(/datum/plant)
 					DNA.potency++
 				if (DNA.endurance < 0)
 					DNA.endurance++
+			if ("gun_infusion")
+				HYPaddCommut(DNA,/datum/plant_gene_strain/gun_genome)
+				S.charges = 1
+
 		for (var/datum/plantmutation/mutation in src.mutations)
 			if (reagent in mutation.infusion_reagents)
 				if (HYPmutationcheck_full(DNA, mutation) && prob(mutation.infusion_chance))

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -2484,3 +2484,10 @@ ABSTRACT_TYPE(/datum/projectile/bullet/homing/rocket)
 
 	on_launch(obj/projectile/O)
 		O.AddComponent(/datum/component/sniper_wallpierce, 3, 0, TRUE)
+
+/datum/projectile/bullet/organic_pellet
+	name = "organic pellet"
+	damage = 12
+	shot_sound = 'sound/weapons/smg_shot.ogg'
+	casing = /obj/item/casing/small
+	impact_image_state = "bullethole-small"

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1645,7 +1645,7 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 
 //This proc handles any manipulation that happens due to plantstats
 //This proc returns the item in question. This is needed to enable a switcheroo with new, randomed items e.g. glowstick tree
-/obj/item/proc/HYPsetup_DNA(var/datum/plantgenes/passed_genes, var/obj/machinery/plantpot/harvested_plantpot, var/datum/plant/origin_plant, var/quality_status)
+/obj/item/proc/HYPsetup_DNA(var/datum/plantgenes/passed_genes, var/obj/machinery/plantpot/harvested_plantpot, var/datum/plant/origin_plant, var/quality_status, var/datum/HYPharvesting_data/h_data)
 	return src
 
 /obj/item/proc/HY_set_species()
@@ -1801,6 +1801,12 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 		src.inhand_image.color = src.inhand_color
 	src.inhand_image.pixel_x = 0
 	src.inhand_image.pixel_y = hand_offset
+
+/// Sets a new inhand_image_icon
+/obj/item/proc/set_new_inhand_image_icon(new_inhand_image_icon)
+	src.inhand_image_icon = new_inhand_image_icon
+	// inhand_image doesn't update unless it's forced
+	src.inhand_image = null
 
 /// Move item to turf, and snap its pixel offsets to a grid of the input size.
 /obj/item/proc/place_to_turf_by_grid(mob/user, params, turf/target, grid = 2, centered = 1, offsetx = 0, offsety = 0)

--- a/code/obj/item/clothing/plants.dm
+++ b/code/obj/item/clothing/plants.dm
@@ -2,13 +2,11 @@
 	name = "rafflesia"
 	desc = "Usually referred to as corpseflower due to its horrid odor. Perfect for masking the smell of your stinky head."
 	icon_state = "rafflesiahat"
-	item_state = "rafflesiahat"
 
 /obj/item/clothing/head/flower
 	name = "flower"
 	desc = "A pretty nice flower... you shouldn't see this, though."
 	icon_state = "flower_gard"
-	item_state = "flower_gard"
 
 	HYPsetup_DNA(var/datum/plantgenes/passed_genes, var/obj/machinery/plantpot/harvested_plantpot, var/datum/plant/origin_plant, var/quality_status)
 		HYPadd_harvest_reagents(src,origin_plant,passed_genes,quality_status)
@@ -19,40 +17,33 @@
 	name = "gardenia"
 	desc = "A delicate flower from the Gardenia shrub native to Earth, trimmed for you to wear. These white flowers are known for their strong and sweet floral scent."
 	icon_state = "flower_gard"
-	item_state = "flower_gard"
 
 /obj/item/clothing/head/flower/bird_of_paradise
 	name = "bird of paradise"
 	desc = "Bird of Paradise flowers, or Crane Flowers, are named for their resemblance to the ACTUAL birds of the same name. Both look great sitting on your head either way."
 	icon_state = "flower_bop"
-	item_state = "flower_bop"
 
 /obj/item/clothing/head/flower/hydrangea
 	name = "hydrangea"
 	desc = " Hydrangeas act as natural pH indicators, sporting blue flowers when the soil is acidic and pink ones when the soil is alkaline. They are popular ornamental flowers due to their colorful pastel blooms; this one has been trimmed nicely for wear as an accessory."
 	icon_state = "flower_hyd"
-	item_state = "flower_hyd"
 
 /obj/item/clothing/head/flower/hydrangea/pink
 	name = "pink hydrangea"
 	icon_state = "flower_hyd-pink"
-	item_state = "flower_hyd-pink"
 
 /obj/item/clothing/head/flower/hydrangea/blue
 	name = "blue hydrangea"
 	icon_state = "flower_hyd-blue"
-	item_state = "flower_hyd-blue"
 
 /obj/item/clothing/head/flower/hydrangea/purple
 	name = "purple hydrangea"
 	icon_state = "flower_hyd-purple"
-	item_state = "flower_hyd-purple"
 
 /obj/item/clothing/head/flower/lavender
 	name = "lavender"
 	desc = "Lavender is usually used as an ingredient or as a source of essential oil; you can tuck a sprig behind your ear for that garden aesthetic too."
 	icon_state = "flower_lav"
-	item_state = "flower_lav"
 
 	New()
 		src.create_reagents(100)
@@ -184,7 +175,6 @@
 	icon_state = "pumpkinlatte"
 	c_flags = COVERSEYES | COVERSMOUTH
 	see_face = FALSE
-	item_state = "pumpkinlatte"
 
 	attackby(obj/item/W, mob/user)
 		if (istype(W, /obj/item/device/light/flashlight))

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1835,3 +1835,10 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 					overlays += "burst_laspistol-100"
 			return
 
+/obj/item/ammo/bullets/produce_gun_ammo
+	name = "Organic bullets"
+	desc = "A collection of organic, hard, nobbly bits of plant-material."
+	ammo_type = new/datum/projectile/bullet/organic_pellet
+	icon_state = "flintlock_ammo_pouch"
+	max_amount = 8
+	ammo_cat = AMMO_FLINTLOCK

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -21,6 +21,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	hide_attack = 2 //Point blanking... gross
 	pickup_sfx = 'sound/items/pickup_gun.ogg'
 	inventory_counter_enabled = 1
+	brew_result = list("gun_distillate" = 10)
 	var/scope_enabled = 0
 
 	var/suppress_fire_msg = 0

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -3642,6 +3642,8 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	//
 	/// The base damage used if the gun was grown
 	var/base_damage = 6
+	/// Damage per point of potency
+	var/potency_damage_multi = 0.05
 	/// The base shoot delay if the gun was grown
 	var/base_shoot_delay = 18
 	/// The base recoil strength if the gun was grown
@@ -3650,6 +3652,11 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	var/base_recoil_max = 120
 	/// The number of bullets this starts with if grown
 	var/base_ammo_count = 2
+	/// Ammo per point of yield
+	var/ammo_multi = 0.05
+	/// Ammo pierce multiplier per point of endurance
+	var/armour_pierce_multi = 0.0015
+
 
 	New()
 		ammo = new default_magazine
@@ -3681,9 +3688,9 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 
 		src.force = temp_item.force
 		// Increase the gun's ammo by the yield
-		src.ammo.amount_left = max(1, base_ammo_count + floor(passed_genes.harvests * 0.03))
+		src.ammo.amount_left = max(1, base_ammo_count + floor(passed_genes.harvests * ammo_multi))
 		// Increase the bullet's damage by the potency
-		src.current_projectile.damage = max(1, base_damage + floor(passed_genes.potency * 0.05))
+		src.current_projectile.damage = max(1, base_damage + floor(passed_genes.potency * potency_damage_multi))
 		// Combine both speed stats into one modifier, and then use it to reduce the shoot delay.
 		// The trailing points just ensures no division by 0 if genes go into the negative.
 		var/delay_modifier = (passed_genes.growtime + passed_genes.harvtime) * 0.5
@@ -3692,7 +3699,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 		src.recoil_strength = src.base_recoil_strength / (1.0001 + (passed_genes.harvests/50 ))
 		src.recoil_max = src.base_recoil_max / (1.0001 + (passed_genes.harvests/50))
 		// Increase armour-piercing by the endurance.
-		src.current_projectile.armor_ignored = passed_genes.endurance * 0.0015
+		src.current_projectile.armor_ignored = passed_genes.endurance * armour_pierce_multi
 		// Jumbo stuff gets some buffs and more punchy cosmetics
 		if (quality_status == "jumbo")
 			src.ammo.amount_left += 3

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -653,6 +653,20 @@ TYPEINFO(/obj/item/plantanalyzer)
 	initial_volume = 250
 	initial_reagents = list("saltpetre"=50, "ammonia"=50, "potash"=50, "poo"=50, "space_fungus"=50)
 
+/obj/item/reagent_containers/glass/bottle/gun_infusion
+	name = "Weaponisation Infusilisation Catalysant"
+	desc = "A highly experimental plant-infusion serum designed for mass production of ballistic weaponry."
+	icon = 'icons/obj/items/chemistry_glassware.dmi'
+	icon_state = "phial"
+	amount_per_transfer_from_this = 10
+	fluid_overlay_states = 5
+	initial_volume = 10
+	container_style = "phial"
+
+	New()
+		..()
+		reagents.add_reagent("gun_infusion", 10)
+
 /obj/item/reagent_containers/glass/water_pipe
 	name = "water pipe"
 	icon = 'icons/obj/items/chemistry_glassware.dmi'

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -269,7 +269,8 @@
 			/obj/item/parts/human_parts/leg,
 			/obj/item/raw_material/cotton,
 			/obj/item/feather,
-			/obj/item/bananapeel)
+			/obj/item/bananapeel,
+			/obj/item/gun/kinetic/produce)
 			exceptions = list(/obj/item/plant/tumbling_creeper) // tumbling creeper have size restrictions and should not be carried in large amount
 
 		matches(atom/movable/inserted, atom/movable/template)

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -958,7 +958,7 @@ TYPEINFO(/obj/machinery/plantpot)
 
 		// At this point all the harvested items are inside the plant pot, and this is the
 		// part where we decide where they're going and get them out.
-		HYPharvesting_satchel_output(h_data, SA)
+		HYPharvesting_produce_output(h_data, SA)
 
 	// Now we determine the harvests remaining or grant extra ones.
 	HYPharvesting_remaining_harvests(h_data)
@@ -974,7 +974,7 @@ TYPEINFO(/obj/machinery/plantpot)
 // Could move some of these to var/datum/plant if plants ever wanted more control over how their produce is harvested
 
 /// Returns a generic quality score based on the given plant genes
-/obj/machinery/plantpot/proc/get_quality_score(var/datum/HYPharvesting_data/h_data)
+/obj/machinery/plantpot/proc/get_quality_score(datum/HYPharvesting_data/h_data)
 	var/quality_score = h_data.base_quality_score
 	quality_score += rand(-2,2)
 	// Just a bit of natural variance to make it interesting
@@ -1106,6 +1106,7 @@ TYPEINFO(/obj/machinery/plantpot)
 		else
 			JOB_XP(h_data.user, "Botanist", 1)
 
+/// Handles stat bonuses and negatives associated with gene strains
 /obj/machinery/plantpot/proc/HYPharvesting_gene_strains(datum/HYPharvesting_data/h_data)
 	if(h_data.DNA.commuts)
 		for(var/datum/plant_gene_strain/G in h_data.DNA.commuts)
@@ -1130,6 +1131,7 @@ TYPEINFO(/obj/machinery/plantpot)
 					h_data.harvest_cap *= Y.yield_mult
 					h_data.harvest_cap += Y.yield_mod
 
+/// Handles mutation crop produce
 /obj/machinery/plantpot/proc/HYPharvesting_mutated_crops(datum/HYPharvesting_data/h_data)
 	// Figure out what crop we use - the base crop or a mutation crop.
 	if(h_data.growing.crop || h_data.MUT?.crop)
@@ -1144,8 +1146,8 @@ TYPEINFO(/obj/machinery/plantpot)
 			h_data.getitem = h_data.growing.crop
 			h_data.dont_rename_crop = h_data.growing.dont_rename_crop
 
+/// Handles bonuses and negatives associated with plant health
 /obj/machinery/plantpot/proc/HYPharvesting_health_bonuses(datum/HYPharvesting_data/h_data)
-
 	if(h_data.pot.health >= h_data.growing.starthealth * 2 && prob(30))
 		boutput(h_data.user, SPAN_NOTICE("This looks like a good harvest!"))
 		h_data.base_quality_score += 5
@@ -1165,6 +1167,7 @@ TYPEINFO(/obj/machinery/plantpot)
 		h_data.base_quality_score -= 12
 		// And this is if you've neglected the plant!
 
+/// Handles the tracking of future harvests for the plant
 /obj/machinery/plantpot/proc/HYPharvesting_remaining_harvests(datum/HYPharvesting_data/h_data)
 	if(!HYPCheckCommut(h_data.DNA,/datum/plant_gene_strain/immortal))
 		// Immortal is a gene strain that means infinite harvests as long as the plant
@@ -1193,8 +1196,8 @@ TYPEINFO(/obj/machinery/plantpot)
 		// remaining, though they do get bonuses for having a good harvests gene.
 		h_data.pot.HYPkillplant()
 
-///
-/obj/machinery/plantpot/proc/HYPharvesting_satchel_output(datum/HYPharvesting_data/h_data, obj/item/satchel/SA)
+/// Handles where the output of the harvest goes
+/obj/machinery/plantpot/proc/HYPharvesting_produce_output(datum/HYPharvesting_data/h_data, obj/item/satchel/SA)
 	if(SA)
 		// If we're putting stuff in a satchel, this is where we do it.
 		for(var/obj/item/I in h_data.pot.contents)
@@ -1219,9 +1222,11 @@ TYPEINFO(/obj/machinery/plantpot)
 		I.set_loc(h_data.user.loc)
 		I.add_fingerprint(h_data.user)
 
+/// Handles the generation of seed items
 /obj/machinery/plantpot/proc/HYPharvesting_seeds(datum/HYPharvesting_data/h_data)
 	if (h_data.seedcount > 0) HYPgenerateseedcopy(h_data.pot.plantgenes, h_data.growing, h_data.pot.generation, h_data.pot, h_data.seedcount)
 
+/// Handles the finalisation of cropcount
 /obj/machinery/plantpot/proc/HYPharvesting_finalise_cropcount(datum/HYPharvesting_data/h_data)
 	if(h_data.cropcount > h_data.harvest_cap)
 		h_data.extra_harvest_chance += h_data.cropcount - h_data.harvest_cap

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -877,321 +877,362 @@ TYPEINFO(/obj/machinery/plantpot)
 			if(!HYPcheck_if_harvestable())
 				return
 	// it's okay if we don't have a satchel at all since it'll just harvest by hand instead
-	var/datum/plant/growing = src.current
-	var/datum/plantgenes/DNA = src.plantgenes
-	var/datum/plantmutation/MUT = DNA.mutation
-	if(!growing)
+
+	// setup harvesting data to make it easier to pass around data related to this harvest
+	var/datum/HYPharvesting_data/h_data = new()
+	h_data.growing = src.current
+	h_data.DNA = src.plantgenes
+	h_data.MUT = h_data.DNA.mutation
+	h_data.pot = src
+	h_data.user = user
+	// This is a modular thing suggested by Cogwerks that can affect the final quality
+	// of produce such as making fruit make you sick or herbs have less reagents.
+	h_data.base_quality_score = 1
+
+	if(!h_data.growing)
 		logTheThing(LOG_DEBUG, user, "<b>Hydro Controls</b>: Plant pot at \[[x],[y],[z]] used by ([user]) attempted a harvest without having a current plant.")
 		return
 
-	if(growing.harvested_proc)
+	if(h_data.growing.harvested_proc)
 		// Does this plant react to being harvested? If so, do it - it also functions as
 		// a check since harvesting will stop here if this returns anything other than 0.
-		if(growing.HYPharvested_proc(src,user)) return
-		if(MUT?.HYPharvested_proc_M(src,user)) return
+		if(h_data.growing.HYPharvested_proc(src,user)) return
+		if(h_data.MUT?.HYPharvested_proc_M(src,user)) return
 		//it can happen during HYPharvested_proc that the planttype in the pot gets replaced, we account for that here
-		growing = src.current
+		h_data.growing = src.current
 
+	// Setup global stuff from hydro_controls
 	if(hydro_controls)
 		src.recently_harvested = 1
 		src.harvest_warning = 0
+		h_data.harvest_cap = 10
 		SPAWN(hydro_controls.delay_between_harvests)
 			src.recently_harvested = 0
 	else
-		logTheThing(LOG_DEBUG, null, "<b>Hydro Controls</b>: Could not access Hydroponics Controller to get Delay cap.")
+		logTheThing(LOG_DEBUG, null, "<b>Hydro Controls</b>: Could not access Hydroponics Controller to get Delay or Harvest cap.")
 
-	var/base_quality_score = 1
-	// This is a modular thing suggested by Cogwerks that can affect the final quality
-	// of produce such as making fruit make you sick or herbs have less reagents.
+	// Replace default harvest cap with mutation override if applicable
+	if(h_data.MUT?.harvest_cap)
+		h_data.harvest_cap = h_data.MUT.harvest_cap
 
-	var/harvest_cap = 10
-	if(hydro_controls)
-		harvest_cap = hydro_controls.max_harvest_cap
-	else
-		logTheThing(LOG_DEBUG, null, "<b>Hydro Controls</b>: Could not access Hydroponics Controller to get Harvest cap.")
-
-	if(MUT?.harvest_cap)
-		harvest_cap = MUT.harvest_cap
-
-	src.growth = max(0, growing.HYPget_growth_to_matured(DNA))
 	// Reset the growth back to the beginning of maturation so we can wait out the
 	// harvest time again.
-	var/getamount = growing.cropsize + DNA?.get_effective_value("cropsize")
-	if(src.health >= growing.starthealth * 2 && prob(30))
-		boutput(user, SPAN_NOTICE("This looks like a good harvest!"))
-		base_quality_score += 5
-		var/bonus = rand(1,3)
-		getamount += bonus
-		harvest_cap += bonus
-		// Good health levels bump the harvest amount up a bit and increase jumbo chances.
-	if(src.health >= growing.starthealth * 4 && prob(30))
-		boutput(user, SPAN_NOTICE("It's a bumper crop!"))
-		base_quality_score += 10
-		var/bonus = rand(2,5)
-		getamount += bonus
-		harvest_cap += bonus
-		// This is if the plant health is absolutely excellent.
-	if(src.health <= growing.starthealth / 2 && prob(70))
-		boutput(user, SPAN_ALERT("This is kind of a crappy harvest..."))
-		base_quality_score -= 12
-		// And this is if you've neglected the plant!
-
-	var/getitem = null
-	var/dont_rename_crop = FALSE
+	src.growth = max(0, h_data.growing.HYPget_growth_to_matured(h_data.DNA))
+	// setup initial crop size
+	h_data.cropcount = h_data.growing.cropsize + h_data.DNA?.get_effective_value("cropsize")
+	// handle bonuses and negatives to do with the plant's health
+	HYPharvesting_health_bonuses(h_data)
 	// Figure out what crop we use - the base crop or a mutation crop.
-	if(growing.crop || MUT?.crop)
-		if(MUT)
-			if(MUT.crop)
-				getitem = MUT.crop
-				dont_rename_crop = MUT.dont_rename_crop
-			else
-				logTheThing(LOG_DEBUG, null, "<b>I Said No/Hydroponics:</b> Plant mutation [MUT] crop is not properly configured")
-				getitem = growing.crop
-		else
-			getitem = growing.crop
-			dont_rename_crop = growing.dont_rename_crop
+	HYPharvesting_mutated_crops(h_data)
+	// handle bonuses and negatives to do with gene strains
+	HYPharvesting_gene_strains(h_data)
+	// Finalise cropcount, making sure it's in accordance with maximums
+	HYPharvesting_finalise_cropcount(h_data)
 
-	if(DNA.commuts)
-		for(var/datum/plant_gene_strain/G in DNA.commuts)
-			// And ones that mess with the quality of crops.
-			// Unstable isn't here because it'd be less random outside the loop.
-			if (istype(G, /datum/plant_gene_strain/quality))
-				var/datum/plant_gene_strain/quality/Q = G
-				if(Q.negative)
-					base_quality_score -= Q.quality_mod
-				else
-					base_quality_score += Q.quality_mod
-			// Gene strains that boost or penalize the cap.
-			else if (istype(G, /datum/plant_gene_strain/yield))
-				var/datum/plant_gene_strain/yield/Y = G
-				if(Y.negative)
-					if(harvest_cap == 0 || Y.yield_mult == 0)
-						continue
-					else
-						harvest_cap /= Y.yield_mult
-						harvest_cap -= Y.yield_mod
-				else
-					harvest_cap *= Y.yield_mult
-					harvest_cap += Y.yield_mod
-
-	var/extra_harvest_chance = 0
-
-	if(getamount > harvest_cap)
-		extra_harvest_chance += getamount - harvest_cap
-		getamount = harvest_cap
-		// Max harvest amount for all plants is capped. If we've got higher output
-		// than the cap it's probably through gene manipulation, so reward the player
-		// with greater chances for an extra harvest if this is the case.
-		// The cap is defined in hydro_controls and can be edited by coders on the fly.
-
-	getamount = round(max(getamount, 0))
-
-	if(getamount < 1)
+	if(h_data.cropcount < 1)
 		boutput(user, SPAN_ALERT("You aren't able to harvest anything worth salvaging."))
 		// We just don't bother if the output is below one.
-	else if(!getitem)
+	else if(!h_data.getitem)
 		boutput(user, SPAN_ALERT("You can't seem to find anything that looks harvestable."))
 		// mostly a fix for a runtime error if getitem was null
 	else
-		var/cropcount = getamount
-		var/seedcount = 0
+		// Generate harvest products
+		HYPharvesting_generate_products(h_data)
+		// Handle seed outputs
+		HYPharvesting_seeds(h_data)
+		// Handle experience gains
+		HYPharvesting_experience(h_data)
 
-		for (var/_ in 1 to getamount)
-			// Start up the loop of grabbing all our produce. Remember, each iteration of
-			// this loop is for one item each.
-
-			//Now we define some variables for quality calculation.
-			var/quality_status = null
-			var/quality_score = base_quality_score
-			quality_score += rand(-2,2)
-			// Just a bit of natural variance to make it interesting
-			if(DNA?.get_effective_value("potency"))
-				quality_score += round(DNA?.get_effective_value("potency") / 6)
-			if(DNA?.get_effective_value("endurance"))
-				quality_score += round(DNA?.get_effective_value("endurance") / 6)
-			if(HYPCheckCommut(DNA,/datum/plant_gene_strain/unstable))
-				quality_score += rand(-7,7)
-
-			//This calculates produce quality and quality status. We need this for changing the name of the produce
-			//since quality status can override each other, they apply to quality status modifier first
-			var/quality_status_modifer = 0
-
-			switch(quality_score)
-				if(25 to INFINITY)
-					// as quality approaches 115, rate of getting jumbo increases
-					if(prob(min(100, quality_score - 15)))
-						quality_status = "jumbo"
-						quality_status_modifer = quality_score
-				if(20 to 24)
-					if(prob(4))
-						quality_status = "jumbo"
-						quality_status_modifer = quality_score
-				if(-9999 to -11)
-					quality_status = "rotten"
-					quality_status_modifer = - 20
-			if(HYPCheckCommut(DNA,/datum/plant_gene_strain/unstable) && prob(33))
-				// The unstable gene can do weird shit to your produce and happily stomp on your jumbo produce.
-				quality_status = "malformed"
-				quality_status_modifer = rand(10,-10)
-
-			//Now, if we got the quality status modifier, we add it to the score for our final score
-			quality_score += quality_status_modifer
-
-
-			//Now we can create an item or mob
-			// Marquesas: I thought of everything and couldn't find another way, but we need this for synthlimbs.
-			// Okay, I meanwhile realized there might be another way but this looks cleaner. IMHO.
-			var/itemtype = null
-			if(istype(getitem, /list))
-				itemtype = pick(getitem)
-			else
-				itemtype = getitem
-
-			var/atom/CROP = new itemtype
-
-			if(istype(CROP, /obj))
-				var/obj/CROP_ITEM = CROP
-				CROP_ITEM.set_loc(src)
-
-				//We call HYPsetup_DNA on each item created before we manipulate it further
-				//This proc handles all crop-related scaling and quirks of produce
-				//This proc also on some items remove the respectable produce and returns a new one, which we will handle further as CROP
-				//This proc calls HYPadd_harvest_reagents on it's respectable items
-				if(istype(CROP_ITEM, /obj/item))
-					var/obj/item/manipulated_item = CROP_ITEM
-					CROP_ITEM = manipulated_item.HYPsetup_DNA(DNA, src, growing, quality_status)
-
-				//last but not least, we give the mob a proper name
-				CROP_ITEM.name = HYPgenerate_produce_name(CROP_ITEM, src, growing, quality_score, quality_status, dont_rename_crop)
-
-				CROP_ITEM.quality = quality_score
-
-				if(!growing.stop_size_scaling) //Keeps plant sprite from scaling if variable is enabled.
-					CROP_ITEM.transform = matrix() * clamp((quality_score + 100) / 100, 0.35, 2)
-
-				if(istype(CROP_ITEM,/obj/critter/))
-					// If it's a critter we don't need to do reagents or shit like that but
-					// we do need to make sure they don't attack the botanist that grew it.
-					var/obj/critter/C = CROP_ITEM
-					C.friends = C.friends | src.contributors
-
-
-			if(istype(CROP, /mob))
-				// Start up the loop of grabbing all our produce. Remember, each iteration of
-				// this loop is for one item each.
-				var/obj/CROP_MOB = CROP
-				CROP_MOB.set_loc(src)
-
-				//We call HYPsetup_DNA on each mob created before we manipulate it further
-				//This proc handles all crop-related scaling and quirks of produce
-				//This proc also on some mobs remove the respectable produce and returns a new one, which we will handle further as CROP_MOB
-				if (istype(CROP_MOB, /mob/living/critter/plant))
-					var/mob/living/critter/plant/manipulated_critter = CROP_MOB
-					CROP_MOB = manipulated_critter.HYPsetup_DNA(DNA, src, growing, quality_status)
-
-				//last but not least, we give the mob a proper name
-				CROP_MOB.name = HYPgenerate_produce_name(CROP_MOB, src, growing, quality_score, quality_status, dont_rename_crop)
-
-
-
-			if(((growing.isgrass || (growing.force_seed_on_harvest > 0 )) && prob(80)) && !istype(getitem,/obj/item/seed/) && !HYPCheckCommut(DNA,/datum/plant_gene_strain/seedless) && (growing.force_seed_on_harvest >= 0 ))
-				// Same shit again. This isn't so much the crop as it is giving you seeds
-				// incase you couldn't get them otherwise, though.
-				seedcount++
-
-		if (seedcount > 0) HYPgenerateseedcopy(src.plantgenes, growing, src.generation, src, seedcount)
-
-		// Give XP based on base quality of crop harvest. Will make better later, like so more plants harvasted and stuff, this is just for testing.
-		// This is only reached if you actually got anything harvested.
-		// (tmp_crop here was causing runtimes in a lot of cases, so changing to just use it like this)
-		// Base quality score:
-		//   1: base
-		// -12: if HP <=  50% w/ 70% chance
-		// + 5: if HP >= 200% w/ 30% chance
-		// +10: if HP >= 400% w/ 30% chance
-		// Mutations can add or remove this, of course
-		// @TODO adjust this later, this is just to fix runtimes and make it slightly consistent
-		if (base_quality_score >= 1 && prob(30))
-			if (base_quality_score >= 11)
-				JOB_XP(user, "Botanist", 4)
-			else if (base_quality_score >= 6)
-				JOB_XP(user, "Botanist", 2)
-			else
-				JOB_XP(user, "Botanist", 1)
-
-		boutput(user, SPAN_NOTICE("You harvest [cropcount] item[s_es(cropcount)][seedcount ? " and [seedcount] seed[s_es(seedcount)]" : ""]."))
-		post_alert(list("event" = "harvest", "plant" = src.current.name, "produce" = cropcount, "seeds" = seedcount))
+		boutput(user, SPAN_NOTICE("You harvest [h_data.cropcount] item[s_es(h_data.cropcount)][h_data.seedcount ? " and [h_data.seedcount] seed[s_es(h_data.seedcount)]" : ""]."))
+		post_alert(list("event" = "harvest", "plant" = src.current.name, "produce" = h_data.cropcount, "seeds" = h_data.seedcount))
 #ifdef DATALOGGER
 		game_stats.Increment("hydro_harvests")
-		game_stats.IncrementBy("hydro_produce", cropcount)
+		game_stats.IncrementBy("hydro_produce", h_data.cropcount)
 #endif
 
 		// Mostly for dangerous produce (explosive tomatoes etc) that should show up somewhere in the logs (Convair880).
-		if(istype(MUT,/datum/plantmutation/))
-			logTheThing(LOG_STATION, user, "harvests [cropcount] items from a [MUT.name] plant ([MUT.type]) at [log_loc(src)].")
+		if(istype(h_data.MUT,/datum/plantmutation/))
+			logTheThing(LOG_STATION, user, "harvests [h_data.cropcount] items from a [h_data.MUT.name] plant ([h_data.MUT.type]) at [log_loc(src)].")
 		else
-			logTheThing(LOG_STATION, user, "harvests [cropcount] items from a [growing.name] plant ([growing.type]) at [log_loc(src)].")
+			logTheThing(LOG_STATION, user, "harvests [h_data.cropcount] items from a [h_data.growing.name] plant ([h_data.growing.type]) at [log_loc(src)].")
 
 		// At this point all the harvested items are inside the plant pot, and this is the
 		// part where we decide where they're going and get them out.
-		if(SA)
-			// If we're putting stuff in a satchel, this is where we do it.
-			for(var/obj/item/I in src.contents)
-				if(length(SA.contents) >= SA.maxitems)
-					boutput(user, SPAN_ALERT("Your satchel is full! You dump the rest on the floor."))
-					break
-				if(istype(I,/obj/item/seed/))
-					continue
-				else
-					if(SA.check_valid_content(I))
-						I.set_loc(SA)
-						I.add_fingerprint(user)
-			SA.UpdateIcon()
-			SA.tooltip_rebuild = TRUE
-
-		// if the satchel got filled up this will dump any unharvested items on the floor
-		// if we're harvesting by hand it'll just default to this anyway! truly magical~
-		for(var/obj/I in src.contents)
-			I.set_loc(user.loc)
-			I.add_fingerprint(user)
-
-		// we got to do the same for mobs
-		for(var/mob/I in src.contents)
-			I.set_loc(user.loc)
-			I.add_fingerprint(user)
-
+		HYPharvesting_satchel_output(h_data, SA)
 
 	// Now we determine the harvests remaining or grant extra ones.
-	if(!HYPCheckCommut(DNA,/datum/plant_gene_strain/immortal))
-		// Immortal is a gene strain that means infinite harvests as long as the plant
-		// is kept alive, it's on melons usually.
-		if(src.health >= growing.starthealth * 4)
-			// If we have excellent health, its a +20% chance for an extra harvest.
-			extra_harvest_chance += 20
-			extra_harvest_chance = clamp(extra_harvest_chance, 0, 100)
-			if(prob(extra_harvest_chance))
-				boutput(user, SPAN_NOTICE("The plant glistens with good health!"))
-				// We got the bonus so don't reduce harvests.
-			else
-				// No bonus, harvest is decremented as usual.
-				src.harvests--
-		else if(prob(33) && HYPCheckCommut(DNA, /datum/plant_gene_strain/variable_harvest))
-			if(prob(10))
-				src.harvests++
-			else if(prob(33))
-				src.harvests -= 2
-			// else just don't reduce the harvests
-		else
-			src.harvests--
-	if(growing.isgrass || src.harvests <= 0)
-		// Vegetable-style plants always die after one harvest irregardless of harvests
-		// remaining, though they do get bonuses for having a good harvests gene.
-		HYPkillplant()
+	HYPharvesting_remaining_harvests(h_data)
 
 	//do we have to run the next life tick manually? maybe
 	playsound(src.loc, "rustle", 50, 1, -5, 2)
 	src.UpdateIcon()
 	src.update_name()
+
+//////////////////////////////////
+// HYPharvesting helper methods //
+//////////////////////////////////
+// Could move some of these to var/datum/plant if plants ever wanted more control over how their produce is harvested
+
+/// Returns a generic quality score based on the given plant genes
+/obj/machinery/plantpot/proc/get_quality_score(var/datum/HYPharvesting_data/h_data)
+	var/quality_score = h_data.base_quality_score
+	quality_score += rand(-2,2)
+	// Just a bit of natural variance to make it interesting
+	if(h_data.DNA?.get_effective_value("potency"))
+		quality_score += round(h_data.DNA?.get_effective_value("potency") / 6)
+	if(h_data.DNA?.get_effective_value("endurance"))
+		quality_score += round(h_data.DNA?.get_effective_value("endurance") / 6)
+	if(HYPCheckCommut(h_data.DNA,/datum/plant_gene_strain/unstable))
+		quality_score += rand(-7,7)
+	return quality_score
+
+/// Updates a quality status and score list based. 'quality' expects list("score" = num, "status" = text).
+/obj/machinery/plantpot/proc/get_quality_and_status(datum/HYPharvesting_data/h_data, list/quality)
+	//This calculates produce quality and quality status. We need this for changing the name of the produce
+	//since quality status can override each other, they apply to quality status modifier first
+	if (!h_data)
+		return
+	var/quality_score_cache = quality["score"]
+
+	switch(quality_score_cache)
+		if(25 to INFINITY)
+			// as quality approaches 115, rate of getting jumbo increases
+			if(prob(min(100, quality["score"] - 15)))
+				quality["status"] = "jumbo"
+				quality["score"] += quality_score_cache
+		if(20 to 24)
+			if(prob(4))
+				quality["status"] = "jumbo"
+				quality["score"] += quality_score_cache
+		if(-9999 to -11)
+			quality["status"] = "rotten"
+			quality["score"] += - 20
+	if(HYPCheckCommut(h_data.DNA,/datum/plant_gene_strain/unstable) && prob(33))
+		// The unstable gene can do weird shit to your produce and happily stomp on your jumbo produce.
+		quality["status"] = "malformed"
+		quality["score"] += rand(10,-10)
+
+/// helper method for picking the item type of produce
+/obj/machinery/plantpot/proc/pick_type(datum/HYPharvesting_data/h_data)
+	var/itemtype = null
+	if(istype(h_data.getitem, /list))
+		itemtype = pick(h_data.getitem)
+	else
+		itemtype = h_data.getitem
+	return itemtype
+
+/// Handles the generation of mobs/items during harvests
+/obj/machinery/plantpot/proc/HYPharvesting_generate_products(datum/HYPharvesting_data/h_data)
+	for (var/_ in 1 to h_data.cropcount)
+		// Start up the loop of grabbing all our produce. Remember, each iteration of
+		// this loop is for one item each.
+
+		//Now we define some variables for quality calculation.
+		var/list/quality = list("status" = "", "score" = 0)
+		quality["score"] = get_quality_score(h_data)
+		get_quality_and_status(h_data, quality)
+
+		//Now we can create an item or mob
+		// Marquesas: I thought of everything and couldn't find another way, but we need this for synthlimbs.
+		// Okay, I meanwhile realized there might be another way but this looks cleaner. IMHO.
+		var/itemtype = pick_type(h_data)
+		var/atom/CROP = new itemtype
+
+		if(istype(CROP, /obj))
+			var/obj/CROP_ITEM = CROP
+			CROP_ITEM.set_loc(h_data.pot)
+
+			//We call HYPsetup_DNA on each item created before we manipulate it further
+			//This proc handles all crop-related scaling and quirks of produce
+			//This proc also on some items remove the respectable produce and returns a new one, which we will handle further as CROP
+			//This proc calls HYPadd_harvest_reagents on it's respectable items
+			if(istype(CROP_ITEM, /obj/item))
+				var/obj/item/manipulated_item = CROP_ITEM
+				CROP_ITEM = manipulated_item.HYPsetup_DNA(h_data.DNA, h_data.pot, h_data.growing, quality["status"])
+
+			//last but not least, we give the mob a proper name
+			CROP_ITEM.name = HYPgenerate_produce_name(CROP_ITEM, h_data.pot, h_data.growing, quality["score"], quality["status"], h_data.dont_rename_crop)
+
+			CROP_ITEM.quality = quality["score"]
+
+			if(!h_data.growing.stop_size_scaling) //Keeps plant sprite from scaling if variable is enabled.
+				CROP_ITEM.transform = matrix() * clamp((quality["score"] + 100) / 100, 0.35, 2)
+
+			if(istype(CROP_ITEM,/obj/critter/))
+				// If it's a critter we don't need to do reagents or shit like that but
+				// we do need to make sure they don't attack the botanist that grew it.
+				var/obj/critter/C = CROP_ITEM
+				C.friends = C.friends | h_data.pot.contributors
+
+
+		if(istype(CROP, /mob))
+			// Start up the loop of grabbing all our produce. Remember, each iteration of
+			// this loop is for one item each.
+			var/obj/CROP_MOB = CROP
+			CROP_MOB.set_loc(h_data.pot)
+
+			//We call HYPsetup_DNA on each mob created before we manipulate it further
+			//This proc handles all crop-related scaling and quirks of produce
+			//This proc also on some mobs remove the respectable produce and returns a new one, which we will handle further as CROP_MOB
+			if (istype(CROP_MOB, /mob/living/critter/plant))
+				var/mob/living/critter/plant/manipulated_critter = CROP_MOB
+				CROP_MOB = manipulated_critter.HYPsetup_DNA(h_data.DNA, h_data.pot, h_data.growing, quality["status"])
+
+			//last but not least, we give the mob a proper name
+			CROP_MOB.name = HYPgenerate_produce_name(CROP_MOB, h_data.pot, h_data.growing, quality["score"], quality["status"], h_data.dont_rename_crop)
+
+		if(((h_data.growing.isgrass || (h_data.growing.force_seed_on_harvest > 0 )) && prob(80)) && !istype(h_data.getitem,/obj/item/seed/) && !HYPCheckCommut(h_data.DNA,/datum/plant_gene_strain/seedless) && (h_data.growing.force_seed_on_harvest >= 0 ))
+			// Same shit again. This isn't so much the crop as it is giving you seeds
+			// incase you couldn't get them otherwise, though.
+			h_data.seedcount++
+
+/// Give XP based on base quality of crop harvest.
+/obj/machinery/plantpot/proc/HYPharvesting_experience(datum/HYPharvesting_data/h_data)
+	// Will make better later, like so more plants harvasted and stuff, this is just for testing.
+	// This is only reached if you actually got anything harvested.
+	// (tmp_crop here was causing runtimes in a lot of cases, so changing to just use it like this)
+	// Base quality score:
+	//   1: base
+	// -12: if HP <=  50% w/ 70% chance
+	// + 5: if HP >= 200% w/ 30% chance
+	// +10: if HP >= 400% w/ 30% chance
+	// Mutations can add or remove this, of course
+	// @TODO adjust this later, this is just to fix runtimes and make it slightly consistent
+	if (h_data.base_quality_score >= 1 && prob(30))
+		if (h_data.base_quality_score >= 11)
+			JOB_XP(h_data.user, "Botanist", 4)
+		else if (h_data.base_quality_score >= 6)
+			JOB_XP(h_data.user, "Botanist", 2)
+		else
+			JOB_XP(h_data.user, "Botanist", 1)
+
+/obj/machinery/plantpot/proc/HYPharvesting_gene_strains(datum/HYPharvesting_data/h_data)
+	if(h_data.DNA.commuts)
+		for(var/datum/plant_gene_strain/G in h_data.DNA.commuts)
+			// And ones that mess with the quality of crops.
+			// Unstable isn't here because it'd be less random outside the loop.
+			if (istype(G, /datum/plant_gene_strain/quality))
+				var/datum/plant_gene_strain/quality/Q = G
+				if(Q.negative)
+					h_data.base_quality_score -= Q.quality_mod
+				else
+					h_data.base_quality_score += Q.quality_mod
+			// Gene strains that boost or penalize the cap.
+			else if (istype(G, /datum/plant_gene_strain/yield))
+				var/datum/plant_gene_strain/yield/Y = G
+				if(Y.negative)
+					if(h_data.harvest_cap == 0 || Y.yield_mult == 0)
+						continue
+					else
+						h_data.harvest_cap /= Y.yield_mult
+						h_data.harvest_cap -= Y.yield_mod
+				else
+					h_data.harvest_cap *= Y.yield_mult
+					h_data.harvest_cap += Y.yield_mod
+
+/obj/machinery/plantpot/proc/HYPharvesting_mutated_crops(datum/HYPharvesting_data/h_data)
+	// Figure out what crop we use - the base crop or a mutation crop.
+	if(h_data.growing.crop || h_data.MUT?.crop)
+		if(h_data.MUT)
+			if(h_data.MUT.crop)
+				h_data.getitem = h_data.MUT.crop
+				h_data.dont_rename_crop = h_data.MUT.dont_rename_crop
+			else
+				logTheThing(LOG_DEBUG, null, "<b>I Said No/Hydroponics:</b> Plant mutation [h_data.MUT] crop is not properly configured")
+				h_data.getitem = h_data.growing.crop
+		else
+			h_data.getitem = h_data.growing.crop
+			h_data.dont_rename_crop = h_data.growing.dont_rename_crop
+
+/obj/machinery/plantpot/proc/HYPharvesting_health_bonuses(datum/HYPharvesting_data/h_data)
+
+	if(h_data.pot.health >= h_data.growing.starthealth * 2 && prob(30))
+		boutput(h_data.user, SPAN_NOTICE("This looks like a good harvest!"))
+		h_data.base_quality_score += 5
+		var/bonus = rand(1,3)
+		h_data.cropcount += bonus
+		h_data.harvest_cap += bonus
+		// Good health levels bump the harvest amount up a bit and increase jumbo chances.
+	if(h_data.pot.health >= h_data.growing.starthealth * 4 && prob(30))
+		boutput(h_data.user, SPAN_NOTICE("It's a bumper crop!"))
+		h_data.base_quality_score += 10
+		var/bonus = rand(2,5)
+		h_data.cropcount += bonus
+		h_data.harvest_cap += bonus
+		// This is if the plant health is absolutely excellent.
+	if(h_data.pot.health <= h_data.growing.starthealth / 2 && prob(70))
+		boutput(h_data.user, SPAN_ALERT("This is kind of a crappy harvest..."))
+		h_data.base_quality_score -= 12
+		// And this is if you've neglected the plant!
+
+/obj/machinery/plantpot/proc/HYPharvesting_remaining_harvests(datum/HYPharvesting_data/h_data)
+	if(!HYPCheckCommut(h_data.DNA,/datum/plant_gene_strain/immortal))
+		// Immortal is a gene strain that means infinite harvests as long as the plant
+		// is kept alive, it's on melons usually.
+		if(h_data.pot.health >= h_data.growing.starthealth * 4)
+			// If we have excellent health, its a +20% chance for an extra harvest.
+			h_data.extra_harvest_chance += 20
+			h_data.extra_harvest_chance = clamp(h_data.extra_harvest_chance, 0, 100)
+			if(prob(h_data.extra_harvest_chance))
+				boutput(h_data.user, SPAN_NOTICE("The plant glistens with good health!"))
+				// We got the bonus so don't reduce harvests.
+			else
+				// No bonus, harvest is decremented as usual.
+				h_data.pot.harvests--
+		else if(prob(33) && HYPCheckCommut(h_data.DNA, /datum/plant_gene_strain/variable_harvest))
+			if(prob(10))
+				h_data.pot.harvests++
+			else if(prob(33))
+				h_data.pot.harvests -= 2
+			// else just don't reduce the harvests
+		else
+			h_data.pot.harvests--
+
+	if(h_data.growing.isgrass || h_data.pot.harvests <= 0)
+		// Vegetable-style plants always die after one harvest irregardless of harvests
+		// remaining, though they do get bonuses for having a good harvests gene.
+		h_data.pot.HYPkillplant()
+
+///
+/obj/machinery/plantpot/proc/HYPharvesting_satchel_output(datum/HYPharvesting_data/h_data, obj/item/satchel/SA)
+	if(SA)
+		// If we're putting stuff in a satchel, this is where we do it.
+		for(var/obj/item/I in h_data.pot.contents)
+			if(length(SA.contents) >= SA.maxitems)
+				boutput(h_data.user, SPAN_ALERT("Your satchel is full! You dump the rest on the floor."))
+				break
+			if(istype(I,/obj/item/seed/))
+				continue
+			else
+				if(SA.check_valid_content(I))
+					I.set_loc(SA)
+					I.add_fingerprint(h_data.user)
+		SA.UpdateIcon()
+		SA.tooltip_rebuild = TRUE
+	// if the satchel got filled up this will dump any unharvested items on the floor
+	// if we're harvesting by hand it'll just default to this anyway! truly magical~
+	for(var/obj/I in h_data.pot.contents)
+		I.set_loc(h_data.user.loc)
+		I.add_fingerprint(h_data.user)
+	// we got to do the same for mobs
+	for(var/mob/I in h_data.pot.contents)
+		I.set_loc(h_data.user.loc)
+		I.add_fingerprint(h_data.user)
+
+/obj/machinery/plantpot/proc/HYPharvesting_seeds(datum/HYPharvesting_data/h_data)
+	if (h_data.seedcount > 0) HYPgenerateseedcopy(h_data.pot.plantgenes, h_data.growing, h_data.pot.generation, h_data.pot, h_data.seedcount)
+
+/obj/machinery/plantpot/proc/HYPharvesting_finalise_cropcount(datum/HYPharvesting_data/h_data)
+	if(h_data.cropcount > h_data.harvest_cap)
+		h_data.extra_harvest_chance += h_data.cropcount - h_data.harvest_cap
+		h_data.cropcount = h_data.harvest_cap
+		// Max harvest amount for all plants is capped. If we've got higher output
+		// than the cap it's probably through gene manipulation, so reward the player
+		// with greater chances for an extra harvest if this is the case.
+		// The cap is defined in hydro_controls and can be edited by coders on the fly.
+	h_data.cropcount = round(max(h_data.cropcount, 0))
+
+/////////////////// end of HYPharvesting helper methods ///////////////////
 
 /obj/machinery/plantpot/proc/HYPmutateplant(var/severity = 1)
 	// This proc is for mutating the plant - gene strains, mutant variants and plain old
@@ -1574,3 +1615,29 @@ TYPEINFO(/obj/machinery/plantpot/bareplant)
 	spawn_plant = pick(/datum/plant/artifact/creeper, /datum/plant/weed/lasher, /datum/plant/weed/slurrypod, /datum/plant/artifact/pukeplant)
 	..()
 
+/// Holds harvest-specific variables during HYPharvesting() execution.
+/datum/HYPharvesting_data
+	// The mob that initiated the harvest
+	var/mob/living/user
+	/// The plantpot associated with this harvest
+	var/obj/machinery/plantpot/pot
+	/// The plant associated with this harvest
+	var/datum/plant/growing
+	/// The plantgenes of the plant associated with this harvest
+	var/datum/plantgenes/DNA
+	/// The plant mutation of the plant associated with this harvest
+	var/datum/plantmutation/MUT
+	/// The item or list of items that the plant can produce
+	var/getitem
+	/// Whether or not the produce should be renamed
+	var/dont_rename_crop
+	/// The number of items this harvest produces
+	var/cropcount = 0
+	/// The maximum number of items that this harvest produces
+	var/harvest_cap
+	/// The number of seeds this harvest produced
+	var/seedcount = 0
+	/// The base quality score of all produce from the plant
+	var/base_quality_score
+	/// The chance that a multi-harvest plant won't reduce in harvest-count
+	var/extra_harvest_chance = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label [feature][hydroponics][input-wanted]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Added a gene strain which causes plants to instead grow guns in the shape of the plant's usual produce.
- These produce guns scale based on the plant's stats; potency affects damage, yield affects ammo quantity, endurance affects armour pierce, production rate and maturation rate both affect firing speed, lifespan affects recoil. 
- They cannot be reloaded.
- They can fit in produce satchels (probably a bad idea)
- They have generic gun inhand sprites if the base produce doesn't have any.
- Jumbo guns get a slight stat boost and punchier audio and visual effect.
- Damage, armour pierce and ammo count scale linearly (probably should be diminishing returns).

Added a chem which can infuse the gene strain into seeds, called "Phytoballistic Infusate". Added a recipe to make said chem. 

Added a prerequisite chem which can be obtained by putting guns in a still. 

The gene strain only affects the produce of plants which grow items, plants which grow objects or otherwise do something else harvest crops as normal. It also reduces the plant's produce count by 85%, but due to how yield works this is rather easy to circumvent. 

This relies on #23953.

TODO

- [ ] Balance via feedback

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Botany doesn't have any whacky "secret"-level chem stuff that affects plants, despite there being a heavy mechanical relationship between chems and plants.

This is intended to be a rarity, as such I've tried to make it require effort to obtain, but the recipe could be a lot more difficult. Traitor botanists are already rather full on specialist items, so it doesn't seem right to put it there. If nothing else, it could be fun as an admin spawn. 

I also don't know how to balance guns, so the numbers are likely very iffy. The intention is that the guns themselves also require a fair bit of stat scaling - and thus time investment - before they become useful. They should be balanced with being dual-wielded in mind. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested most of the different types of produce, including the more complex ones like glowsticks and ore. Tested the cat to make sure mob plants weren't affected. Made the chem in a barrel to make sure the recipe worked. 

![produce gun demo 1](https://github.com/user-attachments/assets/b77655af-b39f-4186-8b10-f73d360363e1)
![produce gun demo 2](https://github.com/user-attachments/assets/22468514-9624-4e28-bc7e-af1da364f03f)
![Produce gun demo 3](https://github.com/user-attachments/assets/b8263510-6246-4ff3-8888-4a6e4046342d)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Egregorious
(*)Botany can now grow guns, if they have the know-how.
```
