### PR TITLE
Add archivist artifact

### DIFF
--- a/code/obj/artifacts/artifact_items/archivist.dm
+++ b/code/obj/artifacts/artifact_items/archivist.dm
@@ -1,0 +1,70 @@
+/obj/item/artifact/archivist
+	name = "artifact archivist"
+	associated_datum = /datum/artifact/archivist
+
+	afterattack(atom/target, mob/user, reach, params)
+		var/datum/artifact/compass/art = src.artifact
+		if (!art.activated)
+			return ..()
+		. = ..()
+		var/obj/O = target
+		if (!istype(O) || !O.artifact)
+			src.say("[O] is not an artifact, results inconclusive.")
+		else if (O.artifact.activated)
+			var/datum/artifact_trigger/activating_trigger = O.artifact.triggers[1]
+			var/list/art_faults = list()
+			for (var/datum/artifact_fault/fault in O.artifact.faults)
+				art_faults += fault.type_name
+			src.say("Analysis results:")
+			sleep(0.1 SECONDS)
+			src.say("Origin disguised: [O.artifact.disguised ? "Yes" : "No"]")
+			sleep(0.1 SECONDS)
+			src.say("Activation method: [art.trigger_names_assoc[activating_trigger.type]]")
+			sleep(0.1 SECONDS)
+			src.say("Faults: [length(art_faults) ? english_list(art_faults) : "None"]")
+			sleep(0.1 SECONDS)
+			//src.say("Artifacts combined: [length(O.combined_artifacts) || 0]"))
+		else
+			if ("\ref[O]" in art.scanned_artifacts)
+				for (var/str in art.scanned_artifacts["\ref[O]"])
+					src.say(str)
+					sleep(0.1 SECONDS)
+			else
+				if (length(O.artifact.triggers))
+					var/datum/artifact_trigger/activating_trigger = O.artifact.triggers[1]
+					var/list/possible_triggers = list(activating_trigger.type_name)
+					var/list/other_triggers = art.trigger_names.Copy() - list(activating_trigger.type_name)
+					for (var/i in 1 to 2)
+						var/trigger = pick(other_triggers)
+						other_triggers -= trigger
+						possible_triggers += trigger
+					shuffle_list(possible_triggers)
+					art.scanned_artifacts["\ref[O]"] = list("Analysis results:",
+						"Possible activation methods: [english_list(possible_triggers)]")
+				else
+					art.scanned_artifacts["\ref[O]"] = list("Analysis results:",
+						"Possible activation methods: None")
+				for (var/str in art.scanned_artifacts["\ref[O]"])
+					src.say(str)
+					sleep(0.1 SECONDS)
+
+/datum/artifact/archivist
+	associated_object = /obj/item/artifact/archivist
+	type_name = "Archivist"
+	type_size = ARTIFACT_SIZE_MEDIUM
+	rarity_weight = 200
+	validtypes = list("precursor")
+	validtriggers = list(/datum/artifact_trigger/language)
+	react_xray = list(16, 45, 95, 8, "ANOMALOUS")
+	examine_hint = "It seems to have a handle you're supposed to hold it by."
+	var/static/list/trigger_names = list()
+	var/static/list/trigger_names_assoc = list()
+	var/list/scanned_artifacts = list()
+
+	New()
+		..()
+		if (!length(src.trigger_names))
+			for (var/datum/artifact_trigger/trigger_type as anything in concrete_typesof(/datum/artifact_trigger))
+				if (initial(trigger_type.used))
+					src.trigger_names += initial(trigger_type.type_name)
+					src.trigger_names_assoc[trigger_type] = initial(trigger_type.type_name)

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -50,6 +50,8 @@ ABSTRACT_TYPE(/datum/artifact/)
 	var/deact_text = null
 	/// How likely this artifact is to appear to be from an origin that it isn't from
 	var/scramblechance = 10
+	/// this artifact is currently disguised as a different origin
+	var/disguised = FALSE
 	/// used to set straight icon_states on activation instead of fx overlays
 	var/nofx = 0
 	/// special_addendum for ArtifactLogs() proc

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -69,6 +69,7 @@
 	var/datum/artifact_origin/appearance = artifact_controls.get_origin_from_string(AO.name)
 	if (prob(A.scramblechance))
 		appearance = null
+		A.disguised = TRUE
 	// rare-ish chance of an artifact appearing to be a different origin, just to throw things off
 
 	if (!istype(appearance,/datum/artifact_origin/))

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -2185,6 +2185,7 @@
 #include "code\obj\artifacts\faults.dm"
 #include "code\obj\artifacts\triggers.dm"
 #include "code\obj\artifacts\artifact_items\activator_key.dm"
+#include "code\obj\artifacts\artifact_items\archivist.dm"
 #include "code\obj\artifacts\artifact_items\attack_wand.dm"
 #include "code\obj\artifacts\artifact_items\dimensional_key.dm"
 #include "code\obj\artifacts\artifact_items\energy_gun.dm"


### PR DESCRIPTION
[SCIENCE][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new artifact, the Archivist

This is meant to be a Lattice origin unique artifact (once Lattice artifacts are merged).

This artifact is always language activated and can be used on other artifacts to reveal info about them

If used on an unactivated artifact, it reveals three possible activation methods with one being the actual method

If used on an activated artifact, it reveals if its origin is disguised, its activation method, and any faults it has

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lattice origin unique artifact

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested using artifact on station objects, unactivated artifacts, activated artifacts, and artifacts with no triggers

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(*)Added a new Archivist artifact. Reveals useful info about other artifacts
```
