### PR TITLE
Refactor and fix trowel

### DIFF
--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -24,10 +24,10 @@ TYPEINFO(/obj/decorative_pot)
 						var/obj/item/gardentrowel/trowel = weapon
 						if(!trowel.holding_plant)
 								return
-						if (holding_plant)
+						if (src.holding_plant)
 								// This probably introduces more bugs than it fixes.
 								src.ClearAllOverlays()
-						holding_plant = TRUE
+						src.holding_plant = TRUE
 						src.UpdateOverlays(trowel.create_plant_image(),"plant")
 						src.UpdateOverlays(trowel.create_plant_overlay_image(), "plantoverlay")
 						trowel.genes.mutation?.HYPpotted_proc_M(src, trowel.grow_level)

--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -7,6 +7,7 @@ TYPEINFO(/obj/decorative_pot)
 		icon_state = "plantpot"
 		anchored = UNANCHORED
 		density = 1
+		var/holding_plant = FALSE
 
 		attackby(obj/item/weapon, mob/user)
 				if((iswrenchingtool(weapon)) || isscrewingtool(weapon))
@@ -20,18 +21,18 @@ TYPEINFO(/obj/decorative_pot)
 								src.anchored = UNANCHORED
 						return
 				else if(istype(weapon,/obj/item/gardentrowel))
-						var/obj/item/gardentrowel/t = weapon
-						if(!t.plantyboi)
+						var/obj/item/gardentrowel/trowel = weapon
+						if(!trowel.holding_plant)
 								return
-						src.UpdateOverlays(t.plantyboi,"plant")
-						src.UpdateOverlays(t.plantyboi_plantoverlay, "plantoverlay")
-						t.plantyboi = null
-						t.plantyboi_plantoverlay = null
-						t.icon_state = "trowel"
+						if (holding_plant)
+								// This probably introduces more bugs than it fixes.
+								src.ClearAllOverlays()
+						holding_plant = TRUE
+						src.UpdateOverlays(trowel.create_plant_image(),"plant")
+						src.UpdateOverlays(trowel.create_plant_overlay_image(), "plantoverlay")
+						trowel.genes.mutation?.HYPpotted_proc_M(src, trowel.grow_level)
+						trowel.empty_trowel()
 						playsound(src, 'sound/effects/shovel2.ogg', 50, TRUE, 0.3)
-						t.genes.mutation?.HYPpotted_proc_M(src, t.grow_level)
-						qdel(t.genes)
-						t.genes = null
 						return
 				if(istype(weapon,/obj/item/seed))
 						boutput(user, "It's an empty pot, there's nowhere to plant the seed! Maybe you need to use a trowel and place an existing plant into it?")

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -511,10 +511,10 @@ TYPEINFO(/obj/item/plantanalyzer)
 		if(overlay_image)
 			plant_icon = overlay_image.icon
 			plant_icon_state = overlay_image.icon_state
-			var/plantoverlay_image = pot.GetOverlayImage("plantoverlay")
+			var/image/plantoverlay_image = pot.GetOverlayImage("plantoverlay")
 			if(plantoverlay_image)
-				plantoverlay_icon = overlay_image.icon
-				plantoverlay_icon_state = overlay_image.icon_state
+				plantoverlay_icon = plantoverlay_image.icon
+				plantoverlay_icon_state = plantoverlay_image.icon_state
 			else
 				plantoverlay_icon = null
 				plantoverlay_icon_state = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label [hydroponics][bug][code quality]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Refactors the trowel and changes the way it holds the plant's overlays so they don't get overriden by altering the contents of the tray the plant was pulled from. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

fixes #23301
fixes #21860
fixes #17265
Cleaner code

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

![trowel bug fix](https://github.com/user-attachments/assets/fc82de84-59b4-4dbc-b07f-da196c25d8ff)
Also made sure the glowstick tree still glowed.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
