### PR TITLE
Fixes rockets leaving ghosts on cookoff

### DIFF
--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -307,9 +307,14 @@
 			SPAWN(rand(0,5)) //randomize a bit so piles of ammo don't shoot in waves
 				//shoot in a truly random direction
 				shoot_projectile_relay_pixel_spread(src, src.ammo_type, src, rand(-32, 32), rand(-32, 32), 360)
+				if(src.delete_on_reload && src.amount_left <= 0)
+					qdel(src)
 				if (prob(30) && src.use(1)) //small chance to do two per tick
 					sleep(0.3 SECONDS)
 					shoot_projectile_DIR(src, src.ammo_type, pick(alldirs))
+					if(src.delete_on_reload && src.amount_left <= 0) //I don't like repeating code, but this is needed to catch if it empties on the second firing
+						qdel(src)
+
 
 //no caliber:
 /obj/item/ammo/bullets/vbullet


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECT][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes ammo items with `delete_on_reload` set qdel themselves on cookoff if they are fully expended, instead of leaving behind ghost ammo.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #22870 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested by dropping a lighter on a pile of pod-seeking missiles.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
