### PR TITLE
Say Channel Fixes

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -490,7 +490,6 @@ TYPEINFO(/atom/movable)
 	/// Temporary value to smuggle newloc to Uncross during Move-related procs
 	var/tmp/atom/movement_newloc = null
 
-	var/soundproofing = 5
 	appearance_flags = LONG_GLIDE | PIXEL_SCALE
 	var/l_spd = 0
 

--- a/code/modules/speech/core.dm
+++ b/code/modules/speech/core.dm
@@ -27,9 +27,11 @@ TYPEINFO(/atom)
 	/// This atom's speech module tree. Lazy loaded on the first `say()` call.
 	var/tmp/datum/speech_module_tree/speech_tree = null
 
-	// Listen Variables:
-	/// Whether objects inside of this atom should be able to hear messages that could be heard by this atom.
+	// Soundproofing Variables:
+	/// Whether this atom should allow messages to pass from its loc to its contents and vice versa.
 	var/open_to_sound = TRUE
+	/// Determines how greatly this atom affects the styling of a message spoken inside of it. See `LISTEN_INPUT_EARS`.
+	var/soundproofing = 5
 
 	// Speech Output Variables:
 	/// The default channel that this atom will attempt to send unprefixed say messages to.

--- a/code/modules/speech/say_channels/_say_channel_parent.dm
+++ b/code/modules/speech/say_channels/_say_channel_parent.dm
@@ -227,7 +227,7 @@ ABSTRACT_TYPE(/datum/say_channel/delimited/local)
 
 	listen_modules_by_type = list()
 
-	if (!ismob(message.message_origin.loc))
+	if (isturf(GET_MESSAGE_OUTERMOST_LISTENER_LOC(message)))
 		var/turf/centre = get_turf(message.message_origin)
 		if (!centre)
 			return
@@ -245,11 +245,9 @@ ABSTRACT_TYPE(/datum/say_channel/delimited/local)
 					// If the input ignores line of sight checks, then the listener may hear the message if they are within the message's heard range.
 					else if (!INPUT_IN_RANGE(input, centre, message.heard_range))
 						continue
-				// If the outermost listener of the listener and the speaker match, the listener may hear the message.
-				else if (GET_INPUT_OUTERMOST_LISTENER(input) != GET_MESSAGE_OUTERMOST_LISTENER(message))
-					// If the outermost listener's loc is the speaker, the listener may hear the message.
-					if (GET_INPUT_OUTERMOST_LISTENER_LOC(input) != message.message_origin)
-						continue
+				// If the outermost listener's loc is not a turf, determine whether the message can be heard based on a shared loc chain.
+				else if (CANNOT_HEAR_MESSAGE_FROM_LOC_CHAIN(input, message))
+					continue
 
 				listen_modules_by_type[type] += input
 
@@ -257,13 +255,9 @@ ABSTRACT_TYPE(/datum/say_channel/delimited/local)
 		for (var/type in src.listeners)
 			listen_modules_by_type[type] ||= list()
 			for (var/datum/listen_module/input/input as anything in src.listeners[type])
-				// If the outermost listener of the listener and the speaker match, the listener may hear the message.
-				if (GET_INPUT_OUTERMOST_LISTENER(input) != GET_MESSAGE_OUTERMOST_LISTENER(message))
-					// If the outermost listener's loc is the speaker, the listener may hear the message.
-					if (GET_INPUT_OUTERMOST_LISTENER_LOC(input) != message.message_origin)
-						// If the speaker's loc is the listener, the listener may hear the message.
-						if (message.message_origin.loc != input.parent_tree.listener_origin)
-							continue
+				// Determine whether the message can be heard based on a shared loc chain.
+				if (CANNOT_HEAR_MESSAGE_FROM_LOC_CHAIN(input, message))
+					continue
 
 				listen_modules_by_type[type] += input
 

--- a/code/modules/speech/say_channels/equipped.dm
+++ b/code/modules/speech/say_channels/equipped.dm
@@ -13,13 +13,9 @@
 	for (var/type in src.listeners)
 		listen_modules_by_type[type] ||= list()
 		for (var/datum/listen_module/input/input as anything in src.listeners[type])
-			// If the outermost listener of the listener and the speaker match, the listener may hear the message.
-			if (GET_INPUT_OUTERMOST_LISTENER(input) != GET_MESSAGE_OUTERMOST_LISTENER(message))
-				// If the outermost listener's loc is the speaker, the listener may hear the message.
-				if (GET_INPUT_OUTERMOST_LISTENER_LOC(input) != message.message_origin)
-					// If the speaker's loc is the listener, the listener may hear the message.
-					if (message.message_origin.loc != input.parent_tree.listener_origin)
-						continue
+			// Determine whether the message can be heard based on a shared loc chain.
+			if (CANNOT_HEAR_MESSAGE_FROM_LOC_CHAIN(input, message))
+				continue
 
 			listen_modules_by_type[type] += input
 

--- a/code/modules/speech/say_channels/listener_tick_cache/_listener_tick_cache_parent.dm
+++ b/code/modules/speech/say_channels/listener_tick_cache/_listener_tick_cache_parent.dm
@@ -16,15 +16,15 @@
 
 	src.cache_tick = world.time
 
-	var/is_in_mob = "[ismob(message.message_origin.loc)]"
+	var/use_range_check = isturf(GET_MESSAGE_OUTERMOST_LISTENER_LOC(message))
 	src.cached_listeners_by_range_message_origin ||= list()
 	src.cached_listeners_by_range_message_origin[message.message_origin] ||= list()
 
-	if (is_in_mob)
-		src.cached_listeners_by_range_message_origin[message.message_origin][is_in_mob] = listeners
+	if (use_range_check)
+		src.cached_listeners_by_range_message_origin[message.message_origin]["[use_range_check]"] ||= list()
+		src.cached_listeners_by_range_message_origin[message.message_origin]["[use_range_check]"]["[message.heard_range]"] = listeners
 	else
-		src.cached_listeners_by_range_message_origin[message.message_origin][is_in_mob] ||= list()
-		src.cached_listeners_by_range_message_origin[message.message_origin][is_in_mob]["[message.heard_range]"] = listeners
+		src.cached_listeners_by_range_message_origin[message.message_origin]["[use_range_check]"] = listeners
 
 /// Attempt to retrieve a list of listeners by type, if it exists.
 /datum/listener_tick_cache/proc/read_from_cache(datum/say_message/message)
@@ -37,12 +37,12 @@
 		src.cached_listeners_by_range_message_origin = null
 		return
 
-	var/is_in_mob = "[ismob(message.message_origin.loc)]"
-	var/list/list/cached_listeners_by_range = src.cached_listeners_by_range_message_origin[message.message_origin][is_in_mob]
+	var/use_range_check = isturf(GET_MESSAGE_OUTERMOST_LISTENER_LOC(message))
+	var/list/list/cached_listeners_by_range = src.cached_listeners_by_range_message_origin[message.message_origin]["[use_range_check]"]
 	if (!cached_listeners_by_range)
 		return
 
-	if (is_in_mob)
+	if (!use_range_check)
 		return cached_listeners_by_range
 
 	. = cached_listeners_by_range["[message.heard_range]"]
@@ -62,5 +62,5 @@
 
 				.[type] += input
 
-		src.cached_listeners_by_range_message_origin[message.message_origin][is_in_mob][message.heard_range] = .
+		src.cached_listeners_by_range_message_origin[message.message_origin]["[use_range_check]"]["[message.heard_range]"] = .
 		return

--- a/code/modules/speech/say_channels/listener_tick_cache/outloud_cache.dm
+++ b/code/modules/speech/say_channels/listener_tick_cache/outloud_cache.dm
@@ -6,16 +6,16 @@
 
 	src.cache_tick = world.time
 
-	var/is_in_mob = ismob(message.message_origin.loc)
-	var/flags = "[(is_in_mob << 0) | ((message.flags & SAYFLAG_WHISPER) << 1) | (heard_clearly << 2)]"
+	var/use_range_check = isturf(GET_MESSAGE_OUTERMOST_LISTENER_LOC(message))
+	var/flags = "[(use_range_check << 0) | ((message.flags & SAYFLAG_WHISPER) << 1) | (heard_clearly << 2)]"
 	src.cached_listeners_by_range_message_origin ||= list()
 	src.cached_listeners_by_range_message_origin[message.message_origin] ||= list()
 
-	if (is_in_mob)
-		src.cached_listeners_by_range_message_origin[message.message_origin][flags] = listeners
-	else
+	if (use_range_check)
 		src.cached_listeners_by_range_message_origin[message.message_origin][flags] ||= list()
 		src.cached_listeners_by_range_message_origin[message.message_origin][flags]["[message.heard_range]"] = listeners
+	else
+		src.cached_listeners_by_range_message_origin[message.message_origin][flags] = listeners
 
 /datum/listener_tick_cache/outloud/read_from_cache(datum/say_message/message, heard_clearly)
 	RETURN_TYPE(/list/list/datum/listen_module/input)
@@ -27,13 +27,13 @@
 		src.cached_listeners_by_range_message_origin = null
 		return
 
-	var/is_in_mob = ismob(message.message_origin.loc)
-	var/flags = "[(is_in_mob << 0) | ((message.flags & SAYFLAG_WHISPER) << 1) | (heard_clearly << 2)]"
+	var/use_range_check = isturf(GET_MESSAGE_OUTERMOST_LISTENER_LOC(message))
+	var/flags = "[(use_range_check << 0) | ((message.flags & SAYFLAG_WHISPER) << 1) | (heard_clearly << 2)]"
 	var/list/list/cached_listeners_by_range = src.cached_listeners_by_range_message_origin[message.message_origin][flags]
 	if (!cached_listeners_by_range)
 		return
 
-	if (is_in_mob)
+	if (!use_range_check)
 		return cached_listeners_by_range
 
 	. = cached_listeners_by_range["[message.heard_range]"]
@@ -53,5 +53,5 @@
 
 				.[type] += input
 
-		src.cached_listeners_by_range_message_origin[message.message_origin][flags][message.heard_range] = .
+		src.cached_listeners_by_range_message_origin[message.message_origin][flags]["[message.heard_range]"] = .
 		return

--- a/code/modules/speech/say_channels/outloud.dm
+++ b/code/modules/speech/say_channels/outloud.dm
@@ -11,7 +11,7 @@
 
 		listen_modules_by_type = list()
 
-		if (!ismob(message.message_origin.loc))
+		if (isturf(GET_MESSAGE_OUTERMOST_LISTENER_LOC(message)))
 			var/turf/centre = get_turf(message.message_origin)
 			if (!centre)
 				return
@@ -35,11 +35,9 @@
 							var/min_heard_range = min(input.hearing_range, message.heard_range)
 							if (!INPUT_IN_RANGE(input, centre, min_heard_range))
 								continue
-					// If the outermost listener of the listener and the speaker match, the listener may hear the message.
-					else if (GET_INPUT_OUTERMOST_LISTENER(input) != GET_MESSAGE_OUTERMOST_LISTENER(message))
-						// If the outermost listener's loc is the speaker, the listener may hear the message.
-						if (GET_INPUT_OUTERMOST_LISTENER_LOC(input) != message.message_origin)
-							continue
+					// If the outermost listener's loc is not a turf, determine whether the message can be heard based on a shared loc chain.
+					else if (CANNOT_HEAR_MESSAGE_FROM_LOC_CHAIN(input, message))
+						continue
 
 					listen_modules_by_type[type] += input
 
@@ -47,13 +45,9 @@
 			for (var/type in src.listeners)
 				listen_modules_by_type[type] ||= list()
 				for (var/datum/listen_module/input/outloud/input as anything in src.listeners[type])
-					// If the outermost listener of the listener and the speaker match, the listener may hear the message.
-					if (GET_INPUT_OUTERMOST_LISTENER(input) != GET_MESSAGE_OUTERMOST_LISTENER(message))
-						// If the outermost listener's loc is the speaker, the listener may hear the message.
-						if (GET_INPUT_OUTERMOST_LISTENER_LOC(input) != message.message_origin)
-							// If the speaker's loc is the listener, the listener may hear the message.
-							if (message.message_origin.loc != input.parent_tree.listener_origin)
-								continue
+					// Determine whether the message can be heard based on a shared loc chain.
+					if (CANNOT_HEAR_MESSAGE_FROM_LOC_CHAIN(input, message))
+						continue
 
 					listen_modules_by_type[type] += input
 
@@ -81,7 +75,7 @@
 
 		heard_distorted_listen_modules_by_type = list()
 
-		if (!ismob(message.message_origin.loc))
+		if (isturf(GET_MESSAGE_OUTERMOST_LISTENER_LOC(message)))
 			var/turf/centre = get_turf(message.message_origin)
 			if (!centre)
 				return
@@ -98,37 +92,40 @@
 							continue
 					// If the outermost listener's loc is a turf, they must be within the speaker's line of sight to hear the message.
 					if (isturf(GET_INPUT_OUTERMOST_LISTENER_LOC(input)))
-						// If within `WHISPER_RANGE`, the message may be heard clearly.
+						// Use heard turfs to determine range.
 						if (!input.ignore_line_of_sight_checks)
+							// If within `WHISPER_RANGE`, the message may be heard clearly.
 							if (heard_clearly_turfs[GET_INPUT_OUTERMOST_LISTENER_LOC(input)])
 								heard_clearly_listen_modules_by_type[type] += input
 								continue
-						else if (INPUT_IN_RANGE(input, centre, WHISPER_RANGE))
-							heard_clearly_listen_modules_by_type[type] += input
-							continue
-						// If outside of `WHISPER_RANGE`, but still within message range, the message will be heard distorted.
-						if (!input.ignore_line_of_sight_checks)
-							if (heard_distorted_turfs[GET_INPUT_OUTERMOST_LISTENER_LOC(input)])
+							// If outside of `WHISPER_RANGE`, but still within message range, the message will be heard distorted.
+							else if (heard_distorted_turfs[GET_INPUT_OUTERMOST_LISTENER_LOC(input)])
 								heard_distorted_listen_modules_by_type[type] += input
 								continue
-						else if (INPUT_IN_RANGE(input, centre, message.heard_range))
-							heard_distorted_listen_modules_by_type[type] += input
+						// Compute range directly without regard for heard turfs.
+						else
+							// If within `WHISPER_RANGE`, the message may be heard clearly.
+							if (INPUT_IN_RANGE(input, centre, WHISPER_RANGE))
+								heard_clearly_listen_modules_by_type[type] += input
+								continue
+							// If outside of `WHISPER_RANGE`, but still within message range, the message will be heard distorted.
+							else if (INPUT_IN_RANGE(input, centre, message.heard_range))
+								heard_distorted_listen_modules_by_type[type] += input
+								continue
+					// If the outermost listener's loc is not a turf, determine whether the message can be heard based on a shared loc chain.
+					else
+						if (CANNOT_HEAR_WHISPER_FROM_LOC_CHAIN(input, message))
 							continue
-					// If the listener's loc is the speaker, they may hear the message clearly. Nested contents will not hear whispers.
-					else if (input.parent_tree.listener_origin.loc == message.message_origin)
+
 						heard_clearly_listen_modules_by_type[type] += input
 
 		else
 			for (var/type in src.listeners)
 				heard_clearly_listen_modules_by_type[type] ||= list()
 				for (var/datum/listen_module/input/outloud/input as anything in src.listeners[type])
-					// If the listener's loc and the speaker's loc match, the listener may hear the message clearly.
-					if (input.parent_tree.listener_origin.loc != message.message_origin.loc)
-						// If the listener's loc is the speaker, the listener may hear the message clearly.
-						if (input.parent_tree.listener_origin.loc != message.message_origin)
-							// If the speaker's loc is the listener, the listener may hear the message clearly.
-							if (message.message_origin.loc != input.parent_tree.listener_origin)
-								continue
+					// Determine whether the message can be heard based on a shared loc chain.
+					if (CANNOT_HEAR_WHISPER_FROM_LOC_CHAIN(input, message))
+						continue
 
 					heard_clearly_listen_modules_by_type[type] += input
 


### PR DESCRIPTION
[Bug]


## About The PR:
Cleans up local delimited say channel code to be slightly more legible by hiding some of the complexity behind macros. This also makes loc chain hearing calculations consistent between the two "modes" of calculating listeners; "line of sight" and "loc chain only".

That mode is now determined by the speaker's outermost listener's loc being a turf, rather than the speaker's loc being a mob. This fixes #23365 and an additional unreported bug wherein a mob's second level or deeper nested contents would calculate listeners using line of sight calculations (i.e. an audio log would not be heard from another mob's hand, but would be heard if inside an unsoundproofed box in that mob's hand.).


## Testing:
Tested to the best of my ability using a tdummy, an audio log, and an `open_to_sound = FALSE` locker, with no surprising behaviour recorded.
I would recommend testmerging this PR, as say channels are highly sensitive to changes.