### PR TITLE
Removes `voice_name` From Announcement Computers

### DIFF
--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -29,13 +29,7 @@
 	light_g = 1
 	light_b = 0.1
 
-	/// This is solely used to reconcile refactoring announcement computers with `.dmm` files. Remove in a followup PR.
-	var/voice_name = null
-
 	New()
-		if (!isnull(src.voice_name))
-			src.computer_say_source_name = src.voice_name
-
 		. = ..()
 		src.computer_say_source = new()
 		src.computer_say_source.name = src.computer_say_source_name


### PR DESCRIPTION
[Code Quality]


## About The PR:
Removes the unused `voice_name` variable from announcement computers.