### PR TITLE
Device Frame QoL + fixes for anchored items in storage

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -334,6 +334,8 @@
 	attackby(obj/item/W, mob/user)
 		if(iswrenchingtool(W)) // prevent unanchoring
 			return FALSE
+		if(istype(W, /obj/item/storage/mechanics/housing_handheld))
+			src.attack_hand()
 		. = ..()
 
 	attack_hand(mob/user)

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -336,6 +336,7 @@
 			return FALSE
 		if(istype(W, /obj/item/storage/mechanics/housing_handheld))
 			src.attack_hand()
+			return FALSE
 		. = ..()
 
 	attack_hand(mob/user)

--- a/code/modules/storage/storage.dm
+++ b/code/modules/storage/storage.dm
@@ -252,6 +252,8 @@
 				return
 		user.visible_message(SPAN_ALERT("[user] dumps the contents of [src.linked_item.name] onto [over_object]!"))
 		for (var/obj/item/I as anything in src.get_contents())
+			if(I.anchored)
+				continue
 			src.transfer_stored_item(I, T, user = user)
 			I.layer = initial(I.layer)
 			if(SEND_SIGNAL(I, COMSIG_ITEM_STORAGE_INTERACTION, user))
@@ -263,6 +265,9 @@
 
 /// after attacking an object with the storage item
 /datum/storage/proc/storage_item_after_attack(atom/target, mob/user, reach)
+	var/obj/O = target
+	if (O.anchored)
+		return
 	// if item is stored, drop storage and take it out
 	if (target in src.get_contents())
 		user.drop_item()
@@ -271,9 +276,6 @@
 			target.Attackhand(user)
 	// attempt to load item into storage if you have a free hand
 	else if (isitem(target) && !istype(target, /obj/item/storage))
-		var/obj/O = target
-		if (O.anchored)
-			return
 		if (!can_reach(user, target))
 			return
 		if (issilicon(user))

--- a/code/modules/storage/storage.dm
+++ b/code/modules/storage/storage.dm
@@ -266,7 +266,7 @@
 /// after attacking an object with the storage item
 /datum/storage/proc/storage_item_after_attack(atom/target, mob/user, reach)
 	var/obj/O = target
-	if (O.anchored)
+	if (istype(O) && O.anchored)
 		return
 	// if item is stored, drop storage and take it out
 	if (target in src.get_contents())


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][GAME OBJECT][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes pressing the button on a mechcomp device frame work even if the frame is in your active hand, rather than smacking the button with it. It also makes a few changes to storage code to prevent it from doing weird things when attempting to dump out or remove anchored items from storage.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Small QoL improvement for working with device frames.
Fixes #13845 
Fixes #13956

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested by attempting to dump out the device frame on the floor, and using the button while the frame was open and in the active hand.

