### PR TITLE
Make ranch produce work for spicy chicken sandwiches

### DIFF
--- a/code/modules/cooking/cookingrecipes.dm
+++ b/code/modules/cooking/cookingrecipes.dm
@@ -56,6 +56,7 @@ ABSTRACT_TYPE(/datum/cookingrecipe/mixer)
 	output = /obj/item/reagent_containers/food/snacks/burger/chicken
 	variants = list(\
 	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget/spicy = /obj/item/reagent_containers/food/snacks/burger/chicken/spicy,
+	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget/ranch_chicken/spicy = /obj/item/reagent_containers/food/snacks/burger/chicken/spicy, //:melterfrog:
 	/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget/flock = /obj/item/reagent_containers/food/snacks/burger/flockburger)
 	category = "Burgers"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][CATERING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Spicy chickens butcher into `/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget/ranch_chicken/spicy` instead of `/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget/spicy`, which has a distinct typepath but is otherwise indistinguishable. This was tripping up recipes which specifically want spicy chicken nuggets. This PR changes those recipes to accept either version.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #10743 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

![image](https://github.com/user-attachments/assets/d030ccad-9e65-4a91-bad1-cd8c762bb98f)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
