### PR TITLE
Contraband trader only sells syndicate headsets to syndies

### DIFF
--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -785,10 +785,16 @@ ABSTRACT_TYPE(/obj/npc/trader/random)
 /obj/npc/trader/random/contraband
 	commercetype = /datum/commodity/contraband
 	descriptions = list("legitimate goods", "perfectly legitimate goods", "extremely legitimate goods")
+	illegal = TRUE
 
 	New()
 		src.possible_icon_states = list("big_spide[pick("","-red","-blue","-green")]")
 		..()
+		// Prevent non-syndies from purchasing syndicate radio access.
+		for(var/datum/commodity/commodity in src.goods_sell)
+			if(istype(commodity, /datum/commodity/contraband/syndicate_headset))
+				src.goods_sell -= commodity
+				src.goods_illegal |= commodity
 
 //actually this just seems to be robotics upgrades and scrap metal?
 // /obj/npc/trader/random/salvage


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the random station contraband trader remove the syndicate headset buy entry from general items and add it to illegal goods (so that it only gets sold to syndies) after buy list is built.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Non-antagonists should not be able to obtain access to the syndicate radio without stealing it from a real syndie.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![image](https://github.com/user-attachments/assets/83442a34-bde1-4f14-8f83-e7df020f9b49)
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)The random contraband trader will now only sell syndicate headsets to real syndies.
```
