### PR TITLE
Implement /obj/proc/ArtifactAfterAttack()

### DIFF
--- a/code/obj/artifacts/artifact_items/attack_wand.dm
+++ b/code/obj/artifacts/artifact_items/attack_wand.dm
@@ -7,21 +7,6 @@
 	// else afterattack will not be called when out of range
 	pixelaction(atom/target, params, mob/user, reach)
 		..()
-
-	afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)
-		if (user.equipped() == src)
-			if (!src.ArtifactSanityCheck())
-				return
-			var/datum/artifact/attack_wand/A = src.artifact
-			if (!istype(A))
-				return
-			if (!A.activated)
-				return
-
-			user.lastattacked = get_weakref(src)
-			var/turf/U = (istype(target, /atom/movable) ? target.loc : target)
-			A.effect_click_tile(src,user,U)
-
 /datum/artifact/attack_wand
 	associated_object = /obj/item/artifact/attack_wand
 	type_name = "Elemental Wand"

--- a/code/obj/artifacts/artifact_items/teleport_wand.dm
+++ b/code/obj/artifacts/artifact_items/teleport_wand.dm
@@ -8,41 +8,6 @@
 	// else afterattack will not be called when out of range
 	pixelaction(atom/target, params, mob/user, reach)
 		..()
-
-	afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)
-		if (!src.ArtifactSanityCheck())
-			return
-		var/datum/artifact/telewand/A = src.artifact
-		if (!istype(A))
-			return
-
-		var/turf/U = (istype(target, /atom/movable) ? target.loc : target)
-		//var/turf/T = get_turf(target)
-		if (A.activated)
-			if (A.can_teleport_here(U,user))
-				if(ishuman(user))
-					var/mob/living/carbon/human/H = user
-					if(H.shoes?.magnetic && istype(H.shoes, /obj/item/clothing/shoes/magnetic))
-						var/obj/item/clothing/shoes/magnetic/stay_behind = H.shoes
-
-						boutput(user, SPAN_ALERT("<b>The magnetic attractor on [stay_behind] overloads!</b>"))
-						playsound(H, pick('sound/impact_sounds/Flesh_Stab_1.ogg','sound/impact_sounds/Metal_Clang_1.ogg','sound/impact_sounds/Slimy_Splat_1.ogg','sound/impact_sounds/Flesh_Tear_2.ogg','sound/impact_sounds/Slimy_Hit_3.ogg'), 30)
-						H.u_equip(stay_behind)
-						stay_behind.set_loc(H.loc)
-						stay_behind.dropped(H)
-						stay_behind.layer = initial(stay_behind.layer)
-
-						H.sever_limb("l_leg")
-						H.sever_limb("r_leg")
-						random_brute_damage(H, rand(15, 45))
-						take_bleeding_damage(H, null, 10, DAMAGE_CRUSH)
-
-						SPAWN(3 SECONDS) // womp womp
-							stay_behind.deactivate()
-				A.effect_click_tile(src,user,U)
-			else
-				boutput(user, "<b>[src]</b> [A.error_phrase]")
-
 /datum/artifact/telewand
 	associated_object = /obj/item/artifact/teleport_wand
 	type_name = "Teleportation Wand"
@@ -85,6 +50,26 @@
 
 		logTheThing(LOG_COMBAT, user, "was teleported by Telewand artifact [O] from [log_loc(user)] to [log_loc(T)].")
 		user.set_loc(T)
+
+		if (src.can_teleport_here(T, user))
+			if(ishuman(user))
+				var/mob/living/carbon/human/H = user
+				if(H.shoes?.magnetic && istype(H.shoes, /obj/item/clothing/shoes/magnetic))
+					var/obj/item/clothing/shoes/magnetic/stay_behind = H.shoes
+					boutput(user, SPAN_ALERT("<b>The magnetic attractor on [stay_behind] overloads!</b>"))
+					playsound(H, pick('sound/impact_sounds/Flesh_Stab_1.ogg','sound/impact_sounds/Metal_Clang_1.ogg','sound/impact_sounds/Slimy_Splat_1.ogg','sound/impact_sounds/Flesh_Tear_2.ogg','sound/impact_sounds/Slimy_Hit_3.ogg'), 30)
+					H.u_equip(stay_behind)
+					stay_behind.set_loc(H.loc)
+					stay_behind.dropped(H)
+					stay_behind.layer = initial(stay_behind.layer)
+					H.sever_limb("l_leg")
+					H.sever_limb("r_leg")
+					random_brute_damage(H, rand(15, 45))
+					take_bleeding_damage(H, null, 10, DAMAGE_CRUSH)
+					SPAWN(3 SECONDS) // womp womp
+						stay_behind.deactivate()
+		else
+			boutput(user, "<b>[O]</b> [src.error_phrase]")
 
 		var/turf/start_loc = get_turf(user)
 		playsound(start_loc, wand_sound, 50, TRUE, -1)

--- a/code/obj/artifacts/artifact_items/wall_wand.dm
+++ b/code/obj/artifacts/artifact_items/wall_wand.dm
@@ -4,16 +4,6 @@
 	artifact = 1
 	associated_datum = /datum/artifact/wallwand
 
-	afterattack(atom/target, mob/user , flag)
-		if (!src.ArtifactSanityCheck())
-			return
-		var/datum/artifact/A = src.artifact
-		if (A.activated && target.loc != user)
-			user.lastattacked = get_weakref(src)
-			var/turf/T = get_turf(target)
-			A.effect_click_tile(src,user,T)
-			src.ArtifactFaultUsed(user)
-
 /datum/artifact/wallwand
 	associated_object = /obj/item/artifact/forcewall_wand
 	type_name = "Forcefield Wand"
@@ -53,6 +43,7 @@
 			for(wallloc = T.y - (src.wall_size - 1),wallloc < T.y + src.wall_size,wallloc++)
 				var/obj/forcefield/wand/FW = new /obj/forcefield/wand(locate(T.x,wallloc,T.z),src.wall_duration,src.icon_state)
 				FW.icon_state = src.icon_state
+		O.ArtifactFaultUsed(user)
 
 /obj/forcefield/wand
 	name = "force field"

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -178,7 +178,7 @@ ABSTRACT_TYPE(/datum/artifact/)
 		return 0
 
 	/// What the artifact does after you clicked some tile with it when activated.
-	/// Basically like afterattack() for activated artifacts.
+	/// Acts like a ranged afterattack() for activated artifacts.
 	proc/effect_click_tile(var/obj/O,var/mob/living/user,var/turf/T)
 		if (!O || !user || !T)
 			return 1

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -379,6 +379,13 @@
 	src.ArtifactHitWith(W, user)
 	return 1
 
+/obj/proc/ArtifactAfterAttack(atom/target, mob/user, reach, params)
+	if (!src.ArtifactSanityCheck())
+		return
+	var/datum/artifact/art = src.artifact
+	if (art.activated)
+		art.effect_click_tile(src, user, get_turf(target))
+
 #define FAULT_RESULT_INVALID 2 // artifact can't do faults
 #define FAULT_RESULT_STOP	1		 // we gotta stop, artifact was destroyed or deactivated
 #define FAULT_RESULT_SUCCESS 0 // everything's cool!

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1068,6 +1068,8 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 	set waitfor = 0
 	PROTECTED_PROC(TRUE)
 	src.storage?.storage_item_after_attack(target, user, reach)
+	if (src.artifact)
+		src.ArtifactAfterAttack(target, user, reach, params)
 	return
 
 /obj/item/dummy/ex_act()


### PR DESCRIPTION
[INTERNAL][CLEANLINESS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title, adding functionality for attacking adjacent objects will be done in a future PR

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Standardizes more of artifact code to be on the datum rather than the object. Also allows for more artifact combination effects for the Combiner artifact

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested attack wands, telewands, and forcefield wands