### PR TITLE
Standardize nuclear operative storage options

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1336,9 +1336,12 @@ TYPEINFO(/obj/item/clothing/suit/hazard/fire/armored)
 	desc = "A suit that protects against low pressure environments. Issued to syndicate operatives."
 	contraband = 3
 	item_function_flags = IMMUNE_TO_ACID
+	var/receives_storage = TRUE
 
 	New()
 		START_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
+		if (src.receives_storage)
+			src.create_storage(/datum/storage, max_wclass = W_CLASS_SMALL, slots = 6, opens_if_worn = TRUE)
 		..()
 
 	disposing()
@@ -1459,6 +1462,7 @@ TYPEINFO(/obj/item/clothing/suit/hazard/fire/armored)
 		unremovable
 			cant_self_remove = 1
 			cant_other_remove = 1
+			receives_storage = FALSE
 
 /obj/item/clothing/suit/space/ntso
 	name = "NT pressure suit"

--- a/code/obj/item/nuclear_operative/handheld_weapon_vendor.dm
+++ b/code/obj/item/nuclear_operative/handheld_weapon_vendor.dm
@@ -109,7 +109,6 @@
 		materiel_stock += new/datum/materiel/loadout/knight
 		materiel_stock += new/datum/materiel/loadout/custom
 
-		materiel_stock += new/datum/materiel/utility/belt
 		materiel_stock += new/datum/materiel/utility/knife
 		materiel_stock += new/datum/materiel/utility/rpg_ammo
 		materiel_stock += new/datum/materiel/utility/donk

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -519,6 +519,7 @@ TYPEINFO(/obj/storage/crate/chest)
 		spawn_contents = list(/obj/item/gun/kinetic/grenade_launcher,
 		/obj/item/storage/pouch/grenade_round,
 		/obj/item/storage/grenade_pouch/mixed_explosive,
+		/obj/item/storage/fanny/syndie/large,
 		/obj/item/clothing/suit/space/syndicate/specialist/grenadier,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist)
 
@@ -539,6 +540,7 @@ TYPEINFO(/obj/storage/crate/chest)
 		/obj/item/storage/pouch/assault_rifle/mixed,
 		/obj/item/storage/grenade_pouch/mixed_standard,
 		/obj/item/breaching_charge = 2,
+		/obj/item/storage/fanny/syndie/large,
 		/obj/item/clothing/suit/space/syndicate/specialist,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist)
 
@@ -552,6 +554,7 @@ TYPEINFO(/obj/storage/crate/chest)
 		/obj/item/old_grenade/smoke = 2,
 		/obj/item/dagger/specialist,
 		/obj/item/card/emag,
+		/obj/item/storage/fanny/syndie/large,
 		/obj/item/clothing/suit/space/syndicate/specialist/infiltrator,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist/infiltrator)
 
@@ -566,6 +569,7 @@ TYPEINFO(/obj/storage/crate/chest)
 		/obj/item/card/emag,
 		/obj/item/storage/backpack/chameleon,
 		/obj/item/device/chameleon,
+		/obj/item/storage/fanny/syndie/large,
 		/obj/item/clothing/suit/space/syndicate/specialist,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist/infiltrator)
 
@@ -579,6 +583,7 @@ TYPEINFO(/obj/storage/crate/chest)
 		/obj/item/cloaking_device,
 		/obj/item/card/emag,
 		/obj/item/lightbreaker,
+		/obj/item/storage/fanny/syndie/large,
 		/obj/item/clothing/suit/space/syndicate/specialist/infiltrator,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist/infiltrator)
 
@@ -648,6 +653,7 @@ TYPEINFO(/obj/storage/crate/chest)
 		name = "Class Crate - Knight"
 		desc = "A crate containing a Specialist Operative loadout. This one contains a Hadar power-sword and heavy-duty combat armor."
 		spawn_contents = list(/obj/item/heavy_power_sword,
+		/obj/item/storage/fanny/syndie/large,
 		/obj/item/clothing/shoes/swat/knight,
 		/obj/item/clothing/gloves/swat/syndicate/knight,
 		/obj/item/clothing/suit/space/syndicate/specialist/knight,

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -202,7 +202,6 @@
 		materiel_stock += new/datum/materiel/storage/belt
 		materiel_stock += new/datum/materiel/storage/satchel
 */
-		materiel_stock += new/datum/materiel/utility/belt
 		materiel_stock += new/datum/materiel/utility/knife
 		materiel_stock += new/datum/materiel/utility/rpg_ammo
 		materiel_stock += new/datum/materiel/utility/donk
@@ -211,7 +210,6 @@
 		materiel_stock += new/datum/materiel/utility/bomb_decoy
 		materiel_stock += new/datum/materiel/utility/comtac
 		materiel_stock += new/datum/materiel/utility/beartraps
-		materiel_stock += new/datum/materiel/utility/miscpouch
 		materiel_stock += new/datum/materiel/utility/sawflies
 
 	accepted_token()
@@ -629,10 +627,6 @@
 	category = "Storage"
 	description = "An ordinary 6 slot messenger bag in menacing red and black."
 */
-/datum/materiel/utility/belt
-	name = "Tactical Espionage Belt"
-	path = /obj/item/storage/fanny/syndie/large
-	description = "The classic 7 slot syndicate belt pack. Has no relation to the fanny pack."
 
 /datum/materiel/utility/knife
 	name = "Combat Knife"
@@ -675,11 +669,6 @@
 	name = "Beartraps"
 	path = /obj/item/storage/beartrap_pouch
 	description = "A pouch of 4 pressure sensitive beartraps used to snare and maim unexpecting victims entering your target area."
-
-/datum/materiel/utility/miscpouch
-	name = "High capacity tactical pouch"
-	path = /obj/item/storage/pouch/highcap
-	description = "A 6-slot pouch for carrying multiple different ammunitions at once"
 
 /datum/materiel/utility/sawflies
 	name = "Sawfly pouch"


### PR DESCRIPTION
[GAME MODES][BALANCE][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reopening of #15519

Adds:
-Nuclear operative suits/coats get a 6 slot storage
-All nuke ops class crates come with a nuclear operative fanny pack

Removes:
-Fanny pack vendor option removed
-Tactical pouch vendor option removed

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
-Removes messiness of needing to manage storage
-On average increases storage space across classes. Nuke ops win rate is around 40% or so, so hopefully it will increase it more towards 50%
-Reduces some of the awkwardness for classes that come with two pouches when you can realistically only use one pouch due to needing a pouch slot for your oxygen


## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Made sure nuclear operative suits were being given storage properly

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)FlameArrow57
(*)Made some inventory changes for nuke ops, see minor changelog for details
(+)All nuke ops suits come with a 6 slot inventory and their class crates all get a fanny pack
(+)Fanny pack and tactical pouch can no longer be bought from the vendor
```
