### PR TITLE
Fix changing UI between TG and Goon not updating the storage HUDs

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -1406,7 +1406,6 @@ var/global/curr_day = null
 		for (var/datum/hud/storage/S in H.huds)
 			S.update(H)
 
-
 /client/verb/set_tg_layout()
 	set hidden = 1
 	set name = "set-tg-layout"

--- a/code/client.dm
+++ b/code/client.dm
@@ -1403,6 +1403,9 @@ var/global/curr_day = null
 		if(H.sims)
 			H.sims.add_hud()
 		H.update_equipment_screen_loc()
+		for (var/datum/hud/storage/S in H.huds)
+			S.update(H)
+
 
 /client/verb/set_tg_layout()
 	set hidden = 1


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Force updates all storage HUDs when the UI preferences are changed so that the storage HUDs change alongside the rest of the new UI.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Graphical bug that has been around for a long time. Surprisingly, though, no bug reports are present about it that I could find.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/02985e69-e441-4495-a4e2-d08771f25ab6

