### PR TITLE
Handling larger inventories

### DIFF
--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -152,16 +152,6 @@
 		if (isicon(hud_style) && boxes.icon != hud_style)
 			boxes.icon = hud_style
 
-		// ??? Mystery fucko code part 1 start
-		var/turfd = FALSE //! 10 brownie points if you can replace this comment with what this variable is supposed to mean
-		if (isturf(master.linked_item?.loc) && !istype(master.linked_item, /obj/item/bible)) // goddamn BIBLES (prevents conflicting positions within different bibles)
-			pos_x = 7
-			pos_y = 8
-			size_x = (num_contents + 1) / 2
-			size_y = 2
-			turfd = TRUE
-		// ??? Mystery fucko code part 1 end
-
 		if (user && user.client?.tg_layout)
 			// TG HUD layout is horizontal, which completely changes implemetation. Thus it is handled here
 			var/pixel_y_adjust = 0
@@ -169,16 +159,6 @@
 			pos_y = 3
 			size_x = num_contents_per_row
 			size_y = ceil(num_contents / MAX_INVENTORY_WIDTH)
-			// ??? Mystery fucko code part 2 start
-			if (turfd) // goddamn BIBLES (prevents conflicting positions within different bibles)
-				CRASH("no")
-				// pos_x = 8
-				// pos_y = 8
-				// size_x = (num_contents_per_row + 1) / 2
-				// size_y = 2
-			else if (user && user.client)
-				pixel_y_adjust = -16
-			// ??? Mystery fucko code part 2 end
 
 			var/left = pos_x - 1
 			var/right = pos_x + size_x-2
@@ -188,14 +168,6 @@
 			if (!close)
 				src.close = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
 			close.screen_loc = "CENTER+[num_contents_per_row/2 - 1/2]:[pixel_y_adjust],[top]:[pixel_y_adjust]"
-
-			// ??? Mystery fucko code part 3 start
-			if (turfd)
-				CRASH("no")
-				// if (user && user.client?.tg_layout) //MBC TG OVERRIDE IM SORTY
-				// 	boxes.screen_loc = "[left],[bottom]:[pixel_y_adjust] to [right],[top]:[pixel_y_adjust]"
-				// 	close.screen_loc = "[right],[bottom]:[pixel_y_adjust]"
-			// ??? Mystery fucko code part 3 end
 
 			src.obj_locs = list()
 			var/i = 0
@@ -217,25 +189,11 @@
 			pos_y = num_contents_per_row + 1
 			size_x = ceil(num_contents / MAX_INVENTORY_WIDTH)
 			size_y = num_contents_per_row + 1
-			// ??? Mystery fucko code start
-			if (turfd) // goddamn BIBLES (prevents conflicting positions within different bibles)
-				pos_x = 8
-				pos_y = 8
-				size_x = (num_contents + 1) / 2
-				size_y = 2
-			// ??? Mystery fucko code end
 
 			boxes.screen_loc = "[pos_x],[pos_y]:[0] to [pos_x+size_x-1],[pos_y-size_y+1]:[0]"
 			if (!close)
 				src.close = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
 			close.screen_loc = "[pos_x+size_x-1]:[0],[pos_y-size_y+1]:[0]"
-
-			// ??? Mystery fucko code part 3 start
-			if (!turfd)
-				if (user && user.client?.tg_layout) //MBC TG OVERRIDE IM SORTY
-					boxes.screen_loc = "[pos_x-1],[pos_y]:[0] to [pos_x+size_x-2],[pos_y+size_y-1]:[0]"
-					close.screen_loc = "[pos_x-1],[pos_y-size_y+1]:[0]"
-			// ??? Mystery fucko code part 3 end
 
 			src.obj_locs = list()
 			var/i = 0

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -29,8 +29,9 @@
 		src.primary_group = null
 		src.secondary_group = null
 		src.close_button.dispose()
-		src.obj_locs.len = 0
-		src.obj_locs = null
+		if (!isnull(src.obj_locs))
+			src.obj_locs.len = 0
+			src.obj_locs = null
 		..()
 
 	clear_master()

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -233,19 +233,19 @@ This is because if one 'square' element was used to cover the entire space, you 
 				var/right_cluster_slots = num_contents - left_cluster_slots // Will always range from 1 to MAX_INVENTORY_WIDTH
 				if (isnull(src.boxes_top))
 					src.boxes_top = src.get_background_cluster()
-				src.boxes_top.screen_loc = "[pos_x],[pos_y] to [pos_x+width-1],[right_cluster_slots-1]"
+				src.boxes_top.screen_loc = "[pos_x],[pos_y] to [pos_x+width-1],[right_cluster_slots]"
 
 			if (!src.close_button)
 				src.close_button = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
-			src.close_button.screen_loc = "[pos_x-1],[pos_y-1]"
+			src.close_button.screen_loc = "[pos_x],[pos_y]"
 
 			src.obj_locs = list()
 			var/i = 1
 			for (var/obj/item/I as anything in hud_contents)
 				if (!(I in src.objects)) // ugh
 					add_object(I, HUD_LAYER+1)
-				var/obj_loc = "[pos_x+round(i/contents_per_column)],[pos_y-(i%contents_per_column)]" //no pixel coords cause that makes click detection harder above
-				var/final_loc = "[pos_x+round(i/contents_per_column)],[pos_y-(i%contents_per_column)]"
+				var/obj_loc = "[pos_x+round(i/contents_per_column)],[pos_y+(i%contents_per_column)]" //no pixel coords cause that makes click detection harder above
+				var/final_loc = "[pos_x+round(i/contents_per_column)],[pos_y+(i%contents_per_column)]"
 				I.screen_loc = do_hud_offset_thing(I, final_loc)
 				src.obj_locs[obj_loc] = I
 				i++
@@ -261,3 +261,4 @@ This is because if one 'square' element was used to cover the entire space, you 
 
 #undef MAX_INVENTORY_WIDTH
 #undef ABS_SCREEN_CENTER_X
+#undef PIXEL_Y_ADJUST

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -155,7 +155,7 @@
 		if (user && user.client?.tg_layout)
 			// TG HUD layout is horizontal, which completely changes implemetation. Thus it is handled here
 			var/pixel_y_adjust = 0
-			pos_x = 11 - (num_contents_per_row / 2)
+			pos_x = num_contents_per_row / 2
 			pos_y = 3
 			size_x = num_contents_per_row
 			size_y = ceil(num_contents / MAX_INVENTORY_WIDTH)
@@ -164,10 +164,10 @@
 			var/right = pos_x + size_x-2
 			var/top = pos_y + size_y-1
 			var/bottom = pos_y
-			boxes.screen_loc = "CENTER-[num_contents_per_row/2],[bottom]:[pixel_y_adjust] to CENTER+[num_contents_per_row/2 - 1],[top]:[pixel_y_adjust]"
+			boxes.screen_loc = "CENTER-[pos_x],[bottom]:[pixel_y_adjust] to CENTER+[pos_x - 1],[top]:[pixel_y_adjust]"
 			if (!close)
 				src.close = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
-			close.screen_loc = "CENTER+[num_contents_per_row/2 - 1/2]:[pixel_y_adjust],[top]:[pixel_y_adjust]"
+			close.screen_loc = "CENTER+[pos_x]:[pixel_y_adjust],[top]:[pixel_y_adjust]"
 
 			src.obj_locs = list()
 			var/i = 0

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -249,7 +249,7 @@ This is because if one 'square' element was used to cover the entire space, you 
 				I.screen_loc = do_hud_offset_thing(I, final_loc)
 				src.obj_locs[obj_loc] = I
 				i++
-			empty_obj_loc =  "[pos_x+round(i/contents_per_column)],[pos_y-(i%contents_per_column)]"
+			empty_obj_loc = "[pos_x+round(i/contents_per_column)],[pos_y+(i%contents_per_column)]"
 			master.linked_item?.UpdateIcon()
 
 	proc/add_item(obj/item/I, mob/user = usr)

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -152,11 +152,6 @@
 /*
 Updates a storage inventory which is being seen by a player/mob. The layout is dependent on the HUD option (TG/Goon).
 
-Here's some helpful images in case you're unsure what either is meant to look like:
-
-image_tg_inventory.png
-image_goon_inventory.png
-
 Both inventories will always have the 'close' button in the bottom-left corner.
 
 The individual inventory 'background' slots are an illusion, the sprite itself is a repeating tile on one UI element. Moreover, the objects are just

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -192,7 +192,7 @@ This is because if one 'square' element was used to cover the entire space, you 
 			var/secondary_cluster_slots = max_slots - primary_cluster_slots // Will always range from 1 to MAX_GROUP_SIZE
 			if (isnull(src.secondary_group))
 				src.secondary_group = create_screen("boxes", "Storage", 'icons/mob/screen1.dmi', "block", ui_storage_area)
-			var/start_x = tg_layout ? pos_x : (pos_x+groups)
+			var/start_x = tg_layout ? pos_x : (pos_x+groups-1)
 			var/start_y = tg_layout ? (pos_y+groups-1) : pos_y
 			var/end_x = tg_layout ? start_x + secondary_cluster_slots - 1 : start_x
 			var/end_y = tg_layout ? start_y : start_y + secondary_cluster_slots - 1

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -174,7 +174,7 @@ This is because if one 'square' element was used to cover the entire space, you 
 		src.update_box_icons(user)
 
 		var/tg_layout = user.client?.tg_layout //! TRUE if the user has a TG layout, FALSE if the user has a Goon layout
-		// var/list/hud_contents = src.master.get_hud_contents() //! This is a list of all the things stored inside this container
+		var/list/hud_contents = src.master.get_hud_contents() //! This is a list of all the things stored inside this container
 		var/max_slots = src.master.get_visible_slots() //! Total amount of storage capacity for this inventory.
 		var/slots_per_group = min(max_slots+1, MAX_GROUP_SIZE) //! The max amount of slots in a group, with +1 for inventories 0-7 for the 'x'
 		var/groups = ceil((max_slots + 1) / slots_per_group) //! The size over the y-axis (y 'tiles'). [+1 to account for close button]
@@ -200,57 +200,24 @@ This is because if one 'square' element was used to cover the entire space, you 
 
 		close_button.screen_loc = "[pos_x-(tg_layout ? 1/2 : 0)]:[pixel_y_adjust],[pos_y]:[pixel_y_adjust]"
 
-		// src.obj_locs = list()
-		// var/i = 1 // start at 1 to skip x on first row
-		// var/num_items_per_row = slots_per_group
-		// for (var/obj/item/I as anything in hud_contents)
-		// 	if (!(I in src.objects)) // ugh
-		// 		add_object(I, HUD_LAYER+1)
-		// 	var/obj_loc = "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]" //no pixel coords cause that makes click detection harder above
-		// 	var/final_loc = "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]:[pixel_y_adjust]"
-		// 	I.screen_loc = do_hud_offset_thing(I, final_loc)
-		// 	src.obj_locs[obj_loc] = I
-		// 	i++
-		// empty_obj_loc =  "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]:[pixel_y_adjust]"
-		// master.linked_item?.UpdateIcon()
-		/*
-		else // goon layout
-			var/list/hud_contents = src.master.get_hud_contents()				//! This is a list of all the items stored inside the container
-			var/num_contents = src.master.get_visible_slots()					//! Total amount of storage capacity for the inventory.
-			var/contents_per_column = min(num_contents+1, MAX_GROUP_SIZE)	//! Amount of items shown in a row at the most. +1 for 1st row as exit button takes a slot
-			var/height = contents_per_column									//! The size over the y-axis (y 'tiles')
-			var/width = ceil((num_contents + 1) / contents_per_column)			//! The size over the x-axis (x 'tiles') [+1 to account for close button]
-			var/pos_x = 1
-			var/pos_y = 1
-
-			// There is an additional -1 to the top-right corner because otherwise the screen_loc will think we want more boxes in each direction than needed
-			// the ternary at the end of pos_y+height-1-(height>1?1:0) just means that we don't go to the usual max height so as not to block the top row obj
-			src.primary_group.screen_loc = "[pos_x],[pos_y] to [pos_x+width-1-(width>1?1:0)],[pos_y+height-1]"
-
-			if (width > 1)
-				var/primary_cluster_slots = ((width-2)*MAX_GROUP_SIZE) + (MAX_GROUP_SIZE-1) // Middle row storage slots + Bottom row storage slots
-				var/secondary_cluster_slots = num_contents - primary_cluster_slots // Will always range from 1 to MAX_GROUP_SIZE
-				if (isnull(src.secondary_group))
-					src.secondary_group = src.get_background_cluster()
-				src.secondary_group.screen_loc = "[pos_x],[pos_y] to [pos_x+width-1],[secondary_cluster_slots]"
-
-			if (!src.close_button)
-				src.close_button = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
-			src.close_button.screen_loc = "[pos_x],[pos_y]"
-
-			src.obj_locs = list()
-			var/i = 1
-			for (var/obj/item/I as anything in hud_contents)
-				if (!(I in src.objects)) // ugh
-					add_object(I, HUD_LAYER+1)
-				var/obj_loc = "[pos_x+round(i/contents_per_column)],[pos_y+(i%contents_per_column)]" //no pixel coords cause that makes click detection harder above
-				var/final_loc = "[pos_x+round(i/contents_per_column)],[pos_y+(i%contents_per_column)]"
-				I.screen_loc = do_hud_offset_thing(I, final_loc)
-				src.obj_locs[obj_loc] = I
-				i++
-			empty_obj_loc = "[pos_x+round(i/contents_per_column)],[pos_y+(i%contents_per_column)]"
-			master.linked_item?.UpdateIcon()
-		*/
+		src.obj_locs = list()
+		var/i = 1 // start at 1 to skip x on first group
+		var/offset_x
+		var/offset_y
+		for (var/obj/item/I as anything in hud_contents)
+			if (!(I in src.objects)) // ugh
+				add_object(I, HUD_LAYER+1)
+			offset_x = tg_layout ? (i%slots_per_group) : round(i/slots_per_group)
+			offset_y = tg_layout ? round(i/slots_per_group) : (i%slots_per_group)
+			var/obj_loc = "[pos_x+offset_x],[pos_y+offset_y]" //no pixel coords cause that makes click detection harder above
+			var/final_loc = "[pos_x+offset_x],[pos_y+offset_y]:[pixel_y_adjust]"
+			I.screen_loc = do_hud_offset_thing(I, final_loc)
+			src.obj_locs[obj_loc] = I
+			i++
+		offset_x = tg_layout ? (i%slots_per_group) : round(i/slots_per_group)
+		offset_y = tg_layout ? round(i/slots_per_group) : (i%slots_per_group)
+		empty_obj_loc =  "[pos_x+offset_x],[pos_y+offset_y]:[pixel_y_adjust]"
+		master.linked_item?.UpdateIcon()
 
 	proc/add_item(obj/item/I, mob/user = usr)
 		update(user)

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -1,8 +1,11 @@
+
+#define MAX_INVENTORY_WIDTH 8 //! Maximum width of an inventory before it begins to wrap around. This is -1 for the first row, as the exit button takes a slot.
+#define ABS_SCREEN_CENTER_X 11.5 //! The center of the screen on the x-axis for everyone. Absolutely messes up with other screen sizes than standard though
 /datum/hud/storage
-	var/atom/movable/screen/hud
-		boxes
-		close
-		sel
+	var/atom/movable/screen/hud/boxes_bottom = null //! The bottom grid of boxes. Used with boxes_top to make the UI
+	var/atom/movable/screen/hud/boxes_top = null //! The top row of boxes. Used with boxes_bottom to make the UI
+	var/atom/movable/screen/close_button = null //! The close button for the UI.
+	var/atom/movable/screen/selection_highlight = null //! The highlight button for the UI. Used to highlight the selected slot in the inventory
 	var/datum/storage/master
 	var/list/obj_locs = null // hi, haine here, I'm gunna crap up this efficient code with REGEX BULLSHIT YEAHH!!
 	var/empty_obj_loc = null
@@ -10,16 +13,18 @@
 	New(master)
 		..()
 		src.master = master
-		src.boxes = create_screen("boxes", "Storage", 'icons/mob/screen1.dmi', "block", ui_storage_area)
-		src.close = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
-		src.sel = create_screen("sel", "sel", 'icons/mob/hud_human_new.dmi', "sel", null, HUD_LAYER+1.2)
+		src.boxes_bottom = src.get_background_cluster()
+		// top cluster only init'd when needed
+		src.close_button = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
+		src.selection_highlight = create_screen("sel", "sel", 'icons/mob/hud_human_new.dmi', "sel", null, HUD_LAYER+1.2)
 		if(src.master)
 			update()
 
 	disposing()
 		src.master = null
-		src.boxes.dispose()
-		src.close.dispose()
+		src.boxes_bottom = null
+		src.boxes_top = null
+		src.close_button.dispose()
 		src.obj_locs.len = 0
 		src.obj_locs = null
 		..()
@@ -53,12 +58,12 @@
 		if (usr)
 			var/obj/item/I = usr.equipped()
 			if (src.master && I && src.master.linked_item.loc == usr && src.master.hud_can_add(I))
-				sel.screen_loc = empty_obj_loc
+				selection_highlight.screen_loc = empty_obj_loc
 
 
 	MouseExited(var/atom/movable/screen/hud/H)
 		if (!H) return
-		sel.screen_loc = null
+		selection_highlight.screen_loc = null
 
 	MouseDrop_T(atom/movable/screen/hud/H, atom/movable/O, mob/user, params)
 		if (!(user in src.mobs))
@@ -125,7 +130,16 @@
 
 		return "[x],[y]"
 
-#define MAX_INVENTORY_WIDTH 7 //! Maximum width of an inventory before it begins to wrap around.
+	proc/get_background_cluster()
+		return create_screen("boxes", "Storage", 'icons/mob/screen1.dmi', "block", ui_storage_area)
+
+	proc/update_box_icons(mob/user)
+		var/icon/hud_style = hud_style_selection[get_hud_style(user)] // Used style of the HUD to determine background slot sprites
+		if (isicon(hud_style))
+			if (src.boxes_bottom && (src.boxes_bottom.icon != hud_style))
+				src.boxes_bottom.icon = hud_style
+			if (src.boxes_top && (src.boxes_top.icon != hud_style))
+				src.boxes_top.icon = hud_style
 
 //idk if i can even use the params of mousedrop for this
 /*
@@ -134,55 +148,72 @@
 		if (I)
 			I.mouse_drop(over_object, src_location, over_location, over_control, params)
 */
+/*
+Updates a storage inventory which is being seen by a player/mob. The layout is dependent on the HUD option (TG/Goon).
+
+Here's some helpful images in case you're unsure what either is meant to look like:
+
+image_tg_inventory.png
+image_goon_inventory.png
+
+Both inventories will always have the 'close' button in the bottom-left corner.
+
+The individual inventory 'background' slots are an illusion, the sprite itself is a repeating tile on one UI element. Moreover, the objects are just
+plastered on top with an offset. Neither are particularly aware of the other, they just happen to co-exist.
+
+For inventories larger than MAX_INVENTORY_WIDTH slots, they are composed of two UI elements for the boxes instead of one.
+This is because if one 'square' element was used to cover the entire space, you would be left with extra slots which do not actually 'hold' items.
+
+*/
+
 	proc/update(mob/user = usr)
-		if (!boxes)
+
+		if (isnull(user))
 			return
 
-		var/list/hud_contents = src.master.get_hud_contents()
-		var/icon/hud_style = hud_style_selection[get_hud_style(user)]
-		var/num_contents = src.master.get_visible_slots()
-		var/num_contents_per_row = min(num_contents, MAX_INVENTORY_WIDTH) + 1 // or column if you are on goonhud i fuckin guess. +1 for close 'x'
+		var/list/hud_contents = src.master.get_hud_contents()				//! This is a list of all the items stored inside the container
+		var/num_contents = src.master.get_visible_slots()					//! Total amount of storage capacity for the inventory.
+		var/num_contents_per_row = min(num_contents, MAX_INVENTORY_WIDTH)	//! Amount of items shown in a row at the most. 1 shorter for 1st row as exit button takes a slot
+		var/tg_layout = user.client?.tg_layout								//! TRUE if the user has a TG layout, FALSE if the user has a Goon layout
+		var/pixel_y_adjust = tg_layout ? 16 : 0								//! Slight y-adjustment for TG UIs, none for Goon UIs. Used to have a gap between inventory and usual UI
+		var/width = num_contents_per_row									//! The size over the x-axis (x 'tiles')
+		var/pos_x = ABS_SCREEN_CENTER_X - 1/2 - width/2
+		var/pos_y = 2														//! The initial position relative to the bottomleft portion of the grid (1,1)
+		var/height = ceil((num_contents + 1) / num_contents_per_row)		//! The size over the y-axis (y 'tiles'). [+1 to account for close button]
+		var/center = user.getScreenParams()
+		src.update_box_icons(user)
 
-		// The initialization here assumes a goonhud layout, where the inventory is organized from the top-left corner, top to bottom.
-		var/pos_x  //! The initial position relative to the bottomleft portion of the grid (1,1)
-		var/pos_y  //! The initial position relative to the bottomleft portion of the grid (1,1)
-		var/size_x //! The size over the x-axis (x 'tiles')
-		var/size_y //! The size over the y-axis (y 'tiles')
+		src.boxes_bottom.screen_loc = "CENTER-[width/2],[pos_y]:[pixel_y_adjust] to CENTER+[width/2-1],[pos_y+height-2]:[pixel_y_adjust]"
 
-		if (isicon(hud_style) && boxes.icon != hud_style)
-			boxes.icon = hud_style
+		if (height > 1)
+			var/bottom_cluster_slots = ((height-2)*MAX_INVENTORY_WIDTH) + (MAX_INVENTORY_WIDTH-1) // Middle row storage slots + Bottom row storage slots
+			var/top_cluster_slots = num_contents - bottom_cluster_slots // Will always range from 0 to MAX_INVENTORY_WIDTH
+			if (top_cluster_slots > 0)
+				if (isnull(src.boxes_top))
+					src.boxes_top = src.get_background_cluster()
+				src.boxes_top.screen_loc = "[pos_x],[pos_y+height]:[pixel_y_adjust] to [pos_x-(MAX_INVENTORY_WIDTH-top_cluster_slots)],[pos_y+height]:[pixel_y_adjust]"
 
+		if (!close_button)
+			src.close_button = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
+		close_button.screen_loc = "[pos_x+1/2]:[pixel_y_adjust],[pos_y]:[pixel_y_adjust]"
+
+		// src.obj_locs = list()
+		// var/i = 0
+		// var/num_items_per_row = num_contents_per_row - 1
+		// for (var/obj/item/I as anything in hud_contents)
+		// 	if (!(I in src.objects)) // ugh
+		// 		add_object(I, HUD_LAYER+1)
+		// 	var/obj_loc = "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]" //no pixel coords cause that makes click detection harder above
+		// 	var/final_loc = "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]:[pixel_y_adjust]"
+		// 	I.screen_loc = do_hud_offset_thing(I, final_loc)
+		// 	src.obj_locs[obj_loc] = I
+		// 	i++
+		// empty_obj_loc =  "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]:[pixel_y_adjust]"
+		// master.linked_item?.UpdateIcon()
+
+		/*
 		if (user && user.client?.tg_layout)
-			// TG HUD layout is horizontal, which completely changes implemetation. Thus it is handled here
-			var/pixel_y_adjust = 0
-			pos_x = num_contents_per_row / 2
-			pos_y = 3
-			size_x = num_contents_per_row
-			size_y = ceil(num_contents / MAX_INVENTORY_WIDTH)
-
-			var/left = pos_x - 1
-			var/right = pos_x + size_x-2
-			var/top = pos_y + size_y-1
-			var/bottom = pos_y
-			boxes.screen_loc = "CENTER-[pos_x],[bottom]:[pixel_y_adjust] to CENTER+[pos_x - 1],[top]:[pixel_y_adjust]"
-			if (!close)
-				src.close = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
-			close.screen_loc = "CENTER+[pos_x]:[pixel_y_adjust],[top]:[pixel_y_adjust]"
-
-			src.obj_locs = list()
-			var/i = 0
-			var/num_items_per_row = num_contents_per_row - 1
-			for (var/obj/item/I as anything in hud_contents)
-				if (!(I in src.objects)) // ugh
-					add_object(I, HUD_LAYER+1)
-				var/obj_loc = "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]" //no pixel coords cause that makes click detection harder above
-				var/final_loc = "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]:[pixel_y_adjust]"
-				I.screen_loc = do_hud_offset_thing(I, final_loc)
-				src.obj_locs[obj_loc] = I
-				i++
-			empty_obj_loc =  "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]:[pixel_y_adjust]"
-			master.linked_item?.UpdateIcon()
-
+			pass
 		else
 			// Goon HUD layout is vertical, implementation is here.
 			pos_x = 1
@@ -207,6 +238,7 @@
 				i++
 			empty_obj_loc =  "[pos_x+(i%size_x)],[pos_y-round(i/size_x)]:[0]"
 			master.linked_item?.UpdateIcon()
+		*/
 
 	proc/add_item(obj/item/I, mob/user = usr)
 		update(user)
@@ -214,3 +246,6 @@
 	proc/remove_item(obj/item/I, mob/user = usr)
 		remove_object(I)
 		update(user)
+
+#undef MAX_INVENTORY_WIDTH
+#undef ABS_SCREEN_CENTER_X

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -121,17 +121,11 @@
 			y = px
 			px = temp
 
-		//ddumb hack for offset storage
-		var/turfd = (isturf(master.linked_item.loc) && !istype(master.linked_item, /obj/item/bible))
-
-		var/pixel_y_adjust = 0
-		if (user && user.client && user.client.tg_layout && !turfd)
-			pixel_y_adjust = 1
-
-		if (pixel_y_adjust && text2num(py) > 16)
-			y = text2num(y) + 1
-			py = text2num(py) - 16
-		//end dumb hack
+		// tg layout is shifted up by some pixel amount, thus clicked location must be offset too in order to be accurate
+		// (it will think the user clicked PIXEL_Y_ADJUST higher/lower than they really did)
+		if (user && user.client && user.client.tg_layout)
+			if (text2num(py) <= PIXEL_Y_ADJUST)
+				y = "[text2num(y)-1]"
 
 		return "[x],[y]"
 

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -1,5 +1,5 @@
 
-#define MAX_GROUP_SIZE 8 //! Maximum width of an inventory before it begins to wrap around. This is -1 for the first row, as the exit button takes a slot.
+#define MAX_GROUP_SIZE 8 //! Maximum slots of an inventory group before it begins to wrap around. This is -1 for the first row, as the exit button takes a slot.
 #define ABS_SCREEN_CENTER_X 11.5 //! The center of the screen on the x-axis for everyone. Absolutely messes up with other screen sizes than standard though
 #define PIXEL_Y_ADJUST 16 //! Amount of pixels to move the UI up on TG layouts. Prevents it from overlapping with the rest of the inventory UI
 
@@ -18,7 +18,7 @@
 		..()
 		src.master = master
 		src.primary_group = create_screen("boxes", "Storage", 'icons/mob/screen1.dmi', "block", ui_storage_area)
-		// top cluster only init'd when needed
+		// secondary cluster only init'd when needed
 		src.close_button = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
 		src.selection_highlight = create_screen("sel", "sel", 'icons/mob/hud_human_new.dmi', "sel", null, HUD_LAYER+1.2)
 		if(src.master)

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -1,11 +1,13 @@
 
-#define MAX_INVENTORY_WIDTH 8 //! Maximum width of an inventory before it begins to wrap around. This is -1 for the first row, as the exit button takes a slot.
+#define MAX_GROUP_SIZE 8 //! Maximum width of an inventory before it begins to wrap around. This is -1 for the first row, as the exit button takes a slot.
 #define ABS_SCREEN_CENTER_X 11.5 //! The center of the screen on the x-axis for everyone. Absolutely messes up with other screen sizes than standard though
 #define PIXEL_Y_ADJUST 16 //! Amount of pixels to move the UI up on TG layouts. Prevents it from overlapping with the rest of the inventory UI
 
 /datum/hud/storage
-	var/atom/movable/screen/hud/boxes_bottom = null //! The bottom grid of boxes. Used with boxes_top to make the UI
-	var/atom/movable/screen/hud/boxes_top = null //! The top row of boxes. Used with boxes_bottom to make the UI
+	/* primary group is the section of the inventory grid that can be a square.
+	   the secondary group is the part which will have less slots than the primary for its group */
+	var/atom/movable/screen/hud/primary_group = null
+	var/atom/movable/screen/hud/secondary_group = null
 	var/atom/movable/screen/close_button = null //! The close button for the UI.
 	var/atom/movable/screen/selection_highlight = null //! The highlight button for the UI. Used to highlight the selected slot in the inventory
 	var/datum/storage/master
@@ -15,7 +17,7 @@
 	New(master)
 		..()
 		src.master = master
-		src.boxes_bottom = src.get_background_cluster()
+		src.primary_group = create_screen("boxes", "Storage", 'icons/mob/screen1.dmi', "block", ui_storage_area)
 		// top cluster only init'd when needed
 		src.close_button = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
 		src.selection_highlight = create_screen("sel", "sel", 'icons/mob/hud_human_new.dmi', "sel", null, HUD_LAYER+1.2)
@@ -24,8 +26,8 @@
 
 	disposing()
 		src.master = null
-		src.boxes_bottom = null
-		src.boxes_top = null
+		src.primary_group = null
+		src.secondary_group = null
 		src.close_button.dispose()
 		src.obj_locs.len = 0
 		src.obj_locs = null
@@ -132,16 +134,13 @@
 
 		return "[x],[y]"
 
-	proc/get_background_cluster()
-		return create_screen("boxes", "Storage", 'icons/mob/screen1.dmi', "block", ui_storage_area)
-
 	proc/update_box_icons(mob/user)
 		var/icon/hud_style = hud_style_selection[get_hud_style(user)] // Used style of the HUD to determine background slot sprites
 		if (isicon(hud_style))
-			if (src.boxes_bottom && (src.boxes_bottom.icon != hud_style))
-				src.boxes_bottom.icon = hud_style
-			if (src.boxes_top && (src.boxes_top.icon != hud_style))
-				src.boxes_top.icon = hud_style
+			if (src.primary_group && (src.primary_group.icon != hud_style))
+				src.primary_group.icon = hud_style
+			if (src.secondary_group && (src.secondary_group.icon != hud_style))
+				src.secondary_group.icon = hud_style
 
 //idk if i can even use the params of mousedrop for this
 /*
@@ -163,60 +162,59 @@ Both inventories will always have the 'close' button in the bottom-left corner.
 The individual inventory 'background' slots are an illusion, the sprite itself is a repeating tile on one UI element. Moreover, the objects are just
 plastered on top with an offset. Neither are particularly aware of the other, they just happen to co-exist.
 
-For inventories larger than MAX_INVENTORY_WIDTH slots, they are composed of two UI elements for the boxes instead of one.
+For inventories larger than MAX_GROUP_SIZE slots, they are composed of two UI elements for the boxes instead of one.
 This is because if one 'square' element was used to cover the entire space, you would be left with extra slots which do not actually 'hold' items.
 
 */
 
 	proc/update(mob/user = usr)
-
 		if (isnull(user))
 			return
 
-		var/tg_layout = user.client?.tg_layout								//! TRUE if the user has a TG layout, FALSE if the user has a Goon layout
-
 		src.update_box_icons(user)
 
-		if (tg_layout)
-			var/list/hud_contents = src.master.get_hud_contents()		//! This is a list of all the things stored inside this container
-			var/max_slots = src.master.get_visible_slots()				//! Total amount of storage capacity for this inventory.
-			var/slots_per_group = min(max_slots+1, MAX_INVENTORY_WIDTH)	//! The max amount of slots in a group, with +1 for inventories 0-7 for the 'x'
-			var/pos_x = ABS_SCREEN_CENTER_X - 1/2 - slots_per_group/2	//! The leftmost starting position for the inventory
-			var/pos_y = 2												//! The bottommost starting position for the inventory
-			var/groups = ceil((max_slots + 1) / slots_per_group)		//! The size over the y-axis (y 'tiles'). [+1 to account for close button]
+		var/tg_layout = user.client?.tg_layout //! TRUE if the user has a TG layout, FALSE if the user has a Goon layout
+		var/list/hud_contents = src.master.get_hud_contents() //! This is a list of all the things stored inside this container
+		var/max_slots = src.master.get_visible_slots() //! Total amount of storage capacity for this inventory.
+		var/slots_per_group = min(max_slots+1, MAX_GROUP_SIZE) //! The max amount of slots in a group, with +1 for inventories 0-7 for the 'x'
+		var/groups = ceil((max_slots + 1) / slots_per_group) //! The size over the y-axis (y 'tiles'). [+1 to account for close button]
+		var/pixel_y_adjust = tg_layout ? PIXEL_Y_ADJUST ? 0 //! TG layouts need to be shifted up a few px to account for the UI below
+		var/pos_x = tg_layout ? (ABS_SCREEN_CENTER_X - 1/2 - slots_per_group/2) : 1 //! The leftmost starting position for the inventory
+		var/pos_y = tg_layout ? 2 : 1 //! The bottommost starting position for the inventory
+		var/width = tg_layout ? (pos_x + slots_per_group-1) : (pos_y + groups-1-(groups>1?1:0)) //! Width which is accurate for either goon/tg layout
+		var/height = tg_layout ? (pos_y + groups-1-(groups>1?1:0)) : (pos_x + slots_per_group-1) //! Height which is accurate for either goon/tg layout
 
-			// There is an additional -1 to the top-right corner because otherwise the screen_loc will think we want more boxes in each direction than needed
-			// the ternary at the end of pos_y+groups-1-(groups>1?1:0) just means that we don't go to the usual max groups so as not to block the top row obj
-			src.boxes_bottom.screen_loc = "[pos_x],[pos_y]:[PIXEL_Y_ADJUST] to [pos_x+slots_per_group-1],[pos_y+groups-1-(groups>1?1:0)]:[PIXEL_Y_ADJUST]"
+		src.primary_group.screen_loc = "[pos_x],[pos_y]:[pixel_y_adjust] to [width],[height]:[pixel_y_adjust]"
 
-			if (groups > 1)
-				var/left_cluster_slots = ((groups-2)*MAX_INVENTORY_WIDTH) + (MAX_INVENTORY_WIDTH-1) // Middle row storage slots + Bottom row storage slots
-				var/right_cluster_slots = max_slots - left_cluster_slots // Will always range from 1 to MAX_INVENTORY_WIDTH
-				if (isnull(src.boxes_top))
-					src.boxes_top = src.get_background_cluster()
-				src.boxes_top.screen_loc = "[pos_x],[pos_y+groups-1]:[PIXEL_Y_ADJUST] to [pos_x+right_cluster_slots-1],[pos_y+groups-1]:[PIXEL_Y_ADJUST]"
+		// Only setup secondary group if its needed
+		if (groups > 1)
+			var/left_cluster_slots = ((groups-2)*MAX_GROUP_SIZE) + (MAX_GROUP_SIZE-1) // Middle row storage slots + Bottom row storage slots
+			var/right_cluster_slots = max_slots - left_cluster_slots // Will always range from 1 to MAX_GROUP_SIZE
+			if (isnull(src.secondary_group))
+				src.secondary_group = create_screen("boxes", "Storage", 'icons/mob/screen1.dmi', "block", ui_storage_area)
+			var/
+			src.secondary_group.screen_loc = "[pos_x],[pos_y+groups-1]:[pixel_y_adjust] to [pos_x+right_cluster_slots-1],[pos_y+groups-1]:[pixel_y_adjust]"
 
-			if (!close_button)
-				src.close_button = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
-			close_button.screen_loc = "[pos_x-1/2]:[PIXEL_Y_ADJUST],[pos_y]:[PIXEL_Y_ADJUST]"
+		close_button.screen_loc = "[pos_x-1/2]:[pixel_y_adjust],[pos_y]:[pixel_y_adjust]"
 
-			src.obj_locs = list()
-			var/i = 1 // start at 1 to skip x on first row
-			var/num_items_per_row = slots_per_group
-			for (var/obj/item/I as anything in hud_contents)
-				if (!(I in src.objects)) // ugh
-					add_object(I, HUD_LAYER+1)
-				var/obj_loc = "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]" //no pixel coords cause that makes click detection harder above
-				var/final_loc = "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]:[PIXEL_Y_ADJUST]"
-				I.screen_loc = do_hud_offset_thing(I, final_loc)
-				src.obj_locs[obj_loc] = I
-				i++
-			empty_obj_loc =  "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]:[PIXEL_Y_ADJUST]"
-			master.linked_item?.UpdateIcon()
+		src.obj_locs = list()
+		var/i = 1 // start at 1 to skip x on first row
+		var/num_items_per_row = slots_per_group
+		for (var/obj/item/I as anything in hud_contents)
+			if (!(I in src.objects)) // ugh
+				add_object(I, HUD_LAYER+1)
+			var/obj_loc = "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]" //no pixel coords cause that makes click detection harder above
+			var/final_loc = "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]:[pixel_y_adjust]"
+			I.screen_loc = do_hud_offset_thing(I, final_loc)
+			src.obj_locs[obj_loc] = I
+			i++
+		empty_obj_loc =  "[pos_x+(i%num_items_per_row)],[pos_y+round(i/num_items_per_row)]:[pixel_y_adjust]"
+		master.linked_item?.UpdateIcon()
+		/*
 		else // goon layout
 			var/list/hud_contents = src.master.get_hud_contents()				//! This is a list of all the items stored inside the container
 			var/num_contents = src.master.get_visible_slots()					//! Total amount of storage capacity for the inventory.
-			var/contents_per_column = min(num_contents+1, MAX_INVENTORY_WIDTH)	//! Amount of items shown in a row at the most. +1 for 1st row as exit button takes a slot
+			var/contents_per_column = min(num_contents+1, MAX_GROUP_SIZE)	//! Amount of items shown in a row at the most. +1 for 1st row as exit button takes a slot
 			var/height = contents_per_column									//! The size over the y-axis (y 'tiles')
 			var/width = ceil((num_contents + 1) / contents_per_column)			//! The size over the x-axis (x 'tiles') [+1 to account for close button]
 			var/pos_x = 1
@@ -224,14 +222,14 @@ This is because if one 'square' element was used to cover the entire space, you 
 
 			// There is an additional -1 to the top-right corner because otherwise the screen_loc will think we want more boxes in each direction than needed
 			// the ternary at the end of pos_y+height-1-(height>1?1:0) just means that we don't go to the usual max height so as not to block the top row obj
-			src.boxes_bottom.screen_loc = "[pos_x],[pos_y] to [pos_x+width-1-(width>1?1:0)],[pos_y+height-1]"
+			src.primary_group.screen_loc = "[pos_x],[pos_y] to [pos_x+width-1-(width>1?1:0)],[pos_y+height-1]"
 
 			if (width > 1)
-				var/left_cluster_slots = ((width-2)*MAX_INVENTORY_WIDTH) + (MAX_INVENTORY_WIDTH-1) // Middle row storage slots + Bottom row storage slots
-				var/right_cluster_slots = num_contents - left_cluster_slots // Will always range from 1 to MAX_INVENTORY_WIDTH
-				if (isnull(src.boxes_top))
-					src.boxes_top = src.get_background_cluster()
-				src.boxes_top.screen_loc = "[pos_x],[pos_y] to [pos_x+width-1],[right_cluster_slots]"
+				var/left_cluster_slots = ((width-2)*MAX_GROUP_SIZE) + (MAX_GROUP_SIZE-1) // Middle row storage slots + Bottom row storage slots
+				var/right_cluster_slots = num_contents - left_cluster_slots // Will always range from 1 to MAX_GROUP_SIZE
+				if (isnull(src.secondary_group))
+					src.secondary_group = src.get_background_cluster()
+				src.secondary_group.screen_loc = "[pos_x],[pos_y] to [pos_x+width-1],[right_cluster_slots]"
 
 			if (!src.close_button)
 				src.close_button = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
@@ -249,6 +247,7 @@ This is because if one 'square' element was used to cover the entire space, you 
 				i++
 			empty_obj_loc = "[pos_x+round(i/contents_per_column)],[pos_y+(i%contents_per_column)]"
 			master.linked_item?.UpdateIcon()
+		*/
 
 	proc/add_item(obj/item/I, mob/user = usr)
 		update(user)
@@ -257,6 +256,6 @@ This is because if one 'square' element was used to cover the entire space, you 
 		remove_object(I)
 		update(user)
 
-#undef MAX_INVENTORY_WIDTH
+#undef MAX_GROUP_SIZE
 #undef ABS_SCREEN_CENTER_X
 #undef PIXEL_Y_ADJUST

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -167,8 +167,6 @@ This is because if one 'square' element was used to cover the entire space, you 
 		if (isnull(user))
 			return
 
-		src.update_box_icons(user)
-
 		var/tg_layout = user.client?.tg_layout //! TRUE if the user has a TG layout, FALSE if the user has a Goon layout
 		var/list/hud_contents = src.master.get_hud_contents() //! This is a list of all the things stored inside this container
 		var/max_slots = src.master.get_visible_slots() //! Total amount of storage capacity for this inventory.
@@ -214,6 +212,7 @@ This is because if one 'square' element was used to cover the entire space, you 
 		offset_y = tg_layout ? round(i/slots_per_group) : (i%slots_per_group)
 		empty_obj_loc =  "[pos_x+offset_x],[pos_y+offset_y]:[pixel_y_adjust]"
 		master.linked_item?.UpdateIcon()
+		src.update_box_icons(user)
 
 	proc/add_item(obj/item/I, mob/user = usr)
 		update(user)

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -178,25 +178,23 @@ This is because if one 'square' element was used to cover the entire space, you 
 		src.update_box_icons(user)
 
 		if (tg_layout)
-			var/list/hud_contents = src.master.get_hud_contents()				//! This is a list of all the items stored inside the container
-			var/num_contents = src.master.get_visible_slots()					//! Total amount of storage capacity for the inventory.
-			var/contents_per_row = min(num_contents+1, MAX_INVENTORY_WIDTH)	//! Amount of items shown in a row at the most. +1 for 1st row as exit button takes a slot
-			var/width = contents_per_row									//! The size over the x-axis (x 'tiles')
-			var/pos_x = ABS_SCREEN_CENTER_X - 1/2 - width/2
-			var/pos_y = 2														//! The initial position relative to the bottomleft portion of the grid (1,1)
-			var/height = ceil((num_contents + 1) / contents_per_row)		//! The size over the y-axis (y 'tiles'). [+1 to account for close button]
-
+			var/list/hud_contents = src.master.get_hud_contents()		//! This is a list of all the things stored inside this container
+			var/max_slots = src.master.get_visible_slots()				//! Total amount of storage capacity for this inventory.
+			var/slots_per_group = min(max_slots+1, MAX_INVENTORY_WIDTH)	//! The max amount of slots in a group, with +1 for inventories 0-7 for the 'x'
+			var/pos_x = ABS_SCREEN_CENTER_X - 1/2 - slots_per_group/2	//! The leftmost starting position for the inventory
+			var/pos_y = 2												//! The bottommost starting position for the inventory
+			var/groups = ceil((max_slots + 1) / slots_per_group)		//! The size over the y-axis (y 'tiles'). [+1 to account for close button]
 
 			// There is an additional -1 to the top-right corner because otherwise the screen_loc will think we want more boxes in each direction than needed
-			// the ternary at the end of pos_y+height-1-(height>1?1:0) just means that we don't go to the usual max height so as not to block the top row obj
-			src.boxes_bottom.screen_loc = "[pos_x],[pos_y]:[PIXEL_Y_ADJUST] to [pos_x+width-1],[pos_y+height-1-(height>1?1:0)]:[PIXEL_Y_ADJUST]"
+			// the ternary at the end of pos_y+groups-1-(groups>1?1:0) just means that we don't go to the usual max groups so as not to block the top row obj
+			src.boxes_bottom.screen_loc = "[pos_x],[pos_y]:[PIXEL_Y_ADJUST] to [pos_x+slots_per_group-1],[pos_y+groups-1-(groups>1?1:0)]:[PIXEL_Y_ADJUST]"
 
-			if (height > 1)
-				var/left_cluster_slots = ((height-2)*MAX_INVENTORY_WIDTH) + (MAX_INVENTORY_WIDTH-1) // Middle row storage slots + Bottom row storage slots
-				var/right_cluster_slots = num_contents - left_cluster_slots // Will always range from 1 to MAX_INVENTORY_WIDTH
+			if (groups > 1)
+				var/left_cluster_slots = ((groups-2)*MAX_INVENTORY_WIDTH) + (MAX_INVENTORY_WIDTH-1) // Middle row storage slots + Bottom row storage slots
+				var/right_cluster_slots = max_slots - left_cluster_slots // Will always range from 1 to MAX_INVENTORY_WIDTH
 				if (isnull(src.boxes_top))
 					src.boxes_top = src.get_background_cluster()
-				src.boxes_top.screen_loc = "[pos_x],[pos_y+height-1]:[PIXEL_Y_ADJUST] to [pos_x+right_cluster_slots-1],[pos_y+height-1]:[PIXEL_Y_ADJUST]"
+				src.boxes_top.screen_loc = "[pos_x],[pos_y+groups-1]:[PIXEL_Y_ADJUST] to [pos_x+right_cluster_slots-1],[pos_y+groups-1]:[PIXEL_Y_ADJUST]"
 
 			if (!close_button)
 				src.close_button = create_screen("close", "Close", 'icons/mob/screen1.dmi', "x", ui_storage_close, HUD_LAYER+1)
@@ -204,7 +202,7 @@ This is because if one 'square' element was used to cover the entire space, you 
 
 			src.obj_locs = list()
 			var/i = 1 // start at 1 to skip x on first row
-			var/num_items_per_row = contents_per_row
+			var/num_items_per_row = slots_per_group
 			for (var/obj/item/I as anything in hud_contents)
 				if (!(I in src.objects)) // ugh
 					add_object(I, HUD_LAYER+1)

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -161,7 +161,7 @@
 	proc/close_storage_menus() // still ugly but probably quite better performing
 		for(var/mob/chump in src.users)
 			for(var/datum/hud/storage/hud in chump.huds)
-				if(hud.master==src.storage) hud.close.clicked()
+				if(hud.master==src.storage) hud.close_button.clicked()
 		src.users = list() // gee golly i hope garbage collection does its job
 		return TRUE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Internally reworks /datum/storage/hud/proc/update() for readability, but more importantly to wrap around storages with 'groups' of inventory slots greater than 8. See the demo below for how this looks in-game at varying inventory slot stages.

![dreamseeker_Smz0zutvBz](https://github.com/user-attachments/assets/1640872e-100d-492a-ab81-57caeb592b53)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #19615
Fixes #12982 (hud preferences only change for humans, so UI pref being ignored if swapping as a mob is presumably intentional. the UI displays appropriately for the original UI chosen)
Allows larger inventory slots to be practical to put on objects in-game if needed, since it will wrap around to be visible and pleasant on the screen instead of just going off the edge.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/af32e1e3-0a2c-43ca-86d2-69b1615f73cc

(The latency on swapping with the UI is fixed by #24043, that code was not included with the demo which is why it looks weird at times)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->