### PR TITLE
Prevents a certain proc from making an abstract item.

### DIFF
--- a/code/modules/chemistry/Chemistry-Reactions.dm
+++ b/code/modules/chemistry/Chemistry-Reactions.dm
@@ -198,7 +198,7 @@
 
 /proc/omega_hairgrownium_drop_hair(var/mob/living/carbon/human/H)
 	H.visible_message("<strong style='font-size: 170%;'>[H.name] [H.is_bald()?"hairn't":"hair"] hair fall out!!</strong>", "<strong style='font-size: 170%;'>you [H.is_bald()?"hairn't":"hair"] fall out!!</strong>")
-	var/obj/item/I = new /obj/item
+	var/obj/item/I
 	if(H.is_bald())
 		I = new /obj/item/clothing/head/bald_cap
 	else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[CHEMISTRY][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR modifies a proc related to a secret chem to prevent it from unnecessarily creating an abstract `obj/item`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Abstract types shouldn't be spawning in-game.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Called the offending proc to verify that it wasn't making abstract objects and still functions as intended.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
