### PR TITLE
Clearer description with the tranq rifle

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -123,12 +123,8 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 					user.show_text("You can't reload this gun.", "red")
 					return
 				if(AMMO_RELOAD_INCOMPATIBLE)
-					if(istype(src, /obj/item/gun/kinetic/dart_rifle))
-						user.show_text("[src] can only accept tranquilizer darts!", "red")
-						return
-					else
-						user.show_text("This ammo won't fit!", "red")
-						return
+					user.show_text("This ammo won't fit!", "red")
+					return
 				if(AMMO_RELOAD_SOURCE_EMPTY)
 					user.show_text("There's no ammo left in [b.name].", "red")
 					return
@@ -855,6 +851,13 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	New()
 		ammo = new default_magazine
 		set_current_projectile(new/datum/projectile/bullet/tranq_dart)
+		..()
+
+	// Clearer description for invalid dart rifle ammo.
+	attackby(obj/item/ammo/bullets/b, mob/user)
+		if(!istype(b, default_magazine))
+			user.show_text("[src] can only accept .308 tranquilizer darts!", "red")
+			return
 		..()
 
 //9mm/0.355

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -123,8 +123,12 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 					user.show_text("You can't reload this gun.", "red")
 					return
 				if(AMMO_RELOAD_INCOMPATIBLE)
-					user.show_text("This ammo won't fit!", "red")
-					return
+					if(istype(src, /obj/item/gun/kinetic/dart_rifle))
+						user.show_text("[src] can only accept tranquilizer darts!", "red")
+						return
+					else
+						user.show_text("This ammo won't fit!", "red")
+						return
 				if(AMMO_RELOAD_SOURCE_EMPTY)
 					user.show_text("There's no ammo left in [b.name].", "red")
 					return
@@ -829,7 +833,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 
 /obj/item/gun/kinetic/dart_rifle
 	name = "tranquilizer rifle"
-	desc = "A veterinary tranquilizer rifle chambered in .308 caliber."
+	desc = "A veterinary tranquilizer rifle chambered in .308 caliber. This rifle can only accept .308 tranquilizer darts."
 	icon = 'icons/obj/items/guns/kinetic48x32.dmi'
 	icon_state = "tranq"
 	item_state = "tranq"

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -51,6 +51,9 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 	/// `icon_state` of the muzzle flash of the gun (if any)
 	muzzle_flash = "muzzle_flash"
 
+	/// Feedback for incompatible ammo can be customized for clarity.
+	var/ammo_incompatible_msg = "This ammo won't fit!"
+
 	// caliber list: update as needed
 	// 0.22 - pistols
 	// 0.308 - rifles
@@ -123,7 +126,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 					user.show_text("You can't reload this gun.", "red")
 					return
 				if(AMMO_RELOAD_INCOMPATIBLE)
-					user.show_text("This ammo won't fit!", "red")
+					user.show_text(src.ammo_incompatible_msg, "red")
 					return
 				if(AMMO_RELOAD_SOURCE_EMPTY)
 					user.show_text("There's no ammo left in [b.name].", "red")
@@ -850,14 +853,8 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 
 	New()
 		ammo = new default_magazine
+		ammo_incompatible_msg = "[src] can only accept .308 tranquilizer darts!"
 		set_current_projectile(new/datum/projectile/bullet/tranq_dart)
-		..()
-
-	// Clearer description for invalid dart rifle ammo.
-	attackby(obj/item/ammo/bullets/b, mob/user)
-		if(!istype(b, default_magazine))
-			user.show_text("[src] can only accept .308 tranquilizer darts!", "red")
-			return
 		..()
 
 //9mm/0.355


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECT][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the tranquilizer rifle's description to mention .308 ammo compatibility. Adds a descriptive message when trying to load incompatible .308 rifle ammo.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Addresses #23997 by making the description and chat feedback clearer.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

![{05DF6DBF-1ADD-42E1-83E4-37F8DDE8D4FF}](https://github.com/user-attachments/assets/9d020756-366b-4ce3-b1a1-f0e68cf8e98b)

![{8745B58C-4744-4863-8B46-9FABFAEF00F7}](https://github.com/user-attachments/assets/283e1b60-26ba-43ba-9fb9-dfbee31fb1a6)

It's possible we don't necessarily need the feedback on attempting to reload, but it does make the issue a little clearer to the user. Can take it or leave it with this one.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
