### PR TITLE
Update APC area upon it creating its own built zone

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -254,10 +254,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 			. += "The cover is open and the power cell is [ cell ? "installed" : "missing"]."
 		else
 			. += "The cover is closed."
-
-/obj/machinery/power/apc/proc/update_area()
-	src.area = get_area(src)
-
+	
 /obj/machinery/power/apc/proc/toggle_operating()
 	src.operating = !src.operating
 	src.update()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -209,6 +209,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 	if (!QDELETED(src.area))
 		if(istype(src.area,/area/unconnected_zone)) //if we built in an as-yet APCless zone, we've created a new built zone as a consequence
 			unconnected_zone.propagate_zone(get_turf(src))
+			src.area = get_area(src)
 		else
 			src.area.area_apc = src
 
@@ -253,6 +254,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 			. += "The cover is open and the power cell is [ cell ? "installed" : "missing"]."
 		else
 			. += "The cover is closed."
+
+/obj/machinery/power/apc/proc/update_area()
+	src.area = get_area(src)
 
 /obj/machinery/power/apc/proc/toggle_operating()
 	src.operating = !src.operating

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -254,7 +254,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 			. += "The cover is open and the power cell is [ cell ? "installed" : "missing"]."
 		else
 			. += "The cover is closed."
-	
+
 /obj/machinery/power/apc/proc/toggle_operating()
 	src.operating = !src.operating
 	src.update()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -209,7 +209,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 	if (!QDELETED(src.area))
 		if(istype(src.area,/area/unconnected_zone)) //if we built in an as-yet APCless zone, we've created a new built zone as a consequence
 			unconnected_zone.propagate_zone(get_turf(src))
-			src.area = get_area(src)
+			var/area/A = get_area(src)
+			src.area = A
+			A.area_apc = src
 		else
 			src.area.area_apc = src
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a APC is built in an unconnected area, it converts it to a built zone. Problem is when it does, it still registers itself as powering the old area (which doesn't exist anymore). This one line fix resolves that by updating its area to the new one

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #22741
(not sure what they were talking about with the APC deleting itself, but it properly powers the area now)

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

![image](https://github.com/user-attachments/assets/a173644e-3149-44da-8fb4-c4b1734b9b69)
