### PR TITLE
Show Fake Laws command

### DIFF
--- a/code/mob/living/intangible/ai-camera.dm
+++ b/code/mob/living/intangible/ai-camera.dm
@@ -403,6 +403,12 @@ TYPEINFO(/mob/living/intangible/aieye)
 		if (mainframe)
 			mainframe.ai_state_fake_laws()
 
+	verb/ai_show_laws_fake()
+		set category = "AI Commands"
+		set name = "Show Fake Laws"
+		if (mainframe)
+			mainframe.ai_show_fake_laws()
+
 	verb/ai_statuschange()
 		set category = "AI Commands"
 		set name = "AI status"

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -609,9 +609,7 @@ var/global/list/module_editors = list()
 			continue
 		fake_laws += nice_law
 
-	src.show_message(SPAN_BOLD("Your new fake laws are: "))
-	for(var/a_law in src.fake_laws)
-		src.show_message(a_law)
+	src.show_fake_laws()
 	#undef FAKE_LAW_LIMIT
 
 /mob/living/silicon/proc/state_fake_laws()
@@ -662,6 +660,22 @@ var/global/list/module_editors = list()
 		// decode the symbols, because they will be encoded again when the law is spoken, and otherwise we'd double-dip
 		src.say(html_decode("[prefix] [a_law]"))
 		logTheThing(LOG_SAY, usr, "states a fake law: \"[a_law]\"")
+
+/mob/living/silicon/proc/show_fake_laws()
+	var/mob/message_mob = src
+	if (istype(src, /mob/living/silicon/ai))
+		var/mob/living/silicon/ai/AI = src
+		message_mob = AI.get_message_mob()
+
+	var/list/laws = src.shell ? src.mainframe.fake_laws : src.fake_laws
+
+	if (length(laws) == 0)
+		boutput(message_mob, SPAN_ALERT("Fake laws not set!"))
+		return
+
+	message_mob.show_message(SPAN_BOLD("Your fake laws are: "))
+	for(var/a_law in laws)
+		message_mob.show_message(a_law)
 
 /mob/living/silicon/get_unequippable()
 	return

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1692,6 +1692,11 @@ or don't if it uses a custom topopen overlay
 	set name = "State Fake Laws"
 	src.state_fake_laws()
 
+/mob/living/silicon/ai/proc/ai_show_fake_laws()
+	set category = "AI Commands"
+	set name = "Show Fake Laws"
+	src.show_fake_laws()
+
 /mob/living/silicon/ai/proc/ai_state_laws_all()
 	set category = "AI Commands"
 	set name = "State All Laws"

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2305,6 +2305,11 @@ TYPEINFO(/mob/living/silicon/robot)
 		set name = "State Fake Laws"
 		src.state_fake_laws() //already handles being a shell
 
+	verb/robot_show_fake_laws()
+		set category = "Robot Commands"
+		set name = "Show Fake Laws"
+		src.show_fake_laws() //already handles being a shell
+
 	verb/cmd_toggle_lock()
 		set category = "Robot Commands"
 		set name = "Toggle Interface Lock"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a "show fake laws" command so that silicons can check their fake laws without needing to set them, state them, or scroll up to when they set them.
Set_fake_laws instead calls show_fake_laws at the end to reduce code duplication
Idea from Username Unavailable on the forums! https://forum.ss13.co/showthread.php?tid=24359

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows silicons to check their fake laws without needing to set or state them

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Works as AI camera, Cyborg shell and Cyborg. AI Core and Shellbots don't have set fake laws so don't get show fake laws.
![image](https://github.com/user-attachments/assets/b305222b-5278-4404-a555-88a0339eda4f)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949 & Username Unavailable
(*)AIs and Cyborgs now have a Show Fake Laws command to check their fake laws. Idea from Username Unavailable on the forums!
```
