### PR TITLE
Make items on kitchen islands properly transfer on mass dragging

### DIFF
--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -568,6 +568,7 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close)
 						continue
 					thing.set_loc(T)
 					SEND_SIGNAL(thing,COMSIG_ATTACKHAND,user) //triggers radiation/explsion/glue stuff
+					SEND_SIGNAL(thing, COMSIG_ATOM_MOUSEDROP, user, src, thing.loc)
 					sleep(0.5)
 					if (!src.open)
 						break


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes items mass-dragged into large containers call the `COMSIG_ATOM_MOUSEDROP` signal for each item, allowing other things to respond to them being moved. Notably, this includes kitchen islands releasing contents dragged this way.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #23452 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Repeated the steps to reproduce outlined in the attached issue.