### PR TITLE
Show maptext countdown on nukes when nuke is inside things

### DIFF
--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -103,9 +103,16 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 		else
 			timer_string = get_countdown_timer()
 
+		var/maptext = "<span style=\"color: red; font-family: Fixedsys, monospace; text-align: center; vertical-align: top; -dm-text-outline: 1 black;\">[timer_string]</span>"
 		for(var/obj/bomb_or_decoy as anything in get_self_and_decoys())
-			bomb_or_decoy.maptext = "<span style=\"color: red; font-family: Fixedsys, monospace; text-align: center; vertical-align: top; -dm-text-outline: 1 black;\">[timer_string]</span>"
-
+			if(istype(bomb_or_decoy.loc, /atom/movable))
+				var/atom/movable/mob_or_objcritter = bomb_or_decoy.loc
+				mob_or_objcritter.maptext = maptext
+				mob_or_objcritter.maptext_y = mob_or_objcritter.bound_height/2
+				mob_or_objcritter.maptext_width = 64 // no wrapping pls
+				mob_or_objcritter.maptext_x = -1 * mob_or_objcritter.maptext_width/4
+			else
+				bomb_or_decoy.maptext = maptext
 
 	proc/set_time_left()
 		if (!src.armed)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so the mapptext of a nuke inside something instead is displayed on whatever it is inside of 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
nice QOL to show players the countdown timer for nukes inside things/people so they can feel appropriately intimidated.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

![dreamseeker_r44UNgDShZ](https://github.com/user-attachments/assets/0838df9c-c02f-4e77-9055-f0cd45a21f58)

![dreamseeker_kMefsblDlA](https://github.com/user-attachments/assets/adcc4191-e41e-4ccd-899d-28797698e75d)

Also properly aligns based off sprite bounds.

![dreamseeker_uORpABXWXE](https://github.com/user-attachments/assets/eea1d441-7290-465b-ab38-0ad548774dfd)
