### PR TITLE
Add check to prevent duplicate genetic research

### DIFF
--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -323,7 +323,9 @@
 			. = TRUE
 			var/datum/geneticsResearchEntry/E = locate(params["ref"])
 			if (!research_sanity_check(E))
-				if (genResearch.addResearch(E))
+				if (E.isResearched)
+					scanner_alert(ui.user, "Research already in progress.", error = TRUE)
+				else if (genResearch.addResearch(E))
 					scanner_alert(ui.user, "Research initiated successfully.")
 				else
 					scanner_alert(ui.user, "Unable to begin research.", error = TRUE)
@@ -385,6 +387,9 @@
 		if("researchmut")
 			. = TRUE
 			var/datum/bioEffect/E = locate(params["ref"])
+			if(GetBioeffectFromGlobalListByID(E.id)?.research_level > EFFECT_RESEARCH_NONE)
+				scanner_alert(ui.user, "Research already in progress.", error = TRUE)
+				return
 			if (params["sample"])
 				if (bioEffect_sanity_check(E, 0))
 					return

--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -387,7 +387,8 @@
 		if("researchmut")
 			. = TRUE
 			var/datum/bioEffect/E = locate(params["ref"])
-			if(GetBioeffectFromGlobalListByID(E.id)?.research_level > EFFECT_RESEARCH_NONE)
+			var/datum/bioEffect/GBE = GetBioeffectFromGlobalListByID(E.id)
+			if(GBE.research_level > EFFECT_RESEARCH_NONE)
 				scanner_alert(ui.user, "Research already in progress.", error = TRUE)
 				return
 			if (params["sample"])


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[UI][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds checks when starting research with the genetics console to make sure it isn't already being researched. This should prevent duplicate research if somebody manages to click the button multiple times before TGUI can respond.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #14018 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![image](https://github.com/user-attachments/assets/27140a16-6425-4db7-9657-adb02c890a23)
Tested by artificially inducing lag and then spam-clicking the research button

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
