### PR TITLE
Standardizes mutantrace stutter system

### DIFF
--- a/code/modules/speech/modules/speech/modifiers/mutantraces/amphibian.dm
+++ b/code/modules/speech/modules/speech/modifiers/mutantraces/amphibian.dm
@@ -1,7 +1,16 @@
 /datum/speech_module/modifier/mutantrace/amphibian
 	id = SPEECH_MODIFIER_MUTANTRACE_AMPHIBIAN
+	var/static/regex/r_regex = regex(@"(r)(.?)", "ig")
 
 /datum/speech_module/modifier/mutantrace/amphibian/process(datum/say_message/message)
 	. = message
 
-	message.content = replacetext(message.content, "r", stutter("rrr"))
+	message.content = src.r_regex.Replace(message.content, /datum/speech_module/modifier/mutantrace/amphibian/proc/letter_r_replacement)
+
+/datum/speech_module/modifier/mutantrace/amphibian/proc/letter_r_replacement(match, r, letter_after)
+	if (is_lowercase_letter(r))
+		return stutter("rrr") + letter_after
+	else if (is_lowercase_letter(letter_after))
+		return capitalize(stutter("rrr")) + letter_after
+	else
+		return stutter("RRR") + letter_after

--- a/code/modules/speech/modules/speech/modifiers/mutantraces/cow.dm
+++ b/code/modules/speech/modules/speech/modifiers/mutantraces/cow.dm
@@ -1,9 +1,17 @@
 /datum/speech_module/modifier/mutantrace/cow
 	id = SPEECH_MODIFIER_MUTANTRACE_COW
+	var/static/regex/m_regex = regex(@"(m)(.?)", "ig")
 
 /datum/speech_module/modifier/mutantrace/cow/process(datum/say_message/message)
 	. = message
 
 	message.content = replacetext(message.content, "cow", "human")
-	message.content = replacetextEx(message.content, "m", stutter("mm"))
-	message.content = replacetextEx(message.content, "M", stutter("MM"))
+	message.content = src.m_regex.Replace(message.content, /datum/speech_module/modifier/mutantrace/cow/proc/letter_m_replacement)
+
+/datum/speech_module/modifier/mutantrace/cow/proc/letter_m_replacement(match, m, letter_after)
+	if (is_lowercase_letter(m))
+		return stutter("mm") + letter_after
+	else if (is_lowercase_letter(letter_after))
+		return capitalize(stutter("mm")) + letter_after
+	else
+		return stutter("MM") + letter_after


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes the stutters of amphibians and cows (the only 2 other mutantraces to have stutters) to use the same system as the lizards, allowing them to capitalize properly. This could impact lizards somehow, but I'm fairly certain it doesn't.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cohesion is good, and improperly capitalized mooing is an eyesore.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="671" height="53" alt="Screenshot 2025-07-10 001831" src="https://github.com/user-attachments/assets/eef49989-aab6-4b6b-a975-4d656144416f" />
<img width="573" height="70" alt="Screenshot 2025-07-10 002019" src="https://github.com/user-attachments/assets/7f74f535-ec15-4e5d-8b53-c46d49f771f3" />

The prolonged Ms and Rs of the cows and amphibians now work properly. Rejoice!

<img width="632" height="30" alt="Screenshot 2025-07-10 123933" src="https://github.com/user-attachments/assets/f16fac19-2b21-4306-97eb-24c9020d45b1" />
<img width="727" height="29" alt="Screenshot 2025-07-10 124204" src="https://github.com/user-attachments/assets/eab92a1b-e759-48a1-883b-43a76c7ad73f" />

Lizards and everyone else appear to be wholly unimpacted. Also rejoice!

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->