### PR TITLE
Fix emoji genes

### DIFF
--- a/code/modules/speech/modules/speech/modifiers/accents.dm
+++ b/code/modules/speech/modules/speech/modifiers/accents.dm
@@ -396,7 +396,10 @@ ABSTRACT_TYPE(/datum/speech_module/modifier/accent)
 		else if (char > 127)
 			output += ascii2text(char)
 
-	message.content = jointext(output, "")
+	if(!output.len)
+		message.content = "😶"
+	else
+		message.content = jointext(output, "")
 
 
 /datum/speech_module/modifier/accent/error

--- a/code/modules/speech/modules/speech/modifiers/accents.dm
+++ b/code/modules/speech/modules/speech/modifiers/accents.dm
@@ -384,6 +384,7 @@ ABSTRACT_TYPE(/datum/speech_module/modifier/accent)
 
 /datum/speech_module/modifier/accent/emoji/only/process(datum/say_message/message)
 	message = ..()
+	. = message
 
 	var/processed = message.content
 	var/list/output = list()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds a single line of code to `/datum/speech_module/modifier/accent/emoji/only/process` so that it returns an actual message datum, allowing people with the gene to actually speak. It also gives the accent a dummy message in case it completely consumes the original message.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #24083 
Fixes #13200 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="320" height="83" alt="image" src="https://github.com/user-attachments/assets/ca880849-e314-49d6-b997-b77853bb72dd" />

Dummy message code was tested with both messages that have no valid emoji words, and empty says. Nothing was produced for the latter.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CodeDude
(+)Frontal Gyrus Alteration Type-🤪 should now work again 🎉💬
(+)Frontal Gyrus Alteration Type-🤪 now gives a blank 😶 message if it completely eats what you were going to say.
```
