### PR TITLE
Message for trying to move unmovable floodlight

### DIFF
--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -664,6 +664,8 @@ TYPEINFO(/obj/item/device/light/floodlight)
 				src.visible_message(SPAN_NOTICE("[user] starts unwrenching \the [src]."))
 				SETUP_GENERIC_ACTIONBAR(user, src, 1 SECONDS, PROC_REF(unanchor), list(user), src.icon, src.icon_state,\
 					SPAN_NOTICE("[user] finishes unwrenching \the [src]."), null)
+			else
+				boutput(user, SPAN_ALERT("[src]'s retaining bolts won't budge! Looks like it's stuck in place."))
 		else if (ispryingtool(W))
 			if (cell)
 				boutput(user, SPAN_NOTICE("You pry [cell] out of [src]."))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds an alert message when trying to unwrench a floodlight with the `moveable` var set to FALSE. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This should probably have some sort of feedback.
Fixes #24076 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="332" height="160" alt="image" src="https://github.com/user-attachments/assets/5bfec4b3-083d-477f-955f-3774e336a757" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
