### PR TITLE
Prevent flamethrowers with tanks from being disassembled

### DIFF
--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -588,7 +588,8 @@ ABSTRACT_TYPE(/obj/item/gun/flamethrower/backtank)
 	// PantsNote: Flamethrower disassmbly.
 	else if (isscrewingtool(W))
 		var/obj/item/gun/flamethrower/assembled/S = src
-		if (( S.gastank ))
+		if (( S.gastank || S.fueltank ))
+			boutput(user, SPAN_ALERT("You can't disassemble [src] while the tank is attached!"))
 			return
 		var/obj/item/flamethrower_construction/new_construction = new /obj/item/flamethrower_construction (null, S.welder, S.rod, S.igniter)
 		user.u_equip(S)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR alters the check that prevents flamethrowers with gas tanks from being disassembled to also check for fueltanks. It additionally adds a feedback message if you try to do so.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #24103 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="342" height="92" alt="image" src="https://github.com/user-attachments/assets/07906943-043a-43af-b87a-23f363c57231" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

