### PR TITLE
Misc. RCD fixes

### DIFF
--- a/code/WorkInProgress/zamujasa.dm
+++ b/code/WorkInProgress/zamujasa.dm
@@ -1642,7 +1642,7 @@ Other Goonstation servers:[serverList]</span>"})
 	matter_remove_light_fixture = 1
 	time_remove_light_fixture = 0
 
-
+	forbidden_walltypes = list()
 
 
 

--- a/code/obj/item/rcd/rcd.dm
+++ b/code/obj/item/rcd/rcd.dm
@@ -1,4 +1,3 @@
-///
 
 TYPEINFO(/obj/item/rcd)
 	mats = list("metal_superdense" = 20,
@@ -117,6 +116,16 @@ TYPEINFO(/obj/item/rcd)
 
 	/// Custom contextActions list so we can handle opening them ourselves
 	var/list/datum/contextAction/contexts = list()
+
+	///Walls that the RCD probably shouldn't be interacting with. Mostly ones that can't be deconstructed normally
+	var/list/forbidden_walltypes = list(
+		/turf/simulated/wall/airbridge,
+		/turf/simulated/wall/ancient,
+		/turf/simulated/wall/void,
+		/turf/simulated/wall/auto/asteroid,
+		/turf/simulated/wall/auto/feather/strong,
+		/turf/simulated/wall/auto/shuttle
+	)
 
 	get_desc()
 		. += "<br>It holds [matter]/[max_matter] [istype(src, /obj/item/rcd/material) ? material_name : "matter"]  units. It is currently set to "
@@ -262,7 +271,7 @@ TYPEINFO(/obj/item/rcd)
 			return
 
 		if (istype(A, /turf/simulated/wall))
-			if (istype(A, /turf/simulated/wall/r_wall) || istype(A, /turf/simulated/wall/auto/reinforced) || istype(A, /turf/simulated/wall/auto/shuttle))
+			if (istype(A, /turf/simulated/wall/r_wall) || istype(A, /turf/simulated/wall/auto/reinforced) || istypes(A, src.forbidden_walltypes))
 				// You can't reinforce walls that are already reinforced
 				return
 
@@ -449,16 +458,16 @@ TYPEINFO(/obj/item/rcd)
 
 			if (RCD_MODE_AIRLOCK)
 				// create_door handles all the other stuff.
-				SPAWN(0) //let's not lock the entire attack call and let people attack with zero delay
-					create_door(A, user)
-
-				return
+				if (istypes(A, list(/turf/simulated/floor, /turf/unsimulated/floor)))
+					SPAWN(0) //let's not lock the entire attack call and let people attack with zero delay
+						create_door(A, user)
+					return
 
 			if (RCD_MODE_DECONSTRUCT)
 				if (length(restricted_materials) && !(A.material?.getID() in restricted_materials))
 					boutput(user, "Target object is not made of a material this RCD can deconstruct.")
 					return
-				if (istype(A, /turf/simulated/wall/auto/feather/strong))
+				if (istypes(A, src.forbidden_walltypes))
 					return
 
 				handle_deconstruct(A, user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes two changes to the RCD to fix some issues.
First, it adds a check to the airlock mode so that it only tries to build doors on simulated turfs (instead of inside any atom you use it on).
Second, it adds a blacklist of wall types that the RCD can't reinforce/deconstruct. Most of the forbidden types are either indestructible, or things like asteroid walls that probably shouldn't be reinforcable. The admin crimes RCD doesn't have this blacklist.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #23609 
Fixes #22444 
Fixes #19252 
Fixes #16679 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested by attempting use the RCD on various non-floor atoms in airlock mode, and then trying to reinforce blacklisted walls

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
