### PR TITLE
makes pride capes wearable in the backpack slot

### DIFF
--- a/code/obj/item/wall_flags.dm
+++ b/code/obj/item/wall_flags.dm
@@ -140,6 +140,7 @@ ABSTRACT_TYPE(/obj/item/clothing/suit/flag)
 	desc = "A makeshift cape made out of a pride flag. Still creased, of course."
 	icon = 'icons/obj/items/flag.dmi'
 	burn_possible = FALSE
+	c_flags = ONBACK
 	var/altside_cape
 
 	attack_self(mob/user as mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This makes the pride flag capes wearable in the backpack slot.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #23942. 
All other capes (such the HoS cape and the bedsheet capes) are wearable in this slot.

## Testing
<img width="270" height="607" alt="image" src="https://github.com/user-attachments/assets/4af4bb48-7d9f-4279-8e3a-9b40cb9b7d93" />

All flags (and alternate styles) work fine. The cape renders over hair when in the backpack slot, though this behaviour is consistent with the HoS cape.
(the bedsheet capes always render over hair regardless of slot)