### PR TITLE
Configurable Radio Jammer range.

### DIFF
--- a/_std/packets.dm
+++ b/_std/packets.dm
@@ -1,10 +1,10 @@
 
-#define RADIO_JAMMER_RANGE 6
+#define DEFAULT_RADIO_JAMMER_RANGE 6
 
 proc/check_for_radio_jammers(atom/source)
 	. = FALSE
 	for (var/atom/A as anything in by_cat[TR_CAT_RADIO_JAMMERS])
-		var/range = RADIO_JAMMER_RANGE
+		var/range = DEFAULT_RADIO_JAMMER_RANGE
 		if(istype(A, /obj/item/radiojammer))
 			var/obj/item/radiojammer/jammer = A
 			range = jammer.range

--- a/_std/packets.dm
+++ b/_std/packets.dm
@@ -4,7 +4,11 @@
 proc/check_for_radio_jammers(atom/source)
 	. = FALSE
 	for (var/atom/A as anything in by_cat[TR_CAT_RADIO_JAMMERS])
-		if (IN_RANGE(source, A, RADIO_JAMMER_RANGE))
+		var/range = RADIO_JAMMER_RANGE
+		if(istype(A, /obj/item/radiojammer))
+			var/obj/item/radiojammer/jammer = A
+			range = jammer.range
+		if (IN_RANGE(source, A, range))
 			SEND_SIGNAL(A, COMSIG_SIGNAL_JAMMED)
 			return TRUE
 

--- a/code/obj/item/device/radios/_radio.dm
+++ b/code/obj/item/device/radios/_radio.dm
@@ -356,9 +356,9 @@ TYPEINFO(/obj/item/radiojammer)
 
 /obj/item/radiojammer/get_desc(dist, mob/user)
 	. = ..()
-	. += "The range is currently set to [src.range]. "
+	. += " The range is currently set to [src.range]."
 	if(!src.active)
-		.+= "It is off."
+		.+= " It is off."
 
 /obj/item/radiojammer/proc/signal_jammed()
 	//hoping this isn't too performance heavy if a lot of signals get blocked at once

--- a/code/obj/item/device/radios/_radio.dm
+++ b/code/obj/item/device/radios/_radio.dm
@@ -354,6 +354,12 @@ TYPEINFO(/obj/item/radiojammer)
 	STOP_TRACKING_CAT(TR_CAT_RADIO_JAMMERS)
 	. = ..()
 
+/obj/item/radiojammer/get_desc(dist, mob/user)
+	. = ..()
+	. += "The range is currently set to [src.range]. "
+	if(!src.active)
+		.+= "It is off."
+
 /obj/item/radiojammer/proc/signal_jammed()
 	//hoping this isn't too performance heavy if a lot of signals get blocked at once
 	if (!src.GetOverlayImage("jammed_light"))
@@ -397,6 +403,7 @@ TYPEINFO(/obj/item/radiojammer)
 		boutput(user, SPAN_ALERT("That number is out of [src]'s range!"))
 		return
 	src.range = inputted_number
+	boutput(user, SPAN_NOTICE("You set [src]'s range to [inputted_number]."))
 
 #undef WIRE_SIGNAL
 #undef WIRE_RECEIVE

--- a/code/obj/item/device/radios/_radio.dm
+++ b/code/obj/item/device/radios/_radio.dm
@@ -344,7 +344,7 @@ TYPEINFO(/obj/item/radiojammer)
 	w_class = W_CLASS_TINY
 	is_syndicate = TRUE
 	var/active = FALSE
-	var/range = RADIO_JAMMER_RANGE
+	var/range = DEFAULT_RADIO_JAMMER_RANGE
 
 /obj/item/radiojammer/New()
 	. = ..()
@@ -383,11 +383,17 @@ TYPEINFO(/obj/item/radiojammer)
 	. = ..()
 
 /obj/item/radiojammer/proc/edit_range(mob/user)
-	var/inputted_number = tgui_input_number(user, "Input radio jammer range", "Radio Jammer", RADIO_JAMMER_RANGE, RADIO_JAMMER_RANGE, 1)
+	var/inputted_number = tgui_input_number(user, "Input radio jammer range", "Radio Jammer", DEFAULT_RADIO_JAMMER_RANGE, DEFAULT_RADIO_JAMMER_RANGE, 1)
 	if(!inputted_number)
 		return
+	if(!can_act(user))
+		boutput(user, SPAN_ALERT("Not while incapacitated!"))
+		return
+	if(BOUNDS_DIST(src,user) > 1)
+		boutput(user, SPAN_ALERT("You are too far away from [src]!"))
+		return
 	inputted_number = trunc(inputted_number)
-	if(!isnum_safe(inputted_number) || inputted_number > RADIO_JAMMER_RANGE || inputted_number < 1)
+	if(!isnum_safe(inputted_number) || inputted_number > DEFAULT_RADIO_JAMMER_RANGE || inputted_number < 1)
 		boutput(user, SPAN_ALERT("That number is out of [src]'s range!"))
 		return
 	src.range = inputted_number

--- a/code/obj/item/device/radios/_radio.dm
+++ b/code/obj/item/device/radios/_radio.dm
@@ -344,10 +344,15 @@ TYPEINFO(/obj/item/radiojammer)
 	w_class = W_CLASS_TINY
 	is_syndicate = TRUE
 	var/active = FALSE
+	var/range = RADIO_JAMMER_RANGE
 
 /obj/item/radiojammer/New()
 	. = ..()
 	src.RegisterSignal(src, COMSIG_SIGNAL_JAMMED, PROC_REF(signal_jammed))
+
+/obj/item/radiojammer/disposing()
+	STOP_TRACKING_CAT(TR_CAT_RADIO_JAMMERS)
+	. = ..()
 
 /obj/item/radiojammer/proc/signal_jammed()
 	//hoping this isn't too performance heavy if a lot of signals get blocked at once
@@ -371,10 +376,21 @@ TYPEINFO(/obj/item/radiojammer)
 		icon_state = "shieldoff"
 		STOP_TRACKING_CAT(TR_CAT_RADIO_JAMMERS)
 
-/obj/item/radiojammer/disposing()
-	STOP_TRACKING_CAT(TR_CAT_RADIO_JAMMERS)
+/obj/item/radiojammer/attackby(obj/item/W, mob/user, params)
+	if(isscrewingtool(W) || ispulsingtool(W))
+		src.edit_range(user)
+		return
 	. = ..()
 
+/obj/item/radiojammer/proc/edit_range(mob/user)
+	var/inputted_number = tgui_input_number(user, "Input radio jammer range", "Radio Jammer", RADIO_JAMMER_RANGE, RADIO_JAMMER_RANGE, 1)
+	if(!inputted_number)
+		return
+	inputted_number = trunc(inputted_number)
+	if(!isnum_safe(inputted_number) || inputted_number > RADIO_JAMMER_RANGE || inputted_number < 1)
+		boutput(user, SPAN_ALERT("That number is out of [src]'s range!"))
+		return
+	src.range = inputted_number
 
 #undef WIRE_SIGNAL
 #undef WIRE_RECEIVE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows the syndicate Radio Jammer's range to be configured with screwdriver/multitool between 1 (You and the tiles adjacent to you) and 6 (the current range of every signal jamming thing).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More precise jamming of radio communication allows for stealthier takedowns. The risk of them having an easier time getting out of range to send a communication vs the reward of not having someone randomly nearby note their radio being jammed allows for far more private and targeted signal jamming.

Example use: Leave a signal jammer at range 1 on a syndicate conversion chamber, only jamming signals from any victims currently inside or adjacent  but not signals from anyone passing through the hall/maints/medbay/wherever your crime den is

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="1384" height="588" alt="image" src="https://github.com/user-attachments/assets/4bd66858-306d-4887-a5c6-2d1951398f37" />
<img width="1324" height="558" alt="image" src="https://github.com/user-attachments/assets/817c3aef-0fce-4460-b535-837e78072d3b" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)You can now edit the range on a syndicate signal jammer with either a screwing or pulsing tool, allowing for more precisely jammed crime dens.
```
