### PR TITLE
Removes stupidity from OD linting

### DIFF
--- a/tools/ci/od_lints.dm
+++ b/tools/ci/od_lints.dm
@@ -5,7 +5,6 @@
 #pragma UndefineMissingDirective error
 #pragma DefinedMissingParen error
 #pragma ErrorDirective error
-#pragma WarningDirective error
 #pragma MiscapitalizedDirective error
 
 //2000-2999


### PR DESCRIPTION
Imagine being silly enough to bump `#warn` to an error.

Hasn't been caught sooner because I just haven't run goon locally in OD in years.