### PR TITLE
Define /datum/artifact/proc/effect_attack_atom()

### DIFF
--- a/code/obj/artifacts/artifact_items/dimensional_key.dm
+++ b/code/obj/artifacts/artifact_items/dimensional_key.dm
@@ -15,43 +15,6 @@
 	var/east_entr_placed = FALSE
 	var/west_entr_placed = FALSE
 
-	afterattack(atom/target, mob/user, reach)
-		..()
-		if (!src.artifact.activated)
-			return
-		if (!reach)
-			return
-		if (!iswall(target))
-			return
-		if (BOUNDS_DIST(user, target) > 0 || isrestrictedz(get_z(target)))
-			boutput(user, SPAN_ALERT("Nothing happens, except for a light stinging sensation in your hand. [src] probably doesn't work here"))
-			return
-
-		if (user.dir == NORTH)
-			if (!src.south_entr_placed)
-				src.create_entrance(SOUTH_ENTRANCE, target, user)
-				src.south_entr_placed = TRUE
-			else
-				boutput(user, SPAN_ALERT("Nothing happens, except for a light stinging sensation in your hand."))
-		else if (user.dir == SOUTH)
-			if (!src.north_entr_placed)
-				src.create_entrance(NORTH_ENTRANCE, target, user)
-				src.north_entr_placed = TRUE
-			else
-				boutput(user, SPAN_ALERT("Nothing happens, except for a light stinging sensation in your hand."))
-		else if (user.dir == EAST)
-			if (!src.west_entr_placed)
-				src.create_entrance(WEST_ENTRANCE, target, user)
-				src.west_entr_placed = TRUE
-			else
-				boutput(user, SPAN_ALERT("Nothing happens, except for a light stinging sensation in your hand."))
-		else if (user.dir == WEST)
-			if (!src.east_entr_placed)
-				src.create_entrance(EAST_ENTRANCE, target, user)
-				src.east_entr_placed = TRUE
-			else
-				boutput(user, SPAN_ALERT("Nothing happens, except for a light stinging sensation in your hand."))
-
 	proc/create_entrance(entrance_dir, turf/entrance, mob/user)
 		var/obj/art_fissure_objs/door/inner_door
 		var/turf/fissure_entr
@@ -129,6 +92,42 @@
 		var/turf/T = artkey.fissure_region.get_center()
 		var/area/artifact_fissure/fissure_area = get_area(T)
 		fissure_area.fissure_region = artkey.fissure_region
+
+	effect_attack_atom(obj/art, mob/living/user, atom/A)
+		if (..())
+			return
+		if (!iswall(A))
+			return
+		if (isrestrictedz(get_z(A)))
+			boutput(user, SPAN_ALERT("Nothing happens, except for a light stinging sensation in your hand. [art] probably doesn't work here."))
+			return
+
+		var/obj/item/artifact/dimensional_key/dim_key = art
+
+		if (user.dir == NORTH)
+			if (!dim_key.south_entr_placed)
+				dim_key.create_entrance(SOUTH_ENTRANCE, A, user)
+				dim_key.south_entr_placed = TRUE
+			else
+				boutput(user, SPAN_ALERT("Nothing happens, except for a light stinging sensation in your hand."))
+		else if (user.dir == SOUTH)
+			if (!dim_key.north_entr_placed)
+				dim_key.create_entrance(NORTH_ENTRANCE, A, user)
+				dim_key.north_entr_placed = TRUE
+			else
+				boutput(user, SPAN_ALERT("Nothing happens, except for a light stinging sensation in your hand."))
+		else if (user.dir == EAST)
+			if (!dim_key.west_entr_placed)
+				dim_key.create_entrance(WEST_ENTRANCE, A, user)
+				dim_key.west_entr_placed = TRUE
+			else
+				boutput(user, SPAN_ALERT("Nothing happens, except for a light stinging sensation in your hand."))
+		else if (user.dir == WEST)
+			if (!dim_key.east_entr_placed)
+				dim_key.create_entrance(EAST_ENTRANCE, A, user)
+				dim_key.east_entr_placed = TRUE
+			else
+				boutput(user, SPAN_ALERT("Nothing happens, except for a light stinging sensation in your hand."))
 
 /****** Supporting items/atoms/etc. *******/
 

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -181,6 +181,17 @@ ABSTRACT_TYPE(/datum/artifact/)
 		ArtifactLogs(user, target, O, "weapon", null, 0)
 		return 0
 
+	/// What the artifact does when it is activated and you smack an atom (other than a mob) with it
+	proc/effect_attack_atom(obj/art, mob/living/user, atom/A)
+		. = FALSE
+		if (!art || !user || !A)
+			return TRUE
+		if (!art.ArtifactSanityCheck())
+			return TRUE
+		if (BOUNDS_DIST(user, A) > 0)
+			return TRUE
+		art.add_fingerprint(user)
+
 	/// What the artifact does after you clicked some tile with it when activated.
 	/// Acts like a ranged afterattack() for activated artifacts.
 	proc/effect_click_tile(var/obj/O,var/mob/living/user,var/turf/T)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1069,6 +1069,8 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 	PROTECTED_PROC(TRUE)
 	src.storage?.storage_item_after_attack(target, user, reach)
 	if (src.artifact?.activated)
+		if (reach)
+			src.artifact.effect_attack_atom(src, user, target)
 		src.artifact.effect_click_tile(src, user, get_turf(target))
 	return
 


### PR DESCRIPTION
[INTERNAL][CLEANLINESS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title, moves artifact item afterattack() usage to this proc

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
-Standardizes more of artifact code on the datum
-Used for Combiner artifact

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Made sure dimensional keys were working properly

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->