### PR TITLE
[TGUI Core] fix for vending machine padding

### DIFF
--- a/tgui/packages/tgui/interfaces/common/ProductList.tsx
+++ b/tgui/packages/tgui/interfaces/common/ProductList.tsx
@@ -66,7 +66,13 @@ const ProductListItem = (props: ProductListItemProps) => {
   return (
     <Table.Row className="candystripe">
       {showImage && (
-        <Table.Cell collapsing verticalAlign="middle">
+        <Table.Cell
+          collapsing
+          verticalAlign="middle"
+          textAlign="right"
+          align="right"
+          px="0.4rem"
+        >
           {image && <Image src={`data:image/png;base64,${image}`} />}
         </Table.Cell>
       )}

--- a/tgui/packages/tgui/interfaces/common/ProductList.tsx
+++ b/tgui/packages/tgui/interfaces/common/ProductList.tsx
@@ -66,13 +66,7 @@ const ProductListItem = (props: ProductListItemProps) => {
   return (
     <Table.Row className="candystripe">
       {showImage && (
-        <Table.Cell
-          collapsing
-          verticalAlign="middle"
-          textAlign="right"
-          align="right"
-          px="0.4rem"
-        >
+        <Table.Cell collapsing verticalAlign="middle" align="right" px="0.4rem">
           {image && <Image src={`data:image/png;base64,${image}`} />}
         </Table.Cell>
       )}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes the padding for icons in the vending machine interface, as well as other interfaces that use the `ProductList` component.
NOTE: I wasn't able to build the project in production mode for reasons I was unable to properly diagnose. I verified this change works using the TGUI dev server.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It was one of the requested UI changes for the update to BYOND 516.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="502" height="606" alt="image" src="https://github.com/user-attachments/assets/a421ada0-60f8-4665-a450-36a4e38c3118" />



