### PR TITLE
Fix stowaways getting stuck in neon's donut hole

### DIFF
--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -11669,6 +11669,13 @@
 /obj/item/kitchen/food_box/donut_box,
 /obj/item/kitchen/food_box/donut_box,
 /obj/item/kitchen/food_box/donut_box,
+/obj/item/weldingtool{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/wrench{
+	pixel_x = -6
+	},
 /obj/item/kitchen/food_box/donut_box,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a wrench and welding tool to the donut hiding hole on neon

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stowaways shouldn't get stuck in a 1x1 box.
Fixes #24150

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="164" height="120" alt="image" src="https://github.com/user-attachments/assets/45f57e19-d86f-42c5-8c5c-17f05284f00d" />
FREEDOM
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

