### PR TITLE
Reinforcing girders properly consume sheets

### DIFF
--- a/code/obj/structure.dm
+++ b/code/obj/structure.dm
@@ -243,6 +243,9 @@ obj/structure/ex_act(severity)
 				else
 					var/datum/material/defaultMaterial = getMaterial("steel")
 					A.setMaterial(defaultMaterial)
+
+				var/obj/item/sheet/S = the_tool
+				S?.change_stack_amount(-2)
 				qdel(the_girder)
 			if (GIRDER_SECURE)
 				if (!istype(the_girder.loc, /turf/simulated/floor/))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ensures that sheets are consumed upon successful reinforcement of a girder.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #24108
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Ensured sheets are removed from stack when reinforcement is complete.

<img width="329" height="296" alt="{D31AC221-3CC5-4315-B991-E6967F6CDA4C}" src="https://github.com/user-attachments/assets/bfa170a2-34ff-4c15-b33a-dccaec781b03" />

