### PR TITLE
Miracle Matter Transmutation Fix

### DIFF
--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -452,6 +452,10 @@ ABSTRACT_TYPE(/datum/material)
 			X.execute(owner, attackatom, attacker, meleeorthrow)
 		return
 
+	/// Some materials have their own icon file
+	proc/get_icon_file()
+		return 'icons/obj/items/materials/materials.dmi'
+
 //Material definitions
 /datum/material/interpolated
 	mat_id = "imcoderium"
@@ -560,6 +564,9 @@ ABSTRACT_TYPE(/datum/material/metal)
 		setProperty("electrical", 4)
 		setProperty("thermal", 4)
 
+	get_icon_file()
+		return 'icons/obj/items/materials/rocks.dmi'
+
 
 /datum/material/metal/electrum
 	mat_id = "electrum"
@@ -635,6 +642,9 @@ ABSTRACT_TYPE(/datum/material/metal)
 		setProperty("density", 2)
 		setProperty("hard", 2)
 
+	get_icon_file()
+		return 'icons/obj/items/materials/pharosium.dmi'
+
 
 /datum/material/metal/cobryl
 	mat_id = "cobryl"
@@ -647,6 +657,9 @@ ABSTRACT_TYPE(/datum/material/metal)
 		setProperty("density", 4)
 		setProperty("hard", 2)
 		setProperty("chemical", 8)
+
+	get_icon_file()
+		return 'icons/obj/items/materials/cobryl.dmi'
 
 
 
@@ -661,6 +674,9 @@ ABSTRACT_TYPE(/datum/material/metal)
 		setProperty("hard", 5)
 		setProperty("chemical", 7)
 
+	get_icon_file()
+		return 'icons/obj/items/materials/bohrum.dmi'
+
 
 /datum/material/metal/mauxite
 	mat_id = "mauxite"
@@ -672,6 +688,9 @@ ABSTRACT_TYPE(/datum/material/metal)
 		setProperty("density", 4)
 		setProperty("hard", 3)
 
+	get_icon_file()
+		return 'icons/obj/items/materials/mauxite.dmi'
+
 
 /datum/material/metal/cerenkite
 	mat_id = "cerenkite"
@@ -682,11 +701,13 @@ ABSTRACT_TYPE(/datum/material/metal)
 	New()
 		..()
 		value = 200
-
 		material_flags |= MATERIAL_ENERGY
 		setProperty("electrical", 6)
 		setProperty("radioactive", 5)
 		setProperty("hard", 2)
+
+	get_icon_file()
+		return 'icons/obj/items/materials/cerenkite.dmi'
 
 
 /datum/material/metal/syreline
@@ -698,12 +719,13 @@ ABSTRACT_TYPE(/datum/material/metal)
 	New()
 		..()
 		value = 400
-
 		setProperty("density", 1)
 		setProperty("hard", 2)
 		setProperty("reflective", 8)
-
 		addTrigger(TRIGGERS_ON_ADD, new /datum/materialProc/gold_add())
+
+	get_icon_file()
+		return 'icons/obj/items/materials/syreline.dmi'
 
 
 /datum/material/metal/gold
@@ -723,6 +745,9 @@ ABSTRACT_TYPE(/datum/material/metal)
 		setProperty("thermal", 7)
 
 		addTrigger(TRIGGERS_ON_ADD, new /datum/materialProc/gold_add())
+
+	get_icon_file()
+		return 'icons/obj/items/materials/gold.dmi'
 
 
 /datum/material/metal/silver
@@ -815,6 +840,9 @@ ABSTRACT_TYPE(/datum/material/metal)
 		setProperty("hard", 8)
 		setProperty("chemical", 9)
 
+	get_icon_file()
+		return 'icons/obj/items/materials/iridium.dmi'
+
 
 /datum/material/metal/negativematter
 	mat_id = "negativematter"
@@ -883,6 +911,9 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		addTrigger(TRIGGERS_ON_TEMP, new /datum/materialProc/molitz_temp())
 		addTrigger(TRIGGERS_ON_EXPLOSION, new /datum/materialProc/molitz_exp())
 
+	get_icon_file()
+		return 'icons/obj/items/materials/molitz.dmi'
+
 	beta
 		mat_id = "molitz_b"
 		name = "molitz beta"
@@ -918,6 +949,9 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		setProperty("hard", 1)
 		setProperty("electrical", 8)
 
+	get_icon_file()
+		return 'icons/obj/items/materials/claretine.dmi'
+
 
 /datum/material/crystal/erebite
 	mat_id = "erebite"
@@ -940,6 +974,9 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		addTrigger(TRIGGERS_ON_ATTACKED, new /datum/materialProc/generic_explode_attack(33))
 		addTrigger(TRIGGERS_ON_HIT, new /datum/materialProc/generic_explode_attack(33))
 
+	get_icon_file()
+		return 'icons/obj/items/materials/erebite.dmi'
+
 
 /datum/material/crystal/plasmastone
 	mat_id = "plasmastone"
@@ -960,6 +997,9 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		addTrigger(TRIGGERS_ON_TEMP, new /datum/materialProc/plasmastone())
 		addTrigger(TRIGGERS_ON_EXPLOSION, new /datum/materialProc/plasmastone())
 		addTrigger(TRIGGERS_ON_HIT, new /datum/materialProc/plasmastone())
+
+	get_icon_file()
+		return 'icons/obj/items/materials/plasmastone.dmi'
 
 
 /datum/material/crystal/plasmaglass
@@ -1126,6 +1166,9 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		setProperty("hard", 4)
 		setProperty("chemical", 9)
 
+	get_icon_file()
+		return 'icons/obj/items/materials/uqill.dmi'
+
 
 // hi it me cirr im doing dumb
 /datum/material/crystal/gnesis //Feather
@@ -1169,6 +1212,8 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		addTrigger(TRIGGERS_ON_ENTERED, new /datum/materialProc/telecrystal_entered())
 		addTrigger(TRIGGERS_ON_ATTACK, new /datum/materialProc/telecrystal_onattack())
 
+	get_icon_file()
+		return 'icons/obj/items/materials/telecrystal.dmi'
 
 
 /datum/material/crystal/miracle
@@ -1187,6 +1232,9 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		setProperty("chemical", rand(1, 8))
 		addTrigger(TRIGGERS_ON_TEMP, new /datum/materialProc/temp_miraclium())
 
+	get_icon_file()
+		return 'icons/obj/items/materials/miracle.dmi'
+
 
 /datum/material/crystal/starstone
 	mat_id = "starstone"
@@ -1203,6 +1251,9 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		setProperty("hard", 9)
 		setProperty("electrical", 1)
 		addTrigger(TRIGGERS_ON_ADD, new /datum/materialProc/gold_add())
+
+	get_icon_file()
+		return 'icons/obj/items/materials/starstone.dmi'
 
 
 /datum/material/crystal/ice
@@ -1224,6 +1275,9 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		addTrigger(TRIGGERS_ON_LIFE, new /datum/materialProc/ice_life())
 		addTrigger(TRIGGERS_ON_ATTACK, new /datum/materialProc/slippery_attack())
 		addTrigger(TRIGGERS_ON_ENTERED, new /datum/materialProc/slippery_entered())
+
+	get_icon_file()
+		return 'icons/obj/items/materials/ice.dmi'
 
 ABSTRACT_TYPE(/datum/material/crystal/wizard)
 /datum/material/crystal/wizard
@@ -1352,6 +1406,9 @@ ABSTRACT_TYPE(/datum/material/organic)
 		setProperty("hard", 3)
 		setProperty("density", 2)
 
+	get_icon_file()
+		return 'icons/obj/items/materials/char.dmi'
+
 
 /datum/material/organic/koshmarite
 	mat_id = "koshmarite"
@@ -1366,6 +1423,9 @@ ABSTRACT_TYPE(/datum/material/organic)
 		setProperty("reflective", 6)
 		setProperty("n_radioactive", 1)
 		setProperty("density", 5)
+
+	get_icon_file()
+		return 'icons/obj/items/materials/koshmarite.dmi'
 
 
 /datum/material/organic/viscerite
@@ -1385,6 +1445,9 @@ ABSTRACT_TYPE(/datum/material/organic)
 		setProperty("chemical", 6)
 		setProperty("flammable", 2)
 		addTrigger(TRIGGERS_ON_EAT, new /datum/materialProc/oneat_viscerite())
+
+	get_icon_file()
+		return 'icons/obj/items/materials/viscerite.dmi'
 
 /datum/material/organic/tensed_viscerite
 	mat_id = "tensed_viscerite"
@@ -1468,6 +1531,9 @@ ABSTRACT_TYPE(/datum/material/organic)
 		material_flags |= MATERIAL_METAL
 		setProperty("density", 2)
 		setProperty("hard", 6)
+
+	get_icon_file()
+		return 'icons/obj/items/materials/chitin.dmi'
 
 
 /datum/material/organic/beeswax
@@ -1758,10 +1824,10 @@ ABSTRACT_TYPE(/datum/material/fabric)
 		setProperty("thermal", 1)
 		setProperty("flammable", 1)
 
-
-	New()
-		..()
 		addTrigger(TRIGGERS_ON_LIFE, new /datum/materialProc/generic_itchy_onlife())
+
+	get_icon_file()
+		return 'icons/obj/items/materials/fibrilith.dmi'
 
 
 /datum/material/fabric/spidersilk
@@ -1948,6 +2014,9 @@ ABSTRACT_TYPE(/datum/material/rubber)
 		setProperty("n_radioactive", 5)
 		setProperty("radioactive", 3)
 		setProperty("electrical", 7)
+
+	get_icon_file()
+		return 'icons/obj/items/materials/plutonium.dmi'
 
 /datum/material/metal/yuranite
 	mat_id = "yuranite"

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -277,10 +277,15 @@
 
 	update_stack_name() //! How the material should be named at different stack sizes
 		UpdateName(src) // get the name in order so it has whatever it needs
+		var/name_mat = ""
+		var/name_rock = "stone"
+		if(src.material.getID() != "rock")
+			name_rock = "chunk"
+			name_mat = src.material.getName()
 		if(src.amount == 1)
-			name = "[src.material.getName()] stone"
+			name = "[name_mat] [name_rock]"
 		else
-			name = "[amount] [src.material.getName()] stones"
+			name = "[amount] [name_mat] [name_rock]s"
 
 /obj/item/raw_material/mauxite
 	name = "mauxite ore"

--- a/code/obj/rocko.dm
+++ b/code/obj/rocko.dm
@@ -179,6 +179,14 @@
 		var/datum/material/dummy = new new_material
 		src.setMaterial(getMaterial(dummy.getID()), setname = FALSE)
 
+		// Force lightly-colored rocks to have dark faces and vise-versa
+		var/list/light_list = list("gold","cobryl","pharosium","syreline")
+		var/list/dark_list = list("bohrum","plutonium")
+		if(light_list.Find(src.material.getID()))
+			src.bright = FALSE
+		else if(dark_list.Find(src.material.getID()))
+			src.bright = TRUE
+
 		// Use ore sprites if available
 		var/list/rock_list = list("bohrum","cerenkite","cobryl","gold","mauxite","pharosium","syreline","plutonium")
 		if(!rock_list.Find(src.material.getID()))
@@ -192,6 +200,7 @@
 				sprite_value = pick(1,2,3,4) // Larger bohrum stack sizes are more piles of rocks than rocks
 			if("plutonium")
 				sprite_prefix = "scrap"
+
 		// Include variants of ores if they exist
 		for(var/letter in list("b","c","d"))
 			if(is_valid_icon_state("[sprite_prefix][sprite_value][letter]_$$[src.material.getID()]"))

--- a/code/obj/rocko.dm
+++ b/code/obj/rocko.dm
@@ -183,7 +183,7 @@
 		var/list/rock_list = list("bohrum","cerenkite","cobryl","gold","mauxite","pharosium","syreline","plutonium")
 		if(!rock_list.Find(src.material.getID()))
 			return
-		src.icon = file("icons/obj/items/materials/[src.material.getID()].dmi")
+		src.icon = src.material.get_icon_file()
 		var/sprite_prefix = "ore"
 		var/sprite_value = pick(1,2,3,4,5,6)
 		var/list/sprite_variants = list("")


### PR DESCRIPTION
[Materials][Bug]
## About the PR
- Miracle matter no longer disappears when transforming into different materials
- Ores no longer disappear when turned into other materials in general
- You can now obtain a material's icon file from the material itself
- Forced Rocko's face color to be more visible for certain ores

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- Fixes #23558
- Easier access to material icon files
- Potentially fixes #23889

## Testing 

<img width="867" height="742" alt="Screenshot 2025-07-16 190715" src="https://github.com/user-attachments/assets/e0593e1d-0deb-4ac8-bcb7-6475b5503949" />
<img width="771" height="426" alt="Screenshot 2025-07-16 043017" src="https://github.com/user-attachments/assets/a6401e3c-df52-4bbd-bc36-a181a06f1a33" />


## Changelog 

```changelog
(u)LorrMaster
(+)Fixed miracle matter transmutation when heated
```
