### PR TITLE
Simplifies Ether's depletion mode

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -129,7 +129,7 @@ datum
 			transparency = 30
 			addiction_prob = 10
 			addiction_min = 15
-			depletion_rate = 0.3
+			depletion_rate = 0.6
 			overdose = 40   //Ether is known for having a big difference in effective to toxic dosage
 			var/counter = 1 //Data is conserved...so some jerkbag could inject a monkey with this, wait for data to build up, then extract some instant KO juice.  Dumb.
 			minimum_reaction_temperature = T0C + 80 //This stuff is extremely flammable
@@ -189,20 +189,14 @@ datum
 					M.changeStatus("stimulants", -4 SECONDS * mult)
 				if(M.hasStatus("recent_trauma")) // can be used to help fix recent trauma
 					M.changeStatus("recent_trauma", -2 SECONDS * mult)
-				if(holder.has_reagent(src.id,10)) // large doses progress somewhat faster than small ones
-					counter += mult
-					depletion_rate = 0.6 // depletes faster in large doses as well
-				else
-					depletion_rate = 0.3
 
 				switch(counter += 1 * mult)
-					if(1 to 7)
+					if(1 to 4)
 						if(probmult(7)) M.emote("yawn")
-					if(7 to 30)
+					if(4 to 15)
 						M.setStatus("drowsy", 40 SECONDS)
 						if(probmult(9)) M.emote(pick("smile","giggle","yawn"))
-					if(30 to INFINITY)
-						depletion_rate = 0.6
+					if(15 to INFINITY)
 						M.setStatusMin("unconscious", 6 SECONDS * mult)
 						M.setStatus("drowsy", 40 SECONDS)
 				..()


### PR DESCRIPTION
[LABEL][chemistry][balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR removes Ether's dual depletion behavior, making it a 0.6 depletion chem by default. The regular and double speed system is also no longer a thing.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This simplifies ether's behavior a bit, as it is already a very complex chem, and frankly that part does not seem to add much to it. The manufacture complexity already seems like a block to most players, and leads to it scarcely being used, and the confusing speed and depletion behavior more often than not just compounds the problem.

Now its much easier to ponder the right dose for a KO, or how fast its going to last. Its something i've been meaning to change for a while, as the person that made the two step system in the first place, it didn't feel quite right and this is just plain more fun and less finicky to use.

One thing i might add is that this IS a slight buff(more of a sidegrade in some ways), in the sense that you could get a small amount of KO from it sooner, but anything below 10 units is just going to deplete faster and be worse than before, and everything above 15 units is going to be basically unchanged, as it would already be pretty much always on mode 2 anyway.


## Changelog 
```changelog
(u) Colossus
(+) Ether no longer works on a 10 unit threshold, always behaving on the fast depletion mode.
```
