### PR TITLE
Add Wheelchairs to Medfabs

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1156,6 +1156,15 @@
 	time = 20 SECONDS
 	category = "Clothing"
 
+/datum/manufacture/wheelchair
+	name = "Wheelchair Parts"
+	item_requirements = list("metal" = 8,
+							 "fabric" = 3)
+	item_outputs = list(/obj/item/furniture_parts/wheelchair)
+	create = 1
+	time = 30 SECONDS
+	category = "Resource"
+
 /datum/manufacture/hypospray
 	name = "Hypospray"
 	item_requirements = list("metal" = 2,

--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -216,6 +216,7 @@
 		/datum/manufacture/glasses,
 		/datum/manufacture/visor,
 		/datum/manufacture/deafhs,
+		/datum/manufacture/wheelchair,
 		/datum/manufacture/hypospray,
 		/datum/manufacture/patch,
 		/datum/manufacture/mender,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds wheelchair parts to the medical fabricator for .8 metal and .3 fabric
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Destroying/hiding the spare wheelchairs in medbay currently means you can't make more unless they were mechscanned, you shouldn't need to get legs for your wheelchair character if someone steals all the chairs

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="1143" height="594" alt="image" src="https://github.com/user-attachments/assets/647a54ed-cb0e-4222-9309-d17b87a674e7" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Wheelchair parts can now be crafted at the medical fabricator
```
