### PR TITLE
Adds rare antag token drops for low population servers

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -998,6 +998,9 @@ var/global/game_force_started = FALSE
 		logTheThing(LOG_DEBUG, null, "Population ratio with largest server: [pop_ratio], greater than threshold [RATIO_THRESHOLD], aborting end round drops.")
 		return // servers are reasonably balanced, no drops for u
 
+	if (global.round_elapsed_ticks < 10 MINUTES) //too short, possibly just an admin restarting the server to change map etc.
+		return
+
 	var/actual_token_chance = BASE_TOKEN_CHANCE * ((RATIO_THRESHOLD - pop_ratio) / RATIO_THRESHOLD)
 	logTheThing(LOG_DEBUG, null, "Population ratio with largest server: [pop_ratio], starting end round drops with token chance [actual_token_chance]")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
At the end of a round, all players who have participated will have a small chance to be awarded a free antag token, provided they don't already have one.
The chance maxes out at 10% and scales down with a couple of factors
- The population imbalance between this server and the highest population Goonstation server. For example, if the highest pop server has 60 people and the one you're on only has 10 you'll have a (relatively) high roll chance.
- The amount of time you've been connected to the round, your chance will be reduced proportionally based on how much of the round you weren't connected for, so logging in for 10 minutes at the end will yield a lower chance than playing the entire round.
- If the ratio between the highest population server and this one is > 0.6 (ie 36/60) there will be no drop chance at all.

TODO: Handle Nightshade separately?
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There's a lot of reasons why people end up flocking to the highest population server and this doesn't pretend to fix any/all of them, buuut it might help a bit! It's a small incentive to try out a lower population server, especially as your antag token can then be spent on any server you like.
Will this lead to 16 bajillion antags every round? Idk! Hopefully not, since inherently the people rolling a high chance to get a token will be a very small number due to being on the lower population server.
Will this abused? I'm sure some people will try to, but it's quite hard to abuse as written and we can as usual take admin action against people obviously fishing (ie joining a round just to go AFK the whole time) in the same way we do against regular antag fishing behaviour.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Due to its nature this pretty much has to be tested on live. Testmerge!

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Playing on one of the less populated servers will now give you a small chance to earn an antag token at the end of each round.
```
