### PR TITLE
ID Cards suppress attacks

### DIFF
--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -85,7 +85,7 @@ TYPEINFO(/obj/item/card/emag)
 	icon_state = "id_basic"
 	item_state = "card-id"
 	desc = "A standardized NanoTrasen microchipped identification card that contains data that is scanned when attempting to access various doors and computers."
-	flags = TABLEPASS | ATTACK_SELF_DELAY
+	flags = TABLEPASS | ATTACK_SELF_DELAY | SUPPRESSATTACK
 	click_delay = 0.4 SECONDS
 	wear_layer = MOB_BELT_LAYER
 	var/datum/pronouns/pronouns = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the SUPPRESSATTACK flag to ID Cards, stopping them from attacking most (some objects have custom attack procs that don't check SUPPRESSATTACK) objects. This specifically applies to Agent IDs attacking other IDs which currently show an attack message in chat, when attacking the Agent ID with other IDs doesn't do this.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Prevents agent IDs from showing an attack message in chat when scanning another ID.
ID cards already do 0 damage and theres a lot of stuff you can vs can't scan your ID on, most things already don't have you bash your ID on it and there's no reason for you to want to bash a plasma tank with your ID anyway, used here as an example as its the only other difference I could find in devtest that shows a bash animation and not just a message in chat of you "attacking" it.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Here you can see the agent ID not having an attack message in chat
<img width="535" height="174" alt="image" src="https://github.com/user-attachments/assets/5906f51d-6540-4a0d-b44d-7089f6dd2dfa" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
