### PR TITLE
Cryopods heal and consume power more consistently

### DIFF
--- a/code/modules/atmospherics/machinery/unary/cryo_cell.dm
+++ b/code/modules/atmospherics/machinery/unary/cryo_cell.dm
@@ -53,16 +53,14 @@ TYPEINFO(/obj/machinery/atmospherics/unary/cryo_cell)
 		return
 
 	if(src.occupant)
-		if(!isdead(src.occupant))
-			if (!ishuman(src.occupant))
-				src.go_out() // stop turning into cyborgs thanks
-			if (src.occupant.health < src.occupant.max_health || src.occupant.bioHolder.HasEffect("premature_clone"))
-				src.use_power(src.occupied_power_use, EQUIP)
-				src.process_occupant()
-			else
-				if(src.occupant.mind && src.eject_full_health_occupant)
-					src.go_out()
-					playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
+		if (!ishuman(src.occupant))
+			src.go_out() // stop turning into cyborgs thanks
+		else if ((src.occupant.health >= src.occupant.max_health) && src.eject_full_health_occupant)
+			src.go_out()
+			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
+		else if (!isdead(src.occupant))
+			src.process_occupant()
+		src.use_power(src.occupied_power_use, EQUIP)
 
 	if(src.air_contents)
 		src.ARCHIVED(temperature) = src.air_contents.temperature

--- a/code/modules/atmospherics/machinery/unary/cryo_cell.dm
+++ b/code/modules/atmospherics/machinery/unary/cryo_cell.dm
@@ -55,7 +55,7 @@ TYPEINFO(/obj/machinery/atmospherics/unary/cryo_cell)
 	if(src.occupant)
 		if (!ishuman(src.occupant))
 			src.go_out() // stop turning into cyborgs thanks
-		else if ((src.occupant.health >= src.occupant.max_health) && src.eject_full_health_occupant)
+		else if (src.occupant.health >= src.occupant.max_health && src.eject_full_health_occupant)
 			src.go_out()
 			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 		else if (!isdead(src.occupant))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label [bug][medical]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Cryopods always process occupants when they're not dead or ejected for any reason. 
Cryopods always consume power when occupied.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Cryopods heal organs when occupants are at full health: fixes #24162

Little more consistent power drain just means a bit more opportunity for players to cause issues. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Got a monkey drunk then healed its liver:
<img width="1292" height="663" alt="cryo_test" src="https://github.com/user-attachments/assets/a602f800-804e-463a-b8ac-b8fcd9aef669" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
