### PR TITLE
Prevent dummy objects from triggering mass driver and cargo router, prevent projectiles from triggering cargo router

### DIFF
--- a/code/obj/machinery/launcherloader.dm
+++ b/code/obj/machinery/launcherloader.dm
@@ -89,7 +89,7 @@
 
 	Crossed(atom/movable/A)
 		..()
-		if (A.anchored || HAS_ATOM_PROPERTY(A, PROP_ATOM_FLOATING) || isflockmob(A) || istype(A, /obj/projectile)) return
+		if (A.anchored || HAS_ATOM_PROPERTY(A, PROP_ATOM_FLOATING) || isflockmob(A) || istypes(A, list(/obj/projectile, /obj/item/dummy))) return
 		return_if_overlay_or_effect(A)
 		activate()
 
@@ -184,7 +184,7 @@
 
 	Crossed(atom/movable/A)
 		..()
-		if (HAS_ATOM_PROPERTY(A, PROP_ATOM_FLOATING) || isflockmob(A)) return
+		if (HAS_ATOM_PROPERTY(A, PROP_ATOM_FLOATING) || isflockmob(A) || istypes(A, list(/obj/projectile, /obj/item/dummy))) return
 
 		if (!trigger_when_no_match)
 			var/atom/movable/AM = A


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title is self-explanatory. This PR makes the `Crossed()` proc on the affected types check for projectiles and `obj/item/dummy` and return early to prevent them from triggering. Mass driver loaders specifically were checking for projectiles already, this PR expands that behavior.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #17314 
Fixes the other bug mentioned in #17554 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested by shooting at/dragging a crate near the affected objects.

