### PR TITLE
Allow players to inject reagents into brownies.

### DIFF
--- a/code/modules/cooking/food_and_drink/snacks.dm
+++ b/code/modules/cooking/food_and_drink/snacks.dm
@@ -3006,8 +3006,6 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/dippable)
 	food_effects = list("food_warm","food_energized")
 	meal_time_flags = MEAL_TIME_SNACK
 
-
-
 /obj/item/reagent_containers/food/snacks/flapjack
 	name = "flapjack"
 	desc = "A golden brown square of syrupy goodness. Yum!"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[C-FEATURE]
[A-GAME-OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes the initial_volume of brownies to 20, and adds the TABLEPASS, and NOSPLASH flags to brownies so that players can inject an entire syringes worth (15u) of reagents into a brownie.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You can inject reagents into donuts, and I feel you should be able to do the same with brownies.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Sorry, none of the GIF recorders I tried would let me interact with SS13 while I recorded. Either or, to test this change I injected one syringe of chocolate milk into the brownie, and attempted to inject more then one syringe which did not work.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
