### PR TITLE
fixes the floor() message for arithmetic components

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -3531,7 +3531,7 @@ ADMIN_INTERACT_PROCS(/obj/item/mechanics/trigger/button, proc/press)
 
 	proc/toggleAutoFloor(obj/item/W as obj, mob/user as mob)
 		src.floorResults = !src.floorResults
-		boutput(user, SPAN_NOTICE("Results will <b>[src.autoEval ? "be" : "not be"] floor()ed</b>."))
+		boutput(user, SPAN_NOTICE("Results will <b>[src.floorResults ? "be" : "not be"] floor()ed</b>."))
 		tooltip_rebuild = TRUE
 		return TRUE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][ENGINEERING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes the message telling you whether output will be floor()'ed or not when the respective setting is toggled on mechcomp arithmetic components

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #24184

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="270" height="87" alt="image" src="https://github.com/user-attachments/assets/e56beb79-7dd6-4748-a651-8ee2fe14ed14" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->