### PR TITLE
Prevent hair from getting stuck in the barberang

### DIFF
--- a/code/modules/barber/barber_shop.dm
+++ b/code/modules/barber/barber_shop.dm
@@ -228,6 +228,8 @@
 					throw_return = FALSE
 					SPAWN(2 SECONDS)
 						throw_return = TRUE
+			else if(stolen_hair) //failsafe to prevent it from bricking itself
+				stolen_hair.set_loc(get_turf(src))
 
 		. = ..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds a check to the barberang if it hits something that isn't a human or whoever throws it in order to drop its stolen hair on the ground.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

If the barberang manages to not hit its thrower on return, any hair it steals will not eject, effectively bricking it for subsequent throws. This fixes that.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="580" height="610" alt="image" src="https://github.com/user-attachments/assets/48dea4aa-fa54-4115-8412-07f0f9f5fc34" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)The barberang should more reliably drop any hair it takes.
```
