### PR TITLE
Give blood oranges their unique sprite

### DIFF
--- a/code/modules/cooking/food_and_drink/plants.dm
+++ b/code/modules/cooking/food_and_drink/plants.dm
@@ -390,6 +390,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 /obj/item/reagent_containers/food/snacks/plant/orange/blood
 	name = "blood orange"
 	desc = "Juicy."
+	icon_state = "orange-blood"
 
 	make_reagents()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Blood oranges use their associated sprite. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Blood oranges have a very cool animated sprite in the files that isn't getting used. I don't know why, I can't find any PR referencing them so I can only assume it's just a thing that's been accidentally lost and forgotten at some point.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/9198915f-8d70-4467-b2fb-37455ccaa794


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
