### PR TITLE
Replace clarion robotics crate with a more useful one

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -29023,11 +29023,7 @@
 	},
 /area/station/medical/medbay)
 "oUh" = (
-/obj/storage/crate/robotparts,
-/obj/item/sheet/steel/fullstack{
-	pixel_x = 7;
-	pixel_y = -4
-	},
+/obj/storage/crate/robotics_supplies_borg,
 /turf/simulated/floor,
 /area/station/medical/robotics)
 "oUo" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING][QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the Clarion robotics bare-bones robot crate and metal sheet stack with the robotics_supplies_borg crate.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Clarion robotics does not have extra materials (especially cables) aside from a basic robot crate and a sheet stack. It can be a hassle to go scavenge every round, so this gives a bit of freedom for early robotics work.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Ran to ensure it spawns properly.

<img width="383" height="205" alt="image" src="https://github.com/user-attachments/assets/82d5e538-de68-4975-9444-c432fa3233d8" />
