### PR TITLE
Standardize Robotics across all maps in rotation.

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -29800,6 +29800,7 @@
 /obj/item/suture{
 	pixel_y = 5
 	},
+/obj/item/surgical_spoon,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "che" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -28697,10 +28697,6 @@
 	pixel_y = 21
 	},
 /obj/decal/tile_edge/stripe/extra_big,
-/obj/item/storage/belt/utility{
-	pixel_x = -8;
-	pixel_y = 10
-	},
 /obj/item/cell/supercell/charged{
 	pixel_x = 7;
 	pixel_y = 11
@@ -29776,6 +29772,29 @@
 "chd" = (
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/surgery_tray,
+/obj/item/circular_saw{
+	pixel_y = 11
+	},
+/obj/item/scalpel{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/hemostat{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/item/scissors/surgical_scissors{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/staple_gun{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/suture{
+	pixel_y = 5
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
@@ -34448,32 +34467,10 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/surgery)
 "cwI" = (
-/obj/surgery_tray,
-/obj/item/circular_saw{
-	pixel_y = 11
-	},
-/obj/item/scalpel{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/hemostat{
-	pixel_x = 3;
-	pixel_y = -5
-	},
-/obj/item/scissors/surgical_scissors{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/staple_gun{
-	pixel_x = 4;
-	pixel_y = 9
-	},
-/obj/item/suture{
-	pixel_y = 5
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10
 	},
+/obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor,
 /area/station/medical/robotics)
 "cwJ" = (
@@ -36345,6 +36342,7 @@
 	icon_state = "0-2"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "dkF" = (
@@ -41196,10 +41194,6 @@
 /area/station/engine/coldloop)
 "gGh" = (
 /obj/table/auto,
-/obj/item/device/prox_sensor{
-	pixel_x = -9;
-	pixel_y = 9
-	},
 /obj/item/clothing/head/helmet/welding{
 	pixel_x = 9;
 	pixel_y = 19
@@ -41925,6 +41919,7 @@
 	},
 /obj/cable,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "hgc" = (
@@ -42572,21 +42567,9 @@
 	pixel_x = 1;
 	pixel_y = 11
 	},
-/obj/item/staple_gun{
-	pixel_x = -6;
-	pixel_y = 2
-	},
 /obj/item/weldingtool{
 	pixel_x = 4;
 	pixel_y = 2
-	},
-/obj/item/hand_labeler{
-	pixel_x = 7;
-	pixel_y = -2
-	},
-/obj/item/crowbar{
-	pixel_x = 2;
-	pixel_y = 4
 	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -43527,6 +43510,7 @@
 	icon_state = "pipe-c";
 	name = "crematorium pipe"
 	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "iqh" = (
@@ -55011,6 +54995,7 @@
 	icon_state = "0-4"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "qRH" = (
@@ -57208,7 +57193,10 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "sFD" = (
-/obj/machinery/firealarm/west,
+/obj/submachine/chef_sink/chem_sink{
+	dir = 4;
+	pixel_x = -5
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "sFO" = (
@@ -57358,6 +57346,7 @@
 	icon_state = "0-4"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "sIr" = (
@@ -57530,6 +57519,9 @@
 	icon_state = "0-8"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "sOS" = (
@@ -57838,6 +57830,9 @@
 /area/station/engine/monitoring)
 "tct" = (
 /obj/machinery/light_switch/north,
+/obj/blind_switch/area/north{
+	pixel_x = 8
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "tcE" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -28738,17 +28738,21 @@
 "cdq" = (
 /obj/table/auto,
 /obj/decal/cleanable/cobweb,
-/obj/item/scalpel{
-	pixel_x = -4;
+/obj/item/weldingtool{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/oilcan{
+	pixel_x = 1;
 	pixel_y = 11
 	},
-/obj/item/circular_saw{
-	pixel_x = -3;
-	pixel_y = 4
+/obj/item/storage/firstaid/regular{
+	pixel_x = 12;
+	pixel_y = 10
 	},
-/obj/item/staple_gun{
-	pixel_x = 8;
-	pixel_y = 1
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -4;
+	pixel_y = 11
 	},
 /turf/simulated/floor/grime,
 /area/station/medical/robotics)
@@ -42555,24 +42559,24 @@
 /area/station/crew_quarters/clown)
 "hFD" = (
 /obj/table/auto,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 12;
-	pixel_y = 10
-	},
-/obj/item/storage/toolbox/emergency{
-	pixel_x = -4;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/glass/oilcan{
-	pixel_x = 1;
-	pixel_y = 11
-	},
-/obj/item/weldingtool{
-	pixel_x = 4;
-	pixel_y = 2
-	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
+	},
+/obj/item/robot_module{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/robot_module{
+	pixel_x = -10;
+	pixel_y = -5
+	},
+/obj/item/robot_module{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/obj/item/robot_module{
+	pixel_x = 5;
+	pixel_y = -5
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -40382,7 +40382,7 @@
 	pixel_x = -10;
 	pixel_y = 5
 	},
-/obj/item/scissors/surgical_scissors,
+/obj/item/surgical_spoon,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "ctw" = (
@@ -50486,6 +50486,9 @@
 "dce" = (
 /obj/machinery/portable_reclaimer,
 /obj/machinery/light_switch/east,
+/obj/blind_switch/area/east{
+	pixel_y = 8
+	},
 /turf/simulated/floor/blueblack{
 	dir = 6
 	},
@@ -54059,6 +54062,7 @@
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/mapping_helper/access/robotics,
 /obj/mapping_helper/firedoor_spawn,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "dZS" = (
@@ -56990,6 +56994,7 @@
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/mapping_helper/access/robotics,
 /obj/mapping_helper/firedoor_spawn,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "haZ" = (
@@ -62346,6 +62351,7 @@
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/mapping_helper/access/robotics,
 /obj/mapping_helper/firedoor_spawn,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "lGN" = (
@@ -67534,6 +67540,9 @@
 	},
 /obj/mapping_helper/access/robotics,
 /obj/mapping_helper/firedoor_spawn,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "qyf" = (
@@ -67655,6 +67664,9 @@
 /obj/mapping_helper/access/robotics,
 /obj/mapping_helper/firedoor_spawn,
 /obj/random_item_spawner/desk_stuff/few,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "qBq" = (
@@ -70406,6 +70418,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/ce)
+"tev" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "teY" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -70769,6 +70788,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/outer/se)
+"tuq" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 10
+	},
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "tuD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -73716,6 +73742,9 @@
 /area/station/science/chemistry)
 "wGP" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 9
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "wHl" = (
@@ -73784,6 +73813,11 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/outer/ne)
+"wMG" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "wNU" = (
 /obj/mesh/grille/steel,
 /turf/simulated/floor/plating,
@@ -110874,8 +110908,8 @@ ckq
 coE
 cqn
 cqn
-tLy
-tLy
+tev
+tev
 cwn
 cxO
 czn
@@ -111783,7 +111817,7 @@ csc
 daZ
 des
 cwp
-wGP
+tuq
 qBp
 qxB
 wGP
@@ -112692,7 +112726,7 @@ csd
 csd
 csd
 cAP
-wGP
+wMG
 cDG
 cFB
 ddb
@@ -114202,7 +114236,7 @@ cwv
 cxS
 czv
 dce
-wGP
+wMG
 cDK
 eXp
 cGY

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -5612,20 +5612,20 @@
 "aGm" = (
 /obj/table/auto,
 /obj/item/robot_module{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/robot_module{
+	pixel_x = -10;
+	pixel_y = -5
+	},
+/obj/item/robot_module{
 	pixel_x = 5;
 	pixel_y = 10
 	},
 /obj/item/robot_module{
 	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/hand_labeler{
-	pixel_x = -10;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/glass/oilcan{
-	pixel_x = -8;
-	pixel_y = 3
+	pixel_y = -5
 	},
 /turf/simulated/floor/black/side{
 	dir = 9
@@ -28585,6 +28585,10 @@
 	pixel_x = 10;
 	pixel_y = 3
 	},
+/obj/item/reagent_containers/glass/oilcan{
+	pixel_x = -8;
+	pixel_y = 3
+	},
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -36316,6 +36320,13 @@
 /obj/item/item_box/assorted/stickers/stickers_limited,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)
+"ozE" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "ozI" = (
 /obj/item/device/radio/beacon,
 /obj/disposalpipe/segment/food{
@@ -38656,13 +38667,6 @@
 /obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
-"pOX" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/window_blinds/cog2/middle{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/robotics)
 "pPv" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -71919,7 +71923,7 @@ faS
 ogH
 oDs
 kqV
-pOX
+ozE
 aYy
 gLb
 aLX

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -6799,6 +6799,9 @@
 /area/station/medical/research)
 "aMZ" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "aNb" = (
@@ -7249,7 +7252,8 @@
 "aPJ" = (
 /obj/machinery/light_switch{
 	name = "S light switch";
-	pixel_y = -24
+	pixel_y = -24;
+	pixel_x = -4
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -7261,6 +7265,9 @@
 	icon_state = "1-4"
 	},
 /obj/landmark/start/job/cyborg,
+/obj/blind_switch/area/south{
+	pixel_x = 4
+	},
 /turf/simulated/floor/black/side,
 /area/station/medical/robotics)
 "aPL" = (
@@ -7299,6 +7306,7 @@
 	icon_state = "0-2"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "aPV" = (
@@ -8823,6 +8831,9 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/window_blinds/cog2/middle{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
@@ -20167,6 +20178,9 @@
 	dir = 4
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "fbi" = (
@@ -28765,6 +28779,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -36469,6 +36486,9 @@
 	dir = 4
 	},
 /obj/mapping_helper/access/robotics,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -38636,6 +38656,13 @@
 /obj/landmark/start/job/technical_trainee,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
+"pOX" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "pPv" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -71892,7 +71919,7 @@ faS
 ogH
 oDs
 kqV
-aMZ
+pOX
 aYy
 gLb
 aLX

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -31628,6 +31628,7 @@
 /obj/item/device/analyzer/healthanalyzer,
 /obj/item/scissors/surgical_scissors,
 /obj/item/scissors/surgical_scissors,
+/obj/item/surgical_spoon,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "lSd" = (
@@ -48955,17 +48956,6 @@
 /area/station/maintenance/west)
 "vLU" = (
 /obj/storage/crate/robotics_supplies_borg,
-/obj/item/circular_saw{
-	pixel_x = 3;
-	pixel_y = 12
-	},
-/obj/item/scalpel,
-/obj/item/scissors/surgical_scissors,
-/obj/item/hemostat,
-/obj/item/suture,
-/obj/item/surgical_spoon{
-	pixel_y = -5
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -21200,10 +21200,6 @@
 /turf/simulated/floor/yellowblack,
 /area/station/engine/engineering)
 "guU" = (
-/obj/decal/poster/wallsign/poster_borg{
-	pixel_x = 22;
-	pixel_y = 4
-	},
 /obj/item/device/radio/intercom/medical{
 	pixel_x = 7;
 	pixel_y = 21
@@ -21214,6 +21210,10 @@
 	pixel_y = 24
 	},
 /obj/surgery_tray,
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 5
+	},
 /turf/simulated/floor/blue,
 /area/station/medical/robotics)
 "gvh" = (
@@ -22005,9 +22005,7 @@
 /area/station/quartermaster/office)
 "gIH" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/window_blinds/cog2/right{
-	id = "chemistry"
-	},
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "gIT" = (
@@ -52710,6 +52708,9 @@
 	pixel_x = -6;
 	pixel_y = -1
 	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -4
+	},
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
@@ -62901,15 +62902,20 @@
 "toz" = (
 /obj/table/reinforced/auto,
 /obj/item/robot_module{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/robot_module{
+	pixel_x = -10;
+	pixel_y = -5
+	},
+/obj/item/robot_module{
 	pixel_x = 5;
 	pixel_y = 10
 	},
 /obj/item/robot_module{
 	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -4
+	pixel_y = -5
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/robotics)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -15969,6 +15969,9 @@
 /area/station/medical/robotics)
 "boW" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "boX" = (
@@ -26311,6 +26314,11 @@
 /obj/machinery/r_door_control/podbay/medbay,
 /turf/simulated/wall/auto/supernorn,
 /area/station/hangar/medical)
+"cgk" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle,
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "cgl" = (
 /obj/machinery/vehicle/miniputt/armed{
 	dir = 1
@@ -28063,20 +28071,19 @@
 /area/station/quartermaster/office)
 "com" = (
 /obj/table/auto,
-/obj/item/weldingtool,
-/obj/item/device/prox_sensor{
-	pixel_x = 2;
-	pixel_y = 8;
-	rand_pos = 0
+/obj/item/weldingtool{
+	pixel_y = 6;
+	pixel_x = -4
 	},
-/obj/item/clothing/head/helmet/welding,
+/obj/item/clothing/head/helmet/welding{
+	pixel_x = 4;
+	pixel_y = 4
+	},
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/item/bandage,
-/obj/item/bandage,
 /turf/simulated/floor/caution/east,
 /area/station/medical/robotics)
 "con" = (
@@ -29285,6 +29292,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
+"cNP" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/blind_switch/area/east{
+	pixel_y = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "cNX" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/gas_sensor{
@@ -30455,19 +30472,8 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "dDU" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/emergency{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/drinks/fueltank{
-	pixel_x = -7;
-	pixel_y = -8
-	},
-/obj/item/reagent_containers/glass/oilcan{
-	pixel_x = 6;
-	pixel_y = -7
-	},
 /obj/machinery/light_switch/west,
+/obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/caution/east,
 /area/station/medical/robotics)
 "dET" = (
@@ -30774,6 +30780,9 @@
 "dPr" = (
 /obj/machinery/portable_reclaimer,
 /obj/machinery/light_switch/east,
+/obj/blind_switch/area/east{
+	pixel_y = 8
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "dPz" = (
@@ -32928,10 +32937,14 @@
 /area/station/crew_quarters/fitness)
 "fjF" = (
 /obj/table/auto,
-/obj/item/storage/box/stma_kit,
 /obj/item/reagent_containers/iv_drip/saline,
 /obj/item/staple_gun,
-/obj/item/clothing/gloves/latex,
+/obj/submachine/chef_sink/chem_sink{
+	dir = 4;
+	pixel_x = -5
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/clothing/mask/surgical_shield,
 /turf/simulated/floor/caution/east,
 /area/station/medical/robotics)
 "fjV" = (
@@ -37300,6 +37313,9 @@
 "ioI" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail/vertical,
+/obj/window_blinds/cog2/middle{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "ioV" = (
@@ -43249,16 +43265,17 @@
 /area/station/mining/refinery)
 "mpA" = (
 /obj/table/auto,
-/obj/item/scalpel,
+/obj/item/scalpel{
+	pixel_y = 7
+	},
 /obj/item/circular_saw{
-	pixel_x = 3;
 	pixel_y = 12
 	},
 /obj/item/suture,
-/obj/item/clothing/mask/surgical_shield,
 /obj/machinery/firealarm/west,
 /obj/item/hemostat,
-/obj/item/hemostat,
+/obj/item/scissors/surgical_scissors,
+/obj/item/surgical_spoon,
 /turf/simulated/floor/caution/east,
 /area/station/medical/robotics)
 "mpI" = (
@@ -43893,6 +43910,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"mNb" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/middle{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "mNo" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -44557,6 +44581,14 @@
 /obj/item/cell/supercell/charged,
 /obj/item/cell/supercell/charged,
 /obj/item/cell/supercell/charged,
+/obj/item/robot_module{
+	pixel_x = 12;
+	pixel_y = 9
+	},
+/obj/item/robot_module{
+	pixel_x = 12;
+	pixel_y = -3
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "nmt" = (
@@ -47593,9 +47625,22 @@
 	})
 "pFF" = (
 /obj/table/auto,
-/obj/item/sheet/steel/fullstack,
-/obj/item/storage/box/cablesbox,
+/obj/item/sheet/steel/fullstack{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/storage/box/cablesbox{
+	pixel_x = 8
+	},
 /obj/machinery/light,
+/obj/item/robot_module{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/robot_module{
+	pixel_x = -6;
+	pixel_y = 9
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "pFI" = (
@@ -51532,6 +51577,14 @@
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
+"svC" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/mail/vertical,
+/obj/window_blinds/cog2/middle{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "svH" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
@@ -59058,18 +59111,22 @@
 /area/space)
 "xGH" = (
 /obj/table/auto,
-/obj/item/storage/belt/utility,
 /obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = -7;
+	pixel_y = -8
+	},
+/obj/item/reagent_containers/glass/oilcan{
+	pixel_x = 6;
+	pixel_y = -7
 	},
 /obj/item/device/multitool{
-	pixel_x = -7;
-	pixel_y = 1
+	pixel_y = -8
 	},
-/obj/item/crowbar,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -1;
-	pixel_y = -9
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 5
 	},
 /turf/simulated/floor/caution/east,
 /area/station/medical/robotics)
@@ -93473,7 +93530,7 @@ aBE
 aBE
 bim
 bip
-aRu
+cNP
 oFF
 aRu
 aRu
@@ -96195,7 +96252,7 @@ bjM
 aXB
 pUv
 cgN
-boW
+cgk
 xhT
 chR
 cpd
@@ -96497,7 +96554,7 @@ bjN
 ivQ
 ivQ
 bnI
-ioI
+svC
 ioI
 cif
 oOz
@@ -97102,7 +97159,7 @@ rLG
 rLG
 rLG
 uxI
-boW
+mNb
 boW
 cpv
 dPr

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -17301,22 +17301,6 @@
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/hall)
 "hxL" = (
-/obj/table/reinforced/auto,
-/obj/item/scalpel,
-/obj/item/scalpel,
-/obj/item/circular_saw{
-	pixel_x = 3;
-	pixel_y = -11
-	},
-/obj/item/circular_saw{
-	pixel_x = 3;
-	pixel_y = -12
-	},
-/obj/item/scissors/surgical_scissors{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/obj/item/scissors/surgical_scissors,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-8"
@@ -17326,6 +17310,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
+/obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "hxU" = (
@@ -22159,7 +22144,9 @@
 "jxY" = (
 /obj/stool/chair/office,
 /obj/landmark/start/job/roboticist,
-/obj/machinery/firealarm/north,
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 12
+	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "jyf" = (
@@ -24871,10 +24858,20 @@
 	pixel_x = 10
 	},
 /obj/item/robot_module{
-	pixel_x = -9
+	pixel_x = -10;
+	pixel_y = -5
 	},
 /obj/item/robot_module{
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/robot_module{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/robot_module{
+	pixel_x = 5;
+	pixel_y = 10
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/robotics)
@@ -41470,6 +41467,12 @@
 /obj/item/hemostat{
 	pixel_y = 6
 	},
+/obj/item/scissors/surgical_scissors,
+/obj/item/circular_saw{
+	pixel_x = 3;
+	pixel_y = -12
+	},
+/obj/item/scalpel,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "rVE" = (
@@ -44878,6 +44881,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "txe" = (

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -2600,6 +2600,14 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/chemistry)
+"bZq" = (
+/obj/machinery/optable,
+/obj/machinery/drainage,
+/obj/machinery/ai_status_display{
+	pixel_y = 28
+	},
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "bZx" = (
 /obj/machinery/firealarm/south,
 /obj/stool/chair{
@@ -8741,11 +8749,10 @@
 	},
 /area/station/hallway/primary/central)
 "gfg" = (
-/obj/machinery/optable,
-/obj/machinery/ai_status_display{
-	pixel_y = 28
+/obj/machinery/computer/operating/small,
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 8
 	},
-/obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "gfz" = (
@@ -14365,11 +14372,11 @@
 /turf/simulated/floor/carpet/blue/decal/innercross,
 /area/station/bridge)
 "kel" = (
-/obj/landmark/start/job/cyborg,
 /obj/disposalpipe/segment/mail{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "kfa" = (
@@ -19357,7 +19364,7 @@
 "nMA" = (
 /obj/table/auto,
 /obj/item/robot_module{
-	pixel_x = 4;
+	pixel_x = 12;
 	pixel_y = 6
 	},
 /obj/machinery/disposal/small/east,
@@ -19369,7 +19376,16 @@
 	},
 /obj/disposalpipe/trunk/north,
 /obj/item/robot_module{
-	pixel_x = 4
+	pixel_x = -2;
+	pixel_y = -8
+	},
+/obj/item/robot_module{
+	pixel_y = 6;
+	pixel_x = -2
+	},
+/obj/item/robot_module{
+	pixel_x = 12;
+	pixel_y = -8
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
@@ -21307,6 +21323,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/landmark/start/job/cyborg,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "pnm" = (
@@ -31454,7 +31471,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/computer/operating/small,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "wjm" = (
@@ -71940,7 +71956,7 @@ jOL
 jOL
 fxY
 fxY
-fxY
+jOL
 pYu
 eCB
 qgk
@@ -72546,7 +72562,7 @@ lOS
 jOL
 jOL
 uBi
-jOL
+wtb
 wtb
 wtb
 wtb
@@ -72849,7 +72865,7 @@ eCB
 rcD
 rML
 wtb
-wtb
+bZq
 bOJ
 utH
 giI

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -5139,11 +5139,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "dLN" = (
-/obj/storage/crate,
-/obj/item/record/atlas,
-/obj/item/clothing/shoes/cowboy,
-/obj/item/clothing/under/misc/tourist/max_payne,
-/obj/item/clothing/head/cowboy,
+/obj/random_item_spawner/gross_with_junk/one_or_zero,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "dLU" = (
@@ -18901,6 +18900,10 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/research_outpost/hangar)
+"nsE" = (
+/obj/storage/closet/emergency,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "nsO" = (
 /obj/rack,
 /obj/item/clothing/shoes/flippers{
@@ -20253,6 +20256,23 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
+"otf" = (
+/obj/rack,
+/obj/item/extinguisher{
+	pixel_x = 9
+	},
+/obj/item/clothing/suit/hazard/fire,
+/obj/item/clothing/head/helmet/firefighter{
+	pixel_x = 5;
+	pixel_y = 13
+	},
+/obj/item/tank/air,
+/obj/item/clothing/mask/gas/emergency{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "otn" = (
 /obj/machinery/lawrack,
 /obj/cable{
@@ -23905,9 +23925,6 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/hangar/science)
 "rcD" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -24661,6 +24678,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
+"rFa" = (
+/obj/random_item_spawner/gross_with_junk/one_or_zero,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "rFL" = (
 /obj/machinery/networked/artifact_console,
 /obj/machinery/power/data_terminal,
@@ -24862,9 +24886,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge)
 "rML" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -29714,20 +29735,11 @@
 /turf/simulated/floor/plating,
 /area/derelict_diner)
 "vff" = (
-/obj/rack,
-/obj/item/clothing/suit/hazard/fire,
-/obj/item/tank/air,
-/obj/item/extinguisher{
-	pixel_x = 9
-	},
-/obj/item/clothing/mask/gas/emergency{
-	pixel_x = 4;
-	pixel_y = 5
-	},
-/obj/item/clothing/head/helmet/firefighter{
-	pixel_x = 5;
-	pixel_y = 13
-	},
+/obj/storage/crate,
+/obj/item/clothing/head/cowboy,
+/obj/item/clothing/under/misc/tourist/max_payne,
+/obj/item/clothing/shoes/cowboy,
+/obj/item/record/atlas,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "vfw" = (
@@ -30266,6 +30278,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/tech_outpost)
+"vzh" = (
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "vzo" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/plate,
@@ -31673,6 +31689,10 @@
 /mob/living/critter/aquatic/shark,
 /turf/space/fluid,
 /area/space/plasma_reef)
+"wqd" = (
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "wql" = (
 /obj/machinery/vending/jobclothing/security,
 /obj/item/device/radio/intercom/security,
@@ -70738,16 +70758,16 @@ qpn
 qpn
 qpn
 qpn
-qpn
-qpn
-qpn
-qpn
-qpn
-qpn
-qpn
-qpn
-qpn
-qpn
+eUE
+cvu
+cvu
+cvu
+eUE
+cvu
+cvu
+cvu
+eUE
+eUE
 eUE
 jOL
 jOL
@@ -71040,17 +71060,17 @@ qpn
 qpn
 qpn
 qpn
-eUE
 cvu
-cvu
-cvu
-eUE
-cvu
-cvu
-cvu
-eUE
-eUE
-eUE
+jOL
+jOL
+wBS
+fxY
+jOL
+jOL
+wBS
+fxY
+vff
+fxY
 jOL
 jOL
 jOL
@@ -71345,13 +71365,13 @@ qpn
 cvu
 jOL
 jOL
-wBS
+jOL
 fxY
 jOL
 jOL
-wBS
-fxY
-dLN
+jOL
+kmn
+uck
 fxY
 jOL
 jOL
@@ -71652,8 +71672,8 @@ fxY
 jOL
 jOL
 jOL
-kmn
-uck
+fxY
+fxY
 fxY
 fxY
 qYs
@@ -71946,16 +71966,16 @@ qpn
 qpn
 qpn
 qpn
-cvu
-jOL
-jOL
-jOL
+eUE
 fxY
-jOL
-jOL
-jOL
+qYs
 fxY
 fxY
+fxY
+qYs
+fxY
+fxY
+jOL
 jOL
 pYu
 eCB
@@ -72249,14 +72269,14 @@ fXA
 wSs
 qpn
 eUE
-fxY
-qYs
-fxY
-fxY
-fxY
-qYs
-fxY
-fxY
+vzh
+jOL
+lOS
+jOL
+jOL
+jOL
+jOL
+jOL
 jOL
 cVY
 dLu
@@ -72551,17 +72571,17 @@ upz
 wSs
 qpn
 eUE
-vff
 jOL
-jOL
-jOL
-jOL
-jOL
-jOL
-lOS
-jOL
-jOL
-uBi
+pYu
+eCB
+eCB
+eCB
+eCB
+eCB
+dLN
+eCB
+eCB
+rFa
 wtb
 wtb
 wtb
@@ -72854,14 +72874,14 @@ wSs
 dxs
 eUE
 jOL
-pYu
-eCB
-dAs
-eCB
-eCB
-eCB
-eCB
-eCB
+dLu
+jOL
+lOS
+otf
+wqd
+nsE
+jOL
+jOL
 rcD
 rML
 wtb

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -1802,6 +1802,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "agj" = (
@@ -1812,34 +1813,56 @@
 /obj/machinery/cell_charger,
 /obj/item/cell/supercell/charged,
 /obj/item/cell/supercell/charged,
-/obj/item/crowbar,
 /obj/item/device/multitool{
-	pixel_x = -7;
+	pixel_x = -12;
 	pixel_y = 1
 	},
 /obj/item/device/multitool{
-	pixel_x = -7;
+	pixel_x = -12;
 	pixel_y = 1
 	},
 /obj/machinery/light/incandescent/cool/very,
+/obj/item/reagent_containers/glass/oilcan{
+	pixel_y = 12;
+	pixel_x = 8
+	},
+/obj/item/storage/belt/utility{
+	pixel_y = 12;
+	pixel_x = -6
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 8
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "agl" = (
 /obj/table/reinforced/auto,
 /obj/machinery/power/apc/autoname_north,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/reagent_containers/glass/oilcan,
-/obj/item/reagent_containers/glass/oilcan,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/item/hand_labeler,
+/obj/item/robot_module{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/robot_module{
+	pixel_x = -10;
+	pixel_y = -5
+	},
+/obj/item/robot_module{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/obj/item/robot_module{
+	pixel_x = 5;
+	pixel_y = -5
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "agq" = (
@@ -9501,8 +9524,12 @@
 /area/station/maintenance/inner/central)
 "aGI" = (
 /obj/storage/crate,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
 /obj/item/rubber_hammer,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
@@ -12676,7 +12703,9 @@
 /area/space)
 "aUh" = (
 /obj/table/round/auto,
-/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
 /turf/space/fluid,
 /area/space)
 "aUi" = (
@@ -19213,8 +19242,12 @@
 /area/station/crew_quarters/info)
 "bvO" = (
 /obj/storage/crate,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor,
 /area/station/hangar/main)
@@ -26140,8 +26173,12 @@
 /turf/simulated/floor/damaged4,
 /area/station/storage/warehouse)
 "bUB" = (
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
 /turf/simulated/floor/plating/random,
 /area/station/storage/warehouse)
 "bUC" = (
@@ -29341,7 +29378,9 @@
 /area/station/engine/engineering)
 "cgB" = (
 /obj/table/auto,
-/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "cgC" = (
@@ -30088,7 +30127,9 @@
 /turf/simulated/floor/grime,
 /area/station/maintenance/inner/central)
 "ckI" = (
-/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/inner/central)
 "ckJ" = (
@@ -40558,6 +40599,13 @@
 	icon_state = "green1"
 	},
 /area/station/crew_quarters/hop)
+"pgc" = (
+/obj/submachine/chef_sink/chem_sink{
+	desc = "A water-filled unit intended for hand-washing purposes.";
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "pgK" = (
 /obj/item/currency/spacecash/tourist,
 /obj/item/reagent_containers/food/drinks/bottle/rum,
@@ -41951,7 +41999,9 @@
 "qZZ" = (
 /obj/machinery/light/incandescent/harsh,
 /obj/storage/crate,
-/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
 /obj/item/weldingtool,
 /obj/item/weldingtool,
 /turf/simulated/floor,
@@ -46387,8 +46437,12 @@
 /obj/item/reagent_containers/food/drinks/bottle/soda,
 /obj/item/reagent_containers/food/drinks/bottle/soda,
 /obj/item/reagent_containers/food/drinks/bottle/soda,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
 /obj/item/reagent_containers/emergency_injector/calomel,
 /obj/item/reagent_containers/emergency_injector/calomel,
 /obj/machinery/light_switch/auto,
@@ -47088,7 +47142,9 @@
 /obj/item/shipcomponent/mainweapon/bad_mining,
 /obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/item/storage/toolbox/mechanical,
-/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 10
+	},
 /obj/item/weldingtool,
 /obj/item/crowbar,
 /obj/item/device/gps,
@@ -96541,7 +96597,7 @@ akB
 agj
 agj
 agj
-agj
+pgc
 agA
 ajQ
 mNG


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[MAPPING][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Standardizes the equipment and tools that spawn in robotics across all maps. Adds blinds, anesthetic storage lockers, sinks, modules, and missing surgical tools wherever required. Also cleans up some largely unnecessary table clutter to make room for some of these adjustments.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not all robotics are made equal. This attempts to address that with some minor QoL tweaks that roboticists may find helpful. Blinds are available to allow for a bit more crime or questionable surgery, sinks for cleaning, and anesthesia is now available right within the lab in all maps. Some maps were even lacking basic tools or had odd duplicates that were unnecessary (cough cough Kondaru and its zero surgical scissors / spoon / modules), so this also adjusts some of the tool spawns. Were they gamebreaking issues? No. Did they bother the roboticist main in me? Yes.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested all maps that I changed within this PR. Tested the blinds to ensure they close and generally just doublechecked that everything works as intended. Screenshots of each departmental change to follow.

<img width="618" height="624" alt="{D18269A7-BAF2-4163-BE9D-275CA3A6FDD7}" src="https://github.com/user-attachments/assets/245a7048-9900-42c7-a558-e12fcebeb338" />

<img width="828" height="635" alt="{62ADC445-AE66-4B55-9F25-BAACD84228EA}" src="https://github.com/user-attachments/assets/aa426667-f10b-4f20-a55d-af0322d618b3" />

<img width="770" height="669" alt="{80FE7F18-8EE7-4114-BC59-8A1C30DA4FBB}" src="https://github.com/user-attachments/assets/e797ffb6-0c08-4032-8b7c-4021b9e631d6" />

<img width="557" height="691" alt="{54D4DCCB-FF32-4C0F-AE65-613C18A190A8}" src="https://github.com/user-attachments/assets/628b0d4b-1e96-41e9-bdd5-1dc168d520cd" />

<img width="751" height="504" alt="{6DCCA105-3EC2-47C3-9244-F175B6908B47}" src="https://github.com/user-attachments/assets/8d95382d-2431-4a9f-b57b-def2adc5adaa" />

<img width="689" height="519" alt="{93188F90-7949-4083-8020-41BD279BA75A}" src="https://github.com/user-attachments/assets/963c3b1e-d9a2-46dc-9ed0-0940b1520181" />

<img width="567" height="698" alt="{E754AFDA-3C2C-4044-BB26-86AE2DA83752}" src="https://github.com/user-attachments/assets/4d24a7ac-65be-4ff1-bc1a-56dce7f0b01c" />

<img width="430" height="478" alt="{0450DFAE-D778-475A-BEF6-FF7DEDD67522}" src="https://github.com/user-attachments/assets/a17ced36-e710-4b06-9598-9dd7cafd5f39" />


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

```changelog
(u)TheGeneralJay
(*)Standardized available equipment that spawns in robotics across each map. See minor changes for details.
(+)All current-rotation robotics departments have been equipped with blinds (yay, crime!), anesthetic storage lockers, sinks, modules, and other minor QoL tweaks.
```
