### PR TITLE
Yet another attempt to fix the issue stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,11 +1,12 @@
 name: "Close stale PRs and unreproduced issues"
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "45 0 * * *"
 
 permissions:
   issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   stale:
@@ -30,3 +31,4 @@ jobs:
           ignore-issue-updates: true
           close-issue-reason: "not_planned"
           remove-issue-stale-when-updated: false
+          operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: "Close stale PRs and unreproduced issues"
 on:
   schedule:
-    - cron: "45 0 * * *"
+    - cron: "45 0,12 * * *"
 
 permissions:
   issues: write


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Adds `actions: write` permissions to the stale workflow because according to this PR https://github.com/actions/stale/pull/1248 we need them to bust the cache because there's two things happening in the same workflow. Confusing? Yes!
- Ups `operations-per-run` to 100, from the default of 30, because I noticed we're really not processing very many issues for a daily job on a repo this size: https://github.com/goonstation/goonstation/actions/runs/16584399453/job/46906833729
- Changes the cron config to run at 45 minute past the hour to avoid our stuff getting dropped by panicking github servers as they try to process the 00:00UTC hell rush aand also schedule it to run every 12 hours instead of 24.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Issue stale workflow should frickin work!!!