### PR TITLE
Convert job categories to be a list

### DIFF
--- a/_std/defines/jobs.dm
+++ b/_std/defines/jobs.dm
@@ -52,6 +52,8 @@
 #define JOB_CIVILIAN "civilian"
 #define JOB_CREATED "created"
 
+#define JOB_CATEGORY_PRIMARY 1
+
 // Job categories
 #define STAPLE_JOBS (1<<0)
 #define SPECIAL_JOBS (1<<1)

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -21,7 +21,7 @@ ABSTRACT_TYPE(/datum/job)
 	var/limit = -1
 	var/list/trait_list = list() // specific job trait string, i.e. "training_security"
 	/// job category flag for use with loops rather than a needing a bunch of type checks
-	var/job_category = JOB_SPECIAL
+	var/job_categories = list(JOB_SPECIAL)
 	var/upper_limit = null //! defaults to `limit`
 	var/lower_limit = 0
 	var/admin_set_limit = FALSE //! has an admin manually set the limit to something
@@ -256,7 +256,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	slot_card = /obj/item/card/id/command
 	map_can_autooverride = FALSE
 	invalid_antagonist_roles = list(ROLE_HEAD_REVOLUTIONARY, ROLE_GANG_MEMBER, ROLE_GANG_LEADER, ROLE_SPY_THIEF, ROLE_CONSPIRATOR)
-	job_category = JOB_COMMAND
+	job_categories = list(JOB_COMMAND)
 	unique = TRUE
 
 	special_setup(mob/M, no_special_spawn)
@@ -472,7 +472,7 @@ ABSTRACT_TYPE(/datum/job/security)
 	linkcolor = SECURITY_LINK_COLOR
 	slot_card = /obj/item/card/id/security
 	receives_miranda = TRUE
-	job_category = JOB_SECURITY
+	job_categories = list(JOB_SECURITY)
 
 /datum/job/security/security_officer
 	name = "Security Officer"
@@ -578,7 +578,7 @@ ABSTRACT_TYPE(/datum/job/research)
 /datum/job/research
 	linkcolor = RESEARCH_LINK_COLOR
 	slot_card = /obj/item/card/id/research
-	job_category = JOB_RESEARCH
+	job_categories = list(JOB_RESEARCH)
 
 /datum/job/research/scientist
 	name = "Scientist"
@@ -618,7 +618,7 @@ ABSTRACT_TYPE(/datum/job/medical)
 /datum/job/medical
 	linkcolor = MEDICAL_LINK_COLOR
 	slot_card = /obj/item/card/id/medical
-	job_category = JOB_MEDICAL
+	job_categories = list(JOB_MEDICAL)
 
 /datum/job/medical/medical_doctor
 	name = "Medical Doctor"
@@ -714,7 +714,7 @@ ABSTRACT_TYPE(/datum/job/engineering)
 /datum/job/engineering
 	linkcolor = ENGINEERING_LINK_COLOR
 	slot_card = /obj/item/card/id/engineering
-	job_category = JOB_ENGINEERING
+	job_categories = list(JOB_ENGINEERING)
 
 /datum/job/engineering/engineer
 	name = "Engineer"
@@ -829,7 +829,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 /datum/job/civilian
 	linkcolor = CIVILIAN_LINK_COLOR
 	slot_card = /obj/item/card/id/civilian
-	job_category = JOB_CIVILIAN
+	job_categories = list(JOB_CIVILIAN)
 
 /datum/job/civilian/chef
 	name = "Chef"
@@ -3094,7 +3094,7 @@ ABSTRACT_TYPE(/datum/job/special/pod_wars)
 
 /datum/job/created
 	name = "Special Job"
-	job_category = JOB_CREATED
+	job_categories = list(JOB_CREATED)
 
 	//handle special spawn location
 	Write(F)

--- a/code/modules/admin/job_manager.dm
+++ b/code/modules/admin/job_manager.dm
@@ -18,11 +18,11 @@
 	var/list/special_job_data = list()
 	var/list/hidden_job_data = list()
 	for (var/datum/job/job in job_controls.staple_jobs)
-		staple_job_data += list(list(name = job.name, type = job.job_category, count = countJob(job.name), limit = job.limit))
+		staple_job_data += list(list(name = job.name, type = job.job_categories[JOB_CATEGORY_PRIMARY], count = countJob(job.name), limit = job.limit))
 	for (var/datum/job/job in job_controls.special_jobs)
-		special_job_data += list(list(name = job.name, type = job.job_category, count = countJob(job.name), limit = job.limit))
+		special_job_data += list(list(name = job.name, type = job.job_categories[JOB_CATEGORY_PRIMARY], count = countJob(job.name), limit = job.limit))
 	for (var/datum/job/job in job_controls.hidden_jobs)
-		hidden_job_data += list(list(name = job.name, type = job.job_category, count = countJob(job.name), limit = job.limit))
+		hidden_job_data += list(list(name = job.name, type = job.job_categories[JOB_CATEGORY_PRIMARY], count = countJob(job.name), limit = job.limit))
 	. = list(
 		"stapleJobs" = staple_job_data,
 		"specialJobs" = special_job_data,

--- a/code/modules/admin/jobban.dm
+++ b/code/modules/admin/jobban.dm
@@ -74,15 +74,15 @@
 				return TRUE
 
 		if(cache.Find("Engineering Department"))
-			if(J.job_category == JOB_ENGINEERING || istype(J, /datum/job/command/chief_engineer))
+			if(JOB_ENGINEERING in J.job_categories || istype(J, /datum/job/command/chief_engineer))
 				return TRUE
 
 		if(cache.Find("Security Department") || cache.Find("Security Officer"))
-			if(J.job_category == JOB_SECURITY || istype(J, /datum/job/command/head_of_security))
+			if(JOB_SECURITY in J.job_categories || istype(J, /datum/job/command/head_of_security))
 				return TRUE
 
 		if(cache.Find("Heads of Staff"))
-			if(J.job_category == JOB_COMMAND)
+			if(JOB_COMMAND in J.job_categories)
 				return TRUE
 
 	if(cache.Find("Ghostdrone"))


### PR DESCRIPTION
[CLEANUP][INTERNAL]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Converts the job category var on job datums into a list, of which only the "primary category" (first in the list) is used to sort jobs in the job panel

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows jobs to have multiple categories and eventually replace the lists of jobs in code\lists\jobs.dm. For example Chief Engineer could be a Command and Engineering role, removing the need for the extra check for CE in engineering department jobbans.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Currently this only changes the job panel and departmental bans, I can confirm the job panel still shows the exact same as before the changes, I have not yet tested department job bans.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
