### PR TITLE
UpdatePaths Camera Script Fixes

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -6976,7 +6976,6 @@
 "aRo" = (
 /obj/machinery/vending/cola/red,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/black,
@@ -16556,7 +16555,6 @@
 /area/station/hallway/primary/east)
 "nDN" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/securearea{
@@ -18919,7 +18917,6 @@
 	},
 /obj/cable,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/item/device/radio/intercom/mining{

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -167,7 +167,6 @@
 "aaA" = (
 /obj/shrub,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -11
 	},
 /turf/simulated/floor/grass/random/alt,
@@ -457,7 +456,6 @@
 	dir = 10
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/item/reagent_containers/food/fish/salmon,
@@ -705,7 +703,6 @@
 "adR" = (
 /obj/shrub,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/grass/random/alt,
@@ -2302,7 +2299,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/sanitary/white,
@@ -3027,7 +3023,6 @@
 "aAf" = (
 /obj/storage/closet/coffin,
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /turf/simulated/floor/black,
@@ -3215,7 +3210,6 @@
 "aBe" = (
 /obj/disposalpipe/segment,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/wood{
@@ -3397,7 +3391,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/black/side{
@@ -3425,7 +3418,6 @@
 /area/station/crew_quarters/kitchen/freezer)
 "aCL" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/caution/west,
@@ -3818,7 +3810,6 @@
 /obj/item/storage/toolbox/electrical,
 /obj/random_item_spawner/tools,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/orangeblack/side{
@@ -3860,7 +3851,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /turf/simulated/floor/wood,
@@ -4109,7 +4099,6 @@
 /obj/item/storage/firstaid/toxin,
 /obj/item/clothing/glasses/sunglasses,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/engine,
@@ -4283,7 +4272,6 @@
 /area/station/engine/inner)
 "aJs" = (
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /turf/simulated/floor/blackwhite{
@@ -4528,7 +4516,6 @@
 	},
 /obj/disposalpipe/segment,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/stairs{
@@ -4774,7 +4761,6 @@
 "aMt" = (
 /obj/storage/secure/closet/civilian/janitor,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/carpet/purple/standard/edge/north,
@@ -4803,7 +4789,6 @@
 /area/station/crew_quarters/diplomat)
 "aMF" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/table/wood/auto/desk,
@@ -5271,7 +5256,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/caution/north{
@@ -5909,7 +5893,6 @@
 /area/station/bridge)
 "aVz" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/item/device/radio/intercom/security{
@@ -6139,7 +6122,6 @@
 	icon_state = "line1"
 	},
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /turf/simulated/floor,
@@ -6274,7 +6256,6 @@
 /area/station/science/bot_storage)
 "aYy" = (
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /obj/decal/stripe_caution,
@@ -6382,7 +6363,6 @@
 "aZf" = (
 /obj/machinery/vending/air_vendor/plasma,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /obj/machinery/firealarm/north,
@@ -6404,7 +6384,6 @@
 /obj/table/reinforced/auto,
 /obj/machinery/phone,
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /turf/simulated/floor,
@@ -7056,7 +7035,6 @@
 /area/station/hallway/primary/southeast)
 "bdV" = (
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = 5
 	},
 /obj/machinery/light_switch/west{
@@ -7186,7 +7164,6 @@
 	icon_state = "line2"
 	},
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /turf/simulated/floor/circuit,
@@ -7316,7 +7293,6 @@
 "bgp" = (
 /obj/machinery/vending/medical_public,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/blueblack{
@@ -7378,7 +7354,6 @@
 /area/station/ai_monitored/armory)
 "bgE" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/machinery/light/emergency{
@@ -8131,7 +8106,6 @@
 	},
 /obj/machinery/vending/medical_public,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor{
@@ -9235,7 +9209,6 @@
 	pixel_y = 28
 	},
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor,
@@ -10176,7 +10149,6 @@
 	pixel_x = 10
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/red/side{
@@ -10515,7 +10487,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/red/side{
@@ -11298,7 +11269,6 @@
 /area/station/ranch)
 "bUU" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/submachine/ATM{
@@ -12119,7 +12089,6 @@
 /area/station/crew_quarters/barber_shop)
 "cxb" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/disposalpipe/segment{
@@ -14075,7 +14044,6 @@
 /obj/stool/chair/blue,
 /obj/landmark/start/job/assistant,
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /turf/simulated/floor/blueblack{
@@ -14264,7 +14232,6 @@
 	pixel_y = 8
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/blind_switch/area/east{
@@ -14821,7 +14788,6 @@
 /area/station/medical/medbay/lobby)
 "eJJ" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/cable{
@@ -14846,7 +14812,6 @@
 	},
 /obj/item/device/radio/intercom/engineering,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /obj/machinery/atmospherics/binary/valve{
@@ -14962,7 +14927,6 @@
 	dir = null
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/yellow,
@@ -16006,7 +15970,6 @@
 /obj/item/paper_bin,
 /obj/item/stamp,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/item/paper_bin/artifact_paper{
@@ -16433,7 +16396,6 @@
 	pixel_x = -1
 	},
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = 5
 	},
 /turf/simulated/floor/white/checker2{
@@ -16901,7 +16863,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /obj/storage/secure/closet/command/research_director,
@@ -17173,7 +17134,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/machinery/computer/general_alert{
@@ -17253,7 +17213,6 @@
 /area/station/crew_quarters/kitchen)
 "gyG" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/machinery/clothingbooth,
@@ -17427,7 +17386,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/engine,
@@ -18355,7 +18313,6 @@
 /obj/item/pen/pencil,
 /obj/item/reagent_containers/food/drinks/water,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /obj/machinery/light{
@@ -18709,7 +18666,6 @@
 	},
 /obj/fitness/weightlifter,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/grime,
@@ -18730,7 +18686,6 @@
 /area/station/maintenance/south)
 "hHL" = (
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/simulated/floor/plating,
@@ -19146,7 +19101,6 @@
 	},
 /obj/decoration/decorativeplant/plant2,
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /obj/item/device/radio/intercom/mining{
@@ -19884,7 +19838,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/white,
@@ -20025,7 +19978,6 @@
 /area/station/crew_quarters/quarters_west)
 "iAm" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/cable{
@@ -21083,7 +21035,6 @@
 	pixel_y = 9
 	},
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /obj/machinery/phone/wall{
@@ -21960,7 +21911,6 @@
 	dir = 5
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/engine,
@@ -22339,7 +22289,6 @@
 	pixel_y = 1
 	},
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /obj/decal/tile_edge/stripe/extra_big,
@@ -23016,7 +22965,6 @@
 	tag = ""
 	},
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /turf/simulated/floor{
@@ -23724,7 +23672,6 @@
 /area/station/engine/substation/west)
 "lhz" = (
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/plating,
@@ -24317,7 +24264,6 @@
 /area/station/security/hos)
 "lEV" = (
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /obj/machinery/light{
@@ -24461,7 +24407,6 @@
 "lIz" = (
 /obj/machinery/manufacturer/engineering,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/yellow,
@@ -24630,9 +24575,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "lMF" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/wood/two,
@@ -25393,7 +25337,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /obj/item/storage/wall/medical{
@@ -25798,7 +25741,6 @@
 "mHd" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/cable/orange{
@@ -26683,7 +26625,6 @@
 /obj/item/crowbar,
 /obj/item/crowbar,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/black,
@@ -26751,7 +26692,6 @@
 /area/station/engine/engineering)
 "nwl" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/disposalpipe/segment/mail,
@@ -26941,7 +26881,6 @@
 	pixel_y = 5
 	},
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/redblack{
@@ -27076,7 +27015,6 @@
 /area/station/teleporter)
 "nFM" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/filing_cabinet,
@@ -27133,7 +27071,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor{
@@ -28062,7 +27999,6 @@
 /area/station/crew_quarters/bar)
 "otN" = (
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -11
 	},
 /obj/machinery/light{
@@ -28324,7 +28260,6 @@
 /obj/disposalpipe/segment,
 /obj/table/reinforced/auto,
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /obj/machinery/networked/printer{
@@ -28589,7 +28524,6 @@
 /area/station/solar/east)
 "oOn" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/disposalpipe/segment/produce{
@@ -28758,7 +28692,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = 12
 	},
 /obj/machinery/manufacturer/medical,
@@ -28936,7 +28869,6 @@
 /area/station/hallway/primary/east)
 "pcg" = (
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /obj/pool/perspective{
@@ -29093,7 +29025,6 @@
 	},
 /obj/decal/stripe_delivery,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /obj/machinery/power/apc/autoname_north{
@@ -29740,7 +29671,6 @@
 	},
 /obj/item/clothing/glasses/healthgoggles,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/black,
@@ -30055,7 +29985,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /obj/disposalpipe/segment{
@@ -30314,7 +30243,6 @@
 	icon_state = "line1"
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/grass/random,
@@ -30877,7 +30805,6 @@
 /area/station/science/research_director)
 "qFe" = (
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /obj/rack,
@@ -31691,7 +31618,6 @@
 /area/station/crew_quarters/captain)
 "roW" = (
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /obj/machinery/coffeemaker/engineering,
@@ -32031,7 +31957,6 @@
 /obj/item/hand_labeler,
 /obj/item/storage/firstaid/regular,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/cable{
@@ -33242,7 +33167,6 @@
 "spY" = (
 /obj/machinery/centrifuge_nuclear,
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /turf/simulated/floor/yellow,
@@ -33584,7 +33508,6 @@
 /obj/item/pen/pencil,
 /obj/item/reagent_containers/food/drinks/water,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /obj/machinery/light{
@@ -33977,7 +33900,6 @@
 	pixel_y = 6
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/blind_switch/area/east{
@@ -34728,7 +34650,6 @@
 /area/station/science/lab)
 "tvY" = (
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /obj/blind_switch/area/west,
@@ -35309,7 +35230,6 @@
 "tQl" = (
 /obj/disposalpipe/segment,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 11
 	},
 /obj/blind_switch/area/east{
@@ -35647,7 +35567,6 @@
 "uaD" = (
 /obj/machinery/traymachine/morgue,
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = 5
 	},
 /turf/simulated/floor/sanitary/white,
@@ -35923,7 +35842,6 @@
 /area/station/crew_quarters/cafeteria)
 "ule" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/machinery/disposal/small{
@@ -36399,7 +36317,6 @@
 	pixel_x = 10
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/machinery/vending/cola/red,
@@ -36532,7 +36449,6 @@
 	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /obj/cable{
@@ -36623,7 +36539,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -11
 	},
 /obj/cable{
@@ -37773,7 +37688,6 @@
 /area/station/science/teleporter)
 "vvU" = (
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /obj/xmastree/ephemeral,
@@ -37830,7 +37744,6 @@
 /area/station/chapel/sanctuary)
 "vzB" = (
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /obj/table/reinforced/auto,
@@ -38353,7 +38266,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/machinery/atmospherics/unary/cryo_cell{
@@ -38593,7 +38505,6 @@
 	},
 /obj/landmark/start/job/assistant,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/blackwhite/side{
@@ -38873,7 +38784,6 @@
 /obj/stool/chair,
 /obj/landmark/start/job/assistant,
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /obj/machinery/turretid/computer_core{
@@ -38947,7 +38857,6 @@
 /area/station/science/chemistry)
 "wvI" = (
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /obj/noticeboard/persistent{
@@ -39072,7 +38981,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/machinery/light{
@@ -39546,7 +39454,6 @@
 	pixel_y = 21
 	},
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/specialroom/chapel,
@@ -39994,7 +39901,6 @@
 	dir = 6
 	},
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = -10
 	},
 /obj/reagent_dispensers/fueltank,
@@ -40389,7 +40295,6 @@
 "xBv" = (
 /obj/mesh/catwalk,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/airless/plating/catwalk{
@@ -41137,7 +41042,6 @@
 "ygU" = (
 /obj/machinery/manufacturer/robotics,
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = 5
 	},
 /turf/simulated/floor/black,
@@ -41169,7 +41073,6 @@
 /area/station/maintenance/southeast)
 "yhF" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/storage/secure/closet/personal,

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -766,7 +766,6 @@
 "adB" = (
 /obj/machinery/vending/paint/broken,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/grime,
@@ -4447,7 +4446,6 @@
 	pixel_y = 2
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/specialroom/freezer,
@@ -34475,7 +34473,6 @@
 /obj/item/pen,
 /obj/item/paper_bin,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/machinery/light/small/floor,
@@ -58429,7 +58426,6 @@
 	dir = 2
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/blue,

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -56295,7 +56295,6 @@
 /area/station/engine/core)
 "gWh" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/carpet/grime,
@@ -69451,7 +69450,6 @@
 "sRj" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/plating,

--- a/maps/density2.dmm
+++ b/maps/density2.dmm
@@ -223,7 +223,6 @@
 	},
 /obj/machinery/camera/directional/east{
 	icon_state = "camera";
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/airless/plating/catwalk{

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -3717,9 +3717,8 @@
 	dir = 10;
 	icon_state = "line1"
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
@@ -4430,7 +4429,6 @@
 /obj/item/storage/belt/utility,
 /obj/item/clothing/mask/balaclava,
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/orangeblack/side{
@@ -5539,9 +5537,8 @@
 	id = "crematorium";
 	pixel_y = 28
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
@@ -6955,7 +6952,6 @@
 	},
 /obj/machinery/light/small/sticky,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/simulated/floor/carpet/grime,
@@ -9175,7 +9171,6 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/space,
@@ -10986,9 +10981,8 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
 "blq" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
@@ -11912,9 +11906,8 @@
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/AIbaseoutside)
 "bqK" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -14779,7 +14772,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/plating,
@@ -15513,7 +15505,6 @@
 /area/station/hallway/primary/south)
 "cpb" = (
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/lattice{
@@ -15998,7 +15989,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/red/side{
@@ -17173,13 +17163,6 @@
 "dlx" = (
 /turf/simulated/wall/false_wall,
 /area/station/maintenance/inner/central)
-"dlC" = (
-/obj/machinery/camera/directional/south{
-	name = "autoname  - SS13";
-	pixel_x = 10
-	},
-/turf/space,
-/area/space)
 "dlZ" = (
 /turf/simulated/wall/false_wall,
 /area/station/medical/medbay/treatment1)
@@ -17562,7 +17545,6 @@
 	},
 /obj/machinery/light/incandescent,
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/redblack{
@@ -18763,7 +18745,6 @@
 "ekD" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/darkblue/side{
@@ -19556,7 +19537,6 @@
 /area/station/hallway/primary/north)
 "eMI" = (
 /obj/machinery/camera/directional/south{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /obj/lattice{
@@ -20417,9 +20397,8 @@
 /area/station/maintenance/west)
 "flB" = (
 /obj/submachine/laundry_machine,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/crew_quarters/locker)
@@ -25292,7 +25271,6 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/plating,
@@ -26061,9 +26039,8 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/white/side{
 	dir = 5
@@ -27354,7 +27331,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -28851,7 +28827,6 @@
 /area/space)
 "kzh" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/lattice{
@@ -29257,7 +29232,6 @@
 /area/station/security/checkpoint/arrivals)
 "kLL" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/unsimulated/floor{
@@ -30549,7 +30523,6 @@
 /area/station/quartermaster/office)
 "lxJ" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/space,
@@ -31208,7 +31181,6 @@
 "lNo" = (
 /obj/machinery/genetics_scanner,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/greenwhite{
@@ -33909,7 +33881,6 @@
 /area/station/hallway/primary/south)
 "noT" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/disposalpipe/segment/food,
@@ -34512,7 +34483,6 @@
 /area/station/science/teleporter)
 "nJh" = (
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/machinery/recharger/wall{
@@ -36154,7 +36124,6 @@
 /area/station/maintenance/disposal)
 "oCk" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/shrub{
@@ -36307,7 +36276,6 @@
 "oEM" = (
 /obj/machinery/weapon_stand/rifle_rack/recharger,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/redblack{
@@ -37526,7 +37494,6 @@
 /area/ghostdrone_factory)
 "prW" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/machinery/arc_electroplater{
@@ -39074,9 +39041,8 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -39267,7 +39233,6 @@
 /area/station/turret_protected/ai)
 "qov" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/escape/corner{
@@ -41186,7 +41151,6 @@
 "rvW" = (
 /obj/decal/boxingrope,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/simulated/floor/wood,
@@ -41353,7 +41317,6 @@
 /area/station/hangar/science)
 "rBP" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/space,
@@ -42471,9 +42434,8 @@
 	pixel_x = -4;
 	pixel_y = 42
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
@@ -42618,7 +42580,6 @@
 "soU" = (
 /obj/machinery/traymachine/locking/tanning,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/simulated/floor/blue/checker,
@@ -48513,7 +48474,6 @@
 	icon_state = "lattice-dir"
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/space,
@@ -48720,7 +48680,6 @@
 /area/station/engine/storage)
 "vOI" = (
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/wood/two,
@@ -48794,9 +48753,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "vSE" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -75790,7 +75748,7 @@ ani
 ani
 ani
 ani
-dlC
+mxn
 dRI
 wIP
 hMd

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -8058,7 +8058,6 @@
 	icon_state = "line1"
 	},
 /obj/machinery/camera/directional/south{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/simulated/floor/circuit,
@@ -10285,7 +10284,6 @@
 	icon_state = "2-9"
 	},
 /obj/machinery/camera/directional/south{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/simulated/floor/blueblack,
@@ -10299,7 +10297,6 @@
 /obj/cable,
 /obj/disposalpipe/segment/brig,
 /obj/machinery/camera/directional/south{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/simulated/floor/redblack{
@@ -11210,7 +11207,6 @@
 /area/station/maintenance/inner/nw)
 "dou" = (
 /obj/machinery/camera/directional/south{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /obj/disposalpipe/segment/mail{
@@ -12246,7 +12242,6 @@
 /area/station/maintenance/outer/se)
 "dIf" = (
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/simulated/floor/blueblack{
@@ -15072,9 +15067,8 @@
 /area/station/mining/staff_room)
 "eCk" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -33747,7 +33741,6 @@
 	icon_state = "line1"
 	},
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 6
 	},
 /obj/machinery/status_display{
@@ -34211,7 +34204,6 @@
 /area/station/crewquarters/fuq3)
 "kCV" = (
 /obj/machinery/camera/directional/south{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/space,
@@ -59936,7 +59928,6 @@
 /area/station/solar/east)
 "sEw" = (
 /obj/machinery/camera/directional/south{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /obj/decal/tile_edge/line/yellow{
@@ -71549,7 +71540,6 @@
 /area/station/crew_quarters/hor)
 "wfA" = (
 /obj/machinery/camera/directional/south{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/simulated/wall/auto/reinforced/jen,

--- a/maps/events/wrestlemap.dmm
+++ b/maps/events/wrestlemap.dmm
@@ -743,9 +743,8 @@
 	},
 /area/shuttle/arrival/station)
 "amn" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/unsimulated/floor/shuttle{
 	dir = 4
@@ -8086,9 +8085,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "dEi" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/shuttlebay,
@@ -9157,9 +9155,8 @@
 /area/station/storage/warehouse)
 "ecp" = (
 /obj/rack,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/random_item_spawner/hat/some,
 /turf/simulated/floor/black,
@@ -17199,9 +17196,8 @@
 	})
 "hLN" = (
 /obj/machinery/vending/monkey/kitchen,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/decal/tile_edge/stripe{
 	icon_state = "bot2";
@@ -19205,9 +19201,8 @@
 	name = "Locker Room"
 	})
 "iJq" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/storage/closet/emergency,
 /turf/simulated/floor,
@@ -21422,9 +21417,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "jEK" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -23725,9 +23719,8 @@
 	dir = 8;
 	tag = ""
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/item/device/radio/signaler,
 /obj/item/device/radio/signaler,
@@ -25632,9 +25625,8 @@
 	},
 /area/station/hallway/primary/south)
 "lzM" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -26514,9 +26506,8 @@
 	name = "Locker Room"
 	})
 "lUR" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/storage/closet/fire,
 /obj/cable/yellow{
@@ -27469,9 +27460,8 @@
 "mrM" = (
 /obj/machinery/vending/security,
 /obj/machinery/power/apc/autoname_north,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/cable{
 	icon_state = "0-2"
@@ -29398,9 +29388,8 @@
 /area/station/mining/cargo_staff_room)
 "nkc" = (
 /obj/table/auto,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
@@ -30472,7 +30461,6 @@
 	icon_state = "line1"
 	},
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/disposalpipe/segment/mail/horizontal,
@@ -30561,9 +30549,8 @@
 /area/station/science/lobby)
 "nLQ" = (
 /obj/decal/cleanable/dirt,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -30996,9 +30983,8 @@
 /obj/machinery/conveyor_switch{
 	id = "chapel"
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/machinery/light/incandescent/warm/very{
 	dir = 8;
@@ -32664,9 +32650,8 @@
 /obj/lattice{
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/machinery/light/emergency{
 	dir = 1
@@ -35682,9 +35667,8 @@
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/crew_quarters/lounge/luxury_seating)
 "qfD" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -35715,9 +35699,8 @@
 /turf/simulated/floor/orange/side,
 /area/station/hallway/secondary/exit)
 "qfU" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/stool/bench/auto,
 /obj/disposalpipe/segment/brig{
@@ -36696,9 +36679,8 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload)
 "qBs" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/orange/side,
 /area/station/hallway/secondary/exit)
@@ -38662,9 +38644,8 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/utility)
 "ryU" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/carpet/green/fancy/junction/se_n,
 /area/station/hallway/primary/central)
@@ -41703,9 +41684,8 @@
 /turf/simulated/floor/caution,
 /area/station/engine/engineering)
 "sTB" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/cable{
 	icon_state = "2-4"
@@ -42706,9 +42686,8 @@
 /turf/simulated/floor/pool/no_animate,
 /area/station/crew_quarters/pool)
 "tmN" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/caution/north,
 /area/station/hallway/secondary/entry)
@@ -44107,9 +44086,8 @@
 /obj/table/wood/auto,
 /obj/item/gun/kinetic/antisingularity,
 /obj/item/paper/antisingularity,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/orange/side{
 	dir = 1
@@ -45927,9 +45905,8 @@
 /obj/machinery/light/emergency{
 	dir = 1
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/hallway/secondary/east{
@@ -46550,9 +46527,8 @@
 "vdA" = (
 /obj/machinery/computer/secure_data/detective_computer,
 /obj/decal/cleanable/dirt,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
@@ -50942,9 +50918,8 @@
 /turf/simulated/floor/airless/grass/random/alt,
 /area/space)
 "wYl" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/shrub,
 /obj/disposalpipe/segment/ejection{
@@ -51853,9 +51828,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "xtt" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/decal/tile_edge/line/purple{

--- a/maps/mushroom.dmm
+++ b/maps/mushroom.dmm
@@ -617,7 +617,6 @@
 /area/station/security/checkpoint/arrivals)
 "adS" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor,
@@ -3697,7 +3696,6 @@
 /obj/submachine/slot_machine,
 /obj/disposalpipe/segment/produce,
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/wood/two,
@@ -8553,7 +8551,6 @@
 /area/mining/magnet)
 "aZc" = (
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/machinery/computer/magnet{
@@ -18017,7 +18014,6 @@
 "gNh" = (
 /obj/machinery/camera/directional/east{
 	icon_state = "camera";
-	name = "autoname  - SS13";
 	network = "SS13";
 	pixel_y = 10
 	},
@@ -28152,7 +28148,6 @@
 	},
 /obj/machinery/camera/directional/east{
 	icon_state = "camera";
-	name = "autoname  - SS13";
 	network = "SS13";
 	pixel_y = 10
 	},
@@ -28412,8 +28407,8 @@
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai_upload)
 "plc" = (
-/obj/machinery/camera{
-	dir = 3
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -28732,7 +28727,6 @@
 /area/station/engine/proto)
 "pyx" = (
 /obj/machinery/camera/directional/east{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
@@ -32664,7 +32658,6 @@
 "snD" = (
 /obj/machinery/camera/directional/east{
 	icon_state = "camera";
-	name = "autoname  - SS13";
 	network = "SS13";
 	pixel_y = 10
 	},
@@ -33461,7 +33454,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/camera/directional/west{
-	name = "autoname  - SS13";
 	pixel_y = 10
 	},
 /turf/simulated/floor/purple/side{

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -4324,9 +4324,8 @@
 	icon_state = "chair_couch-green";
 	name = "tacky green couch"
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
@@ -8222,9 +8221,8 @@
 	},
 /obj/stool/bench/red/auto,
 /obj/machinery/light_switch/north,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/sauna)
@@ -11851,9 +11849,8 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/substation/pylon{
@@ -15086,9 +15083,8 @@
 /obj/stool/chair/couch{
 	dir = 8
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/wood{
@@ -15556,9 +15552,8 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "gVv" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -17545,9 +17540,8 @@
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "hIJ" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/space/fluid/acid,
 /area/space)
@@ -18631,9 +18625,8 @@
 	name = "Shielding Control";
 	pixel_y = 26
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/engine,
 /area/station/science/construction{
@@ -23082,9 +23075,8 @@
 /turf/simulated/floor/engine/caution,
 /area/station/ai_monitored/armory)
 "kcx" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/redblack/corner{
 	dir = 1
@@ -33687,9 +33679,8 @@
 /area/station/engine/core/nuclear)
 "oDX" = (
 /obj/storage/closet/emergency,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/outer/sw{
@@ -35978,9 +35969,8 @@
 	dir = 10;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/space/fluid/acid/clear,
 /area/space)
@@ -39151,9 +39141,8 @@
 	pixel_x = 12
 	},
 /obj/machinery/hair_dye_dispenser,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/barber_shop)
@@ -40414,9 +40403,8 @@
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
 /obj/landmark/pest,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
@@ -41555,9 +41543,8 @@
 	pixel_x = 3;
 	pixel_y = 5
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/machinery/firealarm{
 	pixel_x = 4;
@@ -41801,9 +41788,8 @@
 /turf/simulated/floor/black,
 /area/station/storage/tools)
 "svP" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/decal/tile_edge/line/black{
 	dir = 4;
@@ -42210,7 +42196,6 @@
 /obj/lattice,
 /obj/machinery/launcher_loader/south,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 6
 	},
 /turf/space/fluid/acid/clear,
@@ -47271,9 +47256,8 @@
 	name = "The Warrens"
 	})
 "uSB" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -48257,9 +48241,8 @@
 /obj/machinery/meter{
 	pixel_y = -9
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 9
@@ -50670,9 +50653,8 @@
 /turf/simulated/floor/industrial,
 /area/station/storage/warehouse)
 "wwo" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -23704,9 +23704,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "rhZ" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -28660,9 +28659,8 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "uFZ" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/escape{
 	dir = 9

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -794,16 +794,14 @@
 /area/ghostdrone_factory)
 "acF" = (
 /obj/stool/bench/blue,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "acG" = (
 /obj/stool/bench/blue,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor,
@@ -1735,9 +1733,8 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "agi" = (
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/storage/secure/closet/medical/anesthetic,
 /turf/simulated/floor/black,
@@ -2860,9 +2857,8 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 1
@@ -4464,9 +4460,8 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
@@ -4869,9 +4864,8 @@
 	pixel_y = 4
 	},
 /obj/item/storage/belt/utility,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/item/storage/belt/utility,
 /turf/simulated/floor,
@@ -10028,9 +10022,8 @@
 /obj/shrub{
 	dir = 8
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/item/device/radio/intercom/science{
 	dir = 4
@@ -10323,7 +10316,6 @@
 /area/station/janitor/office)
 "aJU" = (
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /turf/simulated/floor/plating/random,
@@ -11109,9 +11101,8 @@
 /area/station/hallway/primary/east)
 "aOy" = (
 /obj/storage/secure/closet/command/chief_engineer,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/crew_quarters/ce)
@@ -17665,9 +17656,8 @@
 /obj/table/auto,
 /obj/item/device/light/flashlight,
 /obj/item/crowbar,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
@@ -19080,9 +19070,8 @@
 /obj/item/clothing/mask/breath{
 	pixel_x = -3
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /obj/item/clothing/shoes/flippers{
 	pixel_y = -12
@@ -19192,9 +19181,8 @@
 	name = "fedora"
 	},
 /obj/item/storage/fanny,
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/info)
@@ -32112,9 +32100,8 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/machinery/camera{
-	dir = 3;
-	pixel_y = 20
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
@@ -36933,7 +36920,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = 10
 	},
 /obj/machinery/light/incandescent/netural{

--- a/maps/utilities/devtest.dmm
+++ b/maps/utilities/devtest.dmm
@@ -441,7 +441,6 @@
 /area/station/devzone)
 "ib" = (
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /obj/cable{
@@ -485,7 +484,6 @@
 	pixel_x = 16
 	},
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/simulated/floor,
@@ -2628,7 +2626,6 @@
 /area/station/devzone)
 "Wg" = (
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/simulated/floor,
@@ -2722,7 +2719,6 @@
 "Xu" = (
 /obj/item/rcd/construction/safe/admin_crimes,
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/simulated/floor,
@@ -2756,7 +2752,6 @@
 /area/station/devzone)
 "XI" = (
 /obj/machinery/camera/directional/north{
-	name = "autoname  - SS13";
 	pixel_x = -10
 	},
 /turf/simulated/floor/orangeblack,

--- a/tools/UpdatePaths/Scripts/24247_camera_cleanup.txt
+++ b/tools/UpdatePaths/Scripts/24247_camera_cleanup.txt
@@ -1,8 +1,12 @@
-# Temporarily repath TVs, so that they're unaffected by the script.
-/obj/machinery/camera/television/@SUBTYPES : /temporary_tv_repath/@SUBTYPES{@OLD}
+# Temporarily repath subtypes that shouldn't be affected by the script.
+/obj/machinery/camera/@SUBTYPES/directional/@SUBTYPES	: /temporary_directional_repath/@SUBTYPES{@OLD}
+/obj/machinery/camera/vspace/@SUBTYPES					: /temporary_vspace_repath/@SUBTYPES{@OLD}
+/obj/machinery/camera/public/@SUBTYPES					: /temporary_public_repath/@SUBTYPES{@OLD}
+/obj/machinery/camera/television/@SUBTYPES				: /temporary_tv_repath/@SUBTYPES{@OLD}
 
 # Change of default variables.
 /obj/machinery/camera/@SUBTYPES{name = "autoname - SS13"}	: /obj/machinery/camera/@SUBTYPES{@OLD; name = @SKIP}
+/obj/machinery/camera/@SUBTYPES{name = "autoname  - SS13"}	: /obj/machinery/camera/@SUBTYPES{@OLD; name = @SKIP}
 /obj/machinery/camera/mining{name = "autoname - Mining"}	: /obj/machinery/camera/mining{@OLD; name = @SKIP}
 /obj/machinery/camera/mining{name = "autoname -  Mining"}	: /obj/machinery/camera/mining{@OLD; name = @SKIP}
 /obj/machinery/camera/@SUBTYPES{c_tag = "autotag"}			: /obj/machinery/camera/@SUBTYPES{@OLD; c_tag = @SKIP}
@@ -29,6 +33,8 @@
 /obj/machinery/camera/@SUBTYPES{dir = 0; pixel_x = @UNSET}		: /temporary_camera_repath/@SUBTYPES/directional/north{@OLD; dir = @SKIP; pixel_x = -10; pixel_y = @SKIP}
 /obj/machinery/camera/@SUBTYPES{dir = 2; pixel_x = @ANY}		: /temporary_camera_repath/@SUBTYPES/directional/north{@OLD; dir = @SKIP; pixel_x = @ADD:-10; pixel_y = @SKIP}
 /obj/machinery/camera/@SUBTYPES{dir = 2; pixel_x = @UNSET}		: /temporary_camera_repath/@SUBTYPES/directional/north{@OLD; dir = @SKIP; pixel_x = -10; pixel_y = @SKIP}
+/obj/machinery/camera/@SUBTYPES{dir = 3; pixel_x = @ANY}		: /temporary_camera_repath/@SUBTYPES/directional/north{@OLD; dir = @SKIP; pixel_x = @ADD:-10; pixel_y = @SKIP}
+/obj/machinery/camera/@SUBTYPES{dir = 3; pixel_x = @UNSET}		: /temporary_camera_repath/@SUBTYPES/directional/north{@OLD; dir = @SKIP; pixel_x = -10; pixel_y = @SKIP}
 # EAST
 /obj/machinery/camera/@SUBTYPES{dir = 4; pixel_y = @ANY}		: /temporary_camera_repath/@SUBTYPES/directional/west{@OLD; dir = @SKIP; pixel_x = @SKIP; pixel_y = @ADD:10}
 /obj/machinery/camera/@SUBTYPES{dir = 4; pixel_y = @UNSET}		: /temporary_camera_repath/@SUBTYPES/directional/west{@OLD; dir = @SKIP; pixel_x = @SKIP; pixel_y = 10}
@@ -55,5 +61,8 @@
 /obj/machinery/camera/public/directional/@SUBTYPES : /obj/machinery/camera/public{@OLD}
 /obj/machinery/camera/vspace/directional/@SUBTYPES : /obj/machinery/camera/vspace{@OLD}
 
-# Revert the TV repath.
-/temporary_tv_repath/@SUBTYPES : /obj/machinery/camera/television/@SUBTYPES{@OLD}
+# Revert the temporary repaths.
+/temporary_directional_repath/@SUBTYPES	: /obj/machinery/camera/@SUBTYPES{@OLD}
+/temporary_vspace_repath/@SUBTYPES		: /obj/machinery/camera/vspace/@SUBTYPES{@OLD}
+/temporary_public_repath/@SUBTYPES		: /obj/machinery/camera/public/@SUBTYPES{@OLD}
+/temporary_tv_repath/@SUBTYPES			: /obj/machinery/camera/television/@SUBTYPES{@OLD}

--- a/tools/UpdatePaths/Scripts/24247_camera_cleanup.txt
+++ b/tools/UpdatePaths/Scripts/24247_camera_cleanup.txt
@@ -1,9 +1,3 @@
-# Temporarily repath subtypes that shouldn't be affected by the script.
-/obj/machinery/camera/@SUBTYPES/directional/@SUBTYPES	: /temporary_directional_repath/@SUBTYPES{@OLD}
-/obj/machinery/camera/vspace/@SUBTYPES					: /temporary_vspace_repath/@SUBTYPES{@OLD}
-/obj/machinery/camera/public/@SUBTYPES					: /temporary_public_repath/@SUBTYPES{@OLD}
-/obj/machinery/camera/television/@SUBTYPES				: /temporary_tv_repath/@SUBTYPES{@OLD}
-
 # Change of default variables.
 /obj/machinery/camera/@SUBTYPES{name = "autoname - SS13"}	: /obj/machinery/camera/@SUBTYPES{@OLD; name = @SKIP}
 /obj/machinery/camera/@SUBTYPES{name = "autoname  - SS13"}	: /obj/machinery/camera/@SUBTYPES{@OLD; name = @SKIP}
@@ -21,6 +15,12 @@
 /obj/machinery/camera/auto/science		: /obj/machinery/camera/science{@OLD}
 /obj/machinery/camera/auto/vspace		: /obj/machinery/camera/vspace{@OLD}
 /obj/machinery/camera{name = "sensor"}	: /obj/machinery/camera/watchful_eye{@OLD; name = @SKIP; network = @SKIP}
+
+# Temporarily repath subtypes that shouldn't be affected by the main repath.
+/obj/machinery/camera/@SUBTYPES/directional/@SUBTYPES	: /temporary_directional_repath/@SUBTYPES{@OLD}
+/obj/machinery/camera/vspace/@SUBTYPES					: /temporary_vspace_repath/@SUBTYPES{@OLD}
+/obj/machinery/camera/public/@SUBTYPES					: /temporary_public_repath/@SUBTYPES{@OLD}
+/obj/machinery/camera/television/@SUBTYPES				: /temporary_tv_repath/@SUBTYPES{@OLD}
 
 # Repath and flip directions, and clean up pixel offsets. Uses a temporary repath to avoid repathing the same paths twice.
 # NORTH
@@ -54,15 +54,13 @@
 /obj/machinery/camera/@SUBTYPES{dir = 10; pixel_x = @ANY}		: /temporary_camera_repath/@SUBTYPES/directional/south{@OLD; dir = @SKIP; pixel_x = @ADD:10; pixel_y = @SKIP}
 /obj/machinery/camera/@SUBTYPES{dir = 10; pixel_x = @UNSET}		: /temporary_camera_repath/@SUBTYPES/directional/south{@OLD; dir = @SKIP; pixel_x = 10; pixel_y = @SKIP}
 
-# Revert the camera repath.
-/temporary_camera_repath/@SUBTYPES : /obj/machinery/camera/@SUBTYPES{@OLD}
-
-# Ensure non-directional cameras aren't subtyped as directional.
-/obj/machinery/camera/public/directional/@SUBTYPES : /obj/machinery/camera/public{@OLD}
-/obj/machinery/camera/vspace/directional/@SUBTYPES : /obj/machinery/camera/vspace{@OLD}
-
 # Revert the temporary repaths.
+/temporary_camera_repath/@SUBTYPES : /obj/machinery/camera/@SUBTYPES{@OLD}
 /temporary_directional_repath/@SUBTYPES	: /obj/machinery/camera/@SUBTYPES{@OLD}
 /temporary_vspace_repath/@SUBTYPES		: /obj/machinery/camera/vspace/@SUBTYPES{@OLD}
 /temporary_public_repath/@SUBTYPES		: /obj/machinery/camera/public/@SUBTYPES{@OLD}
 /temporary_tv_repath/@SUBTYPES			: /obj/machinery/camera/television/@SUBTYPES{@OLD}
+
+# Ensure non-directional cameras aren't subtyped as directional.
+/obj/machinery/camera/public/directional/@SUBTYPES : /obj/machinery/camera/public{@OLD}
+/obj/machinery/camera/vspace/directional/@SUBTYPES : /obj/machinery/camera/vspace{@OLD}

--- a/tools/UpdatePaths/__main__.py
+++ b/tools/UpdatePaths/__main__.py
@@ -15,6 +15,12 @@ Replacement syntax example:
     /obj/effect/landmark/start/virologist : @DELETE
 Syntax for subtypes also exist, to update a path's type but maintain subtypes:
     /obj/structure/closet/crate/@SUBTYPES : /obj/structure/new_box/@SUBTYPES {@OLD}
+More advanced @SUBTYPES syntax:
+	In the old path, the @SUBTYPES keyword may be used multiple times. This is useful for finding paths that end in a specific path or contain a specific path.
+    In the new path, the @SUBTYPES keyword will refer to the ENTIRE subtype, starting from the first use of @SUBTYPES.
+	If multple @SUBTYPES keywords are used in the old path, in the new path the @SUBTYPES_N keyword will refer to the Nth subtype path.
+    /obj/machinery/camera/@SUBTYPES : /obj/machinery/camera/@SUBTYPES/directional - add the "directional" subtype to every instace (including subtypes that are already directional).
+    /obj/machinery/camera/@SUBTYPES/directional/@SUBTYPES : /obj/machinery/camera/@SUBTYPES_1 - remove all directional subtypes from every instance.
 New paths properties:
     @DELETE - if used as new path name the old path will be deleted
     @OLD - if used as property name copies all modified properties from original path to this one
@@ -76,11 +82,19 @@ def update_path(dmm_data, replacement_string, verbose=False):
         new_paths.append((new_path, new_path_props))
 
     subtypes = ""
-    if old_path.endswith("/@SUBTYPES"):
-        old_path = old_path[:-len("/@SUBTYPES")]
+    split_position = old_path.find("/@SUBTYPES")
+    if split_position != -1:
+        remaining_path = re.escape(old_path[split_position:])
+        old_path = old_path[:split_position]
         if verbose:
             print("Looking for subtypes of", old_path)
-        subtypes = r"(?:/\w+)*"
+
+        i = 1
+        while remaining_path.find("/@SUBTYPES") != -1:
+            remaining_path = remaining_path.replace("/@SUBTYPES", fr"(?P<subtype_{i}>(?:/\w+)*)", 1)
+            i += 1
+
+        subtypes = remaining_path
 
     replacement_pattern = re.compile(rf"(?P<path>{re.escape(old_path)}(?P<subtype>{subtypes}))\s*(:?{{(?P<props>.*)}})?$")
 
@@ -110,8 +124,16 @@ def update_path(dmm_data, replacement_string, verbose=False):
                 if verbose:
                     print("Deleting match : {0}".format(match.group(0)))
                 return [None]
-            elif new_path.find("/@SUBTYPES"):
-                out = new_path.replace("/@SUBTYPES", match.group('subtype'), 1)
+            elif new_path.find("/@SUBTYPES") != -1:
+                find_position = new_path.find("/@SUBTYPES_")
+                if find_position != -1:
+                    out = new_path
+                    while find_position != -1:
+                        i = int(out[find_position + len("/@SUBTYPES_")])
+                        out = out.replace(f"/@SUBTYPES_{i}", match.group(f"subtype_{i}"))
+                        find_position = out.find("/@SUBTYPES_")
+                else:
+                    out = new_path.replace("/@SUBTYPES", match.group('subtype'))
             else:
                 out = new_path
 

--- a/tools/UpdatePaths/readme.md
+++ b/tools/UpdatePaths/readme.md
@@ -201,6 +201,13 @@ Running the script will update this into:
 
 Note how since you kept in `{@OLD}`, it was able to retain the re-named variables of the subtypes.
 
+More advanced `@SUBTYPES` syntax:
+- In the old path, the `@SUBTYPES` keyword may be used multiple times. This is useful for finding paths that end in a specific path or contain a specific path.
+- In the new path, the `@SUBTYPES` keyword will refer to the ENTIRE subtype, starting from the first use of @SUBTYPES.
+- If multple `@SUBTYPES` keywords are used in the old path, in the new path the `@SUBTYPES_N` keyword will refer to the Nth subtype path.
+- `/obj/machinery/camera/@SUBTYPES : /obj/machinery/camera/@SUBTYPES/directional` - add the "directional" subtype to every instace (including subtypes that are already directional).
+- `/obj/machinery/camera/@SUBTYPES/directional/@SUBTYPES : /obj/machinery/camera/@SUBTYPES_1` - remove all directional subtypes from every instance.
+
 
 ### Old Path Variable Filtering
 


### PR DESCRIPTION
[Bug]


## About The PR:
Allows the `24247_camera_cleanup.txt` script to be ran multiple times on the same files without breaking the already remapped cameras.

Additionally implements more advanced `@SUBTYPES` syntax for UpdatePaths to use in future.

Also fixes cameras with `dir = 3` not being remapped and cameras with `name = "autoname  - SS13"` (see double space) not being unset.


## Testing:
I ran the script, and no files were altered (prior to the `dir = 3` and `autoname` fixes).
After the fixed script was ran, `dir = 3` cameras were correctly remapped.