### PR TITLE
Fixes #24277 - Moves Donut2 Interrogation Room Camera Up A Tile

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -10669,6 +10669,9 @@
 /obj/item/device/radio/intercom/brig{
 	dir = 8
 	},
+/obj/machinery/camera/directional/north{
+	pixel_x = -10
+	},
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
 "bki" = (
@@ -27564,9 +27567,6 @@
 "jJj" = (
 /obj/item/device/radio/intercom/security{
 	dir = 8
-	},
-/obj/machinery/camera/directional/north{
-	pixel_x = -10
 	},
 /turf/simulated/floor/black,
 /area/station/security/interrogation)


### PR DESCRIPTION
[Bug]


## About The PR
Fixes #24277.


## Testing:
Loading the map shows that the camera is now correctly offset onto the wall.
<img width="256" height="255" alt="image" src="https://github.com/user-attachments/assets/7b5e18e7-de21-4184-9aae-f7b9018d2118" />