### PR TITLE
Holy water cures artifact curses

### DIFF
--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -831,12 +831,26 @@
 				else
 					if (ishuman(M))
 						var/mob/living/carbon/human/H = M
+						var/removed_curse = FALSE
 						if(H.bioHolder?.HasEffect("blood_curse") || H.bioHolder?.HasEffect("blind_curse") || H.bioHolder?.HasEffect("weak_curse") || H.bioHolder?.HasEffect("rot_curse") || H.bioHolder?.HasEffect("death_curse"))
 							H.bioHolder.RemoveEffect("blood_curse")
 							H.bioHolder.RemoveEffect("blind_curse")
 							H.bioHolder.RemoveEffect("weak_curse")
 							H.bioHolder.RemoveEffect("rot_curse")
 							H.bioHolder.RemoveEffect("death_curse")
+							removed_curse = TRUE
+						else if(M.hasStatus("art_blood_curse") || M.hasStatus("art_aging_curse") || M.hasStatus("art_nightmare_curse") || M.hasStatus("art_maze_curse") || M.hasStatus("art_displacement_curse") || M.hasStatus("art_light_curse"))
+							M.delStatus("art_blood_curse")
+							M.delStatus("art_aging_curse")
+							M.delStatus("art_nightmare_curse")
+							M.delStatus("art_maze_curse")
+							M.delStatus("art_displacement_curse")
+							M.delStatus("art_light_curse")
+							playsound(H, 'sound/effects/lit.ogg', 100, TRUE)
+							removed_curse = TRUE
+						else
+							boutput(M, SPAN_NOTICE("You feel somewhat purified... but mostly just wet."))
+						if(removed_curse)
 							H.visible_message("[H] screams as some black smoke exits their body.")
 							H.emote("scream")
 							random_burn_damage(H, 5)
@@ -846,8 +860,6 @@
 								if (S)
 									S.set_up(5, 0, T, null, "#3b3b3b")
 									S.start()
-						else
-							boutput(M, SPAN_NOTICE("You feel somewhat purified... but mostly just wet."))
 					else
 						boutput(M, SPAN_NOTICE("You feel somewhat purified... but mostly just wet."))
 					M.take_brain_damage(0 - clamp(volume, 0, 10))

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -3106,7 +3106,7 @@
 			boutput(L, SPAN_NOTICE(src.removal_msg))
 		if(id != "art_curser_displaced_soul")
 			src.linked_curser.active_cursees -= L
-		if(length(src.linked_curser.active_cursees) == 0)
+		if(!length(src.linked_curser.active_cursees))
 			src.linked_curser.curse_cleanup()
 		src.linked_curser = null
 		..()

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -3104,6 +3104,10 @@
 		var/mob/living/L = src.owner
 		if (!isdead(L) && src.outputs_removal_msg)
 			boutput(L, SPAN_NOTICE(src.removal_msg))
+		if(id != "art_curser_displaced_soul")
+			src.linked_curser.active_cursees -= L
+		if(length(src.linked_curser.active_cursees) == 0)
+			src.linked_curser.curse_cleanup()
 		src.linked_curser = null
 		..()
 
@@ -3147,7 +3151,6 @@
 				H.bioHolder?.AddEffect("husk")
 				H.bioHolder?.mobAppearance.flavor_text = "A desiccated husk."
 				H.set_clothing_icon_dirty()
-				src.linked_curser?.lift_curse_specific(FALSE, H)
 				src.remove_self()
 
 		onRemove()
@@ -3197,7 +3200,6 @@
 				H.death(FALSE)
 				H.decomp_stage = DECOMP_STAGE_SKELETONIZED
 				H.set_clothing_icon_dirty()
-				src.linked_curser?.lift_curse_specific(FALSE, H)
 				src.remove_self()
 
 		onRemove()
@@ -3230,7 +3232,9 @@
 			..()
 			var/mob/living/carbon/human/H = src.owner
 			if (src.creatures_to_kill <= 0 || QDELETED(H) || isdead(H))
-				src.linked_curser.lift_curse_specific(!QDELETED(H) && !isdead(H), H)
+				if(!(QDELETED(H) || isdead(H)))
+					playsound(H, 'sound/effects/lit.ogg', 100, TRUE)
+				src.remove_self()
 				return
 			src.time_passed += timePassed
 			if (src.time_passed < 10 SECONDS)
@@ -3273,7 +3277,6 @@
 			..()
 			var/mob/living/carbon/human/H = src.owner
 			if (QDELETED(H) || isdead(H))
-				src.linked_curser?.lift_curse_specific(FALSE, H)
 				src.remove_self()
 
 		onRemove()
@@ -3302,7 +3305,7 @@
 		onUpdate()
 			..()
 			if (QDELETED(src.original_body) || isdead(src.original_body))
-				src.linked_curser.lift_curse_specific(FALSE, src.original_body)
+				src.remove_self()
 
 		onRemove()
 			src.soul.delStatus("art_curser_displaced_soul")

--- a/code/obj/artifacts/artifact_objects/curser.dm
+++ b/code/obj/artifacts/artifact_objects/curser.dm
@@ -148,23 +148,14 @@
 		for (var/mob/L as anything in src.active_cursees)
 			L.delStatus(src.chosen_curse)
 			if (do_playsound)
-				playsound(src.holder, 'sound/effects/lit.ogg', 100, TRUE)
-		src.active_cursees = list()
+				playsound(L, 'sound/effects/lit.ogg', 100, TRUE)
+
+	proc/curse_cleanup()
 		src.blood_curse_active = FALSE
 		src.aging_curse_active = FALSE
 		src.disp_curse_active = FALSE
 		if (src.maze)
 			QDEL_NULL(src.maze)
-
-	proc/lift_curse_specific(do_playsound, mob/living/L)
-		if ((L in src.active_cursees) && length(src.active_cursees) == 1)
-			src.lift_curse(do_playsound)
-			return
-		if (do_playsound)
-			L.playsound_local(src.holder, 'sound/effects/lit.ogg', 100, TRUE)
-		if (L in src.active_cursees)
-			L.delStatus(src.active_cursees[L])
-		src.active_cursees -= L
 
 	// maze width is only defined in this proc, if changed, care needs to be taken for other values used
 	// also note, loaded rooms (x1, y1) location is at the bottom left of the room, not the middle
@@ -324,8 +315,7 @@
 
 	Crossed(atom/movable/AM)
 		if (!src.density && AM.hasStatus("art_maze_curse"))
-			var/datum/statusEffect/art_curse/maze/curse = AM.getStatusList()["art_maze_curse"]
-			curse.linked_curser.lift_curse_specific(TRUE, AM)
+			AM.delStatus("art_maze_curse")
 		else
 			return ..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SCIENCE][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds an alternative cure condition to artifact curses in the form of splashing holy water on curse victims. It also slightly refactors artifact curses to enable this.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Alternative PR to #23863. As mentioned in that PR, curse artifacts have disproportionately severe effects compared to how easy it is to be affected by them and how difficult it is to lift the curse. Holy water curing curses has precedence from plague wraiths, and requires cooperation from specific roles which do not normally see much action.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested by touching active curser artifacts and then splashing myself with holy water. Also included lifting the curse normally to make sure that still works as intended.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+) Curses from artifacts can now be cured by splashing holy water.
```
