### PR TITLE
Wheelchair spawns with player regardless of starting location

### DIFF
--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -704,9 +704,10 @@ Equip items from body traits.
 	else if (src.traitHolder && src.traitHolder.hasTrait("allergic"))
 		trinket = new/obj/item/reagent_containers/emergency_injector/epinephrine(src)
 	else if (src.traitHolder && src.traitHolder.hasTrait("wheelchair"))
-		var/obj/stool/chair/comfy/wheelchair/the_chair = new /obj/stool/chair/comfy/wheelchair(get_turf(src))
-		trinket = the_chair
-		the_chair.buckle_in(src, src)
+		SPAWN(0) // Ensures wheelchair spawns with you even if you aren't latejoining at arrivals.
+			var/obj/stool/chair/comfy/wheelchair/the_chair = new /obj/stool/chair/comfy/wheelchair(get_turf(src))
+			trinket = the_chair
+			the_chair.buckle_in(src, src)
 	else
 		trinket = new T(src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Respawning] [Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Forces wheelchair spawn to delay so it isn't lost in arrivals when joining with the heavy sleeper trait. Works with stowaway as well, just placing the wheelchair beneath you when you spawn.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #24273 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Made sure wheelchair now spawns with the player instead of at the cryo machine when using heavy sleeper.

<img width="232" height="183" alt="image" src="https://github.com/user-attachments/assets/4542723d-8dbb-49b5-8689-4c48ed66ad9c" />

