### PR TITLE
Fix owlery access spawners

### DIFF
--- a/code/modules/mapping/helpers/access_spawn.dm
+++ b/code/modules/mapping/helpers/access_spawn.dm
@@ -314,12 +314,12 @@
 
 /obj/mapping_helper/access/owlcommand
 	name = "owlery command access spawn"
-	req_access = list(access_owlerysec)
+	req_access = list(access_owlerycommand)
 	color = COMMAND
 
 /obj/mapping_helper/access/owlsecurity
 	name = "owlery sec access spawn"
-	req_access = list(access_owlerycommand)
+	req_access = list(access_owlerysec)
 	color = SECURITY
 
 /obj/mapping_helper/access/polariscargo


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Swaps the access on owlery command and security access spawners because somehow nobody noticed they were backwards in over 5 years.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Access spawners should spawn their intended accesses

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Owlery security IDs correctly open owlery security airlocks.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
