### PR TITLE
The "pitfall" component will not drop you into a hole if there's a catwalk over it

### DIFF
--- a/code/datums/components/pitfall.dm
+++ b/code/datums/components/pitfall.dm
@@ -62,7 +62,7 @@ ABSTRACT_TYPE(/datum/component/pitfall)
 			return
 		if (HAS_FLAG(AM.event_handler_flags, IMMUNE_TRENCH_WARP))
 			return
-		if (AM.anchored && !allow_anchored || AM.anchored >= ANCHORED_ALWAYS || (locate(/obj/lattice) in src.parent))
+		if (AM.anchored && !allow_anchored || AM.anchored >= ANCHORED_ALWAYS || (locate(/obj/lattice) in src.parent) || ((locate(/obj/mesh) in src.parent)))
 			return
 		if (ismob(AM))
 			var/mob/M = AM

--- a/code/datums/components/pitfall.dm
+++ b/code/datums/components/pitfall.dm
@@ -62,7 +62,7 @@ ABSTRACT_TYPE(/datum/component/pitfall)
 			return
 		if (HAS_FLAG(AM.event_handler_flags, IMMUNE_TRENCH_WARP))
 			return
-		if (AM.anchored && !allow_anchored || AM.anchored >= ANCHORED_ALWAYS || (locate(/obj/lattice) in src.parent) || ((locate(/obj/mesh) in src.parent)))
+		if (AM.anchored && !allow_anchored || AM.anchored >= ANCHORED_ALWAYS || (locate(/obj/lattice) in src.parent) || ((locate(/obj/mesh/catwalk) in src.parent)))
 			return
 		if (ismob(AM))
 			var/mob/M = AM


### PR DESCRIPTION
[BUG] [GAME OBJECTS]

## About the PR 
if you make catwlalk over hole in ocean (all hole, I think?), will not fall through slolid metal into deep pit anymore 

## Why's this needed?
Fixes #24332 

## Testing 
put girder and made catewalk over hole. did not fall. do not think there is other testing?

<img width="1119" height="1082" alt="fall" src="https://github.com/user-attachments/assets/df0b71bc-cf78-426e-888e-71eb2f50ad7d" />

no changinglog, I think.
