### PR TITLE
Fix goonhud storage item positioning

### DIFF
--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -196,7 +196,7 @@ This is because if one 'square' element was used to cover the entire space, you 
 			if (!(I in src.objects)) // ugh
 				add_object(I, HUD_LAYER+1)
 			offset_x = tg_layout ? (i%slots_per_group) : round(i/slots_per_group)
-			offset_y = tg_layout ? round(i/slots_per_group) : (i%slots_per_group)
+			offset_y = tg_layout ? round(i/slots_per_group) : (height-i%slots_per_group)
 			var/obj_loc = "[pos_x+offset_x],[pos_y+offset_y]" //no pixel coords cause that makes click detection harder above
 			var/final_loc = "[pos_x+offset_x],[pos_y+offset_y]:[pixel_y_adjust]"
 			I.screen_loc = do_hud_offset_thing(I, final_loc)

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -208,7 +208,7 @@ This is because if one 'square' element was used to cover the entire space, you 
 			src.obj_locs[obj_loc] = I
 			i++
 		offset_x = tg_layout ? (i%slots_per_group) : round(i/slots_per_group)
-		offset_y = tg_layout ? round(i/slots_per_group) : (i%slots_per_group)
+		offset_y = tg_layout ? round(i/slots_per_group) : (height-(i%slots_per_group))
 		empty_obj_loc =  "[pos_x+offset_x],[pos_y+offset_y]:[pixel_y_adjust]"
 		master.linked_item?.UpdateIcon()
 		src.update_box_icons(user)

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -199,9 +199,8 @@ This is because if one 'square' element was used to cover the entire space, you 
 				add_object(I, HUD_LAYER+1)
 			offset_x = tg_layout ? (i%slots_per_group) : round(i/slots_per_group)
 			offset_y = tg_layout ? round(i/slots_per_group) : (height-(i%slots_per_group))
-			if (!tg_layout)
-				if (groups > 1 && i > primary_cluster_slots) // items need to be brought down through the empty space when in the last group
-					offset_y -= (pos_y + height - secondary_cluster_slots)
+			if (!tg_layout && groups > 1 && i > primary_cluster_slots) // items need to be brought down through the empty space when in the last group
+				offset_y -= (pos_y + height - secondary_cluster_slots)
 			var/obj_loc = "[pos_x+offset_x],[pos_y+offset_y]" //no pixel coords cause that makes click detection harder above
 			var/final_loc = "[pos_x+offset_x],[pos_y+offset_y]:[pixel_y_adjust]"
 			I.screen_loc = do_hud_offset_thing(I, final_loc)
@@ -209,6 +208,8 @@ This is because if one 'square' element was used to cover the entire space, you 
 			i++
 		offset_x = tg_layout ? (i%slots_per_group) : round(i/slots_per_group)
 		offset_y = tg_layout ? round(i/slots_per_group) : (height-(i%slots_per_group))
+		if (!tg_layout && groups > 1 && i > primary_cluster_slots)
+			offset_y -= (pos_y + height - secondary_cluster_slots)
 		empty_obj_loc =  "[pos_x+offset_x],[pos_y+offset_y]:[pixel_y_adjust]"
 		master.linked_item?.UpdateIcon()
 		src.update_box_icons(user)

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -200,7 +200,7 @@ This is because if one 'square' element was used to cover the entire space, you 
 			offset_x = tg_layout ? (i%slots_per_group) : round(i/slots_per_group)
 			offset_y = tg_layout ? round(i/slots_per_group) : (height-(i%slots_per_group))
 			if (!tg_layout)
-				if (i > primary_cluster_slots) // items need to be brought down through the empty space when in the last group
+				if (groups > 1 && i > primary_cluster_slots) // items need to be brought down through the empty space when in the last group
 					offset_y -= (pos_y + height - secondary_cluster_slots)
 			var/obj_loc = "[pos_x+offset_x],[pos_y+offset_y]" //no pixel coords cause that makes click detection harder above
 			var/final_loc = "[pos_x+offset_x],[pos_y+offset_y]:[pixel_y_adjust]"

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -191,7 +191,7 @@ This is because if one 'square' element was used to cover the entire space, you 
 		close_button.screen_loc = "[pos_x-(tg_layout ? 1/2 : 0)]:[pixel_y_adjust],[pos_y]:[pixel_y_adjust]"
 
 		src.obj_locs = list()
-		var/i = 1
+		var/i = 1 // start at 1 to skip x on first group
 		var/offset_x
 		var/offset_y
 		for (var/obj/item/I as anything in hud_contents)

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -191,24 +191,24 @@ This is because if one 'square' element was used to cover the entire space, you 
 		close_button.screen_loc = "[pos_x-(tg_layout ? 1/2 : 0)]:[pixel_y_adjust],[pos_y]:[pixel_y_adjust]"
 
 		src.obj_locs = list()
-		var/iter = 1
+		var/i = 1
 		var/offset_x
 		var/offset_y
 		for (var/obj/item/I as anything in hud_contents)
 			if (!(I in src.objects)) // ugh
 				add_object(I, HUD_LAYER+1)
-			offset_x = tg_layout ? (iter%slots_per_group) : round(iter/slots_per_group)
-			offset_y = tg_layout ? round(iter/slots_per_group) : (height-(iter%slots_per_group))
+			offset_x = tg_layout ? (i%slots_per_group) : round(i/slots_per_group)
+			offset_y = tg_layout ? round(i/slots_per_group) : (height-(i%slots_per_group))
 			if (!tg_layout)
-				if (iter > primary_cluster_slots) // items need to be brought down through the empty space when in the last group
+				if (i > primary_cluster_slots) // items need to be brought down through the empty space when in the last group
 					offset_y -= (pos_y + height - secondary_cluster_slots)
 			var/obj_loc = "[pos_x+offset_x],[pos_y+offset_y]" //no pixel coords cause that makes click detection harder above
 			var/final_loc = "[pos_x+offset_x],[pos_y+offset_y]:[pixel_y_adjust]"
 			I.screen_loc = do_hud_offset_thing(I, final_loc)
 			src.obj_locs[obj_loc] = I
-			iter++
-		offset_x = tg_layout ? (iter%slots_per_group) : round(iter/slots_per_group)
-		offset_y = tg_layout ? round(iter/slots_per_group) : (iter%slots_per_group)
+			i++
+		offset_x = tg_layout ? (i%slots_per_group) : round(i/slots_per_group)
+		offset_y = tg_layout ? round(i/slots_per_group) : (i%slots_per_group)
 		empty_obj_loc =  "[pos_x+offset_x],[pos_y+offset_y]:[pixel_y_adjust]"
 		master.linked_item?.UpdateIcon()
 		src.update_box_icons(user)

--- a/code/datums/hud/storage.dm
+++ b/code/datums/hud/storage.dm
@@ -191,7 +191,7 @@ This is because if one 'square' element was used to cover the entire space, you 
 		close_button.screen_loc = "[pos_x-(tg_layout ? 1/2 : 0)]:[pixel_y_adjust],[pos_y]:[pixel_y_adjust]"
 
 		src.obj_locs = list()
-		var/iter = tg_layout ? 1 : 1 // start at 1 to skip x on first group unless we are goonhud in which case we are skipping iteration i==slots_per_group
+		var/iter = 1
 		var/offset_x
 		var/offset_y
 		for (var/obj/item/I as anything in hud_contents)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Somehow missed that items on goonhud are top to bottom and not bottom to top. Woops. this fixes that

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I MADE A MISTAKE

fixes #24337 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

![dreamseeker_X2jmaY9O3m](https://github.com/user-attachments/assets/cfb6a422-9642-472a-83a3-c499b0648449)

- selection indicator on first group, second group on inventory of 4 slots (pouch), 10 slots (tactical backpack), 20 slots (my custom coder backpack)
- adding/removing items for all above backpacks