### PR TITLE
adjusts semiconductor values to increase cap

### DIFF
--- a/code/datums/teg_transform.dm
+++ b/code/datums/teg_transform.dm
@@ -161,4 +161,4 @@ datum/teg_transformation
 			/*  2*25 / 75 = 0.66 -2  = -1.34 		 TERRIBAD */
 			/* Use above offset * 10 to put it in the -20 to 40 ballpark */
 			efficiency_shift = (2 * electrical_conductivity / thermal_conductivity) - 2 //center on zero
-			src.teg.semiconductor.efficiency_offset = clamp(efficiency_shift*10, -20, 40) //scale shift by 10 which gets it in the ballpark!
+			src.teg.semiconductor.efficiency_offset = clamp(efficiency_shift*10, -20, 48) //scale shift by 10 which gets it in the ballpark!

--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -926,7 +926,7 @@ datum/pump_ui/circulator_ui
 
 		if(semiconductor)
 			//Bound contribution of the semiconductor to +/- 25
-			var/semi_contribution = clamp(src.semiconductor.efficiency_offset, -25, 25)
+			var/semi_contribution = clamp(src.semiconductor.efficiency_offset, -25,48)
 			efficiency_scale += semi_contribution
 
 		if(src.generator_flags & (TEG_HIGH_TEMP | TEG_LOW_TEMP))


### PR DESCRIPTION
<!-- size/XS  -->
<!--:A-Engineering -->
<!--C-Balance -->
<!--C-Feature  -->

 changes semiconductor efficiency code to have a higher cap so it can have more of a contribution to the power and temperature transfer equation 

 I think a higher cap will add a more interesting dynamic to the TEG, especially with the cold loop, as it will be more thermally isolated with higher efficiency semiconductors, making it more worthwhile to go for something like the cryostylane blower reaction effect, as well as giving a reason to actually go for higher materials to meet the new cap. (also considering a lower scaling on the semiconductor material equation to make the highest possible material conductor naturally reach the cap and bring everything else down a bit to add a sensical progression to the best possible option)

 Testing has been multiple launches of the code while adjusting the upper clamp of the TEG semiconductor transform efficiency code and the TEG max semiconductor contribution code on kondaru testing, both how the normal TEG responds to the change, as well as the experimental cold variation at these values, the temperature and contributions act as expected.

 Changelog upped the semiconductor contribution cap


<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Scaltra
(+)upped semiconductor contribution cap
```
