### PR TITLE
Fixes issue #24344

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2385,7 +2385,7 @@ ABSTRACT_TYPE(/datum/manufacture/aiModule)
 	category = "Resource"
 
 /datum/manufacture/mender
-	name = "Auto Mender"
+	name = "Auto Mender (x2)"
 	item_requirements = list("metal_dense" = 5,
 							 "crystal" = 4,
 							 "gold" = 5)


### PR DESCRIPTION
[TRIVIAL] [FIX] [CHORE] [MEDICAL] 
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It turns out when you make automenders through the medical fabricator you get 2, but until now you weren't told that.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People will finally know it makes 2 menders.
## Testing 
Just a text edit so no testing.

