### PR TITLE
Move auxtools debugger attach point to work with 516

### DIFF
--- a/code/world/initialization/1_preMapLoad.dm
+++ b/code/world/initialization/1_preMapLoad.dm
@@ -26,8 +26,6 @@
 	if (should_init_tracy)
 		prof_init()
 
-	enable_auxtools_debugger()
-
 #if defined(SERVER_SIDE_PROFILING) && (defined(SERVER_SIDE_PROFILING_FULL_ROUND) || defined(SERVER_SIDE_PROFILING_PREGAME))
 #warn Profiler enabled at start of init
 	world.Profile(PROFILE_START | PROFILE_AVERAGE, "sendmaps", "json")
@@ -56,7 +54,7 @@
 	world.log << "========================================"
 	world.log << ""
 #endif
-
+	enable_auxtools_debugger()
 	Z_LOG_DEBUG("Preload", "  radio")
 	radio_controller = new /datum/controller/radio()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the `enable_auxtools_debugger()` to slightly further down in the init order. This location was determined through a series of black magic rituals, one spiritual revelation, and some trial and error.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
On certain systems (Windows 10?) having the call earlier and using 516 breaks everything and prevents all future DLL loading. No I don't know why.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I rebuilt repeatedly, moving the proc call until it stopped crashing.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
