### PR TITLE
removes /obj/item/raw_material/fabric

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -653,18 +653,6 @@
 
 // Misc building material
 
-/// This has no material, why does it exist???? Someone replace it
-/obj/item/raw_material/fabric
-	name = "fabric sheet"
-	desc = "Some spun cloth. Useful if you want to make clothing."
-	icon = 'icons/obj/items/materials/materials.dmi'
-	icon_state = "fabric"
-	material_name = "Fabric"
-	scoopable = 0
-
-	get_stack_value()
-		return 0
-
 /obj/item/raw_material/cotton
 	name = "cotton wad"
 	desc = "It's a big puffy white thing. Most likely not a cloud though."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG][REMOVAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title is self-explanatory. This PR removes an unused type from the code.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

`/obj/item/raw_material/fabric` uses the abstract fabric parent material, and probably shouldn't be appearing ingame. Fixes #14329 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

N/A, type was not used or referenced anywhere else in the code. However, it is possible that it may appear in the secret repo. In that case, it should probably be replaced by `obj/item/raw_material/cotton`

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
