### PR TITLE
Clarion QM Office Fix

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -31672,9 +31672,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig)
-"rqa" = (
-/turf/space,
-/area/station/quartermaster/office)
 "rqn" = (
 /obj/cable/orange{
 	icon_state = "2-8"
@@ -81123,7 +81120,7 @@ aaa
 aaa
 aaa
 aaa
-rqa
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
[MAPPING] [BUG]
## About the PR
jorj949 pointed out that, on clarion, there was one tile of quartermaster office area out in space. emily told him to fix it but he didn't want to. so I fixed it

## Why's this needed?
emily asked very nicely I think

## Testing 
looked at it in strongdmm. offending tile was no longer a qm office area. if I need to test this further let me know