### PR TITLE
Radios don't default to general with wrong prefix

### DIFF
--- a/code/modules/speech/modules/listen/effects/radio.dm
+++ b/code/modules/speech/modules/listen/effects/radio.dm
@@ -7,11 +7,15 @@
 		return
 
 	var/signal_frequency
-	if (length(radio.secure_frequencies))
-		// `copytext` returns the message prefix without the leading colon.
-		signal_frequency = radio.secure_frequencies[copytext(message.prefix, 2, length(message.prefix) + 1)]
-
-	signal_frequency ||= radio.frequency
+	// `copytext` returns the message prefix without the leading colon.
+	var/radio_prefix = copytext(message.prefix, 2, length(message.prefix) + 1)
+	// Only default to general frequency if you didn't try talking on a different channel
+	if (length(radio.secure_frequencies) && radio.secure_frequencies[radio_prefix])
+		signal_frequency = radio.secure_frequencies[radio_prefix]
+	else if (!radio_prefix)
+		signal_frequency = radio.frequency
+	else //Just whisper, don't try talking crime on general
+		return
 
 	if (signal_frequency != R_FREQ_DEFAULT)
 		message.hear_sound = 'sound/misc/talk/radio2.ogg'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stops radios from defaulting any prefix you don't have onto the general radio channel, such as trying to use ":Z" with a headset without the syndicate radio. Messages are still whispered as you try to speak into the radio but fail spectacularly, but it may be better for failed uses of innate channels (ling/vamp) to just nullify failed prefix messages completely.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This mostly affects antagonists that may have to juggle various headsets for example to talk on the syndicate channel, accidentally using :z with your normal crew headset instead of your syndicate one to discuss how you killed someone isn't going to look good when that message instead goes to general. Also means that for anyone with other prefixes such as :hive misspelling it won't forward your ":hiv thank goodness they didn't find the body in the bathroom up north" to the general channel.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Messages below had the following prefixes: ":" ":g" ":b" ":hiv"
<img width="532" height="284" alt="image" src="https://github.com/user-attachments/assets/bb097d81-fc39-4d33-85d0-188c2b57b17a" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Radios will no longer default incorrect prefixes (such as ":hiv"), or prefixes you don't have access to (":z" with a non-syndicate headset) to the general frequency.
```
