### PR TITLE
fix cord component range check

### DIFF
--- a/code/datums/components/cord.dm
+++ b/code/datums/components/cord.dm
@@ -25,7 +25,7 @@
 	RegisterSignal(src.handset, XSIG_MOVABLE_TURF_CHANGED, PROC_REF(draw_cord), TRUE)
 
 /datum/component/cord/proc/draw_cord(datum/component/complexsignal/outermost_movable/component)
-	if(QDELETED(src.handset) || (BOUNDS_DIST(src.parent, src.handset) > 0))
+	if(QDELETED(src.handset) || (BOUNDS_DIST(src.parent, src.handset) > range))
 		SEND_SIGNAL(src.parent, COMSIG_CORD_RETRACT)
 		return
 	var/handset_offset_x = -7


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Fixes cord component range check
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* `range` arg was ignored
