### PR TITLE
Makes German and Tyke accents from traits non-mutadone-able

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -484,7 +484,7 @@
 	category = list("language")
 
 	onAdd(var/mob/owner)
-		owner.bioHolder?.AddEffect("accent_tyke")
+		owner.bioHolder?.AddEffect("accent_tyke", 0, 0, 0, 1)
 
 // VISION/SENSES - Green Border
 

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -462,7 +462,7 @@
 	category =  list("language")
 
 	onAdd(var/mob/owner)
-		owner.bioHolder?.AddEffect("accent_german")
+		owner.bioHolder?.AddEffect("accent_german", 0, 0, 0, 1)
 
 /datum/trait/finnish
 	name = "Finnish Accent"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
German and Tyke accents will no longer be removed by mutadone if they exist as a result of their relevant traits being selected.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #24180 , also fixes tyke speech but I can't find any bug reports for that, probably because I don't think I've ever seen anybody take that trait.

## Testing
idk how to add attachments in visual studio hold on I'll add them here soon



## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)nova2053
(+)Accents from the "German" and "Tyke" traits will not be removed by mutadone.
```
