### PR TITLE
Add more checks for pin resisting

### DIFF
--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -354,7 +354,7 @@
 			prev_move = world.time
 			return delay
 		else
-			if (src.restrained() || !isalive(src))
+			if (src.restrained() || !isalive(src) || src.hasStatus("stunned") || src.hasStatus("paralysis") || src.hasStatus("knockdown"))
 				return
 			for (var/obj/item/grab/G as anything in src.grabbed_by)
 				if (G.state == GRAB_PIN)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
You can no longer resist pins while paralyzed. I also noticed while coding this that the knocked-down and stunned status effects don't prevent resisting pins despite their purpose being to block player actions, and changed that as well.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #24368
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spawned and pinned a test dummy before posessing the test dummy and using player options panel to apply relevant status effects to the test dummy.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
