### PR TITLE
Fix openable capcoat bugs

### DIFF
--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -644,9 +644,12 @@
 					succ = TRUE
 
 				if (istype(M, /obj/item/clothing/suit/armor/capcoat))
+					var/obj/item/clothing/suit/armor/capcoat/coat = M
+					coat.coat_style = "centcoat"
+					coat.item_state = "centcoat"
+					var/datum/component/toggle_coat/toggle_component = coat.GetComponent(/datum/component/toggle_coat)
+					toggle_component.update_coat_icon()
 					var/prev = M.name
-					M.icon_state = "centcoat"
-					M.item_state = "centcoat"
 					M.name = "commander's coat"
 					M.real_name = "commander's coat"
 					M.desc = "A luxurious formal coat. It is specifically made for Nanotrasen commanders.(Base Item: [prev])"
@@ -817,9 +820,12 @@
 					succ = TRUE
 
 				if (istype(M, /obj/item/clothing/suit/armor/capcoat))
+					var/obj/item/clothing/suit/armor/capcoat/coat = M
+					coat.coat_style = "centcoat-red"
+					coat.item_state = "centcoat-red"
+					var/datum/component/toggle_coat/toggle_component = coat.GetComponent(/datum/component/toggle_coat)
+					toggle_component.update_coat_icon()
 					var/prev = M.name
-					M.icon_state = "centcoat-red"
-					M.item_state = "centcoat-red"
 					M.name = "\improper CentCom coat"
 					M.real_name = "\improper CentCom coat"
 					M.desc = "A luxurious formal coat. It is specifically made for CENTCOM executives.(Base Item: [prev])"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes opening the captain's coat resetting it's colour when redeemed via medal. Also fixes the medal redeem making the coat seem closed when it is still open.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I have once again been foiled by things just overriding icon state.
Fixes #24439

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Redeemed both the blue and red medal redeems and opened and closed the coat a few times, works as expected.