### PR TITLE
Revert "Fixes paint for tables and chairs" to fix comfy chair layering issue

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -15,7 +15,7 @@ TYPEINFO_NEW(/obj/table)
 	density = 1
 	anchored = ANCHORED
 	flags = NOSPLASH
-		appearance_flags = parent_type::appearance_flags | KEEP_TOGETHER
+	appearance_flags = parent_type::appearance_flags | KEEP_TOGETHER
 	event_handler_flags = USE_FLUID_ENTER
 	layer = OBJ_LAYER-0.1
 	stops_space_move = TRUE


### PR DESCRIPTION
Reverts goonstation/goonstation#24326 as advised by a developer in order to fix the chair layering issue. This will reintroduce the comfy chair paint bug, but I find that it's the lesser of two evils to put it in an insanely melodramatic way.

This is necessary, as presently the player appears above the arm overlay of all comfy type chairs. It is my belief that this visual bug is worse than the paint bug that goonstation/goonstation#24326 was introduced to fix.


I have tested removing this on a test server and it seemed to fix the layering issue. I don't believe testing screenshots are required, as this is just a direct reversion to something that was already in the server.