### PR TITLE
Fixes #24471 - Void Speech Now Uses Mutable Tags

### DIFF
--- a/code/modules/speech/modules/speech/modifiers/accents.dm
+++ b/code/modules/speech/modules/speech/modifiers/accents.dm
@@ -509,7 +509,7 @@ ABSTRACT_TYPE(/datum/speech_module/modifier/accent)
 
 /datum/speech_module/modifier/accent/void
 	id = SPEECH_MODIFIER_ACCENT_VOID
-	accent_proc = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(voidSpeak))
+	accent_proc = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(voidSpeak), TRUE)
 
 
 /datum/speech_module/modifier/accent/vowelitis

--- a/code/procs/accents.dm
+++ b/code/procs/accents.dm
@@ -1375,7 +1375,7 @@ proc/random_accent()
 	P.chars_used = used
 	return P
 
-/proc/voidSpeak(var/message) // sharing the creepiness with everyone!!
+/proc/voidSpeak(message, mutable_tags = FALSE)
 	if (!message)
 		return
 
@@ -1402,10 +1402,20 @@ proc/random_accent()
 			randomPos = " position: relative; top: [rand(-3,3)]px; left: [rand(-3,3)]px;"
 		else
 			randomPos = ""
-		processedMessage += "<span style='font-size: [fontSize]%;[randomPos]'>[c]</span>"
+
+		if (mutable_tags)
+			processedMessage += MAKE_CONTENT_IMMUTABLE("<span style='font-size: [fontSize]%;[randomPos]'>")
+			processedMessage += c
+			processedMessage += MAKE_CONTENT_IMMUTABLE("</span>")
+
+		else
+			processedMessage += "<span style='font-size: [fontSize]%;[randomPos]'>[c]</span>"
 
 
-	return "<em>[processedMessage]</em>"
+	if (mutable_tags)
+		return "[MAKE_CONTENT_IMMUTABLE("<em>")][processedMessage][MAKE_CONTENT_IMMUTABLE("</em>")]"
+	else
+		return "<em>[processedMessage]</em>"
 
 // zalgo text proc, borrowed from eeemo.net
 


### PR DESCRIPTION
## About The PR:
Fixes #24471 by allowing the `voidSpeak` proc to make HTML portions immutable.


## Testing:
<img width="537" height="60" alt="image" src="https://github.com/user-attachments/assets/0340fd8d-3a6e-4922-a26b-2bff851fc2d9" />