### PR TITLE
Prevent seed extraction scrambling plant alleles

### DIFF
--- a/code/modules/hydroponics/hydroponics_misc_procs.dm
+++ b/code/modules/hydroponics/hydroponics_misc_procs.dm
@@ -146,8 +146,8 @@ proc/HYPgenerate_produce_name(var/atom/manipulated_atom, var/obj/machinery/plant
 
 
 
-
-proc/HYPpassplantgenes(var/datum/plantgenes/PARENT,var/datum/plantgenes/CHILD, var/pass_alleles = FALSE)
+/// allele_override: alleles are always passed if TRUE, randomised if FALSE.
+proc/HYPpassplantgenes(var/datum/plantgenes/PARENT,var/datum/plantgenes/CHILD, var/allele_override)
 	if(!PARENT || !CHILD)
 		return
 	// This is a proc used to copy genes from PARENT to CHILD. It's used in a whole bunch
@@ -161,7 +161,7 @@ proc/HYPpassplantgenes(var/datum/plantgenes/PARENT,var/datum/plantgenes/CHILD, v
 	CHILD.potency = PARENT.potency
 	CHILD.endurance = PARENT.endurance
 	// if applicable, also pass the alleles from parent to child.
-	if (pass_alleles)
+	if (allele_override)
 		CHILD.d_species = PARENT.d_species
 		CHILD.d_growtime = PARENT.d_growtime
 		CHILD.d_harvtime = PARENT.d_harvtime
@@ -176,16 +176,18 @@ proc/HYPpassplantgenes(var/datum/plantgenes/PARENT,var/datum/plantgenes/CHILD, v
 		for (var/datum/plant_gene_strain/checked_strain in CHILD.commuts)
 			checked_strain.on_passing(CHILD)
 
+/// allele_override: alleles are always passed if TRUE, randomised if FALSE. If null they're passed only if an appropriate gene strain is present,
+/// otherwise randomised.
 proc/HYPgenerateseedcopy(var/datum/plantgenes/parent_genes, var/datum/plant/parent_planttype, var/parent_generation, var/location_to_create,
-						 charge_quantity = 1, randomise_alleles = TRUE)
+						 charge_quantity = 1, var/allele_override)
 	//This proc generates a seed at location_to_create with a copy of the planttype and genes of a given parent plant.
 	//This can be used, when you want to quickly generate seeds out of objects or other plants e.g. creeper or fruits.
 	charge_quantity = max(charge_quantity, 1) // Assume whoever called this wants a seed regardless, don't deal with returning nulls.
 	var/obj/item/seed/child
 	if (parent_planttype.unique_seed)
-		child = new parent_planttype.unique_seed(location_to_create, randomise_alleles)
+		child = new parent_planttype.unique_seed(location_to_create)
 	else
-		child = new /obj/item/seed(location_to_create, randomise_alleles)
+		child = new /obj/item/seed(location_to_create)
 	child.charges = charge_quantity
 	if (child.charges > 1) child.inventory_counter.update_number(child.charges)
 	var/datum/plant/child_planttype = HYPgenerateplanttypecopy(child, parent_planttype)
@@ -209,7 +211,7 @@ proc/HYPgenerateseedcopy(var/datum/plantgenes/parent_genes, var/datum/plant/pare
 	child.name = "[seedname] seed"
 	if (charge_quantity > 1) child.name += " packet"
 	//What's missing is transfering genes and the generation
-	HYPpassplantgenes(parent_genes, child_genes, !randomise_alleles)
+	HYPpassplantgenes(parent_genes, child_genes, allele_override)
 	child.generation = parent_generation
 	//Now the seed it created and we can release it upon the world
 	return child

--- a/code/modules/hydroponics/hydroponics_misc_procs.dm
+++ b/code/modules/hydroponics/hydroponics_misc_procs.dm
@@ -176,8 +176,7 @@ proc/HYPpassplantgenes(var/datum/plantgenes/PARENT,var/datum/plantgenes/CHILD, v
 		for (var/datum/plant_gene_strain/checked_strain in CHILD.commuts)
 			checked_strain.on_passing(CHILD)
 
-/// allele_override: alleles are always passed if TRUE, randomised if FALSE. If null they're passed only if an appropriate gene strain is present,
-/// otherwise randomised.
+/// allele_override: alleles are always passed if TRUE, randomised if FALSE.
 proc/HYPgenerateseedcopy(var/datum/plantgenes/parent_genes, var/datum/plant/parent_planttype, var/parent_generation, var/location_to_create,
 						 charge_quantity = 1, var/allele_override)
 	//This proc generates a seed at location_to_create with a copy of the planttype and genes of a given parent plant.

--- a/code/modules/hydroponics/hydroponics_misc_procs.dm
+++ b/code/modules/hydroponics/hydroponics_misc_procs.dm
@@ -147,7 +147,7 @@ proc/HYPgenerate_produce_name(var/atom/manipulated_atom, var/obj/machinery/plant
 
 
 
-proc/HYPpassplantgenes(var/datum/plantgenes/PARENT,var/datum/plantgenes/CHILD)
+proc/HYPpassplantgenes(var/datum/plantgenes/PARENT,var/datum/plantgenes/CHILD, var/pass_alleles = FALSE)
 	if(!PARENT || !CHILD)
 		return
 	// This is a proc used to copy genes from PARENT to CHILD. It's used in a whole bunch
@@ -160,6 +160,15 @@ proc/HYPpassplantgenes(var/datum/plantgenes/PARENT,var/datum/plantgenes/CHILD)
 	CHILD.cropsize = PARENT.cropsize
 	CHILD.potency = PARENT.potency
 	CHILD.endurance = PARENT.endurance
+	// if applicable, also pass the alleles from parent to child.
+	if (pass_alleles)
+		CHILD.d_species = PARENT.d_species
+		CHILD.d_growtime = PARENT.d_growtime
+		CHILD.d_harvtime = PARENT.d_harvtime
+		CHILD.d_harvests = PARENT.d_harvests
+		CHILD.d_cropsize = PARENT.d_cropsize
+		CHILD.d_potency = PARENT.d_potency
+		CHILD.d_endurance = PARENT.d_endurance
 	// using the same list as the parent as adding new items is what creates a new list
 	CHILD.commuts = PARENT.commuts
 	if(MUT) CHILD.mutation = new MUT.type(CHILD)
@@ -167,15 +176,16 @@ proc/HYPpassplantgenes(var/datum/plantgenes/PARENT,var/datum/plantgenes/CHILD)
 		for (var/datum/plant_gene_strain/checked_strain in CHILD.commuts)
 			checked_strain.on_passing(CHILD)
 
-proc/HYPgenerateseedcopy(var/datum/plantgenes/parent_genes, var/datum/plant/parent_planttype, var/parent_generation, var/location_to_create, charge_quantity = 1)
+proc/HYPgenerateseedcopy(var/datum/plantgenes/parent_genes, var/datum/plant/parent_planttype, var/parent_generation, var/location_to_create,
+						 charge_quantity = 1, randomise_alleles = TRUE)
 	//This proc generates a seed at location_to_create with a copy of the planttype and genes of a given parent plant.
 	//This can be used, when you want to quickly generate seeds out of objects or other plants e.g. creeper or fruits.
 	charge_quantity = max(charge_quantity, 1) // Assume whoever called this wants a seed regardless, don't deal with returning nulls.
 	var/obj/item/seed/child
 	if (parent_planttype.unique_seed)
-		child = new parent_planttype.unique_seed(location_to_create)
+		child = new parent_planttype.unique_seed(location_to_create, randomise_alleles)
 	else
-		child = new /obj/item/seed(location_to_create)
+		child = new /obj/item/seed(location_to_create, randomise_alleles)
 	child.charges = charge_quantity
 	if (child.charges > 1) child.inventory_counter.update_number(child.charges)
 	var/datum/plant/child_planttype = HYPgenerateplanttypecopy(child, parent_planttype)
@@ -199,7 +209,7 @@ proc/HYPgenerateseedcopy(var/datum/plantgenes/parent_genes, var/datum/plant/pare
 	child.name = "[seedname] seed"
 	if (charge_quantity > 1) child.name += " packet"
 	//What's missing is transfering genes and the generation
-	HYPpassplantgenes(parent_genes, child_genes)
+	HYPpassplantgenes(parent_genes, child_genes, !randomise_alleles)
 	child.generation = parent_generation
 	//Now the seed it created and we can release it upon the world
 	return child

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1225,7 +1225,7 @@ TYPEINFO(/obj/machinery/plantpot)
 /// Handles the generation of seed items
 /obj/machinery/plantpot/proc/HYPharvesting_seeds(datum/HYPharvesting_data/h_data)
 	if (h_data.seedcount > 0) HYPgenerateseedcopy(h_data.pot.plantgenes, h_data.growing, h_data.pot.generation,
-													h_data.pot, h_data.seedcount, randomise_alleles = TRUE)
+													h_data.pot, h_data.seedcount)
 
 /// Handles the finalisation of cropcount
 /obj/machinery/plantpot/proc/HYPharvesting_finalise_cropcount(datum/HYPharvesting_data/h_data)

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1224,7 +1224,8 @@ TYPEINFO(/obj/machinery/plantpot)
 
 /// Handles the generation of seed items
 /obj/machinery/plantpot/proc/HYPharvesting_seeds(datum/HYPharvesting_data/h_data)
-	if (h_data.seedcount > 0) HYPgenerateseedcopy(h_data.pot.plantgenes, h_data.growing, h_data.pot.generation, h_data.pot, h_data.seedcount)
+	if (h_data.seedcount > 0) HYPgenerateseedcopy(h_data.pot.plantgenes, h_data.growing, h_data.pot.generation,
+													h_data.pot, h_data.seedcount, randomise_alleles = TRUE)
 
 /// Handles the finalisation of cropcount
 /obj/machinery/plantpot/proc/HYPharvesting_finalise_cropcount(datum/HYPharvesting_data/h_data)

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -260,7 +260,7 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 						boutput(ui.user, SPAN_ALERT("No viable seeds found in [I]."))
 					else
 						boutput(ui.user, SPAN_NOTICE("Extracted [give] seeds from [I]."))
-						var/obj/item/seed/S = HYPgenerateseedcopy(DNA, stored, P.generation, src, give)
+						var/obj/item/seed/S = HYPgenerateseedcopy(DNA, stored, P.generation, src, give, randomise_alleles = FALSE)
 						if (!src.output_externally)
 							src.seeds.Add(S)
 						else

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -260,7 +260,7 @@ TYPEINFO(/obj/submachine/seed_manipulator)
 						boutput(ui.user, SPAN_ALERT("No viable seeds found in [I]."))
 					else
 						boutput(ui.user, SPAN_NOTICE("Extracted [give] seeds from [I]."))
-						var/obj/item/seed/S = HYPgenerateseedcopy(DNA, stored, P.generation, src, give, randomise_alleles = FALSE)
+						var/obj/item/seed/S = HYPgenerateseedcopy(DNA, stored, P.generation, src, give, allele_override = TRUE)
 						if (!src.output_externally)
 							src.seeds.Add(S)
 						else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Added mechanism for plant alleles (the (D)ominant and (r)ecessive portion of plant stats) to be passed along when a seed is copied. 

Alleles are passed exclusively during seed extraction.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Alleles are always randomised during harvest already, so it doesn't make much sense for them to be rerolled during extraction.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Grew fruit and vegetable to make sure fruits and seeds harvested still rerolled alleles. Then extracted some tomatoes and observed alleles were the same before and after. 

<img width="422" height="541" alt="Screenshot 2025-08-19 165517" src="https://github.com/user-attachments/assets/9f5bcbf1-cb33-4ccb-ad5d-b509c42c8fd5" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->