### PR TITLE
Devtest Syndicate Law rack

### DIFF
--- a/maps/utilities/devtest.dmm
+++ b/maps/utilities/devtest.dmm
@@ -156,15 +156,6 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/devzone)
-"du" = (
-/obj/landmark/start/job/AI,
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/map/light/brighterwhite,
-/turf/simulated/floor,
-/area/station/turret_protected/ai)
 "dx" = (
 /obj/machinery/door/poddoor/buff{
 	dir = 1;
@@ -348,6 +339,10 @@
 	},
 /turf/space,
 /area/station/devzone)
+"gP" = (
+/obj/map/light/brighterwhite,
+/turf/simulated/floor,
+/area/supply/spawn_point)
 "gQ" = (
 /obj/landmark/start/job/head_of_personnel,
 /turf/simulated/floor,
@@ -616,6 +611,10 @@
 	},
 /turf/simulated/floor,
 /area/station/devzone)
+"lb" = (
+/obj/machinery/lawrack/syndicate,
+/turf/simulated/floor,
+/area/station/devzone)
 "ld" = (
 /obj/iv_stand,
 /obj/item/reagent_containers/iv_drip,
@@ -823,10 +822,6 @@
 /obj/machinery/vehicle/pod,
 /turf/simulated/floor/engine/glow/blue,
 /area/space)
-"py" = (
-/mob/living/silicon/hivebot/eyebot,
-/turf/simulated/floor,
-/area/station/turret_protected/ai)
 "pE" = (
 /obj/machinery/door_control{
 	id = "tele";
@@ -962,10 +957,6 @@
 	},
 /turf/simulated/floor,
 /area/station/devzone)
-"rY" = (
-/obj/machinery/computer/robotics,
-/turf/simulated/floor,
-/area/station/turret_protected/ai)
 "se" = (
 /obj/landmark/start/job/head_of_security,
 /turf/simulated/floor,
@@ -1221,9 +1212,6 @@
 /obj/submachine/chef_oven,
 /turf/simulated/floor/white,
 /area/station/devzone)
-"xE" = (
-/turf/simulated/floor,
-/area/supply/spawn_point)
 "xK" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
@@ -1378,9 +1366,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/devzone)
-"Aa" = (
-/turf/simulated/floor,
-/area/supply/sell_point)
 "Ae" = (
 /obj/disposalpipe/type_sensing_outlet/drone_factory{
 	dir = 4
@@ -1731,7 +1716,6 @@
 /turf/simulated/floor/white,
 /area/station/devzone)
 "FT" = (
-/obj/machinery/lawrack,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-4"
@@ -1739,15 +1723,17 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/landmark/start/job/AI,
 /turf/simulated/floor,
-/area/station/turret_protected/ai)
+/area/station/devzone)
 "FV" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/power/apc/autoname_east,
+/mob/living/silicon/hivebot/eyebot,
+/obj/machinery/recharge_station,
 /turf/simulated/floor,
-/area/station/turret_protected/ai)
+/area/station/devzone)
 "Gi" = (
 /obj/machinery/chem_heater,
 /turf/simulated/floor/white,
@@ -2369,6 +2355,10 @@
 	},
 /turf/simulated/floor,
 /area/station/devzone)
+"Qx" = (
+/obj/map/light/brighterwhite,
+/turf/simulated/floor,
+/area/supply/sell_point)
 "Qy" = (
 /obj/decal/tile_edge/line/red{
 	dir = 8;
@@ -2490,20 +2480,6 @@
 	dir = 1
 	},
 /area/station/devzone)
-"SI" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/debug_generator{
-	generating = 100000
-	},
-/obj/map/light/brighterwhite,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable,
-/turf/simulated/floor,
-/area/station/turret_protected/ai)
 "SQ" = (
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -2547,6 +2523,10 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine/vacuum,
+/area/station/devzone)
+"TK" = (
+/obj/machinery/lawrack,
+/turf/simulated/floor,
 /area/station/devzone)
 "TM" = (
 /obj/landmark/start/job/research_director,
@@ -2768,6 +2748,10 @@
 	icon_state = "engine_caution_south"
 	},
 /area/station/devzone)
+"XM" = (
+/obj/machinery/computer/robotics,
+/turf/simulated/floor,
+/area/station/devzone)
 "XR" = (
 /obj/submachine/weapon_vendor/fishing/portable,
 /turf/simulated/floor,
@@ -2864,6 +2848,9 @@
 	},
 /obj/cable{
 	icon_state = "0-2"
+	},
+/obj/machinery/power/debug_generator{
+	generating = 100000
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/devzone)
@@ -3761,12 +3748,12 @@ Yx
 Yx
 Yx
 Yx
-Yx
 ng
 Yx
 EV
 wY
 DU
+ng
 ng
 ng
 ng
@@ -3804,7 +3791,6 @@ Yx
 Yx
 Yx
 Yx
-Yx
 ng
 HZ
 YU
@@ -3814,12 +3800,13 @@ ng
 cj
 LN
 ng
-Aa
+Qx
 hc
 Yx
 XB
 ng
-py
+TK
+Yx
 FT
 hS
 ii
@@ -3847,7 +3834,6 @@ Yx
 Yx
 Yx
 Yx
-Yx
 ng
 Yx
 dq
@@ -3862,8 +3848,9 @@ bi
 Xb
 he
 ng
-du
-SI
+XM
+Yx
+kV
 kz
 kV
 kV
@@ -3899,13 +3886,13 @@ ng
 ng
 ng
 ng
-ng
-xE
+gP
 ag
 wg
 ZD
 ng
-rY
+lb
+Yx
 FV
 ng
 LH


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a syndicate law rack to devtest.
Also removes the separate AI core area from devtest so the area can be in fullbright, if there was a reason to keep this a separate area I can't figure it out, the APC wasn't even connected properly I don't think.
Moves the debug generator up to the mechanics/data terminal area now that the AI core doesn't have a separate area.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Devtest doesn't generate other Z levels, notably the cairngorm on Z2 where the syndicate law rack is, one of the few things that Z2 is needed for, this lets people mess around with syndicate cyborgs while having the proper syndicate lawset and being able to have a look at it in the rack to show that it is on a rack.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Image from before i moved the debug generator
<img width="360" height="386" alt="image" src="https://github.com/user-attachments/assets/e93a28a9-7459-474a-949a-570c2929cdc2" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
