### PR TITLE
Fix missing clarion security wire

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -17267,6 +17267,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
+"gSD" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/security/main)
 "gSF" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light{
@@ -21174,6 +21183,9 @@
 "jDQ" = (
 /obj/stool/chair/office/red,
 /obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -85220,7 +85232,7 @@ vOG
 tKf
 kmj
 rgz
-rgz
+gSD
 vfz
 qzB
 tKu


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Wires in the main security apc on clarion, the brig APC threw me off into thinking id already wired it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
APCs need wires silly!

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="546" height="406" alt="image" src="https://github.com/user-attachments/assets/9a5313a1-345c-48b7-a4ee-4602c8bb9636" />
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

