### PR TITLE
Prevent the Razorbill from shooting ghost bullets on point blank

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1256,7 +1256,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	icon_state = "american180"
 	item_state = "a180"
 	spread_angle = 3
-	shoot_delay = 1
+	shoot_delay = 3
 	has_empty_state = FALSE // non detachable mag, for now...
 	w_class = W_CLASS_BULKY
 	force = MELEE_DMG_RIFLE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR increases the `shoot_delay` of the Razorbill-180 from 1 decisecond to 3, preventing it from shooting multiple bullets at point blank, running into the hit cooldown, and leaving a stationary ghost bullet. This has no effect on its actual fire rate: `shoot_delay` only effects tap-fire.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #24382 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Point blanked a test dummy multiple times to verify it was working. Also shot it in full-auto to verify its firerate was unchanged.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)RubberRats
(+)The Razorbill-180 should no longer leave floating ghost bullets on point-blank
```
