### PR TITLE
Computer frames convert based on inserted board

### DIFF
--- a/code/modules/networks/computer3/buildandrepair.dm
+++ b/code/modules/networks/computer3/buildandrepair.dm
@@ -101,6 +101,7 @@ TYPEINFO(/obj/item/motherboard)
 				new_computer.state = 1
 				new_computer.anchored = src.anchored
 				new_computer.dir = src.dir
+				new_computer.setMaterial(src.material)
 				new_computer.Attackby(P, user)
 				qdel(src)
 			if (isscrewingtool(P) && mainboard)

--- a/code/modules/networks/computer3/buildandrepair.dm
+++ b/code/modules/networks/computer3/buildandrepair.dm
@@ -96,6 +96,13 @@ TYPEINFO(/obj/item/motherboard)
 				src.mainboard = P
 				user.drop_item()
 				P.set_loc(src)
+			else if (istype(P, /obj/item/circuitboard) && !mainboard && istype_exact(src,/obj/computer3frame))
+				var/obj/computerframe/new_computer = new(src.loc)
+				new_computer.state = 1
+				new_computer.anchored = src.anchored
+				new_computer.dir = src.dir
+				new_computer.Attackby(P, user)
+				qdel(src)
 			if (isscrewingtool(P) && mainboard)
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				boutput(user, SPAN_NOTICE("You screw the mainboard into place."))
@@ -108,8 +115,6 @@ TYPEINFO(/obj/item/motherboard)
 				src.icon_state = "0"
 				mainboard.set_loc(src.loc)
 				src.mainboard = null
-			if (istype(P, /obj/item/circuitboard))
-				boutput(user, SPAN_ALERT("This is the wrong type of frame, it won't fit!"))
 
 		if(2)
 			if (isscrewingtool(P) && mainboard && (!peripherals.len))

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -1286,20 +1286,13 @@ ABSTRACT_TYPE(/datum/sheet_crafting_recipe/plastic)
 		tcomputer
 			recipe_id = "tcomputer"
 			craftedType = /obj/computer3frame/terminal
-			name = "Computer Terminal Frame"
+			name = "Terminal Frame"
 			sheet_cost = 3
 			icon = 'icons/obj/terminal_frame.dmi'
 			icon_state = "0"
 		computer
 			recipe_id = "computer"
 			craftedType = /obj/computerframe
-			name = "Console Frame"
-			sheet_cost = 5
-			icon = 'icons/obj/computer_frame.dmi'
-			icon_state = "0"
-		hcomputer
-			recipe_id = "hcomputer"
-			craftedType = /obj/computer3frame
 			name = "Computer Frame"
 			sheet_cost = 5
 			icon = 'icons/obj/computer_frame.dmi'

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -292,6 +292,7 @@ TYPEINFO(/obj/item/circuitboard/announcement/clown)
 			if (!src.circuit)
 				return {"
 					You can insert a circuit board to start assembling a console,
+					or you can insert a motherboard to start assembling a computer,
 					or use a <b>wrench</b> to unanchor it
 				"}
 			else
@@ -336,6 +337,13 @@ TYPEINFO(/obj/item/circuitboard/announcement/clown)
 				src.circuit = P
 				user.drop_item()
 				P.set_loc(src)
+			else if (istype(P, /obj/item/motherboard) && !circuit)
+				var/obj/computer3frame/new_computer = new(src.loc)
+				new_computer.state = STATE_ANCHORED
+				new_computer.anchored = src.anchored
+				new_computer.dir = src.dir
+				new_computer.Attackby(P, user)
+				qdel(src)
 			if (isscrewingtool(P) && circuit)
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				boutput(user, SPAN_NOTICE("You screw the circuit board into place."))

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -342,6 +342,7 @@ TYPEINFO(/obj/item/circuitboard/announcement/clown)
 				new_computer.state = STATE_ANCHORED
 				new_computer.anchored = src.anchored
 				new_computer.dir = src.dir
+				new_computer.setMaterial(src.material)
 				new_computer.Attackby(P, user)
 				qdel(src)
 			if (isscrewingtool(P) && circuit)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Console and Computer frames will convert into each other depending on if a circuitboard or motherboard is inserted.
Removes computer frame from construction list

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having to remember which version of computer/console you need is incredibly annoying.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
The north computers were built from console frames, the south were built from computer3 frames
<img width="335" height="214" alt="image" src="https://github.com/user-attachments/assets/490a1d55-5036-4204-8fcf-d3105bc3fe37" />
<img width="161" height="225" alt="image" src="https://github.com/user-attachments/assets/ba99a14f-eba9-40fa-be55-92f939af01a0" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Computer and Console frames convert into each other depending on if a Circuitboard or Motherboard is inserted.
```
