### PR TITLE
Fix/tweak radioactive material visual effects

### DIFF
--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -74,9 +74,10 @@ TYPEINFO(/datum/component/radioactive)
 			if(isnull(src._turf_glow))
 				src._turf_glow = image('icons/effects/effects.dmi', "greyglow")
 			src._turf_glow.color = color //we can do this because overlays take a copy of the image and do not preserve the link between them
+			src._turf_glow.alpha = 50
 			PA.AddOverlays(src._turf_glow, "radiation_overlay_\ref[src]")
 		else
-			PA.add_filter("radiation_outline_\ref[src]", 2, outline_filter(size=1.3, color=color))
+			PA.add_filter("radiation_outline_\ref[src]", 10, outline_filter(size=1.3, color=color))
 
 	proc/process()
 		if(QDELETED(parent) || !parent.datum_components)

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -477,26 +477,30 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 
 /datum/materialProc/radioactive_add
 	execute(var/atom/location)
-		animate_flash_color_fill_inherit(location, "#1122EE", -1, 40)
+		if (!isturf(location))
+			animate_flash_color_fill_inherit(location, "#69e46f", -1, 40)
 		location.AddComponent(/datum/component/radioactive, location.material.getProperty("radioactive")*10, FALSE, FALSE, 1)
 		return
 
 /datum/materialProc/radioactive_remove
 	execute(var/atom/location)
-		animate_flash_color_fill_inherit(location, "#1122EE", -1, 40)
+		if (!isturf(location))
+			animate(location)
 		var/datum/component/radioactive/R = location.GetComponent(/datum/component/radioactive)
 		R?.RemoveComponent()
 		return
 
 /datum/materialProc/n_radioactive_add
 	execute(var/atom/location)
-		animate_flash_color_fill_inherit(location, "#1122EE", -1, 40)
+		if (!isturf(location))
+			animate_flash_color_fill_inherit(location, "#1122EE", -1, 40)
 		location.AddComponent(/datum/component/radioactive, location.material.getProperty("n_radioactive")*10, FALSE, TRUE, 1)
 		return
 
 /datum/materialProc/n_radioactive_remove
 	execute(var/atom/location)
-		animate_flash_color_fill_inherit(location, "#1122EE", -1, 40)
+		if (!isturf(location))
+			animate(location)
 		var/datum/component/radioactive/R = location.GetComponent(/datum/component/radioactive)
 		R?.RemoveComponent()
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This started out as a review of #24349, look at the radioactive materials in that PR, don't they look off?
So apparently the reason they look weird is that radioactive visuals were janky and kind of broken anyway:
- The glowy effect from radioactive materials was all set to neutron radiation blue, meaning all radioactive materials were actually just glowing blue this whole time. Now it's green again and looks much better.
- The glow was applying to turfs too, BUT the radioactive component also added a glow effect to turfs so there were two overlapping glow animations. I've made the generic material one not apply to turfs, and also tweaked down the alpha of the turf glow effect because it was at 100% and therefore replacing the base colour completely.
- The radioactive outline filter was set to a very low priority and therefore being rendered with colour matrix filters applied to it, meaning it was almost never actually the right colour.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The whole radioactive effect stack was just all kinds of janked up, making it very hard to achieve decent looking radioactive materials.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
The end result is that radioactive materials look way less oversaturated and blue than before (screenshots taken with #24349):
<img width="941" height="697" alt="image" src="https://github.com/user-attachments/assets/ef2a2d31-8f0c-4835-ae2c-2ab052a583d8" />
<img width="967" height="579" alt="image" src="https://github.com/user-attachments/assets/ddcb014a-11ff-4bd6-bdc1-a8cd2bf8c4ad" />
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Tweaked radioactive material effects behind the scenes, they should look a lot more consistent and less blue now.
```
