### PR TITLE
Ghostcritters can't use/pick up Panic Buttons

### DIFF
--- a/code/WorkInProgress/sord.dm
+++ b/code/WorkInProgress/sord.dm
@@ -6,7 +6,7 @@
 	desc = "A big red button that alerts the station Security team that there's a crisis at your location. On the bottom someone has scribbled 'oh shit button', cute."
 	icon_state = "panic_button"
 	w_class = W_CLASS_TINY
-	object_flags = NO_GHOSTCRITTER
+	object_flags = parent_type::object_flags | NO_GHOSTCRITTER
 	var/net_id = null
 	var/alert_group = list(MGD_SECURITY, MGA_CRISIS)
 

--- a/code/WorkInProgress/sord.dm
+++ b/code/WorkInProgress/sord.dm
@@ -6,6 +6,7 @@
 	desc = "A big red button that alerts the station Security team that there's a crisis at your location. On the bottom someone has scribbled 'oh shit button', cute."
 	icon_state = "panic_button"
 	w_class = W_CLASS_TINY
+	object_flags = NO_GHOSTCRITTER
 	var/net_id = null
 	var/alert_group = list(MGD_SECURITY, MGA_CRISIS)
 


### PR DESCRIPTION
[Bug] [Game Objects] [Trivial]

## About the PR 
add "NO_GHOSTCRITTER" flag to panick buttton.

## Why's this needed? 
Fixes #22909
veri sad. :<
freeedom for ghostcriter!

## Testing 
test and ghost fly/mostique cannto pick up the panic button. Other not gost critter (remy) can, and can still use. Simple, i think.
