### PR TITLE
Fixes the quantum telescope menu staying open when it really shouldn't

### DIFF
--- a/code/modules/telescience/telescope/quantumTelescope.dm
+++ b/code/modules/telescience/telescope/quantumTelescope.dm
@@ -22,7 +22,7 @@ TODO: Enforce ping rate limit here as well in case someone futzes with the javas
 			rebuildEventList(using)
 
 	proc/boot_if_away()
-		if(using && (!using.client || using.client.inactivity >= 600 || !in_interact_range(src, using) || !can_act(using) || (!isAI(using) && !(GET_DIST(src, using) <= ((WIDE_TILE_WIDTH - 1)/ 2))))) // copied last bit from default.dm tgui code
+		if(using && (!using.client || using.client.inactivity >= 600 || !in_interact_range(src, using) || (status & (BROKEN|NOPOWER)) || !can_act(using) || (!isAI(using) && !(GET_DIST(src, using) <= ((WIDE_TILE_WIDTH - 1)/ 2))))) // copied last bit from default.dm tgui code
 			src.remove_dialog(using)
 			using.Browse(null, "window=qtelescope;override_setting=1")
 			using = null


### PR DESCRIPTION
[Bug] [Game Objects] 

## About the PR 
Add checkings for mining asteroid finder compter - if BROKEN or NO_POWER or !can_act(personusing), then meunu will close.

## Why's this needed?
Fixes #24232 , fixes #24434 

## Testing 
test by try to use telescoper when shoot self with sleeping gun, and menu close soon after going sleeping.
also test by using compuster, then SHOOT WIHT GUN until break (menu opne), and the menu close also.

## P.S.
i do not know if it is so bad, but there is some of flikcering with menu button! Is it becuase too mahy checkigns at one time make code sllower? Hm...tell me if there is other option...