### PR TITLE
Attacking an object with an object triggers both object's material properties

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -858,6 +858,7 @@ TYPEINFO(/atom/movable)
 	PROTECTED_PROC(TRUE)
 	if (!W || !user || src.storage?.storage_item_attack_by(W, user) || W.should_suppress_attack(src, user, params))
 		return
+	W.material_on_attack_use(user, src)
 	src.material_trigger_when_attacked(W, user, 1)
 	if (silent)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

`material_on_attack_use` is called during `atom/attackby`.

Causes weapon materials to trigger their appropriate properties when they're used to attack an object.

I don't know that this affects much except erebite honestly, which will now explode if you attack objects with a weapon that has the erebite material. 

This only affects attacked objects which don't override the basic attack text. Most that do - e.g. windows and dispensers - seem to forget the material triggers entirely, and thus this doesn't affect interactions which include them. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This is useful for new features involving material properties. 

Throwing objects and attacking mobs triggers the materials of both the attacked and the attacker, but simply using an object to attack another object only triggered the former. So this does just make things more consistent.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Hit various objects with an erebite block, and it tended to explode. 