### PR TITLE
Allow urls in LOOC and OOC

### DIFF
--- a/code/modules/speech/say_channels/_say_channel_parent.dm
+++ b/code/modules/speech/say_channels/_say_channel_parent.dm
@@ -26,6 +26,8 @@ ABSTRACT_TYPE(/datum/say_channel)
 	var/suppress_hear_sound = FALSE
 	/// Whether the speaker of a message sent through this channel should display a speech bubble on sending a message.
 	var/suppress_speech_bubble = FALSE
+	/// Do we allow URLs to be sent in this channel?
+	var/allows_urls = FALSE
 
 /datum/say_channel/New()
 	. = ..()

--- a/code/modules/speech/say_channels/looc.dm
+++ b/code/modules/speech/say_channels/looc.dm
@@ -1,6 +1,7 @@
 /datum/say_channel/delimited/local/looc
 	channel_id = SAY_CHANNEL_LOOC
 	enabled = FALSE
+	allows_urls = TRUE
 	disabled_message = "LOOC is currently disabled. For gameplay questions, try <a href='byond://winset?command=mentorhelp'>mentorhelp</a>."
 	track_outermost_listener = FALSE
 	affected_by_modifiers = FALSE

--- a/code/modules/speech/say_channels/ooc.dm
+++ b/code/modules/speech/say_channels/ooc.dm
@@ -1,5 +1,6 @@
 /datum/say_channel/ooc
 	channel_id = SAY_CHANNEL_OOC
+	allows_urls = TRUE
 	disabled_message = "OOC is currently disabled. For gameplay questions, try <a href='byond://winset?command=mentorhelp'>mentorhelp</a>."
 	affected_by_modifiers = FALSE
 	suppress_say_sound = TRUE

--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -220,12 +220,6 @@
 	// If the message should not strip HTML, make the HTML tags immutable.
 	if (src.flags & SAYFLAG_IGNORE_HTML)
 		message = MAKE_HTML_TAGS_IMMUTABLE(message)
-	// Check for URLs.
-	else if (global.url_regex.Find(message))
-		if (ismob(src.speaker))
-			boutput(src.speaker, "<span class='notice'><b>Web/BYOND links are not allowed in ingame chat.</b></span>")
-
-		return
 
 	// Declare the message mutable.
 	message = MAKE_CONTENT_MUTABLE(message)

--- a/code/modules/speech/trees/speech_module_tree.dm
+++ b/code/modules/speech/trees/speech_module_tree.dm
@@ -151,6 +151,12 @@
 		logTheThing(LOG_ADMIN, message.speaker, "[message.speaker] tried to say \"[message.original_content]\" but it was garbled into \"[message.content]\", which is uncool by the following effects: [jointext(modifier_ids, ", ")]. The uncool words were garbled.")
 		message.content = replacetext(message.content, global.phrase_log.uncool_words, pick("urr", "blargh", "der", "hurr", "pllt"))
 
+	// Check for URLs if we're an IC channel, let people paste wiki links at each other in LOOC if they want to
+	if (!global.SpeechManager.GetSayChannelInstance(message.output_module_channel).allows_urls && global.url_regex.Find(message.content))
+		if (ismob(message.speaker))
+			boutput(message.speaker, "<span class='notice'><b>Web/BYOND links are not allowed in ingame chat.</b></span>")
+		return
+
 	// Apply sayflag message manipulation.
 	global.SpeechManager.ApplyMessageModifierPreprocessing(message)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
^
The URLs still won't be clickable in chat.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Parity with pre say rework behaviour, people used to be able to LOOC wiki urls at each other for teaching purposes.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)You can send URLs in OOC and LOOC channels again.
```
