### PR TITLE
Mindhack module bypasses puritan trait

### DIFF
--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -302,30 +302,33 @@ TYPEINFO(/obj/machinery/clonepod)
 					is_puritan = TRUE
 
 			if (is_puritan)
-				src.mess = TRUE
-				// Puritans have a bad time.
-				// This is a little different from how it was before:
-				// - Immediately take 250 tox and 100 random brute
-				// - Always get a major cloning defect
-				// - 50% chance, per limb, to lose that limb
-				// - enforced premature_clone, which gibs you on death
-				// If you have a clone body that's been allowed to fully heal before
-				// cloning a puritan, you have a sliiiiiiiiiiight chance to get them
-				// out of deep critical health before they turn into chunky salsa
-				// This should be really rare to have happen, but I want to leave it in
-				// just in case someone manages to pull off a miracle save
-				defects.add_random_cloner_defect(CLONER_DEFECT_SEVERITY_MAJOR)
-				src.occupant.bioHolder?.AddEffect("premature_clone")
-				src.occupant.take_toxin_damage(350)
-				APPLY_ATOM_PROPERTY(src.occupant, PROP_HUMAN_DROP_BRAIN_ON_GIB, "puritan")
-				random_brute_damage(src.occupant, 200, 0)
-				if (ishuman(src.occupant))
-					var/mob/living/carbon/human/P = src.occupant
-					if (P.limbs)
-						var/list/limbs = list("l_arm", "r_arm", "l_leg", "r_leg")
-						for (var/limb in limbs)
-							if (prob(50))
-								P.limbs.sever(limb)
+				if (!clonehack) // If mindhack cloner, bypass puritan stuff.
+					src.mess = TRUE
+					// Puritans have a bad time.
+					// This is a little different from how it was before:
+					// - Immediately take 250 tox and 100 random brute
+					// - Always get a major cloning defect
+					// - 50% chance, per limb, to lose that limb
+					// - enforced premature_clone, which gibs you on death
+					// If you have a clone body that's been allowed to fully heal before
+					// cloning a puritan, you have a sliiiiiiiiiiight chance to get them
+					// out of deep critical health before they turn into chunky salsa
+					// This should be really rare to have happen, but I want to leave it in
+					// just in case someone manages to pull off a miracle save
+					defects.add_random_cloner_defect(CLONER_DEFECT_SEVERITY_MAJOR)
+					src.occupant.bioHolder?.AddEffect("premature_clone")
+					src.occupant.take_toxin_damage(350)
+					APPLY_ATOM_PROPERTY(src.occupant, PROP_HUMAN_DROP_BRAIN_ON_GIB, "puritan")
+					random_brute_damage(src.occupant, 200, 0)
+					if (ishuman(src.occupant))
+						var/mob/living/carbon/human/P = src.occupant
+						if (P.limbs)
+							var/list/limbs = list("l_arm", "r_arm", "l_leg", "r_leg")
+							for (var/limb in limbs)
+								if (prob(50))
+									P.limbs.sever(limb)
+				else // Notify puritan victim with new message.
+					boutput(src.occupant, SPAN_NOTICE("<h3>The mindhack module has forced your body to adapt, bypassing your clone instability!</h3>"))
 			#endif
 
 		if (length(defects.active_cloner_defects) > 7)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Medical][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check for the mindhack module before activating the puritan reaction while cloning. This allows traitors to mindhack puritans using their fancy cloner setup.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cybernetic incompatibility does not make you exempt from being conversion chambered or syndicate framed. I have seen many people talk about how bad it can feel to finally pull off your murder plot only to find out the victim is a puritan and cannot be cloned using your mindhack cloner setup. It sucks to have your plans hindered by a trait someone else chooses.

## Testing 
Tested to make sure the new added message pops up. All works as intended, the puritan reaction no longer happens when being cloned with a mindhack module.

<img width="559" height="419" alt="{4F307001-A6F9-4703-845A-89F4CB9C235C}" src="https://github.com/user-attachments/assets/9150a237-0353-474b-80ac-a5a4772d4330" />


## Changelog 

```changelog
(u)TheGeneralJay
(+)The cloning mindhack module now bypasses the puritan trait.
```
