### PR TITLE
DWAINE Mainframe Cleanup

### DIFF
--- a/code/modules/networks/computer3/mainframe2/_base_os.dm
+++ b/code/modules/networks/computer3/mainframe2/_base_os.dm
@@ -44,7 +44,7 @@
 	src.sys_folder = null
 	src.processing_drivers = null
 
-	if (src.master.os == src)
+	if (src.master?.os == src)
 		src.master.os = null
 
 	for (var/datum/dwaine_syscall/syscall as anything in src.syscalls)
@@ -459,13 +459,10 @@
 
 		src.initialize_driver(special_driver)
 
-	// Iterate through current devices and use that to create active device files.
+	// Iterate through current devices and create drivers for them.
 	for (var/i in src.master.terminals)
 		var/datum/terminal_connection/conn = src.master.terminals[i]
-		if (!istype(conn))
-			continue
-
-		if (conn.term_type == "HUI_TERMINAL")
+		if (!istype(conn) || (conn.term_type == "HUI_TERMINAL"))
 			continue
 
 		var/conn_type = lowertext(conn.term_type)

--- a/code/modules/networks/computer3/mainframe2/base_program.dm
+++ b/code/modules/networks/computer3/mainframe2/base_program.dm
@@ -193,7 +193,12 @@
 	src.useracc.user_file.fields[field] = data
 	return TRUE
 
-/// Send a signal from this program to its mainframe computer.
+/**
+ *	Send a signal from this program to a target program through the mainframe computer.
+ *	- `progid`: The program ID of the recipient program.
+ *	- `data`: A key-value list of data to pass to the recipient program.
+ *	- `file`: An optional computer file to pass to the recipient program.
+ */
 /datum/computer/file/mainframe_program/proc/signal_program(progid, list/data, datum/computer/file/file)
 	if (!src.master || !data)
 		return TRUE

--- a/code/modules/networks/computer3/mainframe2/mainframe2.dm
+++ b/code/modules/networks/computer3/mainframe2/mainframe2.dm
@@ -1,972 +1,921 @@
-
-
-/*
- *	The Terminal Connection datum, used to keep track of, well, terminal connections.
+/**
+ *	Terminal connection datums represent an active connection between the mainframe and another networked device.
  */
-
 /datum/terminal_connection
+	/// The master device that this device is connected to.
 	var/obj/machinery/networked/master = null
-	var/net_id = null //Network ID of connected device.
-	var/term_type = null //Terminal type ID of connected device.  i.e. PNET_MAINFRAME or HUI_TERMINAL
+	/// The network ID of the connected device.
+	var/net_id = null
+	/// The device tag of the connected device (PNET_MAINFRAME, HUI_TERMINAL, etc).
+	var/term_type = null
 
-	New(var/obj/machinery/networked/newmaster, var/new_id, var/newterm_type)
-		..()
-		if(istype(newmaster))
-			src.master = newmaster
+/datum/terminal_connection/New(obj/machinery/networked/master, net_id, term_type)
+	. = ..()
 
-		if(new_id)
-			src.net_id = new_id
+	if (istype(master))
+		src.master = master
 
-		if(newterm_type)
-			src.term_type = newterm_type
-		return
+	src.net_id = net_id
+	src.term_type = term_type
 
-	disposing()
-		master = null
+/datum/terminal_connection/disposing()
+	src.master = null
+	. = ..()
 
-		..()
 
-/*
- *	The physical mainframe, communication through wired network.
+
+
+
+/**
+ *	The physical mainframe, responsible for managing network connections, disconnections, and timeouts; for loading, unloading
+ *	and running mainframe programs; and for passing signals to, from, and between mainframe programs.
  */
-
 /obj/machinery/networked/mainframe
 	name = "Mainframe"
 	desc = "A mainframe computer. It's pretty big!"
-	density = 1
+	density = TRUE
 	anchored = ANCHORED
 	icon_state = "dwaine"
 	device_tag = "PNET_MAINFRAME"
 	timeout = 30
 	req_access = list(access_heads)
 	machine_registry_idx = MACHINES_MAINFRAMES
-	var/list/terminals = list() //list of netIDs/terminal profiles of connected terminal devices.
-	var/list/processing = list() //As the name implies, this is the list of programs that should be updated every process call on the mainframe object.
-	var/list/timeout_list = list() //Terminals currently set to time out
-	var/datum/computer/file/mainframe_program/os/os = null //Ref to current operating system program
-	var/datum/computer/file/mainframe_program/os/bootstrap = null //Ref to bootloader program, instanciated when a main OS cannot be located on the memory card
-	var/datum/computer/folder/runfolder = null //Storage folder for currently running programs.
-	var/obj/item/disk/data/memcard/hd = null  //Only internal storage for the mainframe--core memory, used as primary storage.
-
-	var/posted = 1 //Have we run through the POST sequence?  Set to 1 initially so it doesn't freak out during map powernet generation.
-
-	var/setup_drive_size = 4096
-	var/setup_drive_type = /obj/item/disk/data/memcard //Use this path for the hd
-	var/setup_bootstrap_path = /datum/computer/file/mainframe_program/os/bootstrap //The bootstrapping system.
-	var/setup_os_string = null
 	power_usage = 500
 
-	zeta
-		//setup_starting_os = /datum/computer/file/mainframe_program/os/main_os
-		setup_drive_type = /obj/item/disk/data/memcard/main2
+	/// An associative list of terminal connections made to this mainframe, indexed by the device's network ID.
+	var/list/datum/terminal_connection/terminals = null
+	/// An associative list of terminal connections currently set to timeout, indexed by the device's network ID.
+	var/list/datum/terminal_connection/timeout_list = null
+	/// A list of mainframe programs currently running. Each program will have its `process` proc called in sync with the machinery processing loop.
+	var/list/datum/computer/file/mainframe_program/processing = null
 
-	New()
-		..()
-		SPAWN(1 SECOND)
+	/// The current operating system of this mainframe.
+	var/datum/computer/file/mainframe_program/os/os = null
+	/// This mainframe's bootloader, instantiated when a main OS cannot be located on the memory card.
+	var/datum/computer/file/mainframe_program/os/bootloader/bootloader = null
+	/// The storage folder used to contain currently running programs.
+	var/datum/computer/folder/runfolder = null
+	/// The internal storage for this mainframe.
+	var/obj/item/disk/data/memcard/hd = null
 
-			src.net_id = generate_net_id(src)
+	/// Whether the Power-On Self-Test sequence has completed. Set to `TRUE` initially so it doesn't freak out during powernet generation.
+	var/posted = TRUE
 
-			if(!src.link)
-				var/turf/T = get_turf(src)
-				var/obj/machinery/power/data_terminal/test_link = locate() in T
-				if(test_link && !DATA_TERMINAL_IS_VALID_MASTER(test_link, test_link.master))
-					src.link = test_link
-					src.link.master = src
+	/// The storage capacity of this mainframe's internal storage.
+	var/setup_drive_size = 4096
+	/// The typepath to use for this mainframe's harddrive.
+	var/setup_drive_type = /obj/item/disk/data/memcard
+	/// The typepath to use for this mainframe's bootloader.
+	var/setup_bootloader_path = /datum/computer/file/mainframe_program/os/bootloader
 
-			if(!hd && (setup_drive_size > 0))
-				if(src.setup_drive_type)
-					src.hd = new src.setup_drive_type
-					src.hd.set_loc(src)
-				else
-					src.hd = new /obj/item/disk/data/memcard(src)
-				src.hd.file_amount = src.setup_drive_size
+/obj/machinery/networked/mainframe/zeta
+	setup_drive_type = /obj/item/disk/data/memcard/main2
 
-			if(ispath(setup_bootstrap_path))
-				src.bootstrap = new setup_bootstrap_path
-				src.bootstrap.master = src
+/obj/machinery/networked/mainframe/New()
+	. = ..()
 
-			sleep(5.4 SECONDS)
-			src.posted = 0
-			src.post_system()
+	src.terminals = list()
+	src.processing = list()
+	src.timeout_list = list()
+
+	SPAWN(1 SECOND)
+		src.net_id = global.generate_net_id(src)
+
+		if (!src.link)
+			var/obj/machinery/power/data_terminal/test_link = locate() in get_turf(src)
+			if (test_link && !DATA_TERMINAL_IS_VALID_MASTER(test_link, test_link.master))
+				src.link = test_link
+				src.link.master = src
+
+		if (!src.hd && (src.setup_drive_size > 0))
+			if (src.setup_drive_type)
+				src.hd = new src.setup_drive_type(src)
+			else
+				src.hd = new /obj/item/disk/data/memcard(src)
+
+			src.hd.file_amount = src.setup_drive_size
+
+		if (ispath(src.setup_bootloader_path))
+			src.bootloader = new src.setup_bootloader_path()
+			src.bootloader.master = src
+
+		sleep(5.4 SECONDS)
+		src.posted = FALSE
+		src.post_system()
+
+/obj/machinery/networked/mainframe/disposing()
+	if (src.terminals)
+		for (var/device_id as anything in src.terminals)
+			src.terminals[device_id]?.dispose()
+
+		src.terminals.Cut()
+		src.terminals = null
+
+	if (src.os)
+		src.os.dispose()
+		src.os = null
+
+	if (src.bootloader)
+		src.bootloader.dispose()
+		src.bootloader = null
+
+	if (src.runfolder)
+		src.runfolder = null
+
+	if (src.hd)
+		src.hd.dispose()
+		src.hd = null
+
+	if (src.processing)
+		src.processing.Cut()
+		src.processing = null
+
+	if (src.timeout_list)
+		src.timeout_list.Cut()
+		src.timeout_list = null
+
+	. = ..()
+
+/obj/machinery/networked/mainframe/attack_ai(mob/user)
+	return
+
+/obj/machinery/networked/mainframe/attack_hand(mob/user)
+	if (user.stat || user.restrained())
+		return
+
+	if (src.status & BROKEN)
+		if (!src.hd)
+			return
+
+		boutput(user, SPAN_ALERT("The mainframe is trashed, but the memory core could probably salvaged."))
+		return
+
+	var/dat = "<html><head><title>Mainframe Access Panel</title></head><body><hr>"
+	dat += "<b>ACTIVE:</b> [src.os ? "YES" : "NO"]<br>"
+	dat += "<b>BOOTING:</b> [(src.bootloader && istype(src.os, src.bootloader.type)) ? "YES" : "NO"]<br><br>"
+
+	if (src.status & NOPOWER)
+		dat += "<b>Memory Core:</b> <a href='byond://?src=\ref[src];core=1'>[src.hd ? "LOADED" : "---------"]</a><br>"
+		dat += "Core Shield Maglock is <b>OFF</b><hr>[src.net_switch_html()]<hr>"
+	else
+		dat += "<b>Memory Core:</b> [src.hd ? "LOADED" : "---------"]<br>"
+		dat += "Core Shield Maglock is <b>ON</b><hr>"
+
+
+	user.Browse(dat, "window=mainframe;size=245x202")
+	global.onclose(user, "mainframe")
+
+/obj/machinery/networked/mainframe/Topic(href, href_list)
+	if ((src.status & BROKEN) || !isturf(src.loc) || (BOUNDS_DIST(src, usr) != 0) || usr.stat || usr.restrained())
+		return
+
+	src.add_dialog(usr)
+
+	if (href_list["core"])
+		if (!(src.status & NOPOWER))
+			boutput(usr, SPAN_ALERT("The electromagnetic lock is still on!"))
+			return
+
+		if (src.hd)
+			src.hd.set_loc(src.loc)
+			boutput(usr, "You remove the memory core from the mainframe.")
+			usr.unlock_medal("421", TRUE)
+			src.status |= MAINT
+			src.unload_all()
+			src.hd = null
+			src.runfolder = null
+			src.posted = FALSE
+
+		else
+			var/obj/item/I = usr.equipped()
+
+			if (istype(I, /obj/item/disk/data/memcard))
+				usr.drop_item()
+				I.set_loc(src)
+				src.hd = I
+				src.status &= ~MAINT
+				boutput(usr, "You insert [I].")
+
+			else if (istype(I, /obj/item/magtractor))
+				var/obj/item/magtractor/mag = I
+
+				if (istype(mag.holding, /obj/item/disk/data/memcard))
+					I = mag.holding
+					mag.dropItem(FALSE)
+					I.set_loc(src)
+					src.hd = I
+					src.status &= ~MAINT
+					boutput(usr, "You insert [I].")
+
+	else if (href_list["dipsw"] && (src.status & NOPOWER))
+		var/switchNum = text2num_safe(href_list["dipsw"])
+		if ((switchNum < 1) || (switchNum > 8))
+			return TRUE
+
+		switchNum = round(switchNum)
+		if (src.net_number & switchNum)
+			src.net_number &= ~switchNum
+		else
+			src.net_number |= switchNum
+
+	src.updateUsrDialog()
+	src.add_fingerprint(usr)
+
+/obj/machinery/networked/mainframe/attackby(obj/item/W, mob/user)
+	if (!ispryingtool(W))
+		return ..()
+
+	if (!(src.status & BROKEN))
+		return
+
+	if (!src.hd)
+		boutput(user, SPAN_ALERT("The memory core has already been removed."))
+		return
+
+	src.status |= MAINT
+	src.unload_all()
+	src.hd.set_loc(src.loc)
+	src.hd = null
+	src.posted = FALSE
+
+	boutput(user, "You pry out the memory core.")
+	src.updateUsrDialog()
+
+/obj/machinery/networked/mainframe/process()
+	set waitfor = 0
+	. = ..()
+
+	if ((src.status & (NOPOWER | BROKEN | MAINT)) || !src.processing)
+		return
+
+	if (prob(3))
+		SPAWN(1 DECI SECOND)
+			playsound(src.loc, pick(global.ambience_computer), 50, 1)
+
+	for (var/i in 1 to length(src.processing))
+		var/datum/computer/file/mainframe_program/program = src.processing[i]
+		if (!istype(program))
+			continue
+
+		if (program.disposed)
+			src.processing[i] = null
+			continue
+
+		try
+			program.process()
+
+		catch(var/exception/e)
+			if (!findtext(e.name, "Maximum recursion level reached"))
+				throw e
+
+			// Warn all connected users that the mainframe has crashed.
+			if (istype(src.os, /datum/computer/file/mainframe_program/os/kernel))
+				var/datum/computer/file/mainframe_program/os/kernel/kernel = src.os
+				kernel.message_all_users("|nA program encountered a critical error (maximum recursion). Rebooting the mainframe.|n", "System", TRUE)
+
+			src.reboot_mainframe()
+
+	if (src.timeout == 0)
+		src.timeout = initial(src.timeout)
+		src.timeout_alert = FALSE
+
+		for (var/id as anything in src.timeout_list)
+			var/datum/terminal_connection/conn = src.terminals[id]
+			src.terminals -= id
+
+			if (!conn)
+				continue
+
+			src.os?.closed_connection(conn)
+			conn.dispose()
+
+	else
+		src.timeout--
+
+		if ((src.timeout <= 5) && !src.timeout_alert)
+			src.timeout_alert = TRUE
+			src.timeout_list = src.terminals.Copy()
+
+			for (var/id as anything in src.timeout_list)
+				src.post_status(id, "command", "term_ping", "data", "reply")
+
+/obj/machinery/networked/mainframe/receive_signal(datum/signal/signal)
+	if (src.status & (NOPOWER | BROKEN | MAINT) || !src.link)
+		return
+
+	if (!src.net_id || !signal || signal.encryption || (signal.transmission_method != TRANSMISSION_WIRE))
+		return
+
+	var/target = signal.data["sender"]
+
+	// The sender doen't need to target us specifically to ping us.
+	// Otherwise, if the sender isn't addressing us, ignore them.
+	if (signal.data["address_1"] != src.net_id)
+		if ((signal.data["address_1"] == "ping") && ((signal.data["net"] == null) || ("[signal.data["net"]]" == "[src.net_number]")) && signal.data["sender"])
+			SPAWN(0.5 SECONDS)
+				src.post_status(target, "command", "ping_reply", "device", src.device_tag, "netid", src.net_id)
 
 		return
 
-	disposing()
-		if (terminals)
-			for (var/datum/conn in terminals)
+	var/sigcommand = lowertext(signal.data["command"])
+	if (!sigcommand || !signal.data["sender"])
+		return
+
+	switch (sigcommand)
+		if ("term_connect")
+			// If the terminal is already connected, something may be wrong, so disconnect them.
+			if (src.terminals[target])
+				var/datum/terminal_connection/conn = src.terminals[target]
+				src.terminals -= target
+				src.os?.closed_connection(conn)
 				conn.dispose()
 
-			terminals.len = 0
-			terminals = null
+				SPAWN(0.3 SECONDS)
+					src.post_status(target, "command", "term_disconnect")
 
-		if (os)
-			os.dispose()
-			os = null
+				return
 
-		if (bootstrap)
-			bootstrap.dispose()
-			bootstrap = null
+			var/devtype = signal.data["device"]
+			if (!devtype)
+				return
 
-		if (runfolder)
-			runfolder = null
+			// Create a new connection.
+			var/datum/terminal_connection/new_conn = new /datum/terminal_connection(src, target, devtype)
+			src.terminals[target] = new_conn
+			if (signal.data["data"] != "noreply")
+				src.post_status(target, "command", "term_connect", "data", "noreply")
 
-		if (hd)
-			hd.dispose()
-			hd = null
+			// Alert the OS of the new connection.
+			if (src.os)
+				var/datum/computer/connect_file = signal.data_file?.copy_file()
+				src.os.new_connection(new_conn, connect_file)
+				connect_file?.dispose()
 
-		if (processing)
-			processing.len = 0
-			processing = null
+		if ("term_message", "term_file")
+			// Don't accept messages or files from unconnected terminals.
+			if (!src.terminals[target] || !src.os)
+				return
 
-		if (timeout_list)
-			timeout_list.len = 0
-			timeout_list = null
+			var/data = signal.data["data"]
+			if (!data)
+				return
 
-		..()
+			src.os.term_input(data, target, signal.data_file?.copy_file())
+			if (!isnull(usr))
+				logTheThing(LOG_STATION, usr, "message '[html_encode(data)]' sent to [src] [log_loc(src)] from [signal.source] [log_loc(signal.source)]")
 
-	attack_ai(mob/user as mob)
+		if ("term_break")
+			if (!src.terminals[target] || !src.os)
+				return
+
+			src.os.term_input(1, target, null, TRUE)
+
+		if ("term_ping")
+			if (!src.terminals[target])
+				SPAWN(0.3 SECONDS)
+					src.post_status(target, "command", "term_disconnect")
+
+				return
+
+			if (src.timeout_list[target])
+				src.timeout_list -= target
+
+			if (signal.data["data"] == "reply")
+				src.post_status(target, "command", "term_ping")
+
+		if ("term_disconnect")
+			if (!src.terminals[target])
+				return
+
+			var/datum/terminal_connection/conn = src.terminals[target]
+			src.terminals -= target
+			src.os?.closed_connection(conn)
+			conn.dispose()
+
+		if ("ping_reply")
+			if (!src.os)
+				return
+
+			src.os.ping_reply(signal.data["netid"], signal.data["device"])
+
+/obj/machinery/networked/mainframe/power_change()
+	if (src.status & BROKEN)
+		src.icon_state = initial(src.icon_state) + "b"
 		return
 
-	attack_hand(mob/user)
-		if (user.stat || user.restrained())
-			return
-
-		if(status & BROKEN)
-			if(!src.hd)
-				return
-
-			boutput(user, SPAN_ALERT("The mainframe is trashed, but the memory core could probably salvaged."))
-			return
-
-		var/dat = "<html><head><title>Mainframe Access Panel</title></head><body><hr>"
-
-		dat += "<b>ACTIVE:</b> [src.os ? "YES" : "NO"]<br>"
-		dat += "<b>BOOTING:</b> [(src.bootstrap && src.os && istype(src.os, src.bootstrap.type)) ? "YES" : "NO"]<br><br>"
-
-		if(status & NOPOWER)
-
-			dat += "<b>Memory Core:</b> <a href='byond://?src=\ref[src];core=1'>[src.hd ? "LOADED" : "---------"]</a><br>"
-			dat += "Core Shield Maglock is <b>OFF</b><hr>[net_switch_html()]<hr>"
-		else
-
-			dat += "<b>Memory Core:</b> [src.hd ? "LOADED" : "---------"]<br>"
-			dat += "Core Shield Maglock is <b>ON</b><hr>"
-
-
-		user.Browse(dat, "window=mainframe;size=245x202")
-		onclose(user, "mainframe")
+	if (src.powered())
+		src.icon_state = initial(src.icon_state)
+		src.status &= ~NOPOWER
+		src.post_system() // Will simply return if POSTed already.
 		return
 
-	Topic(href, href_list)
-		if(status & BROKEN)
-			return
+	SPAWN(rand(0, 15))
+		src.icon_state = initial(src.icon_state) + "0"
+		src.status |= NOPOWER
+		src.posted = FALSE
+		src.os = null
 
-		if (istype(src.loc, /turf) && BOUNDS_DIST(src, usr) == 0)
-			if (usr.stat || usr.restrained())
-				return
-
-			src.add_dialog(usr)
-
-			if(href_list["core"])
-
-				if(!(status & NOPOWER))
-					boutput(usr, SPAN_ALERT("The electromagnetic lock is still on!"))
-					return
-
-				//Ai/cyborgs cannot physically remove a memory board from a room away.
-				if(issilicon(usr) && BOUNDS_DIST(src, usr) > 0)
-					boutput(usr, SPAN_ALERT("You cannot physically touch the board."))
-					return
-
-				if(src.hd)
-					src.hd.set_loc(src.loc)
-					boutput(usr, "You remove the memory core from the mainframe.")
-					usr.unlock_medal("421", 1)
-					status |= MAINT
-					src.unload_all()
-					src.hd = null
-					src.runfolder = null
-					src.posted = 0
-
-				else
-					var/obj/item/I = usr.equipped()
-					if (istype(I, /obj/item/disk/data/memcard))
-						usr.drop_item()
-						I.set_loc(src)
-						src.hd = I
-						status &= ~MAINT
-						boutput(usr, "You insert [I].")
-					else if (istype(I, /obj/item/magtractor))
-						var/obj/item/magtractor/mag = I
-						if (istype(mag.holding, /obj/item/disk/data/memcard))
-							I = mag.holding
-							mag.dropItem(0)
-							I.set_loc(src)
-							src.hd = I
-							status &= ~MAINT
-							boutput(usr, "You insert [I].")
-
-			else if (href_list["dipsw"] && (status & NOPOWER))
-				var/switchNum = text2num_safe(href_list["dipsw"])
-				if (switchNum < 1 || switchNum > 8)
-					return 1
-
-				switchNum = round(switchNum)
-				if (net_number & switchNum)
-					net_number &= ~switchNum
-				else
-					net_number |= switchNum
-
-			src.updateUsrDialog()
-			src.add_fingerprint(usr)
+/obj/machinery/networked/mainframe/clone()
+	var/obj/machinery/networked/mainframe/clone = ..()
+	if (!clone)
 		return
 
-	attackby(obj/item/W, mob/user)
-		if (ispryingtool(W))
-			if (!(status & BROKEN))
-				return
+	clone.setup_bootloader_path = src.setup_bootloader_path
+	clone.hd = src.hd?.clone()
 
-			if (!src.hd)
-				boutput(user, SPAN_ALERT("The memory core has already been removed."))
-				return
+	return clone
 
-			status |= MAINT
-			src.unload_all()
-			src.hd.set_loc(src.loc)
-			src.hd = null
-			src.posted = 0
+/obj/machinery/networked/mainframe/meteorhit(obj/O)
+	if (src.status & BROKEN)
+		src.dispose()
 
-			boutput(user, "You pry out the memory core.")
-			src.updateUsrDialog()
-			return
+	src.set_broken()
+	var/datum/effects/system/harmless_smoke_spread/smoke = new /datum/effects/system/harmless_smoke_spread()
+	smoke.set_up(5, 0, src)
+	smoke.start()
 
-		else
-			..()
-
-		return
-
-
-	process()
-		set waitfor = 0
-		..()
-		if(status & (NOPOWER|BROKEN|MAINT) || !processing)
-			return
-		if(prob(3))
-			SPAWN(1 DECI SECOND)
-				playsound(src.loc, pick(ambience_computer), 50, 1)
-
-		for (var/progIndex = 1, progIndex <= src.processing.len, progIndex++)
-			var/datum/computer/file/mainframe_program/prog = src.processing[progIndex]
-			if (prog)
-				if (prog.disposed)
-					src.processing[progIndex] = null
-					continue
-				try
-					prog.process()
-				catch(var/exception/e)
-					if (findtext(e.name, "Maximum recursion level reached"))
-						if (istype(src.os, /datum/computer/file/mainframe_program/os/kernel))
-							var/datum/computer/file/mainframe_program/os/kernel/os_kernel = src.os
-							os_kernel.message_all_users("|nA program encountered a critical error (maximum recursion). Rebooting the mainframe.|n", "System", TRUE) // Lets warn all connected users that the mainframe has crashed!
-						src.reboot_mainframe()
-					else
-						throw e
-/*
-		for(var/datum/computer/file/mainframe_program/P in src.processing)
-			if (P)
-				P.process()
-*/
-		if(src.timeout == 0)
-			src.timeout = initial(src.timeout)
-			src.timeout_alert = 0
-			for(var/timed in timeout_list)
-				var/datum/terminal_connection/conn = src.terminals[timed]
-				src.terminals -= timed
-				if(src.os && conn)
-					src.os.closed_connection(conn)
-				//qdel(conn)
-				if (conn)
-					conn.dispose()
-		else
-			src.timeout--
-			if(src.timeout <= 5 && !src.timeout_alert)
-				src.timeout_alert = 1
-				src.timeout_list = src.terminals.Copy()
-				for(var/id in timeout_list)
-					src.post_status(id, "command","term_ping","data","reply")
-
-		return
-
-	receive_signal(datum/signal/signal)
-		if(status & (NOPOWER|BROKEN|MAINT) || !src.link)
-			return
-		if(!signal || !src.net_id || signal.encryption)
-			return
-
-		if(signal.transmission_method != TRANSMISSION_WIRE) //No radio for us thanks
-			return
-
-		var/target = signal.data["sender"]
-
-		//They don't need to target us specifically to ping us.
-		//Otherwise, if they aren't addressing us, ignore them
-		if(signal.data["address_1"] != src.net_id)
-			if((signal.data["address_1"] == "ping") && ((signal.data["net"] == null) || ("[signal.data["net"]]" == "[src.net_number]")) && signal.data["sender"])
-				SPAWN(0.5 SECONDS) //Send a reply for those curious jerks
-					src.post_status(target, "command", "ping_reply", "device", src.device_tag, "netid", src.net_id)
-
-			return
-
-		var/sigcommand = lowertext(signal.data["command"])
-		if(!sigcommand || !signal.data["sender"])
-			return
-
-		switch(sigcommand)
-			if("term_connect") //Terminal interface stuff.
-				if(target in src.terminals)
-					//something might be wrong here, disconnect them!
-					var/datum/terminal_connection/conn = src.terminals[target]
-					src.terminals.Remove(target)
-					src.os?.closed_connection(conn)
-					//qdel(conn)
-					if (conn)
-						conn.dispose()
-					SPAWN(0.3 SECONDS)
-						src.post_status(target, "command","term_disconnect")
-					return
-
-				var/devtype = signal.data["device"]
-				if(!devtype) return
-				var/datum/terminal_connection/newconn = new /datum/terminal_connection(src, target, devtype)
-				src.terminals[target] = newconn //Accept the connection!
-				if(signal.data["data"] != "noreply")
-					src.post_status(target, "command","term_connect","data","noreply")
-				//also say hi.
-				if(src.os)
-					var/datum/computer/theFile = null
-					if (signal.data_file)
-						theFile = signal.data_file.copy_file()
-					src.os.new_connection(newconn, theFile)
-					//qdel(file)
-					if (theFile)
-						theFile.dispose()
-				return
-
-			if("term_message","term_file")
-				if(!(target in src.terminals)) //Huh, who is this?
-					return
-
-				//src.visible_message("[src] beeps.")
-				var/data = signal.data["data"]
-				var/file = null
-				if(signal.data_file)
-					file = signal.data_file.copy_file()
-				if(src.os && data)
-					src.os.term_input(data, target, file)
-					if(!isnull(usr))
-						var/atom/source = signal.source
-						logTheThing(LOG_STATION, usr, "message '[html_encode(data)]' sent to [src] [log_loc(src)] from [source] [log_loc(source)]")
-
-				return
-
-			if ("term_break")
-				if (!(target in src.terminals))
-					return
-
-				if (src.os)
-					src.os.term_input(1, target, null, 1)
-
-			if("term_ping")
-				if(!(target in src.terminals))
-					SPAWN(0.3 SECONDS) //Go away!!
-						src.post_status(target, "command","term_disconnect")
-					return
-				if(target in src.timeout_list)
-					src.timeout_list -= target
-				if(signal.data["data"] == "reply")
-					src.post_status(target, "command","term_ping")
-				return
-
-			if("term_disconnect")
-				if(target in src.terminals)
-					var/datum/terminal_connection/conn = src.terminals[target]
-					src.os?.closed_connection(conn)
-					src.terminals -= target
-					//qdel(conn)
-					if (conn)
-						conn.dispose()
-
-				return
-
-			if("ping_reply")
-				if(src.os)
-					os.ping_reply(signal.data["netid"],signal.data["device"])
-				return
-
-		return
-
-	power_change()
-		if(status & BROKEN)
-			icon_state = initial(src.icon_state)
-			src.icon_state += "b"
-			return
-
-		else if(powered())
-			icon_state = initial(src.icon_state)
-			status &= ~NOPOWER
-			src.post_system() //Will simply return if POSTed already.
-		else
-			SPAWN(rand(0, 15))
-				icon_state = initial(src.icon_state)
-				src.icon_state += "0"
-				status |= NOPOWER
-				src.posted = 0
-				src.os = null
-
-	clone()
-		var/obj/machinery/networked/mainframe/cloneframe = ..()
-		if (!cloneframe)
-			return
-
-		cloneframe.setup_bootstrap_path = src.setup_bootstrap_path
-		cloneframe.setup_os_string = src.setup_os_string
-		if (src.hd)
-			cloneframe.hd = src.hd.clone()
-
-		return cloneframe
-
-	meteorhit(var/obj/O as obj)
-		if(status & BROKEN)
-			//dispose()
+/obj/machinery/networked/mainframe/ex_act(severity)
+	switch (severity)
+		if (1)
 			src.dispose()
-		set_broken()
-		var/datum/effects/system/harmless_smoke_spread/smoke = new /datum/effects/system/harmless_smoke_spread()
-		smoke.set_up(5, 0, src)
-		smoke.start()
+		if (2)
+			if (prob(50))
+				src.set_broken()
+		if (3)
+			if (prob(25))
+				src.set_broken()
+
+/obj/machinery/networked/mainframe/blob_act(power)
+	if (!prob(power * 2.5))
 		return
 
-	ex_act(severity)
-		switch(severity)
-			if(1)
-				//dispose()
-				src.dispose()
-				return
-			if(2)
-				if (prob(50))
-					set_broken()
-			if(3)
-				if (prob(25))
-					set_broken()
+	src.set_broken()
+	src.set_density(FALSE)
 
-	blob_act(var/power)
-		if (prob(power * 2.5))
-			set_broken()
-			src.set_density(0)
+/// Initialise and start running a mainframe program, adding it to the processing list and runfolder.
+/obj/machinery/networked/mainframe/proc/run_program(datum/computer/file/mainframe_program/program, datum/mainframe2_user_data/user, datum/computer/file/mainframe_program/caller_prog, runparams, allow_fork = FALSE)
+	if (!src.hd || !program || (!program.holder && program.needs_holder))
+		return FALSE
 
-	proc
-		run_program(datum/computer/file/mainframe_program/program, var/datum/mainframe2_user_data/user, var/datum/computer/file/mainframe_program/caller_prog, var/runparams, var/allow_fork=0)
-			if(!hd || !program || (!program.holder && program.needs_holder))
-				return 0
+	if (!src.runfolder)
+		// Attempt to locate an existing runfolder.
+		for (var/datum/computer/folder/F in src.hd.root.contents)
+			if (F.name != "proc")
+				continue
 
-			if(!runfolder)
-				for (var/datum/computer/folder/F in src.hd.root.contents)
-					if (F.name == "proc")
-						runfolder = F
-						runfolder.metadata["permission"] = COMP_HIDDEN
-						break
+			src.runfolder = F
+			src.runfolder.metadata["permission"] = COMP_HIDDEN
+			break
 
-				if(!runfolder)
-					runfolder = new /datum/computer/folder(  )
-					runfolder.name = "proc"
-					runfolder.metadata["permission"] = COMP_HIDDEN
-					if(!hd.root.add_file( runfolder ))
-						//qdel(runfolder)
-						runfolder.dispose()
-						return 0
-			if (allow_fork || !(program in src.processing))
-				program = program.copy_file()
-				if(!runfolder.add_file( program ))
-					//qdel(program)
-					program.dispose()
-					return 0
+		// If a runfolder can't be found, attempt to create a new one.
+		if (!src.runfolder)
+			src.runfolder = new /datum/computer/folder()
+			src.runfolder.name = "proc"
+			src.runfolder.metadata["permission"] = COMP_HIDDEN
 
-			if(program.master != src)
-				program.master = src
+			if (!src.hd.root.add_file(src.runfolder))
+				src.runfolder.dispose()
+				return FALSE
 
-			if(istype(program, /datum/computer/file/mainframe_program/os))
-				if (!src.os)
-					src.os = program
-				else
-					//qdel(program)
-					program.dispose()
-					return 0
+	// Add the program to the runfolder.
+	if (allow_fork || !(program in src.processing))
+		program = program.copy_file()
+		if (!src.runfolder.add_file(program))
+			program.dispose()
+			return FALSE
 
-			if(!(program in src.processing))
-				if (src.os == program && length(src.processing))
-					src.processing.len++
-					for (var/x = src.processing.len, x > 0, x--)
-						var/datum/computer/file/mainframe_program/P = src.processing[x]
-						if (istype(P))
-							P.progid = x+1
-						if (length(src.processing) == x)
-							src.processing.len++
-						src.processing[x+1] = P
+	program.master = src
 
-					src.processing[1] = src.os
-					src.os.progid = 1
+	if (istype(program, /datum/computer/file/mainframe_program/os))
+		if (src.os)
+			program.dispose()
+			return FALSE
 
-				else
-					var/success = 0
-					for (var/x = 1, x <= src.processing.len, x++)
-						if (!isnull(src.processing[x]))
-							continue
+		src.os = program
 
-						src.processing[x] = program
-						program.progid = x
-						success = 1
-						break
+	if (!(program in src.processing))
+		// If the program is the OS, insert it at the start of the processing list.
+		if ((src.os == program) && length(src.processing))
+			src.processing.Insert(1, src.os)
 
-					if (!success)
-						src.processing += program
-						program.progid = length(src.processing)
-
-			if (user && !allow_fork)
-				program.useracc = user
-				user.current_prog = program
-
-			if (caller_prog)
-				if (!program.useracc)
-					program.useracc = caller_prog.useracc
-				program.parent_task = caller_prog
-				program.parent_id = caller_prog.progid
-
-			program.initialize(runparams)
-			//program.initialized = 1
-			return program
-
-		unload_program(datum/computer/file/mainframe_program/program)
-			if(!program)
-				return 0
-
-			if(program == src.os)
-				return 0
-
-			if (src.processing[src.processing.len] == program)
-				src.processing -= program
-			else if (program.progid && program.progid <= src.processing.len)
-				src.processing[program.progid] = null
-	//		if(src.active_program == program)
-	//			src.active_program = src.host_program
-			program.initialized = 0
-			program.unloaded()
-
-			if (program.holding_folder == src.runfolder)
-				//qdel(program)
-				program.dispose()
-
-			return 1
-
-		reboot_mainframe()
-			src.unload_all() // Unload all running programs, log out all users
-			src.posted = 0 // Waiting for startup!
-			src.post_system() // Time to start back!
-			src.reconnect_all_devices() // Should probably reconnect all devices as well
-
-		unload_all()
-			if (istype(src.os, /datum/computer/file/mainframe_program/os/kernel))
-				var/datum/computer/file/mainframe_program/os/kernel/os_kernel = src.os
-				os_kernel.logout_all_users(FALSE) // Lets logout all users so when the mainframe reboots, they can log into their old user account, instead of creating a new user.
-			src.os = null
-			for(var/datum/computer/file/mainframe_program/M in src.processing)
-				src.unload_program(M)
-
-			return
-
-
-		delete_file(datum/computer/file/theFile)
-			if((!theFile) || (!theFile.holder) || (theFile.holder.read_only))
-				//boutput(world, "Cannot delete :(")
-				return 0
-
-			//qdel(file)
-			theFile.dispose()
-			return 1
-
-		relay_progsignal(var/datum/computer/file/mainframe_program/caller_prog, var/progid, var/list/data = null, var/datum/computer/file/file)
-			if (progid < 1 || progid > src.processing.len || !caller_prog)
-				return ESIG_GENERIC
-
-			var/datum/computer/file/mainframe_program/P = src.processing[progid]
-			if(!istype(P))
-				return ESIG_GENERIC
-
-			var/callID = src.processing.Find(caller_prog)
-			return P.receive_progsignal(callID, data, file)
-
-		reconnect_all_devices()
-			for (var/device_id in src.terminals)
-				var/datum/terminal_connection/conn = src.terminals[device_id]
-				if (istype(conn) && cmptext(conn.term_type, "hui_terminal"))
+			// Update the program ID of each program in the list.
+			for (var/i in 1 to length(src.processing))
+				var/datum/computer/file/mainframe_program/P = src.processing[i]
+				if (!istype(P))
 					continue
 
-				reconnect_device(device_id)
+				P.progid = i
 
-			return ESIG_SUCCESS
-
-		reconnect_device(var/device_netid)
-			if (!device_netid)
-				return ESIG_GENERIC
-
-			device_netid = lowertext(device_netid)
-			if (device_netid in src.terminals)
-				var/datum/terminal_connection/conn = src.terminals[device_netid]
-				src.os?.closed_connection(conn)
-				src.terminals -= device_netid
-				//qdel(conn)
-				if (conn)
-					conn.dispose()
-
-			src.post_status(device_netid, "command", "term_connect", "device", src.device_tag)
-			return ESIG_SUCCESS
-
-		/*
-		 *	Overview of startup process:
-		 *		If we already have an OS reference, initialize it and return.
-		 *		If not, begin looking for an OS file in memory (Of type /datum/computer/file/mainframe_program/os)
-		 *			Ideally, there is a folder named "sys" in the root directory to look in.
-		 *		If we can't find the OS there, we pass control over the our bootstrapping program.
-		 */
-
-		post_system()
-			if(src.posted || !src.hd)
-				return
-
-			src.posted = 1
-
-			if(src.os) //Let the starting programs set up vars or whatever
-				src.os.initialize()
-
+		// Otherwise add the program to the processing list, replacing any null entries before extending the list.
+		else
+			var/null_index = src.processing.Find(null)
+			if (null_index)
+				src.processing[null_index] = program
+				program.progid = null_index
 			else
+				src.processing += program
+				program.progid = length(src.processing)
 
-				if (src.runfolder)
-					//qdel(src.runfolder)
-					src.runfolder.dispose()
-					src.runfolder = null
+	if (user && !allow_fork)
+		program.useracc = user
+		user.current_prog = program
 
-				if(src.hd && src.hd.root)
-					var/datum/computer/folder/sysfolder = null
-					for (var/datum/computer/folder/F in src.hd.root.contents)
-						if (F.name == "sys")
-							sysfolder = F
-							break
+	if (caller_prog)
+		program.parent_task = caller_prog
+		program.parent_id = caller_prog.progid
+		program.useracc ||= caller_prog.useracc
 
-					if (sysfolder)
-						var/datum/computer/file/mainframe_program/os/newos = locate(/datum/computer/file/mainframe_program/os) in sysfolder.contents
-						if (istype(newos))
-							src.visible_message("[src] beeps")
-							newos.initialized = 0
-							src.run_program(newos)
-							return
+	program.initialize(runparams)
+	return program
 
-					if(!istype(src.bootstrap))
-						src.bootstrap = new src.setup_bootstrap_path
+/// Unload all mainframe programs, removing them from the processing list and runfolder. Also logs out all users.
+/obj/machinery/networked/mainframe/proc/unload_all()
+	// Logout all users so that when the mainframe reboots, they can log into their old user account, instead of creating a new user.
+	if (istype(src.os, /datum/computer/file/mainframe_program/os/kernel))
+		var/datum/computer/file/mainframe_program/os/kernel/kernel = src.os
+		kernel.logout_all_users(FALSE)
 
-					//Run the bootstrapping code!
-					if(bootstrap)
-						src.run_program(bootstrap)
+	src.os = null
+	for (var/datum/computer/file/mainframe_program/P in src.processing)
+		src.unload_program(P)
 
+/// Unload a mainframe program, removing it from the processing list and runfolder.
+/obj/machinery/networked/mainframe/proc/unload_program(datum/computer/file/mainframe_program/program)
+	if (!program || (program == src.os))
+		return FALSE
+
+	var/processing_length = length(src.processing)
+	if (src.processing[processing_length] == program)
+		src.processing -= program
+	else if (program.progid && (program.progid <= processing_length))
+		src.processing[program.progid] = null
+
+	program.initialized = FALSE
+	program.unloaded()
+
+	if (program.holding_folder == src.runfolder)
+		program.dispose()
+
+	return TRUE
+
+/**
+ *	Relay a signal between two mainframe programs.
+ *	- `caller_prog`: The mainframe program sending the signal.
+ *	- `progid`: The program ID of the recipient program.
+ *	- `data`: A key-value list of data to pass to the recipient program.
+ *	- `file`: An optional computer file to pass to the recipient program.
+ */
+/obj/machinery/networked/mainframe/proc/relay_progsignal(datum/computer/file/mainframe_program/caller_prog, progid, list/data, datum/computer/file/file)
+	if ((progid < 1) || (progid > length(src.processing)) || !caller_prog)
+		return ESIG_GENERIC
+
+	var/datum/computer/file/mainframe_program/P = src.processing[progid]
+	if (!istype(P))
+		return ESIG_GENERIC
+
+	return P.receive_progsignal(caller_prog.progid, data, file)
+
+/// Disconnect and issue a reconnect request to all currently connected devices, excluding computer terminals.
+/obj/machinery/networked/mainframe/proc/reconnect_all_devices()
+	for (var/device_id as anything in src.terminals)
+		var/datum/terminal_connection/conn = src.terminals[device_id]
+		if (istype(conn) && cmptext(conn.term_type, "hui_terminal"))
+			continue
+
+		src.reconnect_device(device_id)
+
+	return ESIG_SUCCESS
+
+/// Disconnect and issue a reconnect request to a specific device.
+/obj/machinery/networked/mainframe/proc/reconnect_device(device_id)
+	if (!device_id)
+		return ESIG_GENERIC
+
+	device_id = lowertext(device_id)
+
+	if (src.terminals[device_id])
+		var/datum/terminal_connection/conn = src.terminals[device_id]
+		src.terminals -= device_id
+		src.os?.closed_connection(conn)
+		conn.dispose()
+
+	src.post_status(device_id, "command", "term_connect", "device", src.device_tag)
+	return ESIG_SUCCESS
+
+/// Unload all mainframe programs and reboot the mainframe.
+/obj/machinery/networked/mainframe/proc/reboot_mainframe()
+	src.unload_all()
+	src.posted = FALSE
+	src.post_system()
+	src.reconnect_all_devices()
+
+/// Run the mainframe's Power-On Self-Test sequence, setting up the mainframe's OS.
+/obj/machinery/networked/mainframe/proc/post_system()
+	if (src.posted || !src.hd)
+		return
+
+	src.posted = TRUE
+
+	// If an OS reference already exists, initialise it and return.
+	if (src.os)
+		src.os.initialize()
+		return
+
+	if (src.runfolder)
+		src.runfolder.dispose()
+		src.runfolder = null
+
+	if (!src.hd || !src.hd.root)
+		return
+
+	// Attempt to find an OS file in the SYS folder.
+	var/datum/computer/folder/sysfolder = null
+	for (var/datum/computer/folder/F in src.hd.root.contents)
+		if (F.name != "sys")
+			continue
+
+		sysfolder = F
+		break
+
+	// If found, use that OS file as the new OS.
+	if (sysfolder)
+		var/datum/computer/file/mainframe_program/os/new_os = locate(/datum/computer/file/mainframe_program/os) in sysfolder.contents
+		if (istype(new_os))
+			src.visible_message("[src] beeps")
+			new_os.initialized = FALSE
+			src.run_program(new_os)
 			return
 
+	// Otherwise run the bootloader.
+	if (!istype(src.bootloader))
+		src.bootloader = new src.setup_bootloader_path()
 
-/*
- *	Bootstrapping System
+	src.run_program(src.bootloader)
+
+
+
+
+
+/// When searching, the bootloader will message the current databank and request an OS file and any drivers on-tape.
+#define STAGE_SEARCHING 0
+/// When evaluating, the bootloader will await a reply from the current databank, then attempt to write any OS files and drivers passed into the mainframe's harddrive before starting the new OS.
+#define STAGE_EVALUATING 1
+
+
+/**
+ *	The bootstrap loader, or bootloader, is ran when the mainframe cannot locate an OS file on its harddrive during the POST
+ *	sequence. When ran, the bootloader disconnects all current mainframe connections, wipes the harddrive, and queries all
+ *	available databanks for a backup OS and drivers. Typically used in conjunction with the mainframe recovery tapes.
  */
-
-/datum/computer/file/mainframe_program/os/bootstrap
+/datum/computer/file/mainframe_program/os/bootloader
 	name = "NETBOOT"
 	size = 4
-	needs_holder = 0
-	var/tmp/list/known_banks = list()
-	var/tmp/current = null //Net ID of current bank.
-	var/tmp/stage = 0
+	needs_holder = FALSE
+
+	/**
+	 *	The current stage of the bootloader.
+	 *	- `STAGE_SEARCHING`: When searching, the bootloader will message the current databank and request an OS file and any drivers on-tape.
+	 *	- `STAGE_EVALUATING`: When evaluating, the bootloader will await a reply from the current databank, then attempt to write any OS files and drivers passed into the mainframe's harddrive before starting the new OS.
+	 */
+	var/tmp/stage = STAGE_SEARCHING
+
+	/// A list of the net IDs of databanks that responded to the bootloader's network ping.
+	var/tmp/list/known_banks = null
+	/// The net ID of the databank currently being searched for an OS backup.
+	var/tmp/current = null
+
+	/// The number of cycles for which the bootloader should wait before starting to search for databanks.
 	var/tmp/ping_wait = 0
+	/// The number of cycles for which the bootloader should remain in `STAGE_EVALUATING` before moving onto the next databank.
 	var/tmp/stage_wait = 0
+	/// The number of cycles for which the bootloader should wait before restarting the bootload process.
 	var/tmp/rescan_wait = 0
-	var/setup_system_directory = "/sys"
-	var/setup_driver_directory = "/sys/drvr"
-	var/setup_bin_directory = "/bin"
 
-	disposing()
-		known_banks = null
-		..()
+/datum/computer/file/mainframe_program/os/bootloader/New()
+	. = ..()
+	src.known_banks = list()
 
-	initialize()
-		if(..())
-			return
+/datum/computer/file/mainframe_program/os/bootloader/disposing()
+	src.known_banks = null
+	. = ..()
 
-		src.known_banks.len = 0
-
-		src.clear_core()
-
-		src.find_existing_databanks()
-
-		src.stage_wait = 4
-		src.stage = 1
-		src.ping_wait = 4
-		src.current = null
-		SPAWN(1 DECI SECOND)
-			src.master.post_status("ping","data","NETBOOT","net","[src.master.net_number]")
+/datum/computer/file/mainframe_program/os/bootloader/initialize()
+	if (..())
 		return
 
-	process()
-		if(..())
+	src.known_banks.Cut()
+	src.clear_core()
+	src.disconnect_devices()
+
+	src.stage_wait = 4
+	src.stage = STAGE_EVALUATING
+	src.ping_wait = 4
+	src.current = null
+
+	SPAWN(1 DECI SECOND)
+		src.master.post_status("ping", "data", "NETBOOT", "net", "[src.master.net_number]")
+
+/datum/computer/file/mainframe_program/os/bootloader/process()
+	if (..())
+		return
+
+	if (src.ping_wait)
+		src.ping_wait--
+		return
+
+	if (src.rescan_wait)
+		src.rescan_wait--
+		if (src.rescan_wait <= 0)
+			src.initialized = FALSE
+			src.initialize()
+
+		return
+
+	if (src.stage_wait)
+		src.stage_wait--
+		if (src.stage_wait <= 0)
+			src.stage = STAGE_SEARCHING
+
+	if (src.stage == STAGE_SEARCHING)
+		if (!length(src.known_banks))
+			src.master.os = null
+			src.handle_quit()
+			src.dispose()
 			return
 
-		if(src.ping_wait)
-			src.ping_wait--
-			return
+		src.new_current()
+		src.message_term("command=bootreq", src.current)
 
-		if(src.rescan_wait)
-			if (--src.rescan_wait < 1)
-				src.initialized = 0
-				src.initialize()
-			return
+/datum/computer/file/mainframe_program/os/bootloader/new_connection(datum/terminal_connection/conn)
+	if (!istype(conn) || (conn.term_type != "PNET_DATA_BANK"))
+		return
 
-		if(src.stage_wait)
-			src.stage_wait--
-			if(stage_wait <= 0)
-				stage = 0
+	src.known_banks |= conn.net_id
 
-		if(!stage)
-			if(!known_banks.len)
+/datum/computer/file/mainframe_program/os/bootloader/closed_connection(datum/terminal_connection/conn)
+	if (!istype(conn))
+		return
+
+	src.known_banks -= conn.net_id
+
+/datum/computer/file/mainframe_program/os/bootloader/ping_reply(senderid, sendertype)
+	if (..() || !src.ping_wait)
+		return
+
+	if (src.master.terminals[senderid])
+		return
+
+	if ((sendertype != "PNET_DATA_BANK") && (sendertype != "HUI_TERMINAL"))
+		return
+
+	SPAWN(rand(1, 4))
+		src.master.post_status(senderid, "command", "term_connect", "device", src.master.device_tag)
+
+/datum/computer/file/mainframe_program/os/bootloader/term_input(data, termid, datum/computer/file/file)
+	if (..() || (src.stage != STAGE_EVALUATING))
+		return
+
+	var/datum/terminal_connection/conn = src.master.terminals[termid]
+	if (!conn?.term_type || (conn.term_type != "PNET_DATA_BANK"))
+		return
+
+	var/list/commandlist = params2list(data)
+	if (!commandlist || !commandlist["command"])
+		return
+
+	switch (lowertext(commandlist["command"]))
+		if ("status")
+			src.stage_wait = 1
+
+		if ("file")
+			if (!file)
+				src.new_current()
+				return
+
+			var/datum/computer/file/archive/archive = file.copy_file()
+			if (!istype(archive))
+				archive.dispose()
+				src.new_current()
+				return
+
+			var/datum/computer/file/mainframe_program/os/new_os = locate() in archive.contained_files
+			if (!istype(new_os))
+				archive.dispose()
+				src.new_current()
+				return
+
+			var/datum/computer/folder/sys_folder = src.parse_directory(setup_filepath_system, src.holder.root, TRUE)
+			var/datum/computer/folder/drive_folder = src.parse_directory(setup_filepath_drivers_proto, src.holder.root, TRUE)
+			var/datum/computer/folder/bin_folder = src.parse_directory(setup_filepath_commands, src.holder.root, TRUE)
+			var/datum/computer/folder/srv_folder = src.parse_directory("srv", sys_folder, TRUE)
+
+			if (!sys_folder || !drive_folder || !bin_folder || !srv_folder)
+				src.master.visible_message("[src.master] boops")
 				src.master.os = null
 				src.handle_quit()
-				//qdel (src)
 				src.dispose()
 				return
 
-			new_current()
-			src.message_term("command=bootreq",current)
-			return
-		return
+			for (var/datum/computer/file/mainframe_program/program in archive.contained_files)
+				if (istype(program, /datum/computer/file/mainframe_program/os))
+					continue
 
-	new_connection(datum/terminal_connection/conn)
-		if(!istype(conn))
-			return
+				program = program.copy_file()
 
-		if(conn.term_type == "PNET_DATA_BANK" && !(conn.net_id in known_banks) )
-			known_banks += conn.net_id
+				// If the program is a driver, add it to the driver directory.
+				if (istype(program, /datum/computer/file/mainframe_program/driver))
+					if (src.get_computer_datum(program.name, drive_folder))
+						continue
 
-		return
+					if (!drive_folder.add_file(program))
+						program.dispose()
+						break
 
-	closed_connection(datum/terminal_connection/conn)
-		if(!istype(conn)) return
-		var/del_netid = conn.net_id
-		if(del_netid in src.known_banks)
-			src.known_banks -= del_netid
-		return
+				// If the program is a utility, add it to the binaries directory.
+				else if (istype(program, /datum/computer/file/mainframe_program/utility))
+					if (src.get_computer_datum(program.name, bin_folder))
+						continue
 
-	ping_reply(var/senderid,var/sendertype)
-		if(..() || !ping_wait)
-			return
+					if (!bin_folder.add_file(program))
+						program.dispose()
+						break
 
-		if( !(senderid in master.terminals) && (sendertype == "PNET_DATA_BANK" || sendertype == "HUI_TERMINAL"))
-			SPAWN(rand(1,4))
-				src.master.post_status(senderid,"command","term_connect","device",master.device_tag)
-		return
+				// If the program is a service, add it to the service directory.
+				else if (istype(program, /datum/computer/file/mainframe_program/srv))
+					if (src.get_computer_datum(program.name, srv_folder))
+						continue
 
-	term_input(var/data, var/termid, var/datum/computer/file/the_file)
-		if(..() || !stage)
-			return
+					if (!srv_folder.add_file(program))
+						program.dispose()
+						break
 
-		var/datum/terminal_connection/conn = master.terminals[termid]
-		if(!conn || !conn.term_type)
-			return
-		var/device_type = conn.term_type
-		if(device_type == "PNET_DATA_BANK")
-			var/list/commandlist = params2list(data)
-			if(!commandlist || !commandlist["command"])
-				return
-			var/command = lowertext(commandlist["command"])
+				// Otherwise add the program to the system directory.
+				else
+					if (src.get_computer_datum(program.name, sys_folder))
+						continue
 
-			//boutput(world, "\[[conn.net_id]]")
+					if (!sys_folder.add_file(program))
+						program.dispose()
+						break
 
-			switch(command)
-				if("register")
-					return
-
-				if("file")
-					//boutput(world, "FILE")
-					if(!the_file)
-						new_current()
-						return
-
-					var/datum/computer/file/archive/arc = the_file.copy_file()
-					if(!istype(arc))
-						//qdel(arc)
-						arc.dispose()
-						new_current()
-						return
-
-					var/datum/computer/file/mainframe_program/os/newos = locate() in arc.contained_files
-					if(!istype(newos))
-						//qdel(arc)
-						arc.dispose()
-						new_current()
-						return
-
-					var/datum/computer/folder/sysdir = parse_directory(src.setup_system_directory, src.holder.root, 1)
-					var/datum/computer/folder/drivedir = parse_directory(src.setup_driver_directory, src.holder.root, 1)
-					var/datum/computer/folder/bindir = parse_directory(src.setup_bin_directory, src.holder.root, 1)
-					var/datum/computer/folder/srvdir = parse_directory("srv", sysdir, 1)
-					if(!sysdir || !drivedir || !bindir || !srvdir)
-						master.visible_message("[master] boops")
-						master.os = null
-						src.handle_quit()
-						//dispose()
-						src.dispose()
-						return
-
-					for(var/datum/computer/file/mainframe_program/MP in arc.contained_files)
-						if (istype(MP, /datum/computer/file/mainframe_program/os))
-							continue
-
-						var/datum/computer/file/mainframe_program/MP_copy = MP.copy_file()
-						if (istype(MP_copy, /datum/computer/file/mainframe_program/driver))
-							if(get_computer_datum(MP_copy.name, drivedir))
-								continue
-							if(!drivedir.add_file(MP_copy))
-								//qdel(MP_copy)
-								MP_copy.dispose()
-								break
-
-						else if (istype(MP_copy, /datum/computer/file/mainframe_program/utility))
-							if(get_computer_datum(MP_copy.name, bindir))
-								continue
-							if(!bindir.add_file(MP_copy))
-								///qdel(MP_copy)
-								MP_copy.dispose()
-								break
-
-						else if (istype(MP_copy, /datum/computer/file/mainframe_program/srv))
-							if(get_computer_datum(MP_copy.name, sysdir))
-								continue
-
-							if(!srvdir.add_file(MP_copy))
-								MP_copy.dispose()
-
-						else
-							if(get_computer_datum(MP_copy.name, sysdir))
-								continue
-							if(!sysdir.add_file(MP_copy))
-								//qdel(MP_copy)
-								MP_copy.dispose()
-								break
-
-					newos = newos.copy_file()
-					if(sysdir.add_file(newos))
-						master.os = null
-						//qdel(arc)
-						arc.dispose()
-						master.visible_message("[master] beeps")
-						master.run_program(newos)
-						src.handle_quit()
-						//dispose()
-						src.dispose()
-						return
-					else
-						//qdel(arc)
-						//qdel(newos)
-						if (arc)
-							arc.dispose()
-						if (newos)
-							newos.dispose()
-						/*
-						src.quit()
-						qdel(src)
-						*/
-						master.visible_message("[master] boops sadly.")
-						src.rescan_wait = 20
-						return
-
-
-				if ("status")
-					src.stage_wait = 1
-					return
-
-		return
-
-	proc
-		new_current() //Move on to a new current in the list.
-			if(src.current)
-				src.known_banks.Cut(1,2)
-				src.current = null
-
-			if(!known_banks.len)
-				/*
+			new_os = new_os.copy_file()
+			if (sys_folder.add_file(new_os))
 				src.master.os = null
-				src.quit()
-				qdel(src)
-				*/
+				archive.dispose()
+				src.master.visible_message("[src.master] beeps")
+				src.master.run_program(new_os)
+				src.handle_quit()
+				src.dispose()
+
+			else
+				archive?.dispose()
+				new_os?.dispose()
+				src.master.visible_message("[src.master] boops sadly.")
 				src.rescan_wait = 20
-				return
 
-			stage_wait = 4
-			stage = 1
-			src.current = known_banks[1]
-			return
+/// Move onto evaluting the next databank in the known banks list.
+/datum/computer/file/mainframe_program/os/bootloader/proc/new_current()
+	if (src.current)
+		src.known_banks.Cut(1, 2)
+		src.current = null
 
-		clear_core() //Clear the core memory board.
-			if(!src.holder || !src.holder.root)
-				return 0
+	if (!length(src.known_banks))
+		src.rescan_wait = 20
+		return
 
-			for(var/datum/computer/C in src.holder.root.contents)
-				if(C == src || C == src.holding_folder)
-					continue
+	src.stage_wait = 4
+	src.stage = STAGE_EVALUATING
+	src.current = src.known_banks[1]
 
-				//qdel(C)
-				C.dispose()
+/// Wipe the mainframe's harddrive.
+/datum/computer/file/mainframe_program/os/bootloader/proc/clear_core()
+	if (!src.holder?.root)
+		return FALSE
 
-			return 1
-
-		find_existing_databanks() //Find databank connections already in master.terminals
-			if(!src.master)
-				return
-
-			for(var/x in master.terminals)
-				var/datum/terminal_connection/conn = master.terminals[x]
-				if(!istype(conn))
-					continue
-
-				master.terminals -= x
-				//qdel(conn)
-				conn.dispose()
-
-				var/tempx = x
-				SPAWN(rand(1,4))
-					src.master.post_status(tempx, "command", "term_disconnect")
-
-
-			return
-
-
-/*
- *	A little mass message proc for some SPOOKY ANTICS
- */
-
-/proc/send_spooky_mainframe_message(var/the_message, var/a_spooky_custom_name)
-	if (!the_message)
-		return 1
-
-	for (var/obj/machinery/networked/mainframe/aMainframe as anything in machine_registry[MACHINES_MAINFRAMES])
-		LAGCHECK(LAG_LOW)
-		if (aMainframe.z != 1)
+	for (var/datum/computer/C as anything in src.holder.root.contents)
+		if ((C == src) || (C == src.holding_folder))
 			continue
 
-		if (!aMainframe.os || !hascall(aMainframe.os, "message_all_users"))
+		C.dispose()
+
+	return TRUE
+
+/// Disconnect all devices currently connected to the mainframe.
+/datum/computer/file/mainframe_program/os/bootloader/proc/disconnect_devices()
+	if (!src.master)
+		return
+
+	for (var/device_id as anything in src.master.terminals)
+		var/datum/terminal_connection/conn = src.master.terminals[device_id]
+		if (!istype(conn))
 			continue
 
-		aMainframe.os:message_all_users(the_message, a_spooky_custom_name, 1)
-		return 0
+		src.master.terminals -= device_id
+		conn.dispose()
 
-	return 2
+		SPAWN(rand(1, 4))
+			src.master.post_status(device_id, "command", "term_disconnect")
+
+
+#undef STAGE_SEARCHING
+#undef STAGE_EVALUATING


### PR DESCRIPTION
## About The PR:
Applies modern formatting standards to `mainframe2.dm`, including absolute pathing, use of `src` and `global`, use of `length()` in lieu of `.len`, and early returns.

Additionally thoroughly documents most aspects of the code, including variables, procs, and some of the more obscure logic, among others.


## Why Is This Needed?
See #20533.


## Testing:
Post cleanup, the DWAINE system boots correctly and is able to interface with other networked devices. The mainframe recovery sequence was also tested and works correctly.