### PR TITLE
Make contraband updates properly transfer to the mob that carries them

### DIFF
--- a/_std/macros/atom_properties.dm
+++ b/_std/macros/atom_properties.dm
@@ -356,6 +356,9 @@ To remove:
 // sliiiiiiiightly faster if you don't care about the value
 #define HAS_ATOM_PROPERTY(target, property) (target.atom_properties?[GET_PROP_NAME(property)] ? TRUE : FALSE)
 
+// use this to check if an atom got a property from a specific source
+#define HAS_ATOM_PROPERTY_FROM_SOURCE(target, property, source) (target.atom_properties?[GET_PROP_NAME(property)] ? (source in target.atom_properties[GET_PROP_NAME(property)][ATOM_PROPERTY_SOURCES_LIST]) : FALSE)
+
 
 #define APPLY_ATOM_PROPERTY_MAX(target, property, do_update, update_macro, source, value) \
 	do { \

--- a/code/datums/components/contraband.dm
+++ b/code/datums/components/contraband.dm
@@ -31,7 +31,7 @@ TYPEINFO(/datum/component/contraband)
 			var/obj/item/I = owner
 			var/mob/M = I.loc
 			//if this component gives contraband porperties to the carrier of the item, we should update these as well
-			if (HAS_ATOM_PROPERTY_FROM_SOURCE(M,PROP_MOVABLE_CONTRABAND_OVERRIDE, src) || HAS_ATOM_PROPERTY_FROM_SOURCE(M,PROP_MOVABLE_VISIBLE_GUNS, src))
+			if (HAS_ATOM_PROPERTY_FROM_SOURCE(M,PROP_MOVABLE_VISIBLE_CONTRABAND, src) || HAS_ATOM_PROPERTY_FROM_SOURCE(M,PROP_MOVABLE_VISIBLE_GUNS, src))
 				src.equipped(I, M, I.equipped_in_slot)
 
 		else if(ismovable(owner.loc))

--- a/code/datums/components/contraband.dm
+++ b/code/datums/components/contraband.dm
@@ -29,9 +29,9 @@ TYPEINFO(/datum/component/contraband)
 	else
 		if(isitem(owner) && ismob(owner.loc))
 			var/obj/item/I = owner
-
-			if (I.equipped_in_slot)
-				var/mob/M = I.loc
+			var/mob/M = I.loc
+			//if this component gives contraband porperties to the carrier of the item, we should update these as well
+			if (HAS_ATOM_PROPERTY_FROM_SOURCE(M,PROP_MOVABLE_CONTRABAND_OVERRIDE, src) || HAS_ATOM_PROPERTY_FROM_SOURCE(M,PROP_MOVABLE_VISIBLE_GUNS, src))
 				src.equipped(I, M, I.equipped_in_slot)
 
 		else if(ismovable(owner.loc))


### PR DESCRIPTION
[Bug][Game Objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds a new macro, `HAS_ATOM_PROPERTY_FROM_SOURCE(target, property, source)`. This Macro checks whenever a `source` in question applies a certain `property` onto the `target`.

This Macro is used to update the contraband value on a mob a certain item gives whenever that item has its contraband value updated if that item applied a contraband value on the mob in the first place.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Contraband sticker don't update the contraband value on mobs if they apply a contraband sticker on a non-wielded item in hand. This PR makes it so that this will happen. Thus, this PR fixes #24559

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Compare the behaviour shown in this video with the behaviour shown in the issue report in question.

https://github.com/user-attachments/assets/1788cc4b-f1c4-47a0-ade5-dde83afa7a08

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

