### PR TITLE
Fixes #24569 - DWAINE Script Evaluation Fixes

### DIFF
--- a/_std/math.dm
+++ b/_std/math.dm
@@ -41,7 +41,7 @@ proc/text2num_safe(x)
 /// Similar to `text2num_safe`, but returns the original string on failure.
 /proc/text2num_if_num(x)
 	. = text2num(x)
-	if (isnum_safe(.))
+	if (isnum_safe(.) && ("[.]" == x))
 		return
 	return x
 

--- a/code/modules/networks/computer3/mainframe2/shell/shell.dm
+++ b/code/modules/networks/computer3/mainframe2/shell/shell.dm
@@ -398,6 +398,23 @@
 /datum/computer/file/mainframe_program/shell/proc/script_evaluate(list/token_stream, return_bool = FALSE)
 	src.stack = list()
 
+	// The following allows apostrophes to sit next to text and still be treated as a separate token.
+	// This will eventually be replaced by a proper tokeniser.
+	for (var/i = 1; i <= length(token_stream); i++)
+		var/token = token_stream[i]
+
+		if (findtext(token, "'", 1, 2))
+			token = copytext(token, 2, 0)
+			token_stream[i] = token
+			token_stream.Insert(i, "'")
+			i++
+
+		if (findtext(token, "'", -1, 0))
+			token = copytext(token, 1, -1)
+			token_stream[i] = token
+			token_stream.Insert(i + 1, "'")
+			i++
+
 	while (length(token_stream))
 		var/current_token = text2num_if_num(token_stream[1])
 		token_stream.Cut(1, 2)


### PR DESCRIPTION
## About The PR:
Fixes #24569, which was a result of two distinct bugs:
- `text2num` returns a number if the first character of a string is a digit. This has been fixed by checking the returned number against the original value.
- The DWAINE script evaluator did not count apostrophes as distinct tokens if they were adjacent to another non-space character. This has been fixed by checking for leading and lagging apostrophes in the token stream and separating them into their own tokens.


## Testing:
```
>eval 1 ' 2 3' +
]1 2 3
```

```
>eval 'test 1 2 3'
]test 1 2 3
```

```
>eval 010101a01
]010101a01
```