### PR TITLE
Use loop to autoclose doors

### DIFF
--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -618,7 +618,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 			src.operating = 0
 
 /obj/machinery/door/proc/opened()
-	if(autoclose)
+	while(autoclose && !density && !QDELETED(src))
 		sleep(src.autoclose_delay)
 		if(interrupt_autoclose)
 			interrupt_autoclose = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adjusts the automatic closing of doors to be a loop when autoclose is enabled.  Door will continue to attempt to close while it is not dense, autoclose is still active, and the door is still relevant to the game.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolves #24561 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested multiple sets of doors being blocked by objects and mobs.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
