### PR TITLE
Prevent Vampire Miners

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -797,6 +797,7 @@ ABSTRACT_TYPE(/datum/job/engineering)
 	wages = PAY_TRADESMAN
 	trait_list = list("training_miner")
 	access_string = "Miner"
+	invalid_antagonist_roles = list(ROLE_VAMPIRE)
 	slot_back = list(/obj/item/storage/backpack/engineering)
 	slot_mask = list(/obj/item/clothing/mask/breath)
 	slot_eyes = list(/obj/item/clothing/glasses/toggleable/meson)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents vampires from rolling miner for their job.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Antagonist roles should not impact your ability to do your job normally, Vampire heavily impedes miners whose entire role revolves around being outside the station in space due to the unavoidable damage vampires get from being in space (2.5 burn and (vampire) bloodloss every life tick)

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
With Miner favourited and the round forced to vampire, instead spawned as scientist.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Vampires can no longer be assigned the Miner job.
```
