### PR TITLE
Disables harbinger wraith on RP

### DIFF
--- a/code/modules/antagonists/wraith/abilties/specialize.dm
+++ b/code/modules/antagonists/wraith/abilties/specialize.dm
@@ -6,7 +6,11 @@
 	pointCost = 150
 	tooltip_options = list("align" = TOOLTIP_LEFT | TOOLTIP_CENTER)
 	special_screen_loc = "NORTH-1,EAST"
+#ifdef RP_MODE
+	var/static/list/paths = list("Rot" = 1, "Trickster" = 3)
+#else
 	var/static/list/paths = list("Rot" = 1, "Summoner" = 2, "Trickster" = 3)
+#endif
 	var/list/paths_buttons = list()
 
 
@@ -20,8 +24,8 @@
 		if (!object.contextActions)
 			object.contextActions = list()
 
-		for(var/i in 1 to 3)
-			var/datum/contextAction/wraith_evolve_button/newcontext = new /datum/contextAction/wraith_evolve_button(i)
+		for(var/name in src.paths)
+			var/datum/contextAction/wraith_evolve_button/newcontext = new /datum/contextAction/wraith_evolve_button(src.paths[name])
 			object.contextActions += newcontext
 
 	cast()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
See title, plaguebringer and trickster are still enabled.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Harbinger is based around the idea of just summoning as many minions as possible and overwhelming the crew. In theory there *is* roleplay to be had in that, but in practice it tends to quickly turn rounds into chaotic "everyone for themselves" slaughter fests where security get carpel tunnel and medical use 100u of styptic a minute.
I did think the wraith/summons chat channel would help with controlling the chaos a little but it really doesn't seem to have improved much.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="156" height="202" alt="image" src="https://github.com/user-attachments/assets/cdba5c85-607c-4112-b1ce-5ab45fd75628" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Harbinger wraith is now disabled on the roleplay servers.
```
