### PR TITLE
Say Rework Fixbatch X

### DIFF
--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -173,6 +173,8 @@
 			src.prefix = lowertext(trimtext(copytext(src.content, 1, cut_position)))
 			src.content = copytext(src.content, cut_position, MAX_MESSAGE_LEN)
 
+	src.content = trimtext(src.content)
+
 	// Determine whether this message has a singing prefix, and adjust the content accordingly.
 	if (copytext(src.content, 1, 2) == "%")
 		src.flags |= SAYFLAG_SINGING
@@ -245,13 +247,13 @@
 
 /// Determines the say sound that this message should use, and plays it.
 /datum/say_message/proc/process_say_sound()
+	if (src.flags & SAYFLAG_ADMIN_MESSAGE)
+		return
+
 	if (world.time < src.message_origin.last_voice_sound + VOICE_SOUND_COOLDOWN)
 		return
 
-	if (src.say_sound == NO_SAY_SOUND)
-		return
-
-	if (!src.say_sound && !src.speaker.voice_type && !src.speaker.voice_sound_override)
+	if ((src.say_sound == NO_SAY_SOUND) || (!src.say_sound && !src.speaker.voice_type && !src.speaker.voice_sound_override))
 		return
 
 	src.say_sound ||= src.speaker.voice_sound_override
@@ -280,7 +282,7 @@
 
 /// Determines the speech bubble that this message should use, and displays it on the speaker.
 /datum/say_message/proc/process_speech_bubble()
-	if (!src.speaker.use_speech_bubble)
+	if ((src.flags & SAYFLAG_ADMIN_MESSAGE) || !src.speaker.use_speech_bubble)
 		return
 
 	var/speech_bubble_icon

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -19,6 +19,7 @@
 	tooltip_flags = REBUILD_ALWAYS //TODO: handle better??
 	max_damage = INFINITY
 	throw_speed = 1
+	open_to_sound = FALSE
 
 	var/obj/item/organ/brain/brain = null
 	var/obj/item/skull/skull = null


### PR DESCRIPTION
## About The PR:
Fixes #24060, fixes #24179, and fixes #24585.


## Testing:
Holding a severed head with a headset on no longer lets you hear messages from that headset.
Using the admin say procs (`dsay`, `blobsay`, etc.) no longer displays a speech bubble nor plays a say sound.
<img width="552" height="52" alt="image" src="https://github.com/user-attachments/assets/386f9a59-a9bf-44e7-b395-1aaebb307459" />