### PR TITLE
NPC Living Objects attack objects their target hides in

### DIFF
--- a/code/mob/living/object.dm
+++ b/code/mob/living/object.dm
@@ -409,7 +409,10 @@
 		holder.move_to(holder.target)
 	else
 		if(!ON_COOLDOWN(holder.owner, "livingobj_click_delay", holder.owner.combat_click_delay))
-			holder.owner.weapon_attack(holder.target, holder.owner.equipped(), TRUE)
+			var/atom/movable/thing_to_attack = holder.target
+			if (isobj(thing_to_attack.loc))
+				thing_to_attack = thing_to_attack.loc
+			holder.owner.weapon_attack(thing_to_attack, holder.owner.equipped(), TRUE)
 
 /datum/aiTask/timed/targeted/living_object/frustration_check()
 	. = 0
@@ -431,10 +434,12 @@
 	if (!istype(item, /obj/item/attackdummy)) // marginally more performant- don't bother if we're a possessed non item
 		if (istype(item, /obj/item/baton))
 			var/obj/item/baton/bat = item
-			if (is_incapacitated(src.holder.target) || !(SEND_SIGNAL(bat, COMSIG_CELL_CHECK_CHARGE) & CELL_SUFFICIENT_CHARGE)) // they're down or we're out of juice, let's harm baton
+			// they're down, hiding, or we're out of juice - let's harm baton
+			if (is_incapacitated(src.holder.target) || !isturf(src.holder.target.loc) || !(SEND_SIGNAL(bat, COMSIG_CELL_CHECK_CHARGE) & CELL_SUFFICIENT_CHARGE))
 				if (bat.is_active) // uh oh, we're on. turn off
 					spooker.self_interact()
-				spooker.set_a_intent(INTENT_HARM)
+				if (spooker.intent != INTENT_HARM)
+					spooker.set_a_intent(INTENT_HARM)
 				bat.flipped = TRUE
 
 			else // they're up and we have charge, let's try to stun
@@ -445,7 +450,8 @@
 							spooker.self_interact()
 					spooker.self_interact()
 
-				spooker.set_a_intent(INTENT_DISARM) // have charge, baton normally
+				if (spooker.intent != INTENT_DISARM)
+					spooker.set_a_intent(INTENT_DISARM) // have charge, baton normally
 				bat.flipped = FALSE
 			bat.UpdateIcon()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[balance][feature][critters]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When a living object attacks its target, if the target mob is hiding inside an object it will instead attack the object the person is inside. This includes things such as vehicles, closets, and disposal chutes.

Some logic changes needed to be done for the security baton object's special harm-baton behavior. 

Adds a health value for disposal units, and adds a snowflake exception for living objects attacking chutes. With the change to the logic, the living object would instead repeatedly attempt (and fail) to put itself in the disposal unit. Allowing them to slowly beat down the disposal unit still allows someone to use it as an escape, but only a short-term reprieve. Players currently don't have a way to damage the disposal chutes; gunfire rolls a separate probability to break.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Living objects can currently hit people inside objects:
* Fix #24538

It's spookier if the haunted object trying to kill you slowly but surely bashes open the closet you're hiding in instead of transmitting damage to you through the object.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Frontier Report: Single Haunted Chair Destroys Local Space Station

Disposal Chutes
<img width="298" height="187" alt="Screenshot 2025-08-31 102147" src="https://github.com/user-attachments/assets/0a772daa-01f8-477a-ba4b-19879ac325fe" /><br><br>

Lockers
<img width="306" height="383" alt="Screenshot 2025-08-30 000947" src="https://github.com/user-attachments/assets/04e80435-14af-4f9c-944c-70b526c1dc61" /><br><br>

Space Pod
<img width="338" height="251" alt="Screenshot 2025-08-30 001037" src="https://github.com/user-attachments/assets/4b6e1f63-b487-4694-94d2-314c5c9474fe" /><br><br>


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Living objects attempt to destroy common hiding places.
```
