### PR TITLE
Spy bounty destroyed indication

### DIFF
--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -1124,8 +1124,13 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 				src.menu_message += "<B>Current Bounties (Next Refresh at : [refresh_time_formatted]):</B>"
 				for(var/datum/bounty_item/B in game.active_bounties)
 					var/atext = ""
+					var/item_destroyed = FALSE // If the bounty required a specific item and was destroyed
 					if (B.reveal_area && B.item && !B.claimed)
-						atext = "<br>(Last Seen : [get_area(B.item)])"
+						var/item_area = get_area(B.item)
+						if(!item_area) // Also includes if there's no item because if there's no item then it has no area
+							item_destroyed = TRUE
+						else
+							atext = "<br>(Last Seen : [item_area])"
 					var/rtext = ""
 					if (B.reward)
 						if (req_bounties() <= 1)
@@ -1133,7 +1138,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 						else
 							rtext = "<br><b>Reward</b> : Not available. Deliver [req_bounties()] more bounties."
 
-					src.menu_message += "<small><br><br><tr><td><b>[B.name]</b>[rtext][atext]<br>[(B.claimed) ? "(<b>CLAIMED</b>)" : "(Deliver : <b>[B.delivery_area ? B.delivery_area : "Anywhere"]</b>) [B.photo_containing ? "" : "<a href='byond://?src=\ref[src];action=print;bounty=\ref[B]'>Print</a>"]"]</td></tr></small>"
+					src.menu_message += "<small><br><br><tr><td><b>[B.name]</b>[rtext][atext]<br>[(B.claimed) ? "(<b>CLAIMED</b>)" : (item_destroyed) ? "(<b>DESTROYED</b>)" : "(Deliver : <b>[B.delivery_area ? B.delivery_area : "Anywhere"]</b>) [B.photo_containing ? "" : "<a href='byond://?src=\ref[src];action=print;bounty=\ref[B]'>Print</a>"]"]</td></tr></small>"
 
 		src.menu_message += "<HR>"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If a spy thief bounty requiring a specific item was unable to locate an item then said item will be marked as (DESTROYED) in the listing in the same way it would if it was (CLAIMED)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The information that the item is gone  is already in game via null last seen location, this just makes it clearer and cleans up some of the text uselessly telling you where it is and where to take it.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="305" height="219" alt="image" src="https://github.com/user-attachments/assets/6cdd2b3a-87ab-4963-8b7a-a674398a297a" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Limb and Trinket bounties will now be marked as destroyed in spy uplinks when their target item is destroyed.
```
