### PR TITLE
Adjust access on monkey dome doors

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -22542,7 +22542,6 @@
 	dir = 4;
 	req_access = null
 	},
-/obj/mapping_helper/access/medlab,
 /obj/mapping_helper/firedoor_spawn,
 /obj/cable{
 	icon_state = "4-8"
@@ -22553,6 +22552,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/access/medical,
 /turf/simulated/floor/plating,
 /area/station/medical/dome)
 "gJU" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -44127,7 +44127,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	req_access = null
 	},
-/obj/mapping_helper/access/medlab,
+/obj/mapping_helper/access/medical,
 /turf/simulated/floor/plating/jen,
 /area/station/medical/dome)
 "nKY" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -48479,7 +48479,7 @@
 	dir = 4
 	},
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/medlab,
+/obj/mapping_helper/access/medical,
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Mapping] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Some maps have two doors on the monkey dome-- one that leads into genetics, and one that allows for people to enter without being in genetics. The access requirements reflect this on some maps, but not others; so this goes through Kondaru, Donut2, and Donut3 to ensure at least one of the monkey dome doors is accessible to doctors / roboticists.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map standardization and QoL, largely. Monkeys are useful for emergency organs of those with cybernetic incompatibility and not having immediate access on some maps is odd. Tiny issue, but one that I think doctors would appreciate.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Changed access from medlab to medical on each effected door and ran them all to ensure it works properly.

