### PR TITLE
Possible Fix For Occupation TGUI Crash

### DIFF
--- a/code/datums/preferences/preferences.dm
+++ b/code/datums/preferences/preferences.dm
@@ -184,7 +184,7 @@ var/list/removed_jobs = list(
 			"traitsData" = traitsData,
 		)
 
-		. += src.GetJobStaticData(usr)
+		. += src.GetJobStaticData(user)
 
 	ui_data(mob/user)
 		var/client/client = ismob(user) ? user.client : user


### PR DESCRIPTION
## About The PR:
Replaces `usr` with `user` in the occupation UI's `ui_static_data`, which may be causing a runtime which may be causing the TGUI crash. I can't actually reproduce the crash.

Either way, `usr` shouldn't be used there, and was an error on my part.


## Testing:
N/A, see above.