### PR TITLE
Syndicate description macro

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -163,6 +163,7 @@
 #include "macros\client.dm"
 #include "macros\cooldown.dm"
 #include "macros\debug.dm"
+#include "macros\descriptions.dm"
 #include "macros\dir.dm"
 #include "macros\directional_offsets.dm"
 #include "macros\dist.dm"

--- a/_std/macros/descriptions.dm
+++ b/_std/macros/descriptions.dm
@@ -1,0 +1,7 @@
+// Macro to quickly add syndicate-specific descriptions to stealth items to make them easily identifiable to traitors (and spiefs who use their gear)
+#define SYNDICATE_STEALTH_DESCRIPTION(TYPE, syndie_desc, alt_desc) \
+	TYPE/get_desc(dist, mob/user) { \
+		..(); \
+		if(istrainedsyndie(user) || isspythief(user)) {. += SPAN_ALERT("<b> [syndie_desc]</b>")} \
+		else {. += (" [alt_desc]")} \
+	}

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -421,6 +421,7 @@
 		icon_state = "shrub-dead"
 
 //It'll show up on multitools
+SYNDICATE_STEALTH_DESCRIPTION(/obj/shrub/syndicateplant, "The latest in syndicate spy technology.", "Is that an antenna?")
 TYPEINFO(/obj/shrub/syndicateplant)
 	mats = 2
 /obj/shrub/syndicateplant
@@ -431,12 +432,6 @@ TYPEINFO(/obj/shrub/syndicateplant)
 		. = ..()
 		src.net_id = generate_net_id(src)
 		MAKE_DEFAULT_RADIO_PACKET_COMPONENT(src.net_id, "control", FREQ_HYDRO)
-
-	get_desc(dist, mob/user)
-		if(istrainedsyndie(user))
-			. += SPAN_ALERT("<b>The latest in syndicate spy technology. </b>")
-		else
-			. += "Is that an antenna? "
 
 	proc/fuck_up()
 		var/datum/effects/system/spark_spread/S = new


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a macro for adding traitor (and spief) only descriptions to objects, intended for stealth items that you wouldn't want to get mixed up with the real deal, but only applied to the syndicate shrub for this PR

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lays the groundwork for simpler adding of identifiable descriptions to syndicate stealth items

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Syndicate shrub description works as intended, "latest in spy tech" as syndie/spief, "is that an antenna" otherwise.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
