### PR TITLE
wall igniters now have mechcomp input

### DIFF
--- a/code/obj/machinery/igniter.dm
+++ b/code/obj/machinery/igniter.dm
@@ -58,6 +58,8 @@
 	light = new /datum/light/point
 	light.attach(src)
 	light.set_brightness(0.4)
+	AddComponent(/datum/component/mechanics_holder)
+	SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"ignite", PROC_REF(ignite))
 
 /obj/machinery/sparker/power_change()
 	if ( powered() && disable == 0 )


### PR DESCRIPTION
[ATMOSPHERICS][FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
the wall mounted igniter now can be ignited by a mechcomp signal


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
allows automated igniting


## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
i connected a button, pressed it, it worked.


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)cringe
(+)wall igniters now accept mechcomp igniting
```
