### PR TITLE
volume pump bug fix

### DIFF
--- a/code/modules/atmospherics/machinery/binary/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/binary/volume_pump.dm
@@ -41,12 +41,6 @@
 	if(!on)
 		return FALSE
 
-	if(src.transfer_rate <= 0)
-		src.visible_message(SPAN_ALERT("The [src] turns off automatically due to a zero transfer rate."))
-		src.on = FALSE
-		UpdateIcon()
-		return FALSE
-
 	var/datum/gas_mixture/removed = air1.remove_ratio(src.transfer_rate/air1.volume)
 
 	air2.merge(removed)


### PR DESCRIPTION
[ATMOSPHERICS][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
max_volume was set to 1000 even though air1 caps at 200 so i fixed that.
it didnt have a frequency unlike other shit so i fixed that.
it had a min of 1 for transfer rate even though theres zero reason for that since there aint no divide by zero errors here and it made the pump ui lie about what was actually transferring so i fixed that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
the dang thing works

