### PR TITLE
Makes it able to poke holes into the blindfold

### DIFF
--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -89,7 +89,8 @@
 			src.pinhole = TRUE
 			src.block_vision = FALSE
 			boutput(user, SPAN_NOTICE("You poked two holes into the blindfold, now you can pretend that you can see without seeing"))
-		. = ..()
+		else
+			. = ..()
 
 	get_desc()
 		if (src.pinhole)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It makes it able to poke holes into the blindfold similar to the eyepatch

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
For style reasons so you can wear a blindfold while still being able to see things, otherwise maybe some antags find fun ways to fake that a monkey is actually blinded by the blindfold

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="1906" height="974" alt="Blindfold no holes" src="https://github.com/user-attachments/assets/c905dd42-e901-4524-b598-cddcd1b60273" />

<img width="1874" height="993" alt="blindfold see" src="https://github.com/user-attachments/assets/865d843a-3196-43d8-87fe-6b89c9fa8772" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Drakios
(+)Blindfolds can have holes piked in them now - win every time while hitting a pinata 
```
