### PR TITLE
Removes material wave filters from honey blobs specifically

### DIFF
--- a/code/modules/cooking/food_and_drink/ingredients.dm
+++ b/code/modules/cooking/food_and_drink/ingredients.dm
@@ -392,6 +392,11 @@ TYPEINFO(/obj/item/reagent_containers/food/snacks/ingredient/honey)
 	mat_changename = "honey"
 	default_material = "honey"
 
+	New()
+		..()
+		src.clear_filters() //Overrides the wave-filter normally applied to materials made of honey.
+
+
 /obj/item/reagent_containers/food/snacks/ingredient/royal_jelly
 	name = "royal jelly"
 	desc = "A blob of nutritive gel for larval bees."

--- a/code/modules/cooking/food_and_drink/ingredients.dm
+++ b/code/modules/cooking/food_and_drink/ingredients.dm
@@ -392,11 +392,6 @@ TYPEINFO(/obj/item/reagent_containers/food/snacks/ingredient/honey)
 	mat_changename = "honey"
 	default_material = "honey"
 
-	New()
-		..()
-		src.clear_filters() //Overrides the wave-filter normally applied to materials made of honey.
-
-
 /obj/item/reagent_containers/food/snacks/ingredient/royal_jelly
 	name = "royal jelly"
 	desc = "A blob of nutritive gel for larval bees."

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -691,7 +691,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 
 /datum/materialProc/honey_add
 	execute(var/atom/location)
-		if(endswith(location.icon_state, "$$honey"))
+		if(endswith(location.icon_state, "$$honey") || ("honey" in location.get_typeinfo().mat_appearances_to_ignore))
 			return
 		var/offset = 0
 		if(!isturf(location))


### PR DESCRIPTION
[MATERIALS][SPRITES][REWORK]

## About the PR
make it so honey blob look normal, and is not affect by transfrom apply by #24349 ...but only honey blob!

## Why's this needed? 
I am big fanm of hony sprite! it look a bit not good with wobbly gobbly effect...oteher think so, too. So blob do not have effect anymore. BUT hoeny effect still can happne on other sprite!
no oozeing
<img width="285" height="231" alt="theominiousooze" src="https://github.com/user-attachments/assets/df250b90-620e-409a-84a2-34a88e4ee8c3" />


## Testing
Test with specil color honey blob, big blob, etc.
<img width="567" height="1213" alt="nowaving" src="https://github.com/user-attachments/assets/5aeb2317-9fdf-4d77-ae98-e75673d5e57f" />


no changinglog. probaply?
