### PR TITLE
Wraith salt rework

### DIFF
--- a/code/mob/living/intangible/wraith.dm
+++ b/code/mob/living/intangible/wraith.dm
@@ -367,13 +367,14 @@ TYPEINFO(/mob/living/intangible/wraith)
 				door.open()
 			return ..()
 
-		if (!src.density && !src.justdied)
-			for (var/obj/decal/cleanable/saltpile/salt in NewLoc)
-				src.setStatus("corporeal", src.forced_haunt_duration, TRUE)
-				var/datum/targetable/ability = src.abilityHolder.getAbility(/datum/targetable/wraithAbility/haunt)
-				ability.doCooldown()
-				boutput(src, SPAN_ALERT("You have passed over salt! You now interact with the mortal realm..."))
-				break
+		if (!src.density)
+			var/obj/decal/cleanable/saltpile/salt = locate() in NewLoc
+			if (salt)
+				if (salt.wraith_bump(src)) //destroyed it, take damage and pass
+					src.health -= 15
+					global.health_update_queue |= src
+				else //didn't destroy it, can't pass
+					return
 
 		return ..()
 

--- a/code/modules/antagonists/wraith/abilties/_wraith_ability_holder.dm
+++ b/code/modules/antagonists/wraith/abilties/_wraith_ability_holder.dm
@@ -81,7 +81,6 @@
 			var/obj/decal/cleanable/saltpile/salt = locate() in T
 			if (salt)
 				if (!ON_COOLDOWN(T, "wraith_ability_block", 2 SECONDS))
-					// particleMaster.SpawnSystem(new /datum/particleSystem/localSmoke("#000000", 1, T))
 					salt.add_filter("wraith_ability_block", 1, outline_filter(2, "#000"))
 					animate(salt.filters[length(salt.filters)], alpha = 0, time = 0)
 					animate(alpha = 255, time = 0.5 SECONDS)

--- a/code/modules/antagonists/wraith/abilties/_wraith_ability_holder.dm
+++ b/code/modules/antagonists/wraith/abilties/_wraith_ability_holder.dm
@@ -76,6 +76,21 @@
 			if (W.forced_manifest == TRUE)
 				boutput(W, SPAN_ALERT("You have been forced to manifest! You can't use any abilities for now!"))
 				return CAST_ATTEMPT_FAIL_NO_COOLDOWN
+		var/list/turfs = raytrace(src.holder.owner, target)
+		for (var/turf/T as anything in turfs)
+			var/obj/decal/cleanable/saltpile/salt = locate() in T
+			if (salt)
+				if (!ON_COOLDOWN(T, "wraith_ability_block", 2 SECONDS))
+					// particleMaster.SpawnSystem(new /datum/particleSystem/localSmoke("#000000", 1, T))
+					salt.add_filter("wraith_ability_block", 1, outline_filter(2, "#000"))
+					animate(salt.filters[length(salt.filters)], alpha = 0, time = 0)
+					animate(alpha = 255, time = 0.5 SECONDS)
+					animate(alpha = 0, time = 0.5 SECONDS)
+					SPAWN(1 SECOND)
+						salt.remove_filter("wraith_ability_block")
+					playsound(T, 'sound/impact_sounds/burn_sizzle.ogg', 50, 1)
+					boutput(src.holder.owner, SPAN_ALERT("That [SPAN_BOLD(pick("DISGUSTING", "FEARFUL", "PURE", "HOLY"))] salt blocks your power."), "wraith_ability_fail")
+				return CAST_ATTEMPT_FAIL_NO_COOLDOWN
 		return CAST_ATTEMPT_SUCCESS
 
 	doCooldown()

--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -1361,6 +1361,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	sample_reagent = "salt"
 	sample_verb = "scrape"
 	var/health = 30
+	var/bump_stacks = 0
 
 	New()
 		..()
@@ -1376,6 +1377,27 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 		var/turf/T = get_turf(src)
 		if (T)
 			updateSurroundingSalt(T)
+
+	/// When a wraith or similar bumps into this, returns TRUE if destroyed
+	proc/wraith_bump(mob/living/intangible/wraith/wraith)
+		if (ON_COOLDOWN(src, "wraith_bumped", 1 SECOND))
+			return
+		hit_twitch(src)
+		src.bump_stacks += 1
+		if (src.bump_stacks >= 3)
+			new /obj/effects/impact_energy/smoke(get_turf(src))
+			qdel(src)
+			boutput(wraith, SPAN_NOTICE("You force your way past the holy barrier, losing some of your life force in the process."))
+			return TRUE
+		global.processing_items |= src
+		boutput(wraith, SPAN_NOTICE("The salt stings, but it gives a little as you exert your will against it..."))
+		return FALSE
+
+	process()
+		if (!GET_COOLDOWN(src, "wraith_bumped"))
+			src.bump_stacks -= 1
+			if (src.bump_stacks <= 0)
+				global.processing_items -= src
 
 	Crossed(atom/movable/AM as mob|obj)
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Salt no longer reveals wraiths, it instead blocks them and can be passed by shoving against it repeatedly in exchange for 15 health. Shoving into the salt visibly moves it.
Salt now blocks wraith abilities based on line of sight. Salt that blocks a wraith ability will hiss and glow black for a second.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The polarizing nature of salt is widely hated, wraiths dying instantly because they accidentally glided over a table with a salt pile under it never feels good. This PR is an attempt to fix that without increasing wraith's overall power/threat level.
Now you can draw circles of salt around areas to make them actually immune to wraith effects, or try to trap the wraith in an enclosed region, forcing them to take health damage to escape.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="369" height="166" alt="image" src="https://github.com/user-attachments/assets/0abe8566-5325-4de4-b2a7-20dd046f2642" />
<img width="379" height="355" alt="image" src="https://github.com/user-attachments/assets/a0d41310-8594-4324-b1eb-d11c60e86b98" />


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Salt no longer reveals wraiths, instead it blocks them and can be shoved through for a small health cost.
(*)Salt now blocks wraith abilities based on line of sight.
```
