### PR TITLE
Material color matrices respect mat_changeappearance

### DIFF
--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -626,6 +626,8 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 
 	execute(var/atom/owner)
 		var/added_mat_id = owner.material.getID()
+		if(!owner.mat_changeappearance)
+			return
 		if(endswith(owner.icon_state, "$$[added_mat_id]")) // Ignore if it is a material version of a sprite
 			return
 		if(owner.default_material == added_mat_id && !owner.uses_default_material_appearance)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug][materials]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
added a missing check for mat_changeappearance


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Robot parts were incorrectly getting material appearance when made with materials that used material color matrices.


## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Checked that they do not get material appearance anymore and checked that things that should get material appearance do
