### PR TITLE
Law Linkers show connected rack on examine

### DIFF
--- a/code/obj/item/device/borg_linker.dm
+++ b/code/obj/item/device/borg_linker.dm
@@ -16,6 +16,11 @@ TYPEINFO(/obj/item/device/borg_linker)
 	g_amt = 20
 	var/obj/machinery/lawrack/linked_rack = null
 
+	get_desc(dist, mob/user)
+		if(src.linked_rack)
+			var/area/rack_area = get_area(src.linked_rack)
+			. += " It is linked to a law rack at [rack_area.name]"
+
 	attack_self(var/mob/user)
 		if(src.linked_rack)
 			var/area/A = get_area(src.linked_rack.loc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When examined, law linkers show the location of their connected law rack

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
QoL to see at a glance which rack your linker is connected to. The location of the connected rack can already be identified by trying to link a silicon to it.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="347" height="254" alt="image" src="https://github.com/user-attachments/assets/e2fcdfc0-91d8-4981-9801-08e0cc652c81" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Law Linkers now show the location of their linked rack on examine.
```
