### PR TITLE
Refactors clothing slots to use a bitflag instead of istype (partly)

### DIFF
--- a/_std/defines/clothing.dm
+++ b/_std/defines/clothing.dm
@@ -82,8 +82,6 @@ var/list/all_slots = list(SLOT_BACK, SLOT_WEAR_MASK, SLOT_L_HAND, SLOT_R_HAND, S
 #define ONBELT						(1<<18)
 /// block miasma inhalations (sterile mask)
 #define BLOCKMIASMA					(1<<19)
-/// covers the person's hair
-#define COVERSHAIR					(1<<20)
 
 //Suit blood flags
 #define SUITBLOOD_ARMOR 1

--- a/_std/defines/clothing.dm
+++ b/_std/defines/clothing.dm
@@ -21,6 +21,19 @@
 
 var/list/all_slots = list(SLOT_BACK, SLOT_WEAR_MASK, SLOT_L_HAND, SLOT_R_HAND, SLOT_BELT, SLOT_WEAR_ID, SLOT_EARS, SLOT_GLASSES, SLOT_GLOVES, SLOT_HEAD, SLOT_SHOES, SLOT_WEAR_SUIT, SLOT_L_STORE, SLOT_R_STORE)
 
+// Bitflag for what slots a clothing can be put into
+#define SLOT_FLAG_BACK						(1<<0) // currently unused
+#define SLOT_FLAG_MASK						(1<<1) // MUST be obj/item/clothing/mask
+#define SLOT_FLAG_BELT						(1<<2) // currently unused
+#define SLOT_FLAG_ID						(1<<3)
+#define SLOT_FLAG_EARS						(1<<4) // MUST be obj/item/clothing
+#define SLOT_FLAG_GLASSES					(1<<5) // MUST be obj/item/clothing/glasses
+#define SLOT_FLAG_GLOVES					(1<<6) // MUST be obj/item/clothing/gloves
+#define SLOT_FLAG_HEAD						(1<<7) // MUST be obj/item/clothing/head
+#define SLOT_FLAG_SHOES						(1<<8) // MUST be obj/item/clothing/shoes
+#define SLOT_FLAG_SUIT						(1<<9) // MUST be obj/item/clothing/suit
+#define SLOT_FLAG_UNIFORM					(1<<10)// MUST be obj/item/clothing/under
+
 // bitflags for clothing parts
 #define HEAD			1
 #define TORSO			2
@@ -69,6 +82,8 @@ var/list/all_slots = list(SLOT_BACK, SLOT_WEAR_MASK, SLOT_L_HAND, SLOT_R_HAND, S
 #define ONBELT						(1<<18)
 /// block miasma inhalations (sterile mask)
 #define BLOCKMIASMA					(1<<19)
+/// covers the person's hair
+#define COVERSHAIR					(1<<20)
 
 //Suit blood flags
 #define SUITBLOOD_ARMOR 1

--- a/code/datums/components/hattable.dm
+++ b/code/datums/components/hattable.dm
@@ -40,7 +40,7 @@ TYPEINFO(/datum/component/hattable) // Take a walk through my TWISTED mind.... I
 	var/offsetBy_x = 0
 
 
-	if (istype(item, /obj/item/clothing/head/) || istype(item, /obj/item/organ/head))
+	if (item.equipment_slot & SLOT_FLAG_HEAD || istype(item, /obj/item/organ/head))
 		src.hat = item
 		ADD_FLAG(src.hat.appearance_flags, KEEP_TOGETHER) // Flags needed for wigs!
 		ADD_FLAG(src.hat.vis_flags, VIS_INHERIT_DIR)

--- a/code/datums/critter_mobs/equipment.dm
+++ b/code/datums/critter_mobs/equipment.dm
@@ -8,7 +8,7 @@
 	var/icon_state = "hair"						// the icon state of the HUD object
 	var/obj/item/item							// the item being worn in this slot
 
-	var/list/type_filters = list()				// a list of parent types whose subtypes are equippable
+	var/list/slot_flag = null
 	var/atom/movable/screen/hud/screenObj				// ease of life
 
 	var/mob/holder = null
@@ -29,9 +29,8 @@
 
 
 	proc/can_equip(var/obj/item/I)
-		for (var/T in type_filters)
-			if (istype(I, T))
-				return 1
+		if (I.equipment_slot & src.slot_flag)
+			return 1
 		return 0
 
 	proc/equip(var/obj/item/I)
@@ -76,7 +75,7 @@
 
 	head
 		name = "head"
-		type_filters = list(/obj/item/clothing/head)
+		slot_flag = SLOT_FLAG_HEAD
 		icon = 'icons/mob/hud_human.dmi'
 		icon_state = "hair"
 		armor_coverage = HEAD
@@ -115,14 +114,14 @@
 
 	suit
 		name = "suit"
-		type_filters = list(/obj/item/clothing/suit)
+		slot_flag = SLOT_FLAG_SUIT
 		icon = 'icons/mob/hud_human.dmi'
 		icon_state = "armor"
 		armor_coverage = TORSO
 
 	ears
 		name = "ears"
-		type_filters = list(/obj/item/device/radio)
+		slot_flag = SLOT_FLAG_EARS
 		icon = 'icons/mob/hud_human.dmi'
 		icon_state = "ears"
 

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -117,7 +117,7 @@ TYPEINFO(/mob)
 	var/obj/item/back = null
 	var/obj/item/tank/internal = null
 	var/obj/item/clothing/mask/wear_mask = null
-	var/obj/item/clothing/ears/ears = null
+	var/obj/item/clothing/ears = null
 	var/network_device = null
 	var/Vnetwork = null
 	var/lastDamageIconUpdate

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1818,7 +1818,7 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 		if (SLOT_WEAR_MASK) // It's not pretty, but the mutantrace check will do for the time being (Convair880).
 			if (!src.organHolder.head)
 				return FALSE
-			if (istype(I, /obj/item/clothing) && I.equipment_slot & SLOT_FLAG_MASK)
+			if (I.equipment_slot & SLOT_FLAG_MASK)
 				var/obj/item/clothing/M = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !M.compatible_species.Find(src.mutantrace.name)))
 					//DEBUG_MESSAGE("[src] can't wear [I].")

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1810,11 +1810,7 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 			if ((I.c_flags & ONBELT) && src.w_uniform)
 				return TRUE
 		if (SLOT_WEAR_ID)
-			if (istype(I, /obj/item/card/id) && src.w_uniform)
-				return TRUE
-			if (istype(I, /obj/item/device/pda2) && src.w_uniform) // removed the check for the ID card in here because tbh it was silly that you could only equip it to the ID slot when it had a card  :I
-				return TRUE
-			if (istype(I, /obj/item/clothing/lanyard) && src.w_uniform)
+			if ((I.equipment_slot & SLOT_FLAG_ID) && src.w_uniform)
 				return TRUE
 		if (SLOT_BACK)
 			if (I.c_flags & ONBACK)
@@ -1822,7 +1818,7 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 		if (SLOT_WEAR_MASK) // It's not pretty, but the mutantrace check will do for the time being (Convair880).
 			if (!src.organHolder.head)
 				return FALSE
-			if (istype(I, /obj/item/clothing/mask))
+			if (istype(I, /obj/item/clothing) && I.equipment_slot & SLOT_FLAG_MASK)
 				var/obj/item/clothing/M = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !M.compatible_species.Find(src.mutantrace.name)))
 					//DEBUG_MESSAGE("[src] can't wear [I].")
@@ -1832,22 +1828,22 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 		if (SLOT_EARS)
 			if (!src.organHolder.head)
 				return FALSE
-			if (istype(I, /obj/item/clothing/ears) || istype(I,/obj/item/device/radio/headset))
+			if (I.equipment_slot & SLOT_FLAG_EARS)
 				return TRUE
 		if (SLOT_GLASSES)
 			if (!src.organHolder.head)
 				return FALSE
-			if (istype(I, /obj/item/clothing/glasses))
+			if (I.equipment_slot & SLOT_FLAG_GLASSES)
 				return TRUE
 		if (SLOT_GLOVES)
 			if ((!src.limbs.l_arm) && (!src.limbs.r_arm))
 				return FALSE
-			if (istype(I, /obj/item/clothing/gloves))
+			if (I.equipment_slot & SLOT_FLAG_GLOVES)
 				return TRUE
 		if (SLOT_HEAD)
 			if (!src.organHolder.head)
 				return FALSE
-			if (istype(I, /obj/item/clothing/head))
+			if (I.equipment_slot & SLOT_FLAG_HEAD)
 				var/obj/item/clothing/H = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !(src.mutantrace.name in H.compatible_species)))
 					//DEBUG_MESSAGE("[src] can't wear [I].")
@@ -1859,7 +1855,7 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 		if (SLOT_SHOES)
 			if ((!src.limbs.l_leg) && (!src.limbs.r_leg))
 				return FALSE
-			if (istype(I, /obj/item/clothing/shoes))
+			if (I.equipment_slot & SLOT_FLAG_SHOES)
 				var/obj/item/clothing/SH = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !(src.mutantrace.name in SH.compatible_species)))
 					//DEBUG_MESSAGE("[src] can't wear [I].")
@@ -1867,7 +1863,7 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 				else
 					return TRUE
 		if (SLOT_WEAR_SUIT)
-			if (istype(I, /obj/item/clothing/suit))
+			if (I.equipment_slot & SLOT_FLAG_SUIT)
 				var/obj/item/clothing/SU = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !(src.mutantrace.name in SU.compatible_species)))
 					//DEBUG_MESSAGE("[src] can't wear [I].")
@@ -1875,7 +1871,7 @@ Attempts to put an item in the hand of a mob, if not possible then stow it, then
 				else
 					return TRUE
 		if (SLOT_W_UNIFORM)
-			if (istype(I, /obj/item/clothing/under))
+			if (I.equipment_slot & SLOT_FLAG_UNIFORM)
 				var/obj/item/clothing/U = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !(src.mutantrace.name in U.compatible_species)))
 					//DEBUG_MESSAGE("[src] can't wear [I].")

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -1271,7 +1271,6 @@
 /datum/equipmentHolder/flockAbsorption
 	show_on_holder = 0
 	name = "disintegration reclaimer"
-	type_filters = list(/obj/item)
 	icon = 'icons/mob/flock_ui.dmi'
 	icon_state = "absorber"
 	var/instant_absorb = FALSE

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -115,7 +115,8 @@ ABSTRACT_TYPE(/obj/item)
 	var/tooltip_flags = null
 	var/item_function_flags = null
 	var/force_use_as_tool = 0
-	var/equipment_slot = null
+	var/equipment_slot = null // read _std/defines/clothing.dm for information on what flags can be given without runtimes
+
 
 	var/block_hearing_when_worn = HEARING_NORMAL
 	//fuck me mbc why you do this | | ok i did it to reduce type checking in a proc that gets called A LOT and idk what else to do ok help

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -115,6 +115,7 @@ ABSTRACT_TYPE(/obj/item)
 	var/tooltip_flags = null
 	var/item_function_flags = null
 	var/force_use_as_tool = 0
+	var/equipment_slot = null
 
 	var/block_hearing_when_worn = HEARING_NORMAL
 	//fuck me mbc why you do this | | ok i did it to reduce type checking in a proc that gets called A LOT and idk what else to do ok help

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -87,6 +87,7 @@ TYPEINFO(/obj/item/card/emag)
 	desc = "A standardized NanoTrasen microchipped identification card that contains data that is scanned when attempting to access various doors and computers."
 	flags = TABLEPASS | ATTACK_SELF_DELAY | SUPPRESSATTACK
 	click_delay = 0.4 SECONDS
+	equipment_slot = SLOT_FLAG_ID
 	wear_layer = MOB_BELT_LAYER
 	var/datum/pronouns/pronouns = null
 	var/list/access = list()

--- a/code/obj/item/clothing.dm
+++ b/code/obj/item/clothing.dm
@@ -11,6 +11,8 @@ ABSTRACT_TYPE(/obj/item/clothing)
 	//for clothing that covers other clothing from examines
 	var/hides_from_examine = 0
 
+	var/seal_hair = 0 // best variable name I could come up with, if 1 it forms a seal with a suit so no hair can stick out
+
 	var/body_parts_covered = 0 //see setup.dm for appropriate bit flags
 	//var/c_flags = null // these don't need to be in the general flags when they only apply to clothes  :I
 	// mbc moived c flags up to item bewcause some wearaables things are items and not clothign :)
@@ -146,6 +148,7 @@ ABSTRACT_TYPE(/obj/item/clothing)
 
 ABSTRACT_TYPE(/obj/item/clothing/under)
 /obj/item/clothing/under
+	equipment_slot = SLOT_FLAG_UNIFORM
 	equipped(var/mob/user, var/slot)
 		..()
 		playsound(src.loc, 'sound/items/zipper.ogg', 30, 0.2, pitch = 2)

--- a/code/obj/item/clothing.dm
+++ b/code/obj/item/clothing.dm
@@ -11,7 +11,7 @@ ABSTRACT_TYPE(/obj/item/clothing)
 	//for clothing that covers other clothing from examines
 	var/hides_from_examine = 0
 
-	var/seal_hair = 0 // best variable name I could come up with, if 1 it forms a seal with a suit so no hair can stick out
+	var/seal_hair = 0 // if 1 it forms a seal so no hair can stick out
 
 	var/body_parts_covered = 0 //see setup.dm for appropriate bit flags
 	//var/c_flags = null // these don't need to be in the general flags when they only apply to clothes  :I

--- a/code/obj/item/clothing/ears.dm
+++ b/code/obj/item/clothing/ears.dm
@@ -7,6 +7,7 @@
 	wear_image_icon = 'icons/mob/clothing/ears.dmi'
 	w_class = W_CLASS_TINY
 	wear_layer = MOB_EARS_LAYER
+	equipment_slot = SLOT_FLAG_EARS
 	throwforce = 2
 	block_hearing_when_worn = HEARING_BLOCKED
 

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -10,6 +10,7 @@
 	c_flags = COVERSEYES
 	var/allow_blind_sight = 0
 	wear_layer = MOB_GLASSES_LAYER
+	equipment_slot = SLOT_FLAG_GLASSES
 	block_vision = 0
 	duration_remove = 1.5 SECONDS
 	duration_put = 1.5 SECONDS

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -10,6 +10,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	inhand_image_icon = 'icons/mob/inhand/hand_feethand.dmi'
 	protective_temperature = 400
 	wear_layer = MOB_HAND_LAYER2
+	equipment_slot = SLOT_FLAG_GLOVES
 	duration_remove = 2 SECONDS
 	var/uses = 0
 	var/max_uses = 0 // If can_be_charged == 1, how many charges can these gloves store?

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -6,10 +6,10 @@
 	icon = 'icons/obj/clothing/item_hats.dmi'
 	wear_image_icon = 'icons/mob/clothing/head.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_headgear.dmi'
+	equipment_slot = SLOT_FLAG_HEAD
 	body_parts_covered = HEAD
 	compatible_species = list("human", "cow", "werewolf", "flubber", "martian", "blob")
 	wear_layer = MOB_HEAD_LAYER2
-	var/seal_hair = 0 // best variable name I could come up with, if 1 it forms a seal with a suit so no hair can stick out
 	block_vision = 0
 	var/team_num
 	var/blocked_from_petasusaphilic = FALSE //Replacing the global blacklist
@@ -1621,6 +1621,7 @@ ABSTRACT_TYPE(/obj/item/clothing/head/headband)
 	inhand_image_icon = 'icons/mob/inhand/hand_headgear.dmi'
 	item_state = "earsheadband"
 	w_class = W_CLASS_TINY
+	equipment_slot = SLOT_FLAG_HEAD | SLOT_FLAG_EARS
 	throwforce = 0
 
 	attackby(obj/item/W, mob/user)
@@ -1635,6 +1636,7 @@ ABSTRACT_TYPE(/obj/item/clothing/head/headband)
 				H.wear_image_icon = src.wear_image_icon
 				H.wear_image = src.wear_image
 				H.desc = "Someone has taped a radio headset underneath the headband."
+				H.equipment_slot |= SLOT_FLAG_HEAD
 				qdel(src)
 			else
 				user.show_message("You stuff the headset on the headband and tape it in place. [istype(src, /obj/item/clothing/head/headband/nyan) ? "Meow" : "Now"] you should be able to hear the radio using these!")
@@ -1645,6 +1647,7 @@ ABSTRACT_TYPE(/obj/item/clothing/head/headband)
 				H.wear_image = src.wear_image
 				H.wear_layer = MOB_FULL_SUIT_LAYER
 				H.desc = "Aww, cute and fuzzy. Someone has taped a radio headset onto the headband."
+				H.equipment_slot |= SLOT_FLAG_HEAD
 				qdel(src)
 		else
 			return

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -1636,7 +1636,6 @@ ABSTRACT_TYPE(/obj/item/clothing/head/headband)
 				H.wear_image_icon = src.wear_image_icon
 				H.wear_image = src.wear_image
 				H.desc = "Someone has taped a radio headset underneath the headband."
-				H.equipment_slot |= SLOT_FLAG_HEAD
 				qdel(src)
 			else
 				user.show_message("You stuff the headset on the headband and tape it in place. [istype(src, /obj/item/clothing/head/headband/nyan) ? "Meow" : "Now"] you should be able to hear the radio using these!")
@@ -1647,7 +1646,6 @@ ABSTRACT_TYPE(/obj/item/clothing/head/headband)
 				H.wear_image = src.wear_image
 				H.wear_layer = MOB_FULL_SUIT_LAYER
 				H.desc = "Aww, cute and fuzzy. Someone has taped a radio headset onto the headband."
-				H.equipment_slot |= SLOT_FLAG_HEAD
 				qdel(src)
 		else
 			return

--- a/code/obj/item/clothing/lanyards.dm
+++ b/code/obj/item/clothing/lanyards.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/clothing/item_ids.dmi'
 	wear_image_icon = 'icons/mob/clothing/card.dmi'
 	icon_state = "lanyard"
+	equipment_slot = SLOT_FLAG_ID
 	var/registered = null
 	var/assignment = null
 	var/access = list()

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -10,6 +10,7 @@
 	c_flags = COVERSMOUTH
 	compatible_species = list("human", "cow", "werewolf")
 	wear_layer = MOB_HEAD_LAYER1
+	equipment_slot = SLOT_FLAG_MASK
 	var/is_muzzle = FALSE
 	var/use_bloodoverlay = 1
 	var/stapled = 0

--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -8,6 +8,7 @@
 	icon = 'icons/obj/clothing/item_shoes.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_feethand.dmi'
 	wear_image_icon = 'icons/mob/clothing/feet.dmi'
+	equipment_slot = SLOT_FLAG_SHOES
 	var/chained = 0
 	var/laces = LACES_NORMAL // Laces for /obj/item/gun/energy/pickpocket harass mode.
 	var/kick_bonus = 0 //some shoes will yield extra kick damage!

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -9,6 +9,7 @@ ABSTRACT_TYPE(/obj/item/clothing/suit)
 	inhand_image_icon = 'icons/mob/inhand/overcoat/hand_suit.dmi'
 	wear_image_icon = 'icons/mob/clothing/overcoats/worn_suit.dmi'
 	wear_layer = MOB_ARMOR_LAYER
+	equipment_slot = SLOT_FLAG_SUIT
 	var/fire_resist = T0C+100
 	/// If TRUE the suit will hide whoever is wearing it's hair
 	var/over_hair = FALSE

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -9,6 +9,7 @@
 	w_class = W_CLASS_SMALL
 	rand_pos = 0
 	c_flags = ONBELT
+	equipment_slot = SLOT_FLAG_ID | SLOT_FLAG_BELT
 	wear_layer = MOB_BELT_LAYER
 	var/obj/item/card/id/ID_card = null // slap an ID card into that thang
 	var/datum/db_record/accessed_record = null // the bank account on the id card

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -9,7 +9,7 @@
 	w_class = W_CLASS_SMALL
 	rand_pos = 0
 	c_flags = ONBELT
-	equipment_slot = SLOT_FLAG_ID | SLOT_FLAG_BELT
+	equipment_slot = SLOT_FLAG_ID
 	wear_layer = MOB_BELT_LAYER
 	var/obj/item/card/id/ID_card = null // slap an ID card into that thang
 	var/datum/db_record/accessed_record = null // the bank account on the id card

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -16,6 +16,7 @@
 	icon_override = "civ"
 	icon_tooltip = "Civilian"
 	wear_layer = MOB_EARS_LAYER
+	equipment_slot = SLOT_FLAG_EARS
 	duration_remove = 1.5 SECONDS
 	duration_put = 1.5 SECONDS
 	var/obj/item/device/radio_upgrade/wiretap = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[clothing]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
What can have these flags without runtimes are currently still pretty much limited to what they were previously as described in _std/defines/clothing.dm.
belts and backpacks still use c_flags due to me not wanting this to be a 150 file pr

only player facing change should be being able to wear cat ears on ears and head without putting a radio in. technology

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Originally i wanted to be able to wear the plunger in the mask slot, but quite a lot of things are needed to make that possible
With the changes that are in this pr wearing shoes or gloves as hats could be added (any spriters?)

less istype

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I have tested everything i thought of, including critters and hattables. There is still a decent chance i missed something though
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Things I'd prefer to do in separate prs but I'll do them in this one if it would be better

- change belts and backpacks to use this system
- combine the 4 or so different seals hair variables into one c_flag so any item could be worn on the head
- see what would be needed to be done to relax the path restrictions on other slots
