### PR TITLE
Law Linkers automatically connect to default rack

### DIFF
--- a/code/obj/item/device/borg_linker.dm
+++ b/code/obj/item/device/borg_linker.dm
@@ -16,6 +16,11 @@ TYPEINFO(/obj/item/device/borg_linker)
 	g_amt = 20
 	var/obj/machinery/lawrack/linked_rack = null
 
+	New()
+		. = ..()
+		if(ticker.ai_law_rack_manager.default_ai_rack)
+			src.linked_rack = ticker.ai_law_rack_manager.default_ai_rack
+
 	get_desc(dist, mob/user)
 		if(src.linked_rack)
 			var/area/rack_area = get_area(src.linked_rack)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Law linkers will by default be connected to the default law rack, if there is one.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Law linkers are pretty useless to roboticists that know the borgs are on a different law rack because they will need someone to grant them access to upload first to connect it. This allows law linkers to be used without needing to first break into upload if you don't have access.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not -->
<img width="321" height="173" alt="image" src="https://github.com/user-attachments/assets/d0afc98e-f750-4279-b955-86f7e834e7c1" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Law Linkers now come connected to the default law rack.
```
