### PR TITLE
Make multitool assemblies cause a shock on their tile

### DIFF
--- a/code/obj/item/device/multitool.dm
+++ b/code/obj/item/device/multitool.dm
@@ -83,7 +83,9 @@ TYPEINFO(/obj/item/device/multitool)
 
 /obj/item/device/multitool/proc/assembly_application(var/manipulated_multitool, var/obj/item/assembly/parent_assembly, var/obj/assembly_target)
 	if(!assembly_target)
-		//if there is no target, we don't do anything
+		//if there is no target, we make a shock akin to using the multitools special on a 1-second cooldown
+		if(!ON_COOLDOWN(global, "multitool shock", 1 SECONDS))
+			elecflash(get_turf(src),0, power=2, exclude_center = 0)
 		return
 	else
 		if(istype(assembly_target, /obj/item/tank/plasma))

--- a/code/obj/item/device/multitool.dm
+++ b/code/obj/item/device/multitool.dm
@@ -84,7 +84,7 @@ TYPEINFO(/obj/item/device/multitool)
 /obj/item/device/multitool/proc/assembly_application(var/manipulated_multitool, var/obj/item/assembly/parent_assembly, var/obj/assembly_target)
 	if(!assembly_target)
 		//if there is no target, we make a shock akin to using the multitools special on a 1-second cooldown
-		if(!ON_COOLDOWN(global, "multitool shock", 1 SECONDS))
+		if(!ON_COOLDOWN(src, "multitool shock", 1 SECONDS))
 			elecflash(get_turf(src),0, power=2, exclude_center = 0)
 		return
 	else


### PR DESCRIPTION
[Feature][Game Object]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When a multitool assembly is activated, it creates a shock on their corresponding tile, equal to the effect of using it's special

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Multitools right now only work like igniters when used in plasma tank assemblies. That was only added to further upgrade them to canbombs.

This changes gives a small but funny reason to make multitool assemblies

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/c1a3a0ab-6979-4f6b-b47e-854dbc9e2fae

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Multitools in assemblies will now shock the tile they are on when activated, akin to using their special attack.
```
