### PR TITLE
NPCs without minds don't contribute to global chat spam

### DIFF
--- a/code/modules/speech/core.dm
+++ b/code/modules/speech/core.dm
@@ -114,6 +114,11 @@ TYPEINFO(/atom)
 	RETURN_TYPE(/datum/say_message)
 	SHOULD_NOT_OVERRIDE(TRUE)
 
+	if (ismob(src)) //overrides are illegal, istype(src) is kind of valid here??
+		var/mob/self = src
+		if (!self.mind) //shut UP npcs
+			flags |= SAYFLAG_DELIMITED_CHANNEL_ONLY
+
 	if (dd_hasprefix(message, "*"))
 		src.emote(copytext(message, 2), TRUE)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds `SAYFLAG_DELIMITED_CHANNEL_ONLY` to any say message made by a mob without a mind.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #23571 - being a ghost on disaster round is just solid chat spam
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested using admin force say on Stirstir (has a mind) and a transposed scientist (does not have a mind), worked as expected.