### PR TITLE
Oshan Medbay Remodel

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -38381,7 +38381,7 @@
 /area/station/mining/staff_room)
 "mJt" = (
 /obj/machinery/shieldgenerator/energy_shield,
-/obj/machinery/light/incandescent/netural{
+/obj/machinery/light/incandescent/blueish{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -43982,7 +43982,7 @@
 /turf/simulated/floor/damaged2,
 /area/derelict_diner)
 "tRo" = (
-/obj/machinery/light/incandescent/netural{
+/obj/machinery/light/incandescent/blueish{
 	dir = 1
 	},
 /turf/simulated/floor/plating,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Mapping] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Attempts to address common problems that players have with Oshan medbay. Provides genetics with hall-adjacent windows and shifts the therapy office into its own room with a door. Generally seeks to provide room for crime via maintenance doors at the end of the hall now instead of an open-concept therapy office, and places genetics closer to the booth in general. The morgue has also been made larger to account for the larger population requirement when rolling Oshan and the inevitable trench deaths that follow, giving a bit more room for doctors to work.

<img width="1187" height="860" alt="{78665A0D-AE7C-4FFE-88BB-2353111027CE}" src="https://github.com/user-attachments/assets/acefadd6-725b-4624-bb4b-932e35914901" />

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've heard many complaints that Oshan genetics can be difficult to get volunteers for, sometimes merely because it just isn't near the main hall. This places it where the pharmacy used to be, allowing for people to ask the geneticists for genes more directly without entering medbay as a whole. This also moves the monkey dome, which was always used as a path for Beepsky and ended up loosing the monkeys upon unsuspecting doctors and their clean tables.

Additionally, this does away with the open concept therapy office in exchange for one closed off with blinds and a maintenance door. This follows the formula for how therapy offices are set up on other maps, providing ample space for therapy RP, scheming, or crime.

In general, Oshan medbay is good, but I think it benefits from moving some rooms around.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Ran the changes and ensured all APCs are hooked to the main grid, disposal chutes lead to disposals, and mail chutes are functional. Gave a few run-throughs to ensure lighting is operational and camera coverage should be suitable. If more (or less) camera coverage is required just lmk!

Screenshots of the working map:
<img width="825" height="793" alt="{C6D703F4-1EA5-404E-B3C1-410C47EC3A17}" src="https://github.com/user-attachments/assets/ba92a0fb-de06-46ba-bfc2-6ab5a8568e52" />

<img width="615" height="554" alt="{12BD88C9-8A80-4D4C-AF4F-7D729D6D0208}" src="https://github.com/user-attachments/assets/4a8086c6-09a9-445e-b705-0bdf36cbac87" />

<img width="862" height="542" alt="{80C3EDD5-3028-4FB1-8BB1-834D9B710DBB}" src="https://github.com/user-attachments/assets/ba98e1b2-8e0f-48a1-9981-a6fde4d13316" />

<img width="544" height="463" alt="{9D05D074-DDEC-4988-99CB-D4E9C9B898A4}" src="https://github.com/user-attachments/assets/4e72b408-b535-421b-a76f-8dc63869f2ec" />

<img width="513" height="550" alt="{1B61EBC0-75EF-472B-A5C5-4261146549AA}" src="https://github.com/user-attachments/assets/c2493a2a-2340-45e1-9e4a-6b97f0a8a0b8" />

Sorry about the double post, I really shouldn't be working with PRs before I get my coffee into me.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TheGeneralJay
(*)Oshan medbay has had a remodel! Details to follow in minor changes.
(+)Oshan genetics is now visible from the main hall. The pharmacy, treatment rooms, and therapy office has been moved to accommodate this.
```