### PR TITLE
Sets dna_mutagen_banned to false in the ambassador exclusive mutantraces

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -714,6 +714,7 @@ TYPEINFO(/datum/mutantrace/blob)
 	voice_override = "bloop"
 	firevuln = 1.5
 	typevulns = list("cut" = 1.25, "stab" = 0.5, "blunt" = 0.75)
+	dna_mutagen_banned = FALSE
 
 	ghost_icon_state = "ghost-blob"
 
@@ -1733,6 +1734,7 @@ TYPEINFO(/datum/mutantrace/seamonkey)
 	human_compatible = 0
 	uses_human_clothes = 0
 	override_language = LANGUAGE_MARTIAN
+	dna_mutagen_banned = FALSE
 	mutant_organs = list(\
 		"left_eye"=/obj/item/organ/eye/beady,\
 		"right_eye"=/obj/item/organ/eye/beady,\
@@ -1952,6 +1954,7 @@ TYPEINFO(/datum/mutantrace/amphibian)
 	head_offset = 0
 	hand_offset = -3
 	body_offset = -3
+	dna_mutagen_banned = FALSE
 	movement_modifier = /datum/movement_modifier/amphibian
 	var/original_blood_color = null
 	mutant_folder = 'icons/mob/amphibian.dmi'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows the blob, martian, and amphibian mutantraces to be compatible with stable mutagen. This primarily affects cloning, but also impacts changeling gameplay via the DNA sting, and general stable mutagen usage.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
_Hedonism._ Nah, just kidding. The actual reason pertains primarily to ambassadors and the changelings that prey on them. Presently, if a person playing as an ambassador dies and is cloned, they return to whatever mutantrace trait they have set in their character setup. I've witnessed this leading to significant confusion, and see no reason why it shouldn't be eliminated. Additionally, and ostensibly the more important reason, this change allows the DNA sting to work properly with ambassadors; ate a martian and want to turn someone else into said martian? This would allow that to happen.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="469" height="322" alt="Screenshot 2025-09-16 232134" src="https://github.com/user-attachments/assets/ecf6c28c-9bde-477e-863a-df8a95538aef" />
<img width="451" height="291" alt="Screenshot 2025-09-16 232643" src="https://github.com/user-attachments/assets/3d4194c7-23ac-46a8-99d4-d77408f0d89f" />
<img width="473" height="331" alt="Screenshot 2025-09-16 234403" src="https://github.com/user-attachments/assets/740cb640-502b-46b6-be07-e2d93ff6fef1" />

Cloning tested, all seems to work properly. (Awful jokes are not necessary to the PR functioning properly, and exist purely for my own entertainment.)


<img width="361" height="236" alt="Screenshot 2025-09-16 233502" src="https://github.com/user-attachments/assets/51498e7f-a3dd-42e7-9e77-d0486161a850" />
<img width="299" height="149" alt="Screenshot 2025-09-16 233657" src="https://github.com/user-attachments/assets/01a93dc3-94b3-4b78-bf2d-d6e76f5b69b5" />
<img width="488" height="257" alt="Screenshot 2025-09-16 234127" src="https://github.com/user-attachments/assets/8f0b8e7b-071d-4fa0-a5b9-5248f2b9369e" />

Stable mutagen tested, also all seems to work properly. Works on things it should, doesn't work on things it shouldn't.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->