### PR TITLE
Reduce spatial interdictor component costs

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -3479,7 +3479,7 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 
 /datum/manufacture/interdictor_kit
 	name = "Interdictor Frame Kit"
-	item_requirements = list("metal_dense" = 10)
+	item_requirements = list("metal_dense" = 5)
 	item_outputs = list(/obj/item/interdictor_kit)
 	create = 1
 	time = 10 SECONDS
@@ -3487,7 +3487,7 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 
 /datum/manufacture/interdictor_board_standard
 	name = "Standard Interdictor Mainboard"
-	item_requirements = list("conductive" = 4)
+	item_requirements = list("conductive" = 2)
 	item_outputs = list(/obj/item/interdictor_board)
 	create = 1
 	time = 5 SECONDS
@@ -3495,7 +3495,7 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 
 /datum/manufacture/interdictor_board_nimbus
 	name = "Nimbus Interdictor Mainboard"
-	item_requirements = list("conductive" = 4,
+	item_requirements = list("conductive" = 2,
 							 "insulated" = 2,
 							 "crystal" = 2)
 	item_outputs = list(/obj/item/interdictor_board/nimbus)
@@ -3505,7 +3505,7 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 
 /datum/manufacture/interdictor_board_zephyr
 	name = "Zephyr Interdictor Mainboard"
-	item_requirements = list("conductive" = 4,
+	item_requirements = list("conductive" = 2,
 							 "viscerite" = 5)
 	item_outputs = list(/obj/item/interdictor_board/zephyr)
 	create = 1
@@ -3514,7 +3514,7 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 
 /datum/manufacture/interdictor_board_devera
 	name = "Devera Interdictor Mainboard"
-	item_requirements = list("conductive" = 4,
+	item_requirements = list("conductive" = 2,
 							 "crystal" = 2,
 							 "syreline" = 5)
 	item_outputs = list(/obj/item/interdictor_board/devera)
@@ -3525,8 +3525,8 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 /datum/manufacture/interdictor_rod_lambda
 	name = "Lambda Phase-Control Rod"
 	item_requirements = list("metal_dense" = 2,
-							 "conductive" = 10,
-							 "crystal" = 5,
+							 "conductive" = 5,
+							 "crystal" = 2,
 							 "insulated" = 2)
 	item_outputs = list(/obj/item/interdictor_rod)
 	create = 1
@@ -3536,8 +3536,8 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 /datum/manufacture/interdictor_rod_sigma
 	name = "Sigma Phase-Control Rod"
 	item_requirements = list("metal_dense" = 2,
-							 "conductive_high" = 10,
-							 "insulated" = 5,
+							 "conductive_high" = 5,
+							 "insulated" = 2,
 							 "energy" = 2)
 	item_outputs = list(/obj/item/interdictor_rod/sigma)
 	create = 1
@@ -3547,8 +3547,8 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 /datum/manufacture/interdictor_rod_epsilon
 	name = "Epsilon Phase-Control Rod"
 	item_requirements = list("metal_dense" = 2,
-							 "electrum" = 10,
-							 "dense" = 5,
+							 "electrum" = 5,
+							 "dense" = 2,
 							 "energy" = 2)
 	item_outputs = list(/obj/item/interdictor_rod/epsilon)
 	create = 1
@@ -3558,8 +3558,8 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 /datum/manufacture/interdictor_rod_phi
 	name = "Phi Phase-Control Rod"
 	item_requirements = list("metal_dense" = 5,
-							 "crystal" = 10,
-							 "conductive" = 5)
+							 "conductive" = 5,
+							 "crystal" = 2)
 	item_outputs = list(/obj/item/interdictor_rod/phi)
 	create = 1
 	time = 15 SECONDS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Reduces the manufacturing cost of all components specific to the spatial interdictor.

- Interdictor frame kit requires 5 dense metal, down from 10.
- All interdictor mainboards require 2 conductive material, down from 4 (secondary materials unaltered).
- Lambda phase-control rod (basic standard rod): Conductive material 10 > 5, crystal 5 > 2.
- Sigma phase-control rod (enhanced standard rod): High-conductive 10 > 5, insulator 5 > 2.
- Epsilon phase-control rod (high range, low efficiency): Electrum 10 > 5, dense material 5 > 2.
- Phi phase-control rod (low range, high efficiency): Crystal 10 > 2.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

One common complaint about interdictors is that they have a fairly heavy material cost on top of the elaborate assembly process; cutting the manufacturing cost of the bespoke components lets those who invest the time to gather the necessary materials get a little more return for their effort. This doesn't change the other material costs (cell, wire, plating, etc), so it's proportionally not *quite* as large of a cut as it seems, but it should still make a notable difference.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Skipped due to this being a numbers-only change. If a screenshot of the changes ingame is still desirable, let me know.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Interdictor component material costs have received across-the-board reductions.
```
