### PR TITLE
HOTFIX: Donor Organ Names Fixed

### DIFF
--- a/code/WorkInProgress/sord.dm
+++ b/code/WorkInProgress/sord.dm
@@ -216,7 +216,7 @@
 		if(C)
 			C.registered = src.real_name
 			C.assignment = "Greyhold Mercenary Operative"
-			C.name = "[C.registered]'s ID Card ([C.assignment])"
+			C.name = "[C.registered]’s ID Card ([C.assignment])"
 
 		update_clothing()
 

--- a/code/datums/jobs/special/jobs_special.dm
+++ b/code/datums/jobs/special/jobs_special.dm
@@ -728,7 +728,7 @@ ABSTRACT_TYPE(/datum/job/special/pod_wars)
 		SPAWN(0)
 			var/obj/item/card/id/C = M.get_slot(SLOT_WEAR_ID)
 			C.assignment = "Staff Assistant"
-			C.name = "[C.registered]'s ID Card ([C.assignment])"
+			C.name = "[C.registered]’s ID Card ([C.assignment])"
 
 			M.job = "Staff Assistant" // for observers
 

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -477,7 +477,7 @@ TYPEINFO(/mob/dead/observer)
 			wigmat = wigmat.getMutable()
 			wigmat.setColor(src.bioHolder.mobAppearance.customizations["hair_bottom"].color)
 			O.wig.setMaterial(wigmat)
-			O.wig.name = "[O.name]'s hair"
+			O.wig.name = "[O.name]’s hair"
 			O.wig.icon = 'icons/mob/human_hair.dmi'
 			O.wig.icon_state = cust_one
 			O.wig.color = src.bioHolder.mobAppearance.customizations["hair_bottom"].color

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -495,7 +495,7 @@
 		for(var/atom/limb in list(l_arm, r_arm, l_leg, r_leg))
 			var/list/limb_name_parts = splittext(limb.name, "'s")
 			if(length(limb_name_parts) == 2)
-				limb.name = "[user_name]'s [limb_name_parts[2]]"
+				limb.name = "[user_name]’s [limb_name_parts[2]]"
 
 /mob/living/carbon/human/proc/is_vampire()
 	return get_ability_holder(/datum/abilityHolder/vampire)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2420,8 +2420,8 @@ Tries to put an item in an available backpack, belt storage, pocket, or hand slo
 	if (!src.bioHolder || !src.bioHolder.mobAppearance)
 		return null
 	var/obj/item/clothing/head/wig/W = new(src)
-	W.name = "[real_name]'s hair"
-	W.real_name = "[real_name]'s hair" // The clothing parent setting real_name is probably good for other stuff so I'll just do this
+	W.name = "[real_name]’s hair"
+	W.real_name = "[real_name]’s hair" // The clothing parent setting real_name is probably good for other stuff so I'll just do this
 	W.icon = 'icons/mob/human_hair.dmi'
 	W.icon_state = "bald" // Let's give the actual hair a chance to shine
 

--- a/code/mob/living/carbon/human/normal.dm
+++ b/code/mob/living/carbon/human/normal.dm
@@ -197,7 +197,7 @@
 		if(C)
 			C.registered = src.real_name
 			C.assignment = "NT-SO Rescue Worker"
-			C.name = "[C.registered]'s ID Card ([C.assignment])"
+			C.name = "[C.registered]’s ID Card ([C.assignment])"
 			C.access = get_all_accesses()
 
 		update_clothing()
@@ -223,7 +223,7 @@
 		if(C)
 			C.registered = src.real_name
 			C.assignment = "NT-SO Special Operative"
-			C.name = "[C.registered]'s ID Card ([C.assignment])"
+			C.name = "[C.registered]’s ID Card ([C.assignment])"
 			var/list/ntso_access = get_all_accesses()
 			ntso_access += access_armory // This makes sense, right? They're highly trained and trusted.
 			C.access = ntso_access

--- a/code/mob/living/critter/humanoid/skeleton.dm
+++ b/code/mob/living/critter/humanoid/skeleton.dm
@@ -133,7 +133,7 @@
 		return ..()
 
 	proc/CustomiseSkeleton(var/mob/living/carbon/human/target, var/is_monkey)
-		src.name = "[capitalize(target)]'s skeleton"
+		src.name = "[capitalize(target)]’s skeleton"
 		src.desc = "A horrible skeleton, raised from the corpse of [target] by a wizard."
 		src.revivalChance = 100
 		LAZYLISTADDUNIQUE(src.faction, FACTION_WIZARD)

--- a/code/mob/living/critter/mechmonstrosity.dm
+++ b/code/mob/living/critter/mechmonstrosity.dm
@@ -283,7 +283,7 @@
 			playsound(ownerMob, 'sound/items/hypo.ogg', 80, FALSE)
 
 			var/mob/living/critter/robotic/crawler/crawler = new /mob/living/critter/robotic/crawler(get_turf(target))
-			crawler.name = "[target]'s crawling head"
+			crawler.name = "[target]’s crawling head"
 			crawler.desc = "A horrible crawling monstrosity, ravaged from the corpse of [target]."
 			crawler.revivalChance = 100
 

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -469,7 +469,7 @@ var/global/list/module_editors = list()
 
 /mob/living/silicon/robot/choose_name(var/retries = 3, var/what_you_are = null, var/default_name = null, var/force_instead = 0)
 	. = ..()
-	src.internal_pda.name = "[src.name]'s Internal PDA Unit"
+	src.internal_pda.name = "[src.name]’s Internal PDA Unit"
 	src.internal_pda.owner = "[src.name]"
 
 /proc/borgify_name(var/start_name = "Robot")

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2581,7 +2581,7 @@ proc/get_mobs_trackable_by_AI()
 	. = ..()
 	src.camera.c_tag = src.real_name
 	src.eyecam.UpdateName()
-	src.internal_pda.name = "[src.name]'s Internal PDA Unit"
+	src.internal_pda.name = "[src.name]’s Internal PDA Unit"
 	src.internal_pda.owner = "[src.name]"
 
 // For if an AI needs to disconnect, make their core a latejoin one

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -115,7 +115,7 @@ TYPEINFO(/mob/living/silicon/robot)
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_EXAMINE_ALL_NAMES, src)
 		SPAWN(0) //Delay PDA spawning until the client is in the borg, so it respects preferences
 			src.internal_pda = new /obj/item/device/pda2/cyborg(src)
-			src.internal_pda.name = "[src]'s Internal PDA Unit"
+			src.internal_pda.name = "[src]’s Internal PDA Unit"
 			src.internal_pda.owner = "[src]"
 		APPLY_MOVEMENT_MODIFIER(src, /datum/movement_modifier/robot_part/robot_base, "robot_health_slow_immunity")
 		if (frame)
@@ -778,7 +778,7 @@ TYPEINFO(/mob/living/silicon/robot)
 			src.real_name = borgify_name("Cyborg")
 
 		src.UpdateName()
-		src.internal_pda.name = "[src.name]'s Internal PDA Unit"
+		src.internal_pda.name = "[src.name]’s Internal PDA Unit"
 		src.internal_pda.owner = "[src.name]"
 
 	Login()
@@ -790,7 +790,7 @@ TYPEINFO(/mob/living/silicon/robot)
 		if (src.real_name == "Cyborg")
 			src.real_name = borgify_name(src.real_name)
 			src.UpdateName()
-			src.internal_pda?.name = "[src.name]'s Internal PDA Unit"
+			src.internal_pda?.name = "[src.name]’s Internal PDA Unit"
 			src.internal_pda?.owner = "[src]"
 		if (src.shell && src.mainframe)
 			src.bioHolder.mobAppearance.pronouns = src.client.preferences.AH.pronouns

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1494,7 +1494,7 @@ var/list/fun_images = list()
 		if(!istype(L) || isdead(L))
 			continue
 		var/obj/Pet = new pet_path(get_turf(L))
-		Pet.name = "[L]'s pet [Pet.name]"
+		Pet.name = "[L]’s pet [Pet.name]"
 
 		//Pets should probably not attack their owner
 		if (istype(Pet, /obj/critter))

--- a/code/modules/antagonists/hunter/abilities/hunter_taketrophy.dm
+++ b/code/modules/antagonists/hunter/abilities/hunter_taketrophy.dm
@@ -128,7 +128,7 @@
 				for (var/obj/item/W in HH)
 					if (istype(W, /obj/item/skull/))
 						var/obj/item/skull/S = W
-						S.name = "[HH.real_name]'s skull"
+						S.name = "[HH.real_name]’s skull"
 						tvalue += S.value // Can might have another skull in their pocket, who knows.
 						no_of_skulls++
 						S.set_loc(get_turf(HH)) // We always want to drop that skull, since gib ejectables are a RNG thing.

--- a/code/modules/antagonists/macho_man/abilities/heartpunch.dm
+++ b/code/modules/antagonists/macho_man/abilities/heartpunch.dm
@@ -42,7 +42,7 @@
 				playsound(holder.owner, 'sound/impact_sounds/Metal_Hit_Light_1.ogg', 50, 1)
 				R.emote("scream")
 				var/obj/item/parts/robot_parts/chest/chestpunt = new R.part_chest.type(R.loc)
-				chestpunt.name = "[R.name]'s [chestpunt.name]"
+				chestpunt.name = "[R.name]’s [chestpunt.name]"
 				R.compborg_lose_limb(R.part_chest)
 
 				for (var/I = 1, I <= 5 && chestpunt && step(chestpunt ,direction, 1), I++)

--- a/code/modules/antagonists/wizard/abilities/cluwne.dm
+++ b/code/modules/antagonists/wizard/abilities/cluwne.dm
@@ -135,18 +135,18 @@
 			if(the_id && the_id:registered == target.real_name)
 				if (istype(the_id, /obj/item/card/id))
 					the_id:assignment = "Lawyer"
-					the_id:name = "[target.real_name]'s ID Card (Lawyer)"
+					the_id:name = "[target.real_name]’s ID Card (Lawyer)"
 				else if (istype(the_id, /obj/item/device/pda2))
 					the_id:assignment = "Lawyer"
 					the_id:ID_card:assignment = "Lawyer"
-					the_id:ID_card:name = "[target.real_name]'s ID Card (Lawyer)"
+					the_id:ID_card:name = "[target.real_name]’s ID Card (Lawyer)"
 				else if (istype(the_id, /obj/item/clothing/lanyard))
 					the_id:assignment = "Lawyer"
 					var/obj/item/clothing/lanyard/lanyard = the_id
 					var/obj/item/card/id/id_card = lanyard.get_stored_id()
 					if (id_card)
 						id_card.assignment = "Lawyer"
-						id_card.name = "[target.real_name]'s ID Card (Lawyer)"
+						id_card.name = "[target.real_name]’s ID Card (Lawyer)"
 				target.wear_id = the_id
 
 			for(var/obj/item/W in target)

--- a/code/modules/antagonists/wraith/abilties/harbinger/raise_skeleton.dm
+++ b/code/modules/antagonists/wraith/abilties/harbinger/raise_skeleton.dm
@@ -33,7 +33,7 @@
 				return 1
 			var/personname = H.real_name
 			var/mob/living/critter/skeleton/wraith/S = new /mob/living/critter/skeleton/wraith(get_turf(T))
-			S.name = "[personname]'s skeleton"
+			S.name = "[personname]’s skeleton"
 			S.health_burn = 15
 			S.health_brute = 15
 			H.gib()

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -675,7 +675,7 @@ datum
 								else
 									B = new/obj/critter/domestic_bee(H.loc)
 
-								B.name = "[H.real_name]'s heart"
+								B.name = "[H.real_name]’s heart"
 								B.desc = "[H.real_name]'s heart is flying off. Better catch it quick!"
 								B.beeMom = H
 								B.beeKid = DEFAULT_BLOOD_COLOR
@@ -756,7 +756,7 @@ datum
 								else
 									B = new/obj/critter/domestic_bee/queen(H.loc)
 
-								B.name = "[H.real_name]'s heart"
+								B.name = "[H.real_name]’s heart"
 								B.desc = "[H.real_name]'s heart is flying off. What kind of heart problems did they have!?"
 								B.beeMom = H
 								B.beeKid = DEFAULT_BLOOD_COLOR

--- a/code/modules/items/instruments/instruments.dm
+++ b/code/modules/items/instruments/instruments.dm
@@ -856,7 +856,7 @@ TYPEINFO(/obj/item/instrument/bikehorn/dramatic)
 			gibs(S.loc, null, bdna, btype)
 
 			S.set_mutantrace(/datum/mutantrace/skeleton)
-			S.real_name = "[S.name]'s skeleton"
+			S.real_name = "[S.name]’s skeleton"
 			S.name = S.real_name
 			S.update_body()
 			S.UpdateName()

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -704,7 +704,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 			R.real_name = "[newname]"
 			R.UpdateName()
 			if (R.internal_pda)
-				R.internal_pda.name = "[R.name]'s Internal PDA Unit"
+				R.internal_pda.name = "[R.name]’s Internal PDA Unit"
 				R.internal_pda.owner = "[R.name]"
 			. = TRUE
 		if("occupant-eject")

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -883,7 +883,7 @@ TYPEINFO(/obj/critter/domestic_bee)
 				hat.transform = trans
 				trans.Translate(0, -7 * ((ubertier - 4) / 3 - 1))
 				hat.wear_image.transform = trans
-		hat.name = "[src]'s [hat.name]"
+		hat.name = "[src]’s [hat.name]"
 		src.original_hat = hat
 		src.hat_that_bee(hat)
 		src.UpdateIcon()

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -107,7 +107,7 @@ TYPEINFO(/obj/item/card/emag)
 	var/datum/computer/file/cardfile = null
 
 	proc/update_name()
-		name = "[src.registered]'s ID Card ([src.assignment])"
+		name = "[src.registered]’s ID Card ([src.assignment])"
 
 	get_desc()
 		. = ..()
@@ -355,7 +355,7 @@ TYPEINFO(/obj/item/card/emag)
 				return // Abort process.
 		src.registered = reg
 		src.assignment = ass
-		src.name = "[src.registered]'s ID Card ([src.assignment])"
+		src.name = "[src.registered]’s ID Card ([src.assignment])"
 		boutput(user, SPAN_NOTICE("You successfully forge the ID card."))
 	else
 		..()
@@ -440,7 +440,7 @@ TYPEINFO(/obj/item/card/emag)
 				assignment = "loading arena matches..."
 				tag = "gauntlet-id-[user.client.key]"
 				queryGauntletMatches(user.client.key)
-		name = "[registered]'s ID Card ([assignment])"
+		name = "[registered]’s ID Card ([assignment])"
 
 	proc/SetMatchCount(var/matches)
 		switch (matches)
@@ -467,7 +467,7 @@ TYPEINFO(/obj/item/card/emag)
 				assignment = "Legendary Gladiator ([matches] rounds played)"
 			else
 				assignment = "what the fuck ([matches] rounds played)"
-		name = "[registered]'s ID Card ([assignment])"
+		name = "[registered]’s ID Card ([assignment])"
 
 // Experimental item that may be made into a 100k spacebux reward in the future?
 /obj/item/card/license_to_kill

--- a/code/obj/item/mob_parts.dm
+++ b/code/obj/item/mob_parts.dm
@@ -180,7 +180,7 @@ ABSTRACT_TYPE(/obj/item/parts)
 		object.set_loc(src.holder.loc)
 
 		//https://forum.ss13.co/showthread.php?tid=1774
-		//object.name = "[src.holder.real_name]'s [initial(object.name)]"
+		//object.name = "[src.holder.real_name]’s [initial(object.name)]"
 		object.add_fingerprint(src.holder)
 
 		if(show_message) holder.visible_message(SPAN_ALERT("[holder.name]'s [object.name] falls off!"))
@@ -235,7 +235,7 @@ ABSTRACT_TYPE(/obj/item/parts)
 		object.set_loc(src.holder.loc)
 
 		//https://forum.ss13.co/showthread.php?tid=1774
-		//object.name = "[src.holder.real_name]'s [initial(object.name)]" //Luis Smith's Dr. Kay's Luis Smith's Sailor Dave's Left Arm
+		//object.name = "[src.holder.real_name]’s [initial(object.name)]" //Luis Smith's Dr. Kay's Luis Smith's Sailor Dave's Left Arm
 		object.add_fingerprint(src.holder)
 
 		if (setDir)

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -87,7 +87,7 @@
 			// zam note - removing this again.
 			SPAWN(2 SECONDS)
 				if (new_holder && istype(new_holder))
-					name = "[new_holder.real_name]'s [initial(name)]"
+					name = "[new_holder.real_name]’s [initial(name)]"
 		if (src.skintoned)
 			if (holder_ahol)
 				colorize_limb_icon()

--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -544,7 +544,7 @@
 			organ_list["brain"] = brain
 			SPAWN(2 SECONDS)
 				if (src.brain && src.donor)
-					src.brain.name = "[src.donor.real_name]'s [initial(src.brain.name)]"
+					src.brain.name = "[src.donor.real_name]’s [initial(src.brain.name)]"
 					if (src.donor.mind)
 						src.brain.setOwner(src.donor.mind)
 
@@ -624,9 +624,9 @@
 			var/obj/item/organ/O = organ_list[thing]
 			if(isnull(O))
 				continue
-			var/list/organ_name_parts = splittext(O.name, "'s")
+			var/list/organ_name_parts = splittext(O.name, "’s")
 			if(length(organ_name_parts) == 2)
-				O.name = "[user_name]'s [organ_name_parts[2]]"
+				O.name = "[user_name]’s [organ_name_parts[2]]"
 				O.donor_name = user_name
 
 	//input organ = string value of organ_list assoc list

--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -1580,7 +1580,7 @@
 			organ_list["brain"] = brain
 			SPAWN(2 SECONDS)
 				if (src.brain && src.donor)
-					//src.brain.name = "[src.donor.real_name]'s [initial(src.brain.name)]"
+					//src.brain.name = "[src.donor.real_name]’s [initial(src.brain.name)]"
 					if (src.donor.mind)
 						src.brain.setOwner(src.donor.mind)
 

--- a/code/obj/item/organs/butt.dm
+++ b/code/obj/item/organs/butt.dm
@@ -53,8 +53,8 @@ TYPEINFO(/obj/item/clothing/head/butt)
 			src.donor = nholder.donor
 		if (src.donor)
 			src.donor_name = src.donor.real_name
-			src.name = "[src.donor_name]'s [initial(src.name)]"
-			src.real_name = "[src.donor_name]'s [initial(src.name)]" // Gotta do this somewhere!
+			src.name = "[src.donor_name]’s [initial(src.name)]"
+			src.real_name = "[src.donor_name]’s [initial(src.name)]" // Gotta do this somewhere!
 			src.donor_DNA = src.donor.bioHolder ? src.donor.bioHolder.Uid : null
 			if (src.toned && src.donor.bioHolder) //NO RACIALLY INSENSITIVE ASSHATS ALLOWED
 				src.s_tone = src.donor.bioHolder.mobAppearance.s_tone

--- a/code/obj/item/organs/eye.dm
+++ b/code/obj/item/organs/eye.dm
@@ -391,7 +391,7 @@ TYPEINFO(/obj/item/organ/eye/cyber/camera)
 
 	on_transplant(var/mob/M)
 		..()
-		src.camera.c_tag = "[M]'s Eye"
+		src.camera.c_tag = "[M]’s Eye"
 		return ..()
 
 TYPEINFO(/obj/item/organ/eye/cyber/nightvision)

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -178,7 +178,7 @@
 				src.skintone = AHead.s_tone
 			src.head_image.color = src.skintone
 			if(src.donor_name)
-				src.name = "[src.donor_name]'s [src.organ_name]"
+				src.name = "[src.donor_name]’s [src.organ_name]"
 			else
 				src.name = src.organ_name
 

--- a/code/obj/item/organs/organ_parent.dm
+++ b/code/obj/item/organs/organ_parent.dm
@@ -140,10 +140,10 @@
 				src.donor_AH = src.donor.bioHolder.mobAppearance
 			if (src.donor.real_name)
 				src.donor_name = src.donor.real_name
-				src.name = "[src.donor_name]'s [initial(src.name)]"
+				src.name = "[src.donor_name]’s [initial(src.name)]"
 			else if (src.donor.name)
 				src.donor_name = src.donor.name
-				src.name = "[src.donor_name]'s [initial(src.name)]"
+				src.name = "[src.donor_name]’s [initial(src.name)]"
 			src.donor_DNA = src.donor.bioHolder ? src.donor.bioHolder.Uid : null
 			src.blood_DNA = src.donor_DNA
 			src.blood_type = src.donor.bioHolder?.bloodType

--- a/code/obj/item/organs/skull.dm
+++ b/code/obj/item/organs/skull.dm
@@ -33,7 +33,7 @@
 				src.donor = nholder.donor
 			if (src.donor)
 				src.donor_name = src.donor.real_name
-				src.name = "[src.donor_name]'s [initial(src.name)]"
+				src.name = "[src.donor_name]’s [initial(src.name)]"
 
 	disposing()
 		..()

--- a/code/obj/storage/closets.dm
+++ b/code/obj/storage/closets.dm
@@ -540,7 +540,7 @@ TYPEINFO(/obj/storage/closet/coffin)
 					src.UpdateIcon()
 					if (!src.registered)
 						src.registered = I.registered
-						src.name = "[I.registered]'s [src.name]"
+						src.name = "[I.registered]’s [src.name]"
 						src.desc = "Owned by [I.registered]."
 					for (var/mob/M in src.contents)
 						src.log_me(user, M, src.locked ? "locks" : "unlocks")

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -372,7 +372,7 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close, proc/break_open)
 					src.UpdateIcon()
 					if (!src.registered)
 						src.registered = ID.registered
-						src.name = "[ID.registered]'s [src.name]"
+						src.name = "[ID.registered]’s [src.name]"
 						src.desc = "Owned by [ID.registered]."
 					for (var/mob/M in src.contents)
 						src.log_me(user, M, src.locked ? "locks" : "unlocks")

--- a/code/procs/basketball.dm
+++ b/code/procs/basketball.dm
@@ -283,7 +283,7 @@
 
 		if(the_id && the_id.registered == H.real_name)
 			the_id.assignment = "Lawyer"
-			the_id.name = "[H.real_name]'s ID Card (Lawyer)"
+			the_id.name = "[H.real_name]’s ID Card (Lawyer)"
 			H.wear_id = the_id
 
 		for(var/obj/item/W in H)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -784,7 +784,7 @@ Equip items from body traits.
 
 		C.registered = realName
 		C.assignment = JOB.name
-		C.name = "[C.registered]'s ID Card ([C.assignment])"
+		C.name = "[C.registered]’s ID Card ([C.assignment])"
 		C.access = JOB.access.Copy()
 		C.pronouns = src.get_pronouns()
 

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -73,4 +73,9 @@ if grep -P 'as anything in o?(range|hearers)' */**/*.dm;	then
     st=1
 fi;
 
+if grep -P "(?<!UNLINT\().*name = .*\"\[.*\]'s" */**/*.dm;    then
+	echo "ERROR: Using an apostrophe in a name like [mob]'s brain may cause Byond to get confused between the two objects in click verbs etc. Please use ’ (U+2019) instead."
+	st=1
+fi;
+
 exit $st

--- a/tools/ci/check_grep_secret.sh
+++ b/tools/ci/check_grep_secret.sh
@@ -58,5 +58,3 @@ if grep -P "(?<!UNLINT\().*name = .*\"\[.*\]'s" */**/*.dm;   then
 	echo "ERROR: Using an apostrophe in a name like [mob]'s brain may cause Byond to get confused between the two objects in click verbs etc. Please use ’ (U+2019) instead."
 
 exit $st
-
-exit $st

--- a/tools/ci/check_grep_secret.sh
+++ b/tools/ci/check_grep_secret.sh
@@ -54,4 +54,9 @@ if grep -P '^ABSTRACT_TYPE\([^/]' */**/*.dm;	then
     st=1
 fi;
 
+if grep -P "(?<!UNLINT\().*name = .*\"\[.*\]'s" */**/*.dm;   then
+	echo "ERROR: Using an apostrophe in a name like [mob]'s brain may cause Byond to get confused between the two objects in click verbs etc. Please use ’ (U+2019) instead."
+
+exit $st
+
 exit $st


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
During surgery it was noticed that if you try to pick up limb or organ that had the name of the mob that was within reach of you it would cause you to left click them instead of pick up the organ with the right click context menu "Pick up / Left Click". It seems that people noticed this before and it was related to the apostrophe ' which I had to change to ’ (U+2019). 

This only fixes wigs and organs and nothing else that may cause this like spawned in items at spawn time (like random items such as *Character Name*'s Award Winning *item*). 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This restores the ability to pick up limbs and organs named after the donor while being within reach of the mob they came from. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Once the unicode apostrophe was used I loaded into the game in debug and proceeded to remove limbs from a monkey and a genetically humanized monkey. I was now able to pick up their brain, their limbs and move them without it left clicking them instead.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->