### PR TITLE
Allow any mob inside a wizard to enter the den

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -3795,12 +3795,16 @@ ABSTRACT_TYPE(/area/station/catwalk)
 
 	CanEnter(atom/movable/A)
 		var/mob/living/M = A
-		if(istype(M) && M.mind && !(M.mind.get_antagonist(ROLE_WIZARD) || M.mind.special_role == ROLE_WIZARD || M.mind.get_antagonist(ROLE_BASKETBALL_WIZARD) || M.mind.special_role == ROLE_BASKETBALL_WIZARD || M.mind.assigned_role == "Santa Claus)"))
-			if(M.client && M.client.holder)
-				return TRUE
+		if(istype(M) && M.mind && !src.lives_here(M) && !isadmin(M) && !ismob(M.loc)) //Wizards and anyone in a wizard (headspiders) only!
 			boutput(M, SPAN_ALERT("A magical barrier prevents you from entering!")) //or something
 			return FALSE
 		return TRUE
+
+	proc/lives_here(mob/living/M)
+		if (!istype(M) || !M.mind) return TRUE
+		if (M.mind.get_antagonist(ROLE_WIZARD) || M.mind.special_role == ROLE_WIZARD) return TRUE
+		if (M.mind.get_antagonist(ROLE_BASKETBALL_WIZARD) || M.mind.special_role == ROLE_BASKETBALL_WIZARD) return TRUE
+		if (M.mind.assigned_role == "Santa Claus") return TRUE
 
 /area/wizard_station_space
 	name = "Wizard's Den Space"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows any mob inside another mob to enter the wizard's den, of course if the other mob they are in isn't a wizard they'll be teleported out of the den alongside the other mob. This prevents wizards from teleporting to the den to immediately drop their headspider on the floor.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #24707
There's not any other ways for mobs to be inside another mob beyond admin shenanigans that come to mind

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="1176" height="625" alt="image" src="https://github.com/user-attachments/assets/19a627bd-3af0-4ad2-bf0f-1b29d824ad34" />
