### PR TITLE
Syndicate robot frame and conversion chamber descriptions

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -284,8 +284,10 @@ TYPEINFO(/mob/living/silicon/robot)
 						chest.cell = src.cell
 						src.cell = null
 						chest.cell.set_loc(chest)
-
-			var/obj/item/parts/robot_parts/robot_frame/frame =  new(T)
+			var/frame_type = /obj/item/parts/robot_parts/robot_frame
+			if(src.syndicate)
+				frame_type = /obj/item/parts/robot_parts/robot_frame/syndicate
+			var/obj/item/parts/robot_parts/robot_frame/frame =  new frame_type(T)
 			frame.setMaterial(src.frame_material)
 			frame.emagged = src.emagged
 			frame.syndicate = src.syndicate

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -442,6 +442,7 @@ TYPEINFO(/obj/machinery/recharge_station)
 	is_syndicate = 1
 	anchored = UNANCHORED
 	p_class = 1.5
+	SYNDICATE_STEALTH_DESCRIPTION("It is full of sharp instruments designed to tear open human flesh.", null)
 
 /obj/machinery/recharge_station/syndicate/attackby(obj/item/W, mob/user)
 	if (iswrenchingtool(W))

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -1338,7 +1338,9 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/leg/right)
 		return
 
 /obj/item/parts/robot_parts/robot_frame/syndicate
+	tooltip_flags = REBUILD_USER
 	syndicate = TRUE
+	SYNDICATE_STEALTH_DESCRIPTION("The law connection light is blinking a sinister syndicate red.", null)
 
 // UPGRADES
 // Cyborg


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds syndicate stealth descriptions to both Syndicate robot frames and Conversion chambers.
Makes syndicate cyborgs specifically drop a syndicate type frame, to keep the special description.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows syndicate roboticists to differentiate their frames and charging stations at a glance.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Description properly shows if I remove/add traitor to myself.
Syndicate cyborgs properly drop syndicate type robot frames when killed
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Syndicate operatives can now identify syndicate robot frames and conversion chambers at a glance
```
