### PR TITLE
Add ability to deconstruct destroyed canisters

### DIFF
--- a/_std/defines/construction.dm
+++ b/_std/defines/construction.dm
@@ -28,11 +28,6 @@
 #define RAILING_UNFASTEN 1
 #define RAILING_FASTEN 2
 
-//canister defines
-#define CANISTER_DISASSEMBLE 0
-#define CANISTER_DISCONNECT 1
-#define CANISTER_CONNECT 2
-
 //deconstruction_flags
 
 #define DECON_NONE 0

--- a/code/modules/atmospherics/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/portable/portable_atmospherics.dm
@@ -82,16 +82,6 @@
 
 			return 1
 
-		can_connect(obj/machinery/atmospherics/unary/portables_connector/new_port)
-			//Make sure not already connected to something else
-			if(connected_port || !new_port || new_port.connected_device)
-				return 0
-
-			//Make sure are close enough for a valid connection
-			if(new_port.loc != loc)
-				return 0
-			return 1
-
 		disconnect()
 			if(!connected_port)
 				return 0
@@ -131,110 +121,45 @@
 				boutput(user, SPAN_ALERT("The detonating mechanism blocks you from modifying the anchors on the [src.name] with a wrench."))
 				return
 		if(connected_port)
-			actions.start(new /datum/action/bar/icon/canister_tool_use(user, src, W, CANISTER_DISCONNECT), user)
+			logTheThing(LOG_STATION, user, "has disconnected \the [src] [log_atmos(src)] from the port at [log_loc(src)].")
+			disconnect()
+			boutput(user, SPAN_NOTICE("You disconnect [name] from the port."))
+			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+			tgui_process.update_uis(src)
 			return
 		else
-			actions.start(new /datum/action/bar/icon/canister_tool_use(user, src, W, CANISTER_CONNECT), user)
-			return
+			var/obj/machinery/atmospherics/unary/portables_connector/possible_port = locate(/obj/machinery/atmospherics/unary/portables_connector) in loc
+			if(possible_port)
+				if(connect(possible_port))
+					logTheThing(LOG_STATION, user, "has connected \the [src] [log_atmos(src)] to the port at [log_loc(src)].")
+					boutput(user, SPAN_NOTICE("You connect [name] to the port."))
+					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+					tgui_process.update_uis(src)
+					return
+				else
+					boutput(user, SPAN_NOTICE("[name] failed to connect to the port."))
+					return
+			else
+				boutput(user, SPAN_NOTICE("Nothing happens."))
+				return
 	else if (isweldingtool(W))
-		if (src.destroyed)
-			actions.start(new /datum/action/bar/icon/canister_tool_use(user, src, W, CANISTER_DISASSEMBLE, 2 SECONDS), user)
+		if (!src.destroyed)
+			return
+		if (W:try_weld(user,0,-1,1,1))
+			SETUP_GENERIC_ACTIONBAR(user, src, 1 SECONDS, /obj/machinery/portable_atmospherics/proc/canister_disassemble, list(user, src, W), W.icon, W.icon_state, null,\
+				INTERRUPT_MOVE | INTERRUPT_ACTION | INTERRUPT_ATTACKED | INTERRUPT_STUNNED | INTERRUPT_ACT)
 	return
+
+/obj/machinery/portable_atmospherics/proc/canister_disassemble(mob/user, obj/machinery/portable_atmospherics/canister/C)
+	user.visible_message(SPAN_NOTICE("[user] disassembles \the [C]."))
+	logTheThing(LOG_STATION, user, "disassembles \the [C] at [log_loc(C)].")
+	var/obj/item/I = new /obj/item/sheet(get_turf(C))
+	if (C.material)
+		I.setMaterial(C.material)
+	else
+		var/datum/material/M = getMaterial("steel")
+		I.setMaterial(M)
+	qdel(C)
 
 /obj/machinery/portable_atmospherics/return_air(direct = FALSE)
 	return air_contents
-
-/datum/action/bar/icon/canister_tool_use
-	duration = 1 SECONDS
-	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
-	icon = 'icons/obj/items/tools/weldingtool.dmi'
-	icon_state = "weldingtool-on"
-	var/obj/machinery/portable_atmospherics/canister/C
-	var/mob/ownerMob
-	var/obj/item/tool
-	var/obj/machinery/atmospherics/unary/portables_connector/possible_port
-	var/interaction = CANISTER_DISASSEMBLE
-
-	New(The_Owner, The_Can, var/obj/item/The_Tool, The_Interaction, The_Duration, The_Port)
-		..()
-		if (The_Can)
-			C = The_Can
-		if (The_Owner)
-			owner = The_Owner
-			ownerMob = The_Owner
-		if (The_Tool)
-			tool = The_Tool
-			icon = The_Tool.icon
-			icon_state = The_Tool.icon_state
-		if (The_Duration)
-			duration = The_Duration
-		if (ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			if (H.traitHolder.hasTrait("carpenter") || H.traitHolder.hasTrait("training_engineer"))
-				duration = round(duration / 2)
-		if (The_Interaction)
-			interaction = The_Interaction
-		if (iswrenchingtool(tool))
-			possible_port = locate(/obj/machinery/atmospherics/unary/portables_connector) in C.loc
-
-	onUpdate()
-		..()
-		if (tool == null || C == null || owner == null || BOUNDS_DIST(owner, C) > 0 || (interaction == CANISTER_CONNECT && !possible_port))
-			interrupt(INTERRUPT_ALWAYS)
-			return
-
-	onStart()
-		..()
-		if (BOUNDS_DIST(ownerMob, C) > 0 || C == null || ownerMob == null)
-			interrupt(INTERRUPT_ALWAYS)
-			return
-		if (!tool)
-			interrupt(INTERRUPT_ALWAYS)
-			logTheThing(LOG_DEBUG, src, "tried to interact with [C] at [log_loc(C)] using a null tool... somehow.")
-			return
-		switch (interaction)
-			if (CANISTER_DISASSEMBLE)
-				if (isweldingtool(tool) && tool:welding)
-					playsound(C, 'sound/items/Welder.ogg', 50, TRUE)
-					ownerMob.visible_message(SPAN_NOTICE("[owner] begins to disassemble \the [C]."))
-				else
-					ownerMob.show_message(SPAN_ALERT("You have to turn the welding tool on."))
-					interrupt(INTERRUPT_ALWAYS)
-					return
-			if (CANISTER_CONNECT)
-				if(!C.destroyed && C.can_connect(possible_port))
-					playsound(C, 'sound/items/Ratchet.ogg', 50, TRUE)
-					ownerMob.visible_message(SPAN_NOTICE("[owner] begins connecting \the [C] to the port."))
-				else
-					ownerMob.visible_message(SPAN_ALERT("[owner] failed to connect to the port."))
-					interrupt(INTERRUPT_ALWAYS)
-					return
-			if (CANISTER_DISCONNECT)
-				playsound(C, 'sound/items/Ratchet.ogg', 50, TRUE)
-				ownerMob.visible_message(SPAN_NOTICE("[owner] begins disconnecting \the [C] from the port."))
-
-	onEnd()
-		..()
-		switch (interaction)
-			if (CANISTER_DISASSEMBLE)
-				ownerMob.visible_message(SPAN_NOTICE("[owner] disassembles \the [C]."))
-				logTheThing(LOG_STATION, ownerMob, "disassembles \the [C] at [log_loc(C)].")
-				var/obj/item/I = new /obj/item/sheet(get_turf(C))
-				if (C.material)
-					I.setMaterial(C.material)
-				else
-					var/datum/material/M = getMaterial("steel")
-					I.setMaterial(M)
-				qdel(C)
-			if (CANISTER_CONNECT)
-				ownerMob.visible_message(SPAN_NOTICE("[owner] connects \the [C] to the port."))
-				C.connect(possible_port)
-				playsound(C, 'sound/items/Deconstruct.ogg', 50, TRUE)
-				tgui_process.update_uis(C)
-				logTheThing(LOG_STATION, owner, "has connected \the [C] [log_atmos(C)] to the port at [log_loc(C)].")
-			if (CANISTER_DISCONNECT)
-				ownerMob.visible_message(SPAN_NOTICE("[owner] disconnects \the [C] from the port."))
-				C.disconnect()
-				playsound(C, 'sound/items/Deconstruct.ogg', 50, TRUE)
-				logTheThing(LOG_STATION, owner, "has disconnected \the [C] [log_atmos(C)] from the port at [log_loc(C)].")
-				tgui_process.update_uis(C)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects] [QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the ability to disassemble destroyed canisters.

Adds a `/obj/machinery/portable_atmospherics/proc/canister_disassemble` action that's used when targeting a destroyed canister with a welding torch.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Canisters get destroyed almost every other game, but there's no convenient way to just get them out of the way except for piling them onto one tile in a corner, which is weird. Crates can be disassembled because they're a nuisance, so I feel like canisters should be given the same treatment.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="504" height="220" alt="image" src="https://github.com/user-attachments/assets/759a92f3-70c4-4a28-b475-39fabb10f3e4" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Glamurio (Ryou)
(+)Canisters can now be disassembled with a welding tool.
```
