### PR TITLE
Fixes #24608 - Phone Handset Range Fix

### DIFF
--- a/code/modules/speech/modules/listen/modifiers/phone_formatting.dm
+++ b/code/modules/speech/modules/listen/modifiers/phone_formatting.dm
@@ -14,6 +14,7 @@
 
 	message.flags |= SAYFLAG_NO_MAPTEXT
 	message.flags &= ~(SAYFLAG_WHISPER | SAYFLAG_NO_SAY_VERB)
+	message.heard_range = 0
 	message.output_module_channel = SAY_CHANNEL_OUTLOUD
 	message.atom_listeners_override = null
 	message.atom_listeners_to_be_excluded = null


### PR DESCRIPTION
## About The PR:
Fixes #24608 by restricting the range of messages spoken by phone handsets to 0.


## Testing:
Using a test dummy to answer a phone, I am no longer able to hear the phone handset in their hand.