### PR TITLE
Fix satchel teleportation

### DIFF
--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -79,6 +79,8 @@
 				if (length(src.contents) > 1)
 					if (user.a_intent == INTENT_GRAB)
 						getItem = src.search_through(user)
+						if (!getItem) // prevents the satchel teleporting back to the hand if the search is cancelled
+							return
 
 					else
 						user.visible_message(SPAN_NOTICE("<b>[user]</b> rummages through \the [src]."),\
@@ -125,6 +127,9 @@
 		sortList(satchel_contents, /proc/cmp_text_asc)
 		var/chosenItem = input("Select an item to pull out.", "Choose Item") as null|anything in satchel_contents
 		if (!chosenItem || !(satchel_contents[chosenItem] in src.contents))
+			return
+		if (!user.is_in_hands(src))
+			boutput(user, SPAN_ALERT("You could have sworn [src] was just in your hand a moment ago."))
 			return
 		return satchel_contents[chosenItem]
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a couple of checks to prevent weird behaviour when discarding a satchel while using its rummage-menu. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #24695

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Fill satchel, grab intent to open the menu, throw satchel far away, cancel/choose item, and observe that the satchel stays where it is and the action is cancelled.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->


