### PR TITLE
Fix genebooth contexts overriding all clicks

### DIFF
--- a/code/datums/components/tool/deconstructing.dm
+++ b/code/datums/components/tool/deconstructing.dm
@@ -8,11 +8,13 @@ TYPEINFO(/datum/component/deconstructing)
 /datum/component/deconstructing
 	var/base_duration = 2 SECONDS
 	var/complexity_mult = 1 //! How much complexity affects deconstruction time
+	var/contextLayout
 
 	Initialize(baseDuration=2 SECONDS, complexityMult=1)
 		..()
 		src.base_duration = baseDuration
 		src.complexity_mult = complexityMult
+		src.contextLayout = new/datum/contextLayout/flexdefault()
 
 	///
 	proc/finish_decon(atom/target, mob/user, atom/deconstructor)
@@ -57,7 +59,7 @@ TYPEINFO(/datum/component/deconstructing)
 			var/decon_time = (decon_complexity * 2.5 SECONDS * src.complexity_mult) + src.base_duration
 			actions.start(new/datum/action/bar/icon/deconstruct_obj(target,decon_tool,decon_time), user)
 		else
-			user.showContextActions(O.decon_contexts, O)
+			user.showContextActions(O.decon_contexts, O, src.contextLayout)
 			boutput(user, SPAN_ALERT("You need to use some tools on [target] before it can be deconstructed."))
 		return ATTACK_PRE_DONT_ATTACK
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements custom context handling for the Genetics Booth to only show context actions when clicked with an empty hand to allow deconstructing and other features that make use of attacking with an item, such as the feature in which dealing 50 damage to the gene booth will spit someone out. 

Forces the deconstruction context layout to always be the same regardless of target object's context layout

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Default context behaviour will apply on any click, overriding any items you're trying to click with, which I learnt when trying to add an emag act, you can't currently click the genebooth with ANY item, meaning they presently can't be deconstructed due to deconstruction needing you to click it with a decon tool.

Due to the genebooth now having two available context menus (gene select, deconstruct) I have to force the deconstruct menu to use the same layout always or it will try to use the genebooth's 32x32 layout

Fixes #11919 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="846" height="466" alt="image" src="https://github.com/user-attachments/assets/508a8600-4078-48eb-a74c-deded4dcff2a" />
<img width="173" height="194" alt="image" src="https://github.com/user-attachments/assets/b81a9fb4-86b8-4e21-91f7-4d7bcbbd2336" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Fixed the Gene Booth making all your clicks be empty hands, allowing you to deconstruct it and bash it (50 hp) to force the occupant out (doesn't break the booth).
```
