### PR TITLE
Adds "persists_on_clone" var to fix nonhuman cloning weirdness

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -84,6 +84,8 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	/// Should stable mutagen not copy from this mutant?
 	var/dna_mutagen_banned = TRUE
 	/// Should a genetics terminal be able to remove this mutantrace?
+	var/persists_on_clone = TRUE
+	/// Should this mutantrace be clonable? (see thralls as a relevant example)
 	var/genetics_removable = TRUE
 	/// Should they be able to walk on shards barefoot
 	var/can_walk_on_shards = FALSE
@@ -310,7 +312,7 @@ ABSTRACT_TYPE(/datum/mutantrace)
 				src.blood_color_changed = TRUE
 
 		src.AH = M.bioHolder?.mobAppearance // i mean its called appearance holder for a reason
-		if (!src.dna_mutagen_banned)
+		if (src.persists_on_clone)
 			AH.original_mutant_race = src
 		if(!(src.mutant_appearance_flags & NOT_DIMORPHIC))
 			MakeMutantDimorphic(M)
@@ -490,7 +492,7 @@ ABSTRACT_TYPE(/datum/mutantrace)
 			AH.s_tone = AH.s_tone_original
 
 		AH.mutant_race = src
-		if (!src.dna_mutagen_banned)
+		if (src.persists_on_clone)
 			AH.original_mutant_race = src
 		AH.body_icon = src.mutant_folder
 		AH.body_icon_state = src.icon_state
@@ -714,6 +716,7 @@ TYPEINFO(/datum/mutantrace/blob)
 	voice_override = "bloop"
 	firevuln = 1.5
 	typevulns = list("cut" = 1.25, "stab" = 0.5, "blunt" = 0.75)
+	persists_on_clone = FALSE
 
 	ghost_icon_state = "ghost-blob"
 
@@ -926,6 +929,7 @@ TYPEINFO_NEW(/datum/mutantrace/lizard)
 	movement_modifier = /datum/movement_modifier/zombie
 	r_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/right/zombie
 	l_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/left/zombie
+	persists_on_clone = FALSE
 	var/strain = 0
 
 	//this is terrible, but I do anyway.
@@ -1073,6 +1077,7 @@ TYPEINFO(/datum/mutantrace/vampiric_thrall)
 	special_head = HEAD_VAMPTHRALL
 	jerk = TRUE
 	genetics_removable = FALSE
+	persists_on_clone = FALSE
 
 	on_attach(var/mob/living/carbon/human/M)
 		..()
@@ -1280,6 +1285,7 @@ TYPEINFO(/datum/mutantrace/abomination)
 	anchor_to_floor = 1
 	movement_modifier = /datum/movement_modifier/abomination
 	self_click_fluff = "disgusting writhing appendages"
+	persists_on_clone = FALSE
 
 	var/last_drain = 0
 	var/drains_dna_on_life = 1
@@ -2092,6 +2098,7 @@ TYPEINFO(/datum/mutantrace/kudzu)
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/kudzu/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_HUMAN_SKINTONE | TORSO_HAS_SKINTONE | HAS_HUMAN_HAIR | HAS_HUMAN_EYES | HAS_SPECIAL_HAIR | HAS_EXTRA_DETAILS | BUILT_FROM_PIECES)
 	override_attack = 1
+	persists_on_clone = FALSE
 
 	mutant_abilityholder = /datum/abilityHolder/kudzu
 	mutant_abilities = list(

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -84,9 +84,9 @@ ABSTRACT_TYPE(/datum/mutantrace)
 	/// Should stable mutagen not copy from this mutant?
 	var/dna_mutagen_banned = TRUE
 	/// Should a genetics terminal be able to remove this mutantrace?
-	var/persists_on_clone = TRUE
-	/// Should this mutantrace be clonable? (see thralls as a relevant example)
 	var/genetics_removable = TRUE
+	/// Should this mutantrace be kept upon cloning?
+	var/persists_on_clone = TRUE
 	/// Should they be able to walk on shards barefoot
 	var/can_walk_on_shards = FALSE
 	var/icon_state = "blank_c"
@@ -716,7 +716,6 @@ TYPEINFO(/datum/mutantrace/blob)
 	voice_override = "bloop"
 	firevuln = 1.5
 	typevulns = list("cut" = 1.25, "stab" = 0.5, "blunt" = 0.75)
-	persists_on_clone = FALSE
 
 	ghost_icon_state = "ghost-blob"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pull request adds a "persists_on_clone" var to mutantraces.dm that defaults to true, allowing most mutantraces to be cloned, with exceptions for things like thralls, zombies, and kudzupeople. Functional replacement of #24678.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Presently, the nonhuman diplomat mutantraces pop out of the cloner as whatever mutantrace the character is set to in character setup. This has been mentioned to be unintentional by developers, so I fixed it. This time with allowances for stable mutagen to still work!

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="499" height="351" alt="Screenshot 2025-09-23 182909" src="https://github.com/user-attachments/assets/fbb6eeeb-d9bb-4831-883e-cf91a709be55" />

<img width="462" height="403" alt="Screenshot 2025-09-23 182639" src="https://github.com/user-attachments/assets/f2f7932b-d40c-4265-ab76-29709c258c36" />

For sake of testing, since I was unable to turn myself into a thrall in a test branch, I briefly set the blob mutantrace to have "persists_on_clone = FALSE" to verify mutantraces with it set to false don't get cloned as themselves.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->