### PR TITLE
Adds the Wellspring artifact.

### DIFF
--- a/code/obj/artifacts/artifact_machines/wellspring.dm
+++ b/code/obj/artifacts/artifact_machines/wellspring.dm
@@ -13,7 +13,7 @@
 	type_name = "Wellspring"
 	rarity_weight = 350
 	react_xray = list(5,65,20,11,"HOLLOW")
-	validtypes = list("ancient", "martian", "eldritch")
+	validtypes = list("ancient", "martian", "eldritch", "precursor", "wizard")
 	//validtypes = list("ancient", "martian", "eldritch", "lattice")
 	validtriggers = list(/datum/artifact_trigger/carbon_touch, /datum/artifact_trigger/silicon_touch, /datum/artifact_trigger/force, /datum/artifact_trigger/heat, /datum/artifact_trigger/cold, /datum/artifact_trigger/radiation, /datum/artifact_trigger/electric, /datum/artifact_trigger/language)
 	activated = 0
@@ -29,11 +29,15 @@
 		. = ..()
 		switch(artitype.name)
 			if ("ancient")
-				src.payload_reagent = pick("fuel", "charcoal", "silicate", "graphene_compound")
+				src.payload_reagent = pick("fuel", "goodnanites")
 			if ("martian")
 				src.payload_reagent = pick("water")
 			if ("eldritch")
-				src.payload_reagent = pick("blood", "sewage")
+				src.payload_reagent = pick("blood")
+			if ("precursor")
+				src.payload_reagent = pick("ephedrine")
+			if ("wizard")
+				src.payload_reagent = pick("reversium", "fliptonium")
 			//if ("lattice")
 			//	src.payload_reagent = pick("flockdrone_fluid") //Looks like Gnesis can't form liquids.
 		src.payload_amount = rand(100, 3000)

--- a/code/obj/artifacts/artifact_machines/wellspring.dm
+++ b/code/obj/artifacts/artifact_machines/wellspring.dm
@@ -9,17 +9,16 @@
 
 /datum/artifact/wellspring
 	associated_object = /obj/machinery/artifact/wellspring
+	type_size = ARTIFACT_SIZE_LARGE
 
 	type_name = "Wellspring"
 	rarity_weight = 350
-	react_xray = list(5,65,20,11,"HOLLOW")
+	react_xray = list(5,65,20,11,"LIQUID RESERVOIR")
 	validtypes = list("ancient", "martian", "eldritch", "precursor", "wizard")
-	//validtypes = list("ancient", "martian", "eldritch", "lattice")
 	validtriggers = list(/datum/artifact_trigger/carbon_touch, /datum/artifact_trigger/silicon_touch, /datum/artifact_trigger/force, /datum/artifact_trigger/heat, /datum/artifact_trigger/cold, /datum/artifact_trigger/radiation, /datum/artifact_trigger/electric, /datum/artifact_trigger/language)
 	activated = 0
 	activ_text = "begins to flood the area with liquid!"
 	deact_text = "stops flooding."
-	touch_descriptors = list("It feels damp.")
 	var/payload_reagent = "water"
 	var/payload_amount = 1
 	var/payload_cooldown = 1 SECONDS
@@ -28,18 +27,16 @@
 	post_setup()
 		. = ..()
 		switch(artitype.name)
-			if ("ancient")
-				src.payload_reagent = pick("fuel", "goodnanites")
-			if ("martian")
-				src.payload_reagent = pick("water")
-			if ("eldritch")
-				src.payload_reagent = pick("blood")
-			if ("precursor")
-				src.payload_reagent = pick("ephedrine")
-			if ("wizard")
-				src.payload_reagent = pick("reversium", "fliptonium")
-			//if ("lattice")
-			//	src.payload_reagent = pick("flockdrone_fluid") //Looks like Gnesis can't form liquids.
+            if ("ancient")
+                src.payload_reagent = pick("fuel", "goodnanites")
+            if ("martian")
+                src.payload_reagent = pick("water", "viscerite_viscera", "martian_flesh", "hemolymph")
+            if ("eldritch")
+                src.payload_reagent = pick("blood", "bloodc", "black_goop", "sewage")
+            if ("precursor")
+                src.payload_reagent = pick("ephedrine", "cryostylane") //cryo fluid?
+            if ("wizard")
+                src.payload_reagent = pick("reversium", "mugwort", "fliptonium")
 		src.payload_amount = rand(100, 3000)
 		src.payload_cooldown = rand(1, 10) SECONDS
 

--- a/code/obj/artifacts/artifact_machines/wellspring.dm
+++ b/code/obj/artifacts/artifact_machines/wellspring.dm
@@ -22,6 +22,7 @@
 	var/payload_reagent = "water"
 	var/payload_amount = 1
 	var/payload_cooldown = 1 SECONDS
+	var/payload_duration = 60 SECONDS
 	var/cooldowns = new/list()
 
 	post_setup()
@@ -39,6 +40,12 @@
 				src.payload_reagent = pick("reversium", "mugwort", "fliptonium")
 		src.payload_amount = rand(100, 3000)
 		src.payload_cooldown = rand(1, 10) SECONDS
+		src.payload_duration = rand(5, 10) * 60 SECONDS
+
+	effect_activate(var/obj/O)
+		if (..())
+			return
+		ON_COOLDOWN(src, "payload_duration", src.payload_duration)
 
 	effect_process(var/obj/O)
 		if (..())
@@ -48,3 +55,5 @@
 			O.reagents.add_reagent(src.payload_reagent, src.payload_amount)
 			location.visible_message("<b>[O]</b> pulses.")
 			O.reagents.reaction(location, 1, src.payload_amount, can_spawn_fluid=1)
+		if(!ON_COOLDOWN(src, "payload_duration", src.payload_duration))
+			O.ArtifactDeactivated()

--- a/code/obj/artifacts/artifact_machines/wellspring.dm
+++ b/code/obj/artifacts/artifact_machines/wellspring.dm
@@ -1,0 +1,50 @@
+/obj/machinery/artifact/wellspring
+	name = "wellspring"
+	associated_datum = /datum/artifact/wellspring
+
+	New()
+		..()
+		src.create_reagents(750)
+
+
+/datum/artifact/wellspring
+	associated_object = /obj/machinery/artifact/wellspring
+
+	type_name = "Wellspring"
+	rarity_weight = 350
+	react_xray = list(5,65,20,11,"HOLLOW")
+	validtypes = list("ancient", "martian", "eldritch")
+	//validtypes = list("ancient", "martian", "eldritch", "lattice")
+	validtriggers = list(/datum/artifact_trigger/carbon_touch, /datum/artifact_trigger/silicon_touch, /datum/artifact_trigger/force, /datum/artifact_trigger/heat, /datum/artifact_trigger/cold, /datum/artifact_trigger/radiation, /datum/artifact_trigger/electric, /datum/artifact_trigger/language)
+	activated = 1
+	activ_text = "begins to flood the area with liquid!"
+	deact_text = "stops flooding."
+	touch_descriptors = list("It feels damp.")
+	var/payload_reagents = list() //If multiple reagents are listed, it will split the payload_amount evenly between them.
+	var/payload_amount = 1
+	var/payload_cooldown = 1 SECONDS
+	var/cooldowns = new/list()
+
+	post_setup()
+		. = ..()
+		switch(artitype.name)
+			if ("ancient")
+				src.payload_reagents = list("fuel")
+			if ("martian")
+				src.payload_reagents = list("water") //water on mars, get it?
+			if ("eldritch")
+				src.payload_reagents = list("blood")
+			//if ("lattice") //Looks like Gnesis can't form liquids.
+			//	src.payload_reagents = list("flockdrone_fluid", "water")
+		src.payload_amount = rand(100, 750)
+		src.payload_cooldown = rand(1, 10) SECONDS
+
+	effect_process(var/obj/O)
+		if (..())
+			return
+		if(!ON_COOLDOWN(src, "deploy_payload", src.payload_cooldown))
+			var/turf/location = get_turf(O)
+			for (var/i_reagent in src.payload_reagents)
+				O.reagents.add_reagent(i_reagent, src.payload_amount/length(src.payload_reagents))
+			location.visible_message("<b>[O]</b> pulses.")
+			O.reagents.reaction(location, 1, src.payload_amount, can_spawn_fluid=1)

--- a/code/obj/artifacts/artifact_machines/wellspring.dm
+++ b/code/obj/artifacts/artifact_machines/wellspring.dm
@@ -34,8 +34,8 @@
 				src.payload_reagents = list("water") //water on mars, get it?
 			if ("eldritch")
 				src.payload_reagents = list("blood")
-			//if ("lattice") //Looks like Gnesis can't form liquids.
-			//	src.payload_reagents = list("flockdrone_fluid", "water")
+			//if ("lattice")
+			//	src.payload_reagents = list("flockdrone_fluid", "water") //Looks like Gnesis can't form liquids.
 		src.payload_amount = rand(100, 750)
 		src.payload_cooldown = rand(1, 10) SECONDS
 

--- a/code/obj/artifacts/artifact_machines/wellspring.dm
+++ b/code/obj/artifacts/artifact_machines/wellspring.dm
@@ -4,7 +4,7 @@
 
 	New()
 		..()
-		src.create_reagents(750)
+		src.create_reagents(3000)
 
 
 /datum/artifact/wellspring
@@ -16,11 +16,11 @@
 	validtypes = list("ancient", "martian", "eldritch")
 	//validtypes = list("ancient", "martian", "eldritch", "lattice")
 	validtriggers = list(/datum/artifact_trigger/carbon_touch, /datum/artifact_trigger/silicon_touch, /datum/artifact_trigger/force, /datum/artifact_trigger/heat, /datum/artifact_trigger/cold, /datum/artifact_trigger/radiation, /datum/artifact_trigger/electric, /datum/artifact_trigger/language)
-	activated = 1
+	activated = 0
 	activ_text = "begins to flood the area with liquid!"
 	deact_text = "stops flooding."
 	touch_descriptors = list("It feels damp.")
-	var/payload_reagents = list() //If multiple reagents are listed, it will split the payload_amount evenly between them.
+	var/payload_reagent = "water"
 	var/payload_amount = 1
 	var/payload_cooldown = 1 SECONDS
 	var/cooldowns = new/list()
@@ -29,14 +29,14 @@
 		. = ..()
 		switch(artitype.name)
 			if ("ancient")
-				src.payload_reagents = list("fuel")
+				src.payload_reagent = pick("fuel", "charcoal", "silicate", "graphene_compound")
 			if ("martian")
-				src.payload_reagents = list("water") //water on mars, get it?
+				src.payload_reagent = pick("water")
 			if ("eldritch")
-				src.payload_reagents = list("blood")
+				src.payload_reagent = pick("blood", "sewage")
 			//if ("lattice")
-			//	src.payload_reagents = list("flockdrone_fluid", "water") //Looks like Gnesis can't form liquids.
-		src.payload_amount = rand(100, 750)
+			//	src.payload_reagent = pick("flockdrone_fluid") //Looks like Gnesis can't form liquids.
+		src.payload_amount = rand(100, 3000)
 		src.payload_cooldown = rand(1, 10) SECONDS
 
 	effect_process(var/obj/O)
@@ -44,7 +44,6 @@
 			return
 		if(!ON_COOLDOWN(src, "deploy_payload", src.payload_cooldown))
 			var/turf/location = get_turf(O)
-			for (var/i_reagent in src.payload_reagents)
-				O.reagents.add_reagent(i_reagent, src.payload_amount/length(src.payload_reagents))
+			O.reagents.add_reagent(src.payload_reagent, src.payload_amount)
 			location.visible_message("<b>[O]</b> pulses.")
 			O.reagents.reaction(location, 1, src.payload_amount, can_spawn_fluid=1)

--- a/code/obj/artifacts/artifact_machines/wellspring.dm
+++ b/code/obj/artifacts/artifact_machines/wellspring.dm
@@ -27,16 +27,16 @@
 	post_setup()
 		. = ..()
 		switch(artitype.name)
-            if ("ancient")
-                src.payload_reagent = pick("fuel", "goodnanites")
-            if ("martian")
-                src.payload_reagent = pick("water", "viscerite_viscera", "martian_flesh", "hemolymph")
-            if ("eldritch")
-                src.payload_reagent = pick("blood", "bloodc", "black_goop", "sewage")
-            if ("precursor")
-                src.payload_reagent = pick("ephedrine", "cryostylane") //cryo fluid?
-            if ("wizard")
-                src.payload_reagent = pick("reversium", "mugwort", "fliptonium")
+			if ("ancient")
+				src.payload_reagent = pick("fuel", "goodnanites")
+			if ("martian")
+				src.payload_reagent = pick("water", "viscerite_viscera", "martian_flesh", "hemolymph")
+			if ("eldritch")
+				src.payload_reagent = pick("blood", "bloodc", "black_goop", "sewage")
+			if ("precursor")
+				src.payload_reagent = pick("ephedrine", "cryostylane") //cryo fluid?
+			if ("wizard")
+				src.payload_reagent = pick("reversium", "mugwort", "fliptonium")
 		src.payload_amount = rand(100, 3000)
 		src.payload_cooldown = rand(1, 10) SECONDS
 

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -2336,6 +2336,7 @@
 #include "code\obj\artifacts\artifact_machines\robot.dm"
 #include "code\obj\artifacts\artifact_machines\turret.dm"
 #include "code\obj\artifacts\artifact_machines\warper.dm"
+#include "code\obj\artifacts\artifact_machines\wellspring.dm"
 #include "code\obj\artifacts\artifact_objects\augmentor.dm"
 #include "code\obj\artifacts\artifact_objects\bombs.dm"
 #include "code\obj\artifacts\artifact_objects\borgifier.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
[A-SCIENCE][C-FEATURE]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds the Wellspring large artifact.

The Wellspring artifact, once activated, will continuously spawn a random amount of a origin-determined liquid at its location, at a random interval. The artifact will stay active 5-10 minutes before deactivating.

Martian origin Wellsprings will create Water, Viscerite fluid, Martian flesh or Hemolymph.
Silicon origin Wellsprings will create Welding Fuel or Directed Nanites.
Eldritch origin Wellsprings will create Blood, Bloodc, Black Goop or Sewage.
Precursor origin Wellsprings will create Ephedrine or Cryo fluid.
Wizard origin Wellsprings will create Reversium, Fliptonium or Mugwort.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
ArtSci is all about fun through randomness. More artifacts equals more randomness, equals more fun.

The Wellspring will create the potential for flooding on space-based stations, giving Janitors a chance to be the bastion defending the station from a wall of blood, and give occasional roleplay opportunities such as blood sacrifices in the Chapel.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Lowest possible roll, 100 units every 10 seconds:

https://github.com/user-attachments/assets/e5181449-958c-4e73-b4b8-1c2a8ab1c66c

Highest possible roll, 3000 units every 1 second:

https://github.com/user-attachments/assets/036ec481-723b-46b9-8dd4-15430347638c



<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kanthes
(*)Adds the Wellspring artifact.
