### PR TITLE
Fixes the description text on the eyepatch after a hole is in it

### DIFF
--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -471,10 +471,12 @@ TYPEINFO(/obj/item/clothing/glasses/visor)
 				appearance_flags |= RESET_COLOR
 				user.show_message(SPAN_NOTICE("You poke a tiny pinhole into [src]!"))
 				return
+		return ..()
 
 	get_desc ()
 		if (src.pinhole)
 			. += " Unfortunately, its not so cool anymore since there's a tiny pinhole in it."
+
 
 	attack_self(mob/user)
 

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -437,7 +437,7 @@ TYPEINFO(/obj/item/clothing/glasses/visor)
 	item_state = "headset"
 	block_eye = "R"
 	nudge_compatible = FALSE
-	var/pinhole = 0
+	var/pinhole = FALSE
 	var/mob/living/carbon/human/equipper
 	wear_layer = MOB_GLASSES_LAYER2
 
@@ -452,11 +452,11 @@ TYPEINFO(/obj/item/clothing/glasses/visor)
 		return ..()
 
 	attackby(obj/item/W, mob/user)
-		if ((isscrewingtool(W) || istype(W, /obj/item/pen)) && !pinhole)
+		if ((isscrewingtool(W) || istype(W, /obj/item/pen)) && !src.pinhole)
 			if( equipper && equipper.glasses == src )
 				var/obj/item/organ/eye/theEye = equipper.drop_organ((src.icon_state == "eyepatch-L") ? "left_eye" : "right_eye")
-				pinhole = 1
-				block_eye = null
+				src.pinhole = TRUE
+				src.block_eye = FALSE
 				appearance_flags |= RESET_COLOR
 				if(!theEye)
 					user.show_message(SPAN_ALERT(">Um. Wow. Thats kinda grode."))
@@ -466,14 +466,16 @@ TYPEINFO(/obj/item/clothing/glasses/visor)
 				logTheThing(LOG_COMBAT, user, "removes their [log_object(theEye)] using an eyepatch and [log_object(W)] at [log_loc(user)].")
 				return
 			else
-				pinhole = 1
-				block_eye = null
+				pinhole = TRUE
+				block_eye = FALSE
 				appearance_flags |= RESET_COLOR
 				user.show_message(SPAN_NOTICE("You poke a tiny pinhole into [src]!"))
-				if (!pinhole)
-					desc = "[desc] Unfortunately, its not so cool anymore since there's a tiny pinhole in it."
 				return
-		return ..()
+
+	get_desc ()
+		if (src.pinhole)
+			. += " Unfortunately, its not so cool anymore since there's a tiny pinhole in it."
+
 	attack_self(mob/user)
 
 		if (src.icon_state == "eyepatch-R")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Poking a hole into an eyepatch didn't change the examine text now it does
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It was supposed to have text
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="1075" height="522" alt="eyepatch fix 1" src="https://github.com/user-attachments/assets/fc1992f1-0e0d-49dc-9399-6647f95c9aef" />
<img width="1275" height="562" alt="eyepatch fix 2" src="https://github.com/user-attachments/assets/d92a0300-01fc-48c1-9990-c29cba8e6d2b" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

