### PR TITLE
Fixes #24292 - Auto-Capitalisation Fix

### DIFF
--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -184,9 +184,10 @@
 	// Ensure that a channel is assigned to this message.
 	src.output_module_channel ||= src.speaker.default_speech_output_channel
 
-	src.content = src.make_safe_for_chat(src.content)
 	if (ismob(src.speaker))
 		src.run_mob_and_client_checks()
+
+	src.content = src.make_safe_for_chat(src.content)
 
 /datum/say_message/disposing()
 	src.speaker = null


### PR DESCRIPTION
## About The PR:
Fixes #24292 by moving auto-capitalisation to before mutable tag application.


## Testing:
Auto-capitalisation now works as expected when enabled, and does not occur when disabled. This was tested with normal speech and with prefixed speech.