### PR TITLE
Adds the artifact bomb (radioactive) variant.

### DIFF
--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -556,6 +556,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 	type_name = "Bomb (radioactive)"
 	rarity_weight = 90
 	react_xray = list(12,75,30,11,"SHIELDED")
+	touch_descriptors = list("Your fingers continue to tingle after touching it.")
 	var/explosion_strength = 1
 	var/nuclear_fallout_cooldown = 10 SECONDS
 	var/nuclear_fallout_amount = 5

--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -560,13 +560,13 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 	var/explosion_strength = 1
 	var/nuclear_fallout_cooldown = 10 SECONDS
 	var/nuclear_fallout_amount = 5
+	var/nuclear_fallout_decay_rate = 0.90
 
 	New()
 		..()
-		//We don't need a big explosion, it's just to make a point.
-		src.explosion_strength = rand(50, 150)
+		src.explosion_strength = rand(25, 75)
 		src.nuclear_fallout_cooldown = rand(1, 10) SECONDS
-		src.nuclear_fallout_amount = rand(2, 10)
+		src.nuclear_fallout_amount = rand(6, 30)
 
 	post_setup()
 		. = ..()
@@ -580,9 +580,6 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 		for(var/i = 1 to src.nuclear_fallout_amount * 10)
 			shoot_projectile_XY(O, new /datum/projectile/neutron(100), rand(-10,10), rand(-10,10))
 
-		//O.ArtifactDestroyed()
-		//Oh, you thought it left no trace?
-
 	effect_process(var/obj/O)
 		if(..())
 			return
@@ -590,5 +587,8 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 			if(!ON_COOLDOWN(O, "nuclear_fallout", src.nuclear_fallout_cooldown))
 				var/turf/location = get_turf(O)
 				location.visible_message("<b>[O]</b> spews out radiation!")
-				for(var/i = 1 to src.nuclear_fallout_amount)
+				for(var/i = 1 to floor(src.nuclear_fallout_amount))
 					shoot_projectile_XY(O, new /datum/projectile/neutron(100), rand(-10,10), rand(-10,10))
+				src.nuclear_fallout_amount = src.nuclear_fallout_amount * src.nuclear_fallout_decay_rate
+				if(floor(src.nuclear_fallout_amount) < 1)
+					O.ArtifactDestroyed()

--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -587,5 +587,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 			return
 		if(src.blewUp)
 			if(!ON_COOLDOWN(O, "nuclear_fallout", src.nuclear_fallout_cooldown))
+				var/turf/location = get_turf(O)
+				location.visible_message("<b>[O]</b> spews out radiation!")
 				for(var/i = 1 to src.nuclear_fallout_amount)
 					shoot_projectile_XY(O, new /datum/projectile/neutron(100), rand(-10,10), rand(-10,10))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
[A-Science][C-Feature]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a radioactive variant of the regular artifact bomb. The bomb is largely based on the regular artifact bomb, but with an added radioactive element. The bomb will emit a large burst of neutrons on exploding, and stay around after exploding to continue emitting radiation with a decaying rate until it eventually deletes itself.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
ArtSci is all about fun through randomness. More artifacts equals more randomness, equals more fun.

The neutron and radioactivity system has been part of the game for a while, it only feels right that there's a bomb that utilizes it.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested on a local server, works just like a regular artifact bomb for the most part.
![vlc_2Zj0j9MXCd](https://github.com/user-attachments/assets/ba78df93-2ae5-4be5-bb2a-eac7f42067b6)

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kanthes
(*)Adds the artifact bomb (radioactive) variant.
```
