### PR TITLE
Fix Chameleon Projector Nullspacings

### DIFF
--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -163,6 +163,12 @@ TYPEINFO(/obj/item/device/chameleon)
 		if (!anim)
 			anim = new(src)
 
+		if (!src.cham || src.cham.qdeled || src.cham.disposed) //Stop sending people to nullspace after the dummy is destroyed >:(
+			boutput(user, SPAN_ALERT("[src] detects an error in its projection registry and performs an emergency factory reset!"))
+			src.disrupt()
+			src.cham = null
+			src.can_use = FALSE //Go scan something to get a new dummy object
+			return
 		if (active) //active_dummy)
 			active = 0
 			playsound(src, 'sound/effects/pop.ogg', 100, TRUE, 1)

--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -139,7 +139,7 @@ TYPEINFO(/obj/item/device/chameleon)
 			if(!testIcon) //weird edgecases
 				return
 
-			if (!cham)
+			if (!cham || src.cham.qdeled || src.cham.disposed)
 				cham = new(src)
 				cham.master = src
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Causes the toggle proc on the chameleon projector to return early and prevent projector's usage until you scan a new object (the scan proc makes a new dummy if there isn't one) if the chameleon dummy object was destroyed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The toggle proc for turning on the projector didn't have a check for if the dummy object still existed and so would set the user's location to null, upon reconnecting this would place them at (0,0) and thus was reported as an exploit so it fixes an outstanding bug I just can't link it due to it being reported as an exploit (easily reproducable warp to 0,0)

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Activated chameleon projector, deleted dummy object, got spat out, attempted to toggle projector, reset happened as expected and i could not use the projector until i scanned a new object, at which point it works as usual.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

