### PR TITLE
HOTFIX: Trinkets now use unicode 2019 apostrophe

### DIFF
--- a/strings/trinkets.txt
+++ b/strings/trinkets.txt
@@ -1,8 +1,8 @@
 modifiers@=
-	's dad's@,'s mom's@,'s grampa's@,'s grandma's@,'s favorite@,'s trusty@,'s favorite@,'s heirloom@,'s pet
-	's beloved@,'s lucky@,'s best@,'s antique@,'s old@,'s ol'@,'s prized@,'s neat@,'s good old@,'s good ol'@,'s son's
-	's daughter's@,'s aunt's@,'s uncle's@,'s finest@,'s shiniest@,'s lovely@,'s stupid@,'s prize winning@,'s top shelf
-	's 'prize winning'@,'s 'top shelf'@,'s autographed@,'s monogramed@,'s bejazzled@,'s jewel encrusted@,'s fanciest@,
-	's worn out@,'s custom@,'s luxurious@,'s superb@,'s precious@,'s roommate's@,'s neighbor's@,'s stolen@,'s fire sale@,'s counterfeit@,'s collectible@,
-	's limited edition@,'s ex's@,'s grody old@,'s family keepsake@,'s personalized@,'s smuggled@,'s shameful secret@,'s half-off@,'s bargain-bin@,'s spouse's@,
+	’s dad’s@,’s mom’s@,’s grampa’s@,’s grandma’s@,’s favorite@,’s trusty@,’s favorite@,’s heirloom@,’s pet
+	’s beloved@,’s lucky@,’s best@,’s antique@,’s old@,’s ol’@,’s prized@,’s neat@,’s good old@,’s good ol’@,’s son’s
+	’s daughter’s@,’s aunt’s@,’s uncle’s@,’s finest@,’s shiniest@,’s lovely@,’s stupid@,’s prize winning@,’s top shelf
+	’s ’prize winning’@,’s ’top shelf’@,’s autographed@,’s monogramed@,’s bejazzled@,’s jewel encrusted@,’s fanciest@,
+	’s worn out@,’s custom@,’s luxurious@,’s superb@,’s precious@,’s roommate’s@,’s neighbor’s@,’s stolen@,’s fire sale@,’s counterfeit@,’s collectible@,
+	’s limited edition@,’s ex’s@,’s grody old@,’s family keepsake@,’s personalized@,’s smuggled@,’s shameful secret@,’s half-off@,’s bargain-bin@,’s spouse’s@,
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This corrects the trinkets.txt string file to use apostrophe unicode 2019 as opposed to standard ' apostrophe which has caused multiple issues in the past (see PR #24697 for example).

based on the Issue #1780 
Fixes #1780
Fixes #17748
Fixes #23316

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This allows you to point to an item that is named after someone, their spawning trinket. This was the same issue as the organs named after their donor.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Launched the game after mass replacing the ' with the right unicode apostrophe in the strings/trinkets.txt and respawned multiple times with new trinkets and pointed at them while standing right nex to them

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
## Fix Screenshot
<img width="1295" height="291" alt="Screenshot 2025-09-30 114802" src="https://github.com/user-attachments/assets/118eb033-c6db-44dc-9b25-2266af6e31c7" />
<img width="1871" height="364" alt="Screenshot 2025-09-30 122345" src="https://github.com/user-attachments/assets/61c5d3a8-4abb-4094-8857-0b586b87b7e0" />
