### PR TITLE
Enable poltergeist limit on classic

### DIFF
--- a/code/modules/antagonists/wraith/abilties/trickster/make_poltergeist.dm
+++ b/code/modules/antagonists/wraith/abilties/trickster/make_poltergeist.dm
@@ -1,3 +1,5 @@
+#define POLTERGEISTS_PER_WRAITH 2
+
 /datum/targetable/wraithAbility/make_poltergeist
 	name = "Make Poltergeist"
 	desc = "Attempt to breach the veil between worlds to allow a lesser spirit to enter this realm."
@@ -12,12 +14,10 @@
 	cast(atom/target, params)
 		if (..())
 			return CAST_ATTEMPT_FAIL_CAST_FAILURE
-#ifdef RP_MODE
 		var/mob/living/intangible/wraith/wraith = src.holder.owner
-		if (istype(wraith) && length(wraith.poltergeists) >= 2)
+		if (istype(wraith) && length(wraith.poltergeists) >= POLTERGEISTS_PER_WRAITH)
 			boutput(wraith, SPAN_ALERT("This world is already loud with the voices of your children. No more ghosts will come for now."))
 			return CAST_ATTEMPT_FAIL_NO_COOLDOWN
-#endif
 		var/turf/T = get_turf(src.holder.owner)
 		if (!isturf(T) || istype(T, /turf/space))
 			boutput(src.holder.owner, SPAN_ALERT("You can't summon a poltergeist here!"))
@@ -68,3 +68,5 @@
 			message_ghosts("<b>[P]</b>, a poltergeist, has manifested at [log_loc(P, ghostjump = TRUE)].")
 			boutput(W, SPAN_NOTICE("The poltergeist you called has entered this realm. Its name is <b>[P]</b>."))
 		W.spawn_marker = null
+
+#undef POLTERGEISTS_PER_WRAITH


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the ifdef RP_MODE check for the limit on trickster poltergeists, introducing the limit of 2 poltergeists per wraith to the classic server.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Poltergeists are incredibly strong if you can consistently get a lot of them, even 3 possessed items at once is strong, more is nearly impossible to handle when you have 5 poltergeists all possessing items at once. Mechanical differences between classic and RP should be kept to what's required.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Edited my wraith poltergeist list to list("buh", "guh") and accurately could not spawn additional poltergeists

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)The limit of 2 poltergeists per wraith is now present on all servers, rather than just RP.
```
