### PR TITLE
HOTFIX: Fixes John Bill's items not being pullable/picked up when he is near you.

### DIFF
--- a/code/WorkInProgress/warcrimes.dm
+++ b/code/WorkInProgress/warcrimes.dm
@@ -8,19 +8,19 @@ TYPEINFO(/area/diner/tug)
 	valid_bounty_area = FALSE
 /area/diner/tug
 	icon_state = "green"
-	name = "Big Yank's Cheap Tug"
+	name = "Big Yank’s Cheap Tug"
 TYPEINFO(/area/diner/juicer_trader)
 	valid_bounty_area = FALSE
 /area/diner/jucer_trader
 	icon_state = "green"
-	name = "Placeholder Paul's $STORE_NAME.shuttle"
+	name = "Placeholder Paul’s $STORE_NAME.shuttle"
 
 /obj/item/clothing/head/paper_hat/john
-	name = "John Bill's paper bus captain hat"
+	name = "John Bill’s paper bus captain hat"
 	desc = "This is made from someone's tax returns"
 
 /obj/item/clothing/mask/cigarette/john
-	name = "John Bill's cigarette"
+	name = "John Bill’s cigarette"
 	on = 1
 	put_out(var/mob/user as mob, var/message as text)
 		// how about we do literally nothing instead?
@@ -525,7 +525,7 @@ ABSTRACT_TYPE(/obj/machinery/vending/meat)
 	icon_state = "engineshit2"
 
 /obj/item/paper/tug/invoice
-	name = "Big Yank's Space Tugs, Limited."
+	name = "Big Yank’s Space Tugs, Limited."
 	desc = "Looks like a bill of sale."
 	info = {"<b>Client:</b> Bill, John
 			<br><b>Date:</b> TBD
@@ -536,7 +536,7 @@ ABSTRACT_TYPE(/obj/machinery/vending/meat)
 			<br>Big Yank's Cheap Tug"}
 
 /obj/item/paper/tug/warehouse
-	name = "Big Yank's Space Tugs, Limited."
+	name = "Big Yank’s Space Tugs, Limited."
 	desc = "Looks like a bill of sale. It is blank"
 	info = {"<b>Client:</b>
 			<br><b>Date:</b>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Issue 16386 reports that they could not pull John Bill's items as it would grab them as seen in their video. This is a common issue with the apostrophe causing issues and thus needing to change it to Unicode 2019.

Fixes #16386 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Items should be selectable even with them on the tile or within 1 tile range of themselves. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Was able to pull his cigarette away from him and also his paper hat when debugging changes. 

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
