### PR TITLE
Magic May Not Steal The Tongue Of Man

### DIFF
--- a/code/modules/rituals/chaplainRitualObjects.dm
+++ b/code/modules/rituals/chaplainRitualObjects.dm
@@ -665,12 +665,12 @@
 
 	Del()
 		if(ritualComponent)
-			del(ritualComponent)
+			qdel(ritualComponent)
 		return ..()
 
 	disposing()
 		if(ritualComponent)
-			del(ritualComponent)
+			qdel(ritualComponent)
 		return ..()
 
 
@@ -692,7 +692,7 @@
 				// invisibility = INVIS_ALWAYS
 				alpha = 0
 				mouse_opacity = 0
-				del(src)
+				qdel(src)
 			else
 				// invisibility = INVIS_NONE
 				alpha = 255

--- a/code/modules/rituals/chaplainRitualObjects.dm
+++ b/code/modules/rituals/chaplainRitualObjects.dm
@@ -543,7 +543,7 @@
 				return
 			else
 				boutput(usr, SPAN_ALERT("<b>You replace the [S] ..."))
-				del(S)
+				qdel(S)
 		if(target && BOUNDS_DIST(target, src) == 0)
 			var/obj/decal/cleanable/ritualSigil/R = new/obj/decal/cleanable/ritualSigil(target, C.type)
 			R.color = src.color


### PR DESCRIPTION
## About the PR:
Fixes a bug wherein replacing a ritual sigil would wipe out spoken language. It was caused by ritual sigils hard deleting and thus leaving their listen trees parentless, which causes say channels to runtime.

Fixes #24785, fixes #24786, fixes #24787, fixes #24789, fixes #24795, and fixes #24796.


## Testing:
Replacing sigils works as expected after the fix.