### PR TITLE
Fix wool-stacking causing chat spam

### DIFF
--- a/code/obj/ranch/knitting.dm
+++ b/code/obj/ranch/knitting.dm
@@ -125,12 +125,12 @@
 			if(W.ball != src.ball)
 				boutput(usr, SPAN_ALERT("You can't combine spun and unspun wool!"))
 				. = 0
-		if(src.color != O.color)
-			boutput(usr, SPAN_ALERT("You can't combine different colors of wool!"))
-			. = 0
-		if (!O.material?.isSameMaterial(src.material))
-			boutput(usr, SPAN_ALERT("You can't combine two different kinds of wool!"))
-			. = 0
+			if(src.color != O.color)
+				boutput(usr, SPAN_ALERT("You can't combine different colors of wool!"))
+				. = 0
+			if (!O.material?.isSameMaterial(src.material))
+				boutput(usr, SPAN_ALERT("You can't combine two different kinds of wool!"))
+				. = 0
 
 	split_stack(var/toRemove)
 		. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes chat spam when click-dragging to stack wool in your hands.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #24800 
Fixes #16363 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Made sure it still gives the proper error message when trying to stack wool with different material.

<img width="423" height="62" alt="image" src="https://github.com/user-attachments/assets/bf1461ef-d1e6-46b0-9156-b1a3172d18a3" />

<img width="398" height="83" alt="image" src="https://github.com/user-attachments/assets/7de3bd54-89cb-4cc1-b03b-81c3f6b6fd58" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

