### PR TITLE
Genetics Booth Emag act

### DIFF
--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -62,6 +62,7 @@ TYPEINFO(/obj/machinery/genetics_booth)
 	var/image/abilityoverlay = null
 	var/image/workingoverlay = null
 	var/eject_dir = 0
+	var/eject_strength = THROW_NORMAL
 	var/entry_time = 0
 
 	var/datum/geneboothproduct/selected_product = null
@@ -147,6 +148,11 @@ TYPEINFO(/obj/machinery/genetics_booth)
 			src.show_admin_panel(user)
 		else
 			user.show_text("[src] has no products available for purchase right now.", "blue")
+
+	emag_act(mob/user, obj/item/card/emag/E)
+		if(src.eject_strength != THROW_THROUGH_WALL)
+			boutput(user, SPAN_NOTICE("You run [E] over [src]'s eject circuitry."))
+			src.eject_strength = THROW_THROUGH_WALL
 
 	proc/reload_contexts()//IM ASORRY
 		for(var/datum/contextAction/C as anything in src.contexts)
@@ -266,7 +272,7 @@ TYPEINFO(/obj/machinery/genetics_booth)
 			//occupant.set_loc(src.loc)
 
 			if (eject_dir && do_throwing)
-				occupant.throw_at(get_edge_target_turf(src, eject_dir), 2, 1)
+				occupant.throw_at(get_edge_target_turf(src, eject_dir), 2, 1, throw_type = src.eject_strength)
 			occupant = null
 
 			UpdateIcon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an emag_act to the genebooth that makes it throw customers with the THROUGH_THROUGH_WALL throw strength, causing them to destroy one wall when thrown and causing an explosion when they hit somethiing

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More emag acts messing with machines is good

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Got thrown normally before emagging, after emagging got thrown into a nearby computer, blowing it up and causing about 30 brute to myself
<img width="532" height="201" alt="image" src="https://github.com/user-attachments/assets/a28c1516-19f1-4aef-aaee-91b56105af3d" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Emagging a genetics booth will now make it throw people with extra power.
```
