### PR TITLE
Full Nukes declare round completion instead of rebooting the server

### DIFF
--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -6,6 +6,7 @@ ABSTRACT_TYPE(/datum/game_mode)
 	var/regular = TRUE
 	var/probability = 0 // Overridden by the server config. If you don't have access to that repo, keep it 0.
 	var/crew_shortage_enabled = 1
+	var/force_round_finished = FALSE //Force the ticker to immediately declare the round as finished
 
 	var/shuttle_available = 1 // 0: Won't dock. | 1: Normal. | 2: Won't dock if called too early.
 	var/shuttle_available_threshold = 12000 // 20 min. Only works when shuttle_available == SHUTTLE_AVAILABLE_DELAY.
@@ -70,6 +71,8 @@ ABSTRACT_TYPE(/datum/game_mode)
 			shuttle_initial_auto_call_done = 1
 
 /datum/game_mode/proc/check_finished()
+	if(src.force_round_finished)
+		return 1
 	if(emergency_shuttle.location == SHUTTLE_LOC_RETURNED)
 		return 1
 	return 0

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -71,8 +71,6 @@ ABSTRACT_TYPE(/datum/game_mode)
 			shuttle_initial_auto_call_done = 1
 
 /datum/game_mode/proc/check_finished()
-	if(src.force_round_finished)
-		return 1
 	if(emergency_shuttle.location == SHUTTLE_LOC_RETURNED)
 		return 1
 	return 0

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -527,7 +527,7 @@ var/global/game_force_started = FALSE
 			src.add_minds(1)
 			src.last_readd_lost_minds_to_ticker = world.time
 
-		if(mode.check_finished())
+		if(mode.check_finished() || mode.force_round_finished)
 			current_state = GAME_STATE_FINISHED
 
 			// This does a little more than just declare - it handles all end of round processing

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -483,13 +483,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 
 		creepify_station()
 
-		if(!istype(gamemode))
-			sleep(1 SECOND)
-			boutput(world, "<B>Everyone was killed by the nuclear blast! Resetting in 30 seconds!</B>")
-
-			sleep(30 SECONDS)
-			logTheThing(LOG_DIARY, null, "Rebooting due to nuclear destruction of station", "game")
-			Reboot_server()
+		if(!istype(gamemode)) //The station exploded, the cinematic has played, end the round naturally instead of forcing a reboot
+			ticker?.mode?.force_round_finished = TRUE
 
 	proc/change_status_display()
 		var/datum/signal/status_signal = get_free_signal()

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -484,7 +484,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 		creepify_station()
 
 		if(!istype(gamemode)) //The station exploded, the cinematic has played, end the round naturally instead of forcing a reboot
-			ticker?.mode?.force_round_finished = TRUE
+			ticker.mode.force_round_finished = TRUE
 
 	proc/change_status_display()
 		var/datum/signal/status_signal = get_free_signal()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds "force_round_finished" variable to gamemode parent, if this variable is true the ticker will complete the round the same as it would if the shuttle's location was returned to centcom.
Full size "nuke" strength nuclear bombs outside of the nuclear emergency mode now set this variable to true, ending the round properly instead of taking 30 seconds to reboot the server. Previously this only worked in the Nuclear Emergency mode due to its own check_completion checking for a null the_bomb variable.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Admin gimmick nukes and any other future potential roundending nuke spawns not in the Nuclear Emergency mode should end the round the normal way, rather than forcing a server reboot and not performing other roundend things such as showing crew credits and enabling OOC.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/463542db-701f-4101-8120-6056a8476e6e


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
