### PR TITLE
Inserting the fancy video card causes the law rack to toast any bread inserted into it

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -139,14 +139,6 @@
 				else
 					logTheThing(LOG_ADMIN, null, "Law Rack Corruption added supplied AI law to law number [law_number]: [picked_law]")
 					message_admins("Law Rack Corruption added supplied law [law_number]: [picked_law]")
-				// last, but not least, toast all laws
-
-/* Law Rack Toasting */
-	proc/toast_all_racks(var/update_laws = TRUE)
-		for(var/obj/machinery/lawrack/R in src.registered_racks)
-			R.toast_laws()
-			if (update_laws)
-				R.UpdateLaws()
 
 
 /* General ai_law functions */

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -139,6 +139,14 @@
 				else
 					logTheThing(LOG_ADMIN, null, "Law Rack Corruption added supplied AI law to law number [law_number]: [picked_law]")
 					message_admins("Law Rack Corruption added supplied law [law_number]: [picked_law]")
+				// last, but not least, toast all laws
+
+/* Law Rack Toasting */
+	proc/toast_all_racks(var/update_laws = TRUE)
+		for(var/obj/machinery/lawrack/R in src.registered_racks)
+			R.toast_laws()
+			if (update_laws)
+				R.UpdateLaws()
 
 
 /* General ai_law functions */

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -703,6 +703,8 @@
 				playsound(src, 'sound/effects/electric_shock_short.ogg', 50)
 				src.UpdateParticles(new/particles/rack_spark,"mine_spark")
 				src.visible_message(SPAN_ALERT("<b>The [src] starts sparking!</b>"))
+			sleep(1 SECONDS)
+			src.toast_laws(TRUE)
 			sleep(2 SECONDS)
 			if (!src) return
 			src.use_power(500)
@@ -792,6 +794,25 @@
 	proc/DeleteAllLaws()
 		for (var/i in 1 to MAX_CIRCUITS)
 			src.DeleteLaw(i)
+
+	///toasts each bread-law in the law rack and eject them out
+	proc/toast_laws(var/update_laws = TRUE)
+		var/amount_of_toast = 0
+		for (var/i in 1 to MAX_CIRCUITS)
+			if(istype(src.law_circuits[i], /obj/item/aiModule/bread))
+				src.DeleteLaw(i)
+				amount_of_toast++
+		if (amount_of_toast > 1)
+			logTheThing(LOG_ADMIN, null, "Law Rack Corruption toasted a total of [amount_of_toast] bread. Scrumptious!")
+			src.visible_message(SPAN_ALERT("[src] expels some fresh toast!"))
+			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
+			for(var/i in 1 to amount_of_toast)
+				var/obj/item/reagent_containers/food/snacks/breadslice/toastslice/new_slice = new /obj/item/reagent_containers/food/snacks/breadslice/toastslice(get_turf(src))
+				var/turf/target_turf = get_ranged_target_turf(get_turf(src), pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST), 7 * 32)
+				new_slice.throw_at(target_turf, 7, rand(2,4))
+			if(update_laws)
+				src.UpdateLaws()
+
 
 	/**
 	 * This will cause a module to glitch, either totally replace it law or adding picked_law to its text (depening on replace).

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -703,8 +703,6 @@
 				playsound(src, 'sound/effects/electric_shock_short.ogg', 50)
 				src.UpdateParticles(new/particles/rack_spark,"mine_spark")
 				src.visible_message(SPAN_ALERT("<b>The [src] starts sparking!</b>"))
-			sleep(1 SECONDS)
-			src.toast_laws(TRUE)
 			sleep(2 SECONDS)
 			if (!src) return
 			src.use_power(500)
@@ -737,6 +735,8 @@
 			if (I)
 				fireflash(I,0, checkLos = FALSE, chemfire = CHEM_FIRE_RED)
 				I.combust()
+			sleep(1 SECONDS)
+			src.toast_laws(TRUE)
 
 	/**
 	 * Sets an arbitrary slot to the passed aiModule - will override any module in the slot.
@@ -802,16 +802,17 @@
 			if(istype(src.law_circuits[i], /obj/item/aiModule/bread))
 				src.DeleteLaw(i)
 				amount_of_toast++
-		if (amount_of_toast > 1)
-			logTheThing(LOG_ADMIN, null, "Law Rack Corruption toasted a total of [amount_of_toast] bread. Scrumptious!")
-			src.visible_message(SPAN_ALERT("[src] expels some fresh toast!"))
-			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
-			for(var/i in 1 to amount_of_toast)
-				var/obj/item/reagent_containers/food/snacks/breadslice/toastslice/new_slice = new /obj/item/reagent_containers/food/snacks/breadslice/toastslice(get_turf(src))
-				var/turf/target_turf = get_ranged_target_turf(get_turf(src), pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST), 7 * 32)
-				new_slice.throw_at(target_turf, 7, rand(2,4))
-			if(update_laws)
-				src.UpdateLaws()
+		if (amount_of_toast < 1)
+			return
+		logTheThing(LOG_ADMIN, null, "[log_object(src)] toasted a total of [amount_of_toast] bread. Scrumptious!")
+		src.visible_message(SPAN_ALERT("[src] expels some fresh toast!"))
+		playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
+		for(var/i in 1 to amount_of_toast)
+			var/obj/item/reagent_containers/food/snacks/breadslice/toastslice/new_slice = new /obj/item/reagent_containers/food/snacks/breadslice/toastslice(get_turf(src))
+			var/turf/target_turf = get_ranged_target_turf(get_turf(src), pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST), 7 * 32)
+			new_slice.throw_at(target_turf, 7, rand(2,4))
+		if(update_laws)
+			src.UpdateLaws()
 
 
 	/**


### PR DESCRIPTION
[feature][game objects]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This introduces `proc/toast_law` into the lawrack.

These procs causes the affected lawracks to convert all bread inserted into them into toast and shot it out in a range of 7.

This will now get called when the fancy video card is inserted into the lawrack.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's funny to turn the law rack into a toaster.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/90616d9d-8268-467d-bf3b-7e12993ecfaf

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Clowns found a method to turn the AI lawrack into a toaster!
```
