### PR TITLE
Emergency shuttle announcements are now more conspicuous

### DIFF
--- a/code/modules/transport/shuttle/shuttle_controller.dm
+++ b/code/modules/transport/shuttle/shuttle_controller.dm
@@ -203,9 +203,11 @@ var/global/datum/shuttle_controller/emergency_shuttle/emergency_shuttle
 								C.mob.playsound_local_not_inworld('sound/misc/clock_tick.ogg', 50, FALSE)
 								tgui_alert(C.mob, {"The round is ending in five minutes. You can restart the tutorial next round and use the top-left arrow buttons to skip ahead."}, "Five Minute Warning!")
 
-						boutput(world, "<B>The Emergency Shuttle has docked with the station! You have [src.timeleft()/60] minutes to board the Emergency Shuttle.</B>")
+						command_announcement("The Emergency Shuttle has docked with the station! You have [src.timeleft()/60] minutes to board the Emergency Shuttle.", \
+							"Emergency Shuttle Arrival", \
+							'sound/misc/shuttle_arrive1.ogg', \
+							alert_origin=ALERT_COMMAND);
 						ircbot.event("shuttledock")
-						playsound_global(world, 'sound/misc/shuttle_arrive1.ogg', 100)
 
 						processScheduler.enableProcess("Fluid_Turfs")
 
@@ -217,7 +219,9 @@ var/global/datum/shuttle_controller/emergency_shuttle/emergency_shuttle
 						var/display_time = round(src.timeleft()/60)
 						//if (display_time <= 0) // The Emergency Shuttle will be entering the wormhole to CentCom in 0 minutes!
 							//display_time = 1 // fuckofffffffffff
-						boutput(world, "<B>The Emergency Shuttle will be entering the Channel in [display_time] minute[s_es(display_time)]! Please prepare for Channel traversal.</B>")
+						command_announcement("The Emergency Shuttle will be entering the Channel in [display_time] minute[s_es(display_time)]! Please prepare for Channel traversal.", \
+							"Emergency Shuttle Departing", \
+							alert_origin=ALERT_COMMAND);
 						src.announcement_done = SHUTTLE_ANNOUNCEMENT_WILL_DEPART_IN
 
 					else if (src.announcement_done < SHUTTLE_ANNOUNCEMENT_SHIP_CHARGE && timeleft < 30)
@@ -306,8 +310,10 @@ var/global/datum/shuttle_controller/emergency_shuttle/emergency_shuttle
 
 						DEBUG_MESSAGE("Done moving shuttle!")
 						settimeleft(SHUTTLETRANSITTIME)
-						boutput(world, "<B>The Emergency Shuttle has left for CentCom! It will arrive in [src.timeleft() / 60] minute[s_es(src.timeleft() / 60)]!</B>")
-						playsound_global(world, 'sound/misc/shuttle_enroute.ogg', 100)
+						command_announcement("The Emergency Shuttle has left for CentCom! It will arrive in [src.timeleft() / 60] minute[s_es(src.timeleft() / 60)]!", \
+							"Emergency Shuttle Departed", \
+							'sound/misc/shuttle_enroute.ogg', \
+							alert_origin=ALERT_COMMAND);
 						//online = 0
 
 						return TRUE
@@ -337,8 +343,10 @@ var/global/datum/shuttle_controller/emergency_shuttle/emergency_shuttle
 						for (var/turf/G in end_location)
 							if (istype(G, src.transit_turf))
 								G.ReplaceWith(filler_turf, keep_old_material = 0, force = 1)
-						boutput(world, "<BR><B>The Emergency Shuttle has arrived at CentCom!")
-						playsound_global(world, 'sound/misc/shuttle_centcom.ogg', 100)
+						command_announcement("The Emergency Shuttle has arrived at CentCom!", \
+							"Emergency Shuttle at CentCom", \
+							'sound/misc/shuttle_centcom.ogg', \
+							alert_origin=ALERT_COMMAND);
 						logTheThing(LOG_STATION, null, "The emergency shuttle has arrived at Centcom.")
 						src.online = FALSE
 
@@ -360,7 +368,9 @@ var/global/datum/shuttle_controller/emergency_shuttle/emergency_shuttle
 						for (var/turf/O in end_location)
 							if (istype(O, transit_turf))
 								O.ReplaceWith(centcom_turf, keep_old_material = 0, force = 1)
-						boutput(world, "<BR><B>The Emergency Shuttle has arrived at CentCom!")
+						command_announcement("The Emergency Shuttle has arrived at CentCom!", \
+							"Emergency Shuttle at CentCom", \
+							alert_origin=ALERT_COMMAND);
 						logTheThing(LOG_STATION, null, "The emergency shuttle has arrived at Centcom.")
 						src.online = FALSE
 						return TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[STATION SYSTEMS][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes some `boutput`s to `command_announcement`s in emergency shuttle code.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Feedback relating to the shuttle's arrival, departure, and landing at CentCom could do with being more obvious for the benefit of players.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Compiles without issue on Atlas + `STOP_DISTRACTING_ME`.

<img width="547" height="626" alt="image" src="https://github.com/user-attachments/assets/b0ca87c9-622f-481d-ab7b-e836ff081095" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
