### PR TITLE
Added Click-drag filling for egg cartons

### DIFF
--- a/code/WorkInProgress/UrsStuff.dm
+++ b/code/WorkInProgress/UrsStuff.dm
@@ -229,12 +229,32 @@
 				tooltip_rebuild = TRUE
 				boutput(user, "You place [W] into [src].")
 				src.update()
+				SEND_SIGNAL(W, COMSIG_ITEM_STORED, user)
 			else return ..()
 
 	mouse_drop(mob/user as mob) // no I ain't even touchin this mess it can keep doin whatever it's doin
 		if(user == usr && !user.restrained() && !user.stat && (user.contents.Find(src) || in_interact_range(src, user)))
 			if(!user.put_in_hand(src))
 				return ..()
+
+	MouseDrop_T(var/atom/movable/target, var/mob/user)
+		if (src.icon_state == "eggbox-closed" || !istype(target, /obj/item/reagent_containers/food/snacks/ingredient/egg) || !in_interact_range(src, user)  || BOUNDS_DIST(target, user) > 0 || !can_act(user))
+			return
+		if (src.count < src.max_count)
+			user.visible_message(SPAN_NOTICE("[user] begins quickly filling \the [src]."))
+			var/turf/staystill = get_turf(user)
+			for(var/obj/item/checked_item in view(1,user))
+				if (!istype(checked_item, target.type) || (checked_item in user) || QDELETED(checked_item)) continue
+				if (get_turf(user) != staystill) break
+				checked_item.add_fingerprint(user)
+				checked_item.set_loc(src)
+				src.insert_egg(checked_item)
+				SEND_SIGNAL(checked_item, COMSIG_ITEM_STORED, user)
+				sleep(0.2 SECONDS)
+				if (src.count >= src.max_count)
+					boutput(user, SPAN_NOTICE("\The [src] is now full!"))
+					break
+			boutput(user, SPAN_NOTICE("You finish filling \the [src]."))
 
 	proc/insert_egg(var/obj/item/egg = null)
 		if (src.count < src.max_count)


### PR DESCRIPTION
[feature][game objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds Satchel-esque drag-click filling for egg cartons.

Also, this PR adds a missing COMSIG_ITEM_STORED-signal to adding eggs to the carton.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

With satchels being incompatible with eggs, egg cartons are the only option to deal with the hefty amount of eggs chickens can pump out. Clicking every single egg when you can end up with 100+ of them in a ranch round is a bit tedious, so this method is a nice QoL-Feature to handle eggs.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

https://github.com/user-attachments/assets/e5763976-4a7f-4f82-824a-9a9878df0e6f

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)You can click-drag eggs onto egg cartons to quickly fill the carton with eggs in the area, akin to how satchels work. 
```
