### PR TITLE
Make eggs in egg cartons visible in inventories

### DIFF
--- a/code/WorkInProgress/UrsStuff.dm
+++ b/code/WorkInProgress/UrsStuff.dm
@@ -332,6 +332,7 @@
 	name = null
 	icon = 'icons/obj/foodNdrink/food_related.dmi'
 	icon_state = null
+	vis_flags = VIS_INHERIT_ID | VIS_INHERIT_PLANE |  VIS_INHERIT_LAYER
 	var/obj/item/kitchen/egg_box/my_egg_box = null
 	var/my_index = null
 


### PR DESCRIPTION
[game objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the vis_flags `VIS_INHERIT_ID | VIS_INHERIT_PLANE |  VIS_INHERIT_LAYER` to `/obj/carton_egg_proxy`. this makes eggs put in the egg carton visible even when the egg carton is in the inventory of someone else.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's nice to see the eggs even while you are carrying around the egg carton.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

https://github.com/user-attachments/assets/3c0af5f9-6196-4221-a56a-1ed8b8bdb918
## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Eggs in egg cartons are also visible while in inventories.
```
