### PR TITLE
combines seal_hair and over_hair into a c_flag

### DIFF
--- a/_std/defines/clothing.dm
+++ b/_std/defines/clothing.dm
@@ -69,6 +69,8 @@ var/list/all_slots = list(SLOT_BACK, SLOT_WEAR_MASK, SLOT_L_HAND, SLOT_R_HAND, S
 #define ONBELT						(1<<18)
 /// block miasma inhalations (sterile mask)
 #define BLOCKMIASMA					(1<<19)
+// covers the person's hair
+#define COVERSHAIR					(1<<20)
 
 //Suit blood flags
 #define SUITBLOOD_ARMOR 1

--- a/code/datums/components/toggle_hood.dm
+++ b/code/datums/components/toggle_hood.dm
@@ -28,7 +28,7 @@
 		var/mob/M = suit.loc
 		if (!ishuman(M))
 			suit.body_parts_covered ^= HEAD
-			suit.over_hair = !suit.over_hair
+			suit.c_flags ^= COVERSHAIR
 		M.set_clothing_icon_dirty()
 
 	suit.UpdateIcon()

--- a/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
+++ b/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
@@ -1328,7 +1328,7 @@ ABSTRACT_TYPE(/obj/deployable_turret/pod_wars)
 	desc = "For the inner space commander in you."
 	icon_state = "ntberet_commander"
 	item_state = "ntberet_commander"
-	seal_hair = 0
+	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE
 	see_face = TRUE
 
 	setupProperties()
@@ -1360,7 +1360,7 @@ ABSTRACT_TYPE(/obj/deployable_turret/pod_wars)
 	name = "syndicate commander's cap"
 	icon_state = "syndie_commander"
 	desc = "For the inner space commander in you."
-	seal_hair = 0
+	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE
 	see_face = TRUE
 
 	setupProperties()

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -561,7 +561,7 @@
 	ClearSpecificOverlays(TRUE, "hair_one", "hair_two", "hair_three", "hair_special_one", "hair_special_two", "hair_special_three")
 
 	var/obj/item/clothing/suit/back_clothing = src.back // typed version of back to check hair sealage; might not be clothing, we check type below
-	var/seal_hair = ((src.wear_suit && src.c_flags & COVERSHAIR) || (src.head && src.head.c_flags & COVERSHAIR) \
+	var/seal_hair = ((src.wear_suit && src.wear_suit.c_flags & COVERSHAIR) || (src.head && src.head.c_flags & COVERSHAIR) \
 						|| (istype(back_clothing) && back_clothing.c_flags & COVERSHAIR))
 	var/hooded = (src.wear_suit && src.wear_suit.hooded)
 	var/obj/item/organ/head/my_head

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -561,8 +561,8 @@
 	ClearSpecificOverlays(TRUE, "hair_one", "hair_two", "hair_three", "hair_special_one", "hair_special_two", "hair_special_three")
 
 	var/obj/item/clothing/suit/back_clothing = src.back // typed version of back to check hair sealage; might not be clothing, we check type below
-	var/seal_hair = ((src.wear_suit && src.wear_suit.over_hair) || (src.head && src.head.c_flags & COVERSHAIR) \
-						|| (src.wear_suit && src.wear_suit.body_parts_covered & HEAD) || (istype(back_clothing) && back_clothing.over_hair))
+	var/seal_hair = ((src.wear_suit && src.c_flags & COVERSHAIR) || (src.head && src.head.c_flags & COVERSHAIR) \
+						|| (istype(back_clothing) && back_clothing.c_flags & COVERSHAIR))
 	var/hooded = (src.wear_suit && src.wear_suit.hooded)
 	var/obj/item/organ/head/my_head
 	if (src?.organHolder?.head)
@@ -740,7 +740,7 @@
 	UpdateOverlays(i_l_hand, "i_l_hand")
 
 /mob/living/carbon/human/proc/update_hair_layer()
-	if ((src.wear_suit && src.wear_suit.over_hair) || (src.head && src.head.c_flags & COVERSHAIR) || (src.wear_suit && src.wear_suit.body_parts_covered & HEAD))
+	if ((src.wear_suit && src.wear_suit.c_flags & COVERSHAIR) || (src.head && src.head.c_flags & COVERSHAIR))
 		src.image_cust_one?.layer = MOB_HAIR_LAYER1
 		src.image_cust_two?.layer = MOB_HAIR_LAYER1
 		src.image_cust_three?.layer = MOB_HAIR_LAYER1

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -561,7 +561,7 @@
 	ClearSpecificOverlays(TRUE, "hair_one", "hair_two", "hair_three", "hair_special_one", "hair_special_two", "hair_special_three")
 
 	var/obj/item/clothing/suit/back_clothing = src.back // typed version of back to check hair sealage; might not be clothing, we check type below
-	var/seal_hair = ((src.wear_suit && src.wear_suit.over_hair) || (src.head && src.head.seal_hair) \
+	var/seal_hair = ((src.wear_suit && src.wear_suit.over_hair) || (src.head && src.head.c_flags & COVERSHAIR) \
 						|| (src.wear_suit && src.wear_suit.body_parts_covered & HEAD) || (istype(back_clothing) && back_clothing.over_hair))
 	var/hooded = (src.wear_suit && src.wear_suit.hooded)
 	var/obj/item/organ/head/my_head
@@ -740,7 +740,7 @@
 	UpdateOverlays(i_l_hand, "i_l_hand")
 
 /mob/living/carbon/human/proc/update_hair_layer()
-	if ((src.wear_suit && src.wear_suit.over_hair) || (src.head && src.head.seal_hair) || (src.wear_suit && src.wear_suit.body_parts_covered & HEAD))
+	if ((src.wear_suit && src.wear_suit.over_hair) || (src.head && src.head.c_flags & COVERSHAIR) || (src.wear_suit && src.wear_suit.body_parts_covered & HEAD))
 		src.image_cust_one?.layer = MOB_HAIR_LAYER1
 		src.image_cust_two?.layer = MOB_HAIR_LAYER1
 		src.image_cust_three?.layer = MOB_HAIR_LAYER1

--- a/code/modules/barber/barber_shop.dm
+++ b/code/modules/barber/barber_shop.dm
@@ -120,7 +120,7 @@
 	desc = "You can't tell the difference, Honest!"
 	icon_state = "baldcap"
 	item_state = "baldcap"
-	seal_hair = 1
+	c_flags = COVERSHAIR
 
 /obj/item/scissors
 	name = "scissors"

--- a/code/obj/item/clothing/cardboard.dm
+++ b/code/obj/item/clothing/cardboard.dm
@@ -7,9 +7,8 @@
 	item_state = "c_box"
 	density = 1
 	see_face = FALSE
-	over_hair = 1
 	wear_layer = MOB_LAYER_OVER_FUCKING_EVERYTHING_LAYER
-	c_flags = COVERSEYES | COVERSMOUTH
+	c_flags = COVERSEYES | COVERSMOUTH | COVERSHAIR
 	body_parts_covered = HEAD|TORSO|LEGS|ARMS
 	hides_from_examine = C_UNIFORM|C_GLOVES|C_SHOES|C_EARS|C_GLASSES|C_MASK
 	var/eyeholes = FALSE

--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -318,7 +318,6 @@
 	var/current_choice = new/datum/chameleon_hat_pattern
 	blocked_from_petasusaphilic = TRUE
 	item_function_flags = IMMUNE_TO_ACID
-	seal_hair = FALSE
 
 	New()
 		..()
@@ -348,7 +347,7 @@
 			P.sprite_item = U.icon
 			P.sprite_worn = U.wear_image_icon
 			P.sprite_hand = U.inhand_image_icon
-			P.seal_hair = U.seal_hair
+			P.seal_hair = U.c_flags & COVERSHAIR
 			src.clothing_choices += P
 
 			boutput(user, SPAN_NOTICE("[U.name]'s appearance has been copied!"))
@@ -364,7 +363,7 @@
 			src.hides_from_examine = null
 			wear_image = image(wear_image_icon)
 			inhand_image = image(inhand_image_icon)
-			src.seal_hair = FALSE
+			src.c_flags &= ~COVERSHAIR
 			M.set_clothing_icon_dirty()
 
 	verb/change()
@@ -393,9 +392,12 @@
 			src.inhand_image_icon = T.sprite_hand
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
-			src.seal_hair = T.seal_hair
 			src.tooltip_rebuild = TRUE
 			usr.set_clothing_icon_dirty()
+			if (T.seal_hair)
+				c_flags |= COVERSHAIR
+			else
+				c_flags &= ~COVERSHAIR
 
 /datum/chameleon_hat_pattern
 	var/name = "hat"

--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -392,12 +392,12 @@
 			src.inhand_image_icon = T.sprite_hand
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
-			src.tooltip_rebuild = TRUE
-			usr.set_clothing_icon_dirty()
 			if (T.seal_hair)
 				c_flags |= COVERSHAIR
 			else
 				c_flags &= ~COVERSHAIR
+			src.tooltip_rebuild = TRUE
+			usr.set_clothing_icon_dirty()
 
 /datum/chameleon_hat_pattern
 	var/name = "hat"
@@ -578,7 +578,6 @@
 	item_state = "hoodie"
 	icon = 'icons/obj/clothing/overcoats/hoods/hoodies.dmi'
 	wear_image_icon = 'icons/mob/clothing/overcoats/hoods/worn_hoodies.dmi'
-	over_hair = FALSE
 	var/list/clothing_choices = list()
 	var/current_choice = new/datum/chameleon_suit_pattern/hoodie
 
@@ -610,7 +609,7 @@
 			P.sprite_item = U.icon
 			P.sprite_worn = U.wear_image_icon
 			P.sprite_hand = U.inhand_image_icon
-			P.over_hair = U.over_hair
+			P.over_hair = U.c_flags & COVERSHAIR
 			src.clothing_choices += P
 
 			boutput(user, SPAN_NOTICE("[U.name]'s appearance has been copied!"))
@@ -653,11 +652,14 @@
 			src.icon_state = T.icon_state
 			src.item_state = T.item_state
 			src.icon = T.sprite_item
-			src.over_hair = T.over_hair
 			src.wear_image_icon = T.sprite_worn
 			src.inhand_image_icon = T.sprite_hand
 			src.wear_image = image(wear_image_icon)
 			src.inhand_image = image(inhand_image_icon)
+			if (T.over_hair)
+				c_flags |= COVERSHAIR
+			else
+				c_flags &= ~COVERSHAIR
 			src.tooltip_rebuild = TRUE
 			usr.set_clothing_icon_dirty()
 
@@ -906,7 +908,7 @@ ABSTRACT_TYPE(/datum/chameleon_suit_pattern)
 		sprite_item = 'icons/obj/clothing/overcoats/item_suit_gimmick.dmi'
 		sprite_worn = 'icons/mob/clothing/overcoats/worn_suit_gimmick.dmi'
 		sprite_hand = 'icons/mob/inhand/overcoat/hand_suit_gimmick.dmi'
-		over_hair = FALSE
+		over_hair = TRUE
 		hides_from_examine = C_UNIFORM|C_SHOES|C_GLOVES|C_GLASSES|C_EARS
 
 	chef_coat

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -795,7 +795,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	wear_image_icon = 'icons/mob/clothing/overcoats/worn_suit_gimmick.dmi'
 	icon_state = "adeptus"
 	item_state = "adeptus"
-	over_hair = TRUE
+	c_flags = COVERSHAIR
 	body_parts_covered = TORSO|LEGS|ARMS
 	hides_from_examine = C_UNIFORM|C_GLOVES|C_SHOES|C_EARS
 	wear_layer = MOB_FULL_SUIT_LAYER
@@ -974,9 +974,8 @@ TYPEINFO(/obj/item/clothing/under/gimmick/dawson)
 	inhand_image_icon = 'icons/mob/inhand/overcoat/hand_suit_gimmick.dmi'
 	icon_state = "monkey"
 	item_state = "monkey"
-	over_hair = TRUE
 	body_parts_covered = TORSO|LEGS|ARMS
-	c_flags = COVERSMOUTH | COVERSEYES
+	c_flags = COVERSMOUTH | COVERSEYES | COVERSHAIR
 	wear_layer = MOB_LAYER_BASE
 	hides_from_examine = C_UNIFORM|C_GLOVES|C_SHOES|C_MASK|C_GLASSES|C_EARS
 
@@ -1012,10 +1011,9 @@ TYPEINFO(/obj/item/clothing/under/gimmick/dawson)
 	icon_state = "light_borg"
 	item_state = "light_borg"
 	body_parts_covered = TORSO|LEGS|ARMS
-	c_flags = COVERSMOUTH | COVERSEYES
+	c_flags = COVERSMOUTH | COVERSEYES | COVERSHAIR
 	wear_layer = MOB_FULL_SUIT_LAYER
 	hides_from_examine = C_UNIFORM|C_GLOVES|C_SHOES|C_MASK|C_GLASSES|C_EARS
-	over_hair = TRUE
 	see_face = FALSE
 
 /obj/item/clothing/under/gimmick/utena //YJHTGHTFH's utena suit
@@ -1515,9 +1513,8 @@ TYPEINFO(/obj/item/clothing/gloves/ring/gold)
 	icon_state = "joyful"
 	body_parts_covered = TORSO|LEGS|ARMS
 	wear_layer = MOB_FULL_SUIT_LAYER
-	c_flags = COVERSMOUTH | COVERSEYES
+	c_flags = COVERSMOUTH | COVERSEYES | COVERSHAIR
 	hides_from_examine = C_UNIFORM|C_GLOVES|C_SHOES|C_MASK|C_GLASSES|C_EARS
-	over_hair = TRUE
 
 /obj/item/clothing/head/rando
 	name = "red skull mask and cowl"
@@ -1676,7 +1673,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 	wear_layer = MOB_FULL_SUIT_LAYER // ?????
 	hides_from_examine = C_UNIFORM|C_EARS
 	icon_state = "hotdogsuit"
-	over_hair = TRUE
+	c_flags = COVERSHAIR
 
 /obj/item/clothing/suit/gimmick/pickle
 	name = "pickle suit"
@@ -1685,7 +1682,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 	wear_layer = MOB_FULL_SUIT_LAYER // ?????
 	hides_from_examine = C_UNIFORM|C_EARS
 	icon_state = "picklesuit"
-	over_hair = TRUE
+	c_flags = COVERSHAIR
 
 /obj/item/clothing/under/gimmick/vampire
 	name = "absurdly stylish suit and vest"

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -811,8 +811,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	desc = "Wow this really looks like a noise marine helmet. But it's not!"
 	icon_state = "nm_helm"
 	hides_from_examine = C_EARS|C_GLASSES|C_MASK
-	c_flags = COVERSEYES | COVERSMOUTH
-	seal_hair = 1
+	c_flags = COVERSEYES | COVERSMOUTH | COVERSHAIR
 	see_face = FALSE
 
 /obj/item/clothing/suit/power
@@ -1051,9 +1050,8 @@ TYPEINFO(/obj/item/clothing/under/gimmick/dawson)
 	desc = "A familiar, yet legally distinct helmet."
 	icon_state = "mobile_suit"
 	item_state = "mobile_suit"
-	c_flags = COVERSMOUTH | COVERSEYES
+	c_flags = COVERSMOUTH | COVERSEYES | COVERSHAIR
 	hides_from_examine = C_GLASSES|C_EARS|C_MASK
-	seal_hair = 1
 	see_face = FALSE
 
 /obj/item/clothing/suit/armor/sneaking_suit
@@ -1525,9 +1523,8 @@ TYPEINFO(/obj/item/clothing/gloves/ring/gold)
 	name = "red skull mask and cowl"
 	desc = "Looking at this fills you with joy! You're not sure why. That's kind of a weird thing to feel about something that looks like this."
 	icon_state = "joyful"
-	c_flags = COVERSMOUTH | COVERSEYES
+	c_flags = COVERSMOUTH | COVERSEYES | COVERSHAIR
 	hides_from_examine = C_MASK|C_GLASSES|C_EARS
-	seal_hair = 1
 
 /obj/item/clothing/under/rotten
 	name = "suit and vest"
@@ -1632,9 +1629,8 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 /obj/item/clothing/head/werewolf
 	name = "werewolf mask"
 	desc = "The mask of a wolfman getup."
-	c_flags = COVERSMOUTH | COVERSEYES | MASKINTERNALS
+	c_flags = COVERSMOUTH | COVERSEYES | MASKINTERNALS | COVERSHAIR
 	hides_from_examine = C_GLASSES|C_MASK|C_EARS
-	seal_hair = 1
 	icon_state = "wwmask"
 
 /obj/item/clothing/suit/gimmick/werewolf/odd
@@ -1662,17 +1658,15 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 /obj/item/clothing/head/abomination
 	name = "abomination mask"
 	desc =  "The abomination mask straight out of the studio of Jon Woodworker's horror thriller, <i>The Whaddyacallit</i>"
-	c_flags = COVERSMOUTH | COVERSEYES | MASKINTERNALS
+	c_flags = COVERSMOUTH | COVERSEYES | MASKINTERNALS | COVERSHAIR
 	hides_from_examine = C_EARS
-	seal_hair = 1
 	icon_state = "abommask"
 
 /obj/item/clothing/head/zombie
 	name = "zombie mask"
 	desc = "The mask of a zombie. Man, they really captured the discolouration of rotten flesh."
-	c_flags = COVERSMOUTH | COVERSEYES | MASKINTERNALS
+	c_flags = COVERSMOUTH | COVERSEYES | MASKINTERNALS | COVERSHAIR
 	hides_from_examine = C_EARS
-	seal_hair = 1
 	icon_state = "zombmask"
 
 /obj/item/clothing/suit/gimmick/hotdog
@@ -1782,14 +1776,14 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 	desc = "This hat looks patently ridiculous. Is this what passes for fashionable in the Commonwealth of Free Worlds?"
 	icon_state = "cwhat"
 	item_state = "cwhat"
-	seal_hair = 1
+	c_flags = COVERSHAIR
 
 /obj/item/clothing/head/fthat
 	name = "trader's headwear"
 	desc = "Why in the name of space would anyone trade with someone who wears a hat that looks this dumb? Yuck."
 	icon_state = "fthat"
 	item_state = "fthat"
-	seal_hair = 1
+	c_flags = COVERSHAIR
 
 /obj/item/clothing/gloves/handcomp
 	name = "Compudyne 0451 Handcomp"
@@ -1904,9 +1898,8 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 	desc = "Wow! It's just like the real thing!"
 	icon_state = "big_lizard"
 	item_state = "big_lizard"
-	c_flags = COVERSMOUTH | COVERSEYES
+	c_flags = COVERSMOUTH | COVERSEYES | COVERSHAIR
 	hides_from_examine = C_EARS|C_GLASSES|C_MASK
-	seal_hair = 1
 	see_face = FALSE
 
 

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -9,7 +9,6 @@
 	body_parts_covered = HEAD
 	compatible_species = list("human", "cow", "werewolf", "flubber", "martian", "blob")
 	wear_layer = MOB_HEAD_LAYER2
-	var/seal_hair = 0 // best variable name I could come up with, if 1 it forms a seal with a suit so no hair can stick out
 	block_vision = 0
 	var/team_num
 	var/blocked_from_petasusaphilic = FALSE //Replacing the global blacklist
@@ -90,11 +89,10 @@ proc/filter_trait_hats(var/type)
 	name = "bio hood"
 	icon_state = "bio"
 	item_state = "bio_hood"
-	c_flags = COVERSEYES | COVERSMOUTH | BLOCKCHOKE
+	c_flags = COVERSEYES | COVERSMOUTH | BLOCKCHOKE | COVERSHAIR
 	hides_from_examine = C_EARS
 
 	desc = "This hood protects you from harmful biological contaminants."
-	seal_hair = 1
 
 	setupProperties()
 		..()
@@ -133,10 +131,9 @@ proc/filter_trait_hats(var/type)
 	name = "emergency hood"
 	icon_state = "emerg"
 	item_state = "emerg"
-	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE
+	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE | COVERSHAIR
 	desc = "Helps protect from vacuum for a short period of time."
 	hides_from_examine = C_EARS|C_MASK|C_GLASSES
-	seal_hair = 1
 	acid_survival_time = 3 MINUTES
 
 	setupProperties()
@@ -154,10 +151,9 @@ proc/filter_trait_hats(var/type)
 /obj/item/clothing/head/rad_hood
 	name = "Class II radiation hood"
 	icon_state = "radiation"
-	c_flags = COVERSEYES | COVERSMOUTH | BLOCKCHOKE
+	c_flags = COVERSEYES | COVERSMOUTH | BLOCKCHOKE | COVERSHAIR
 	hides_from_examine = C_EARS
 	desc = "Asbestos, right near your face. Perfect!"
-	seal_hair = 1
 
 	setupProperties()
 		..()
@@ -737,7 +733,7 @@ TYPEINFO(/obj/item/clothing/head/that/gold)
 	desc = "A green hood, full of magic, wonder, cromulence, and maybe a spider or two."
 	icon_state = "wizardgreen"
 	item_state = "wizardgreen"
-	seal_hair = 1
+	c_flags = COVERSHAIR
 
 /obj/item/clothing/head/wizard/witch
 	name = "witch hat"
@@ -751,7 +747,7 @@ TYPEINFO(/obj/item/clothing/head/that/gold)
 	icon_state = "wizardnec"
 	item_state = "wizardnec"
 	see_face = FALSE
-	seal_hair = 1
+	c_flags = COVERSHAIR
 	hides_from_examine = C_EARS|C_MASK|C_GLASSES
 
 /obj/item/clothing/head/wizard/traveller
@@ -1445,16 +1441,15 @@ TYPEINFO(/obj/item/clothing/head/that/gold)
 	desc = "A nurse hat from the past."
 	icon_state = "traditionalnursehat"
 	item_state = "traditionalnursehat"
-	seal_hair = 1
+	c_flags = COVERSHAIR
 
 /obj/item/clothing/head/chemhood
 	name = "chemical protection hood"
 	desc = "A thick rubber hood which protects you from almost any harmful chemical substance."
 	icon_state = "chemhood"
 	item_state = "chemhood"
-	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE
+	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE | COVERSHAIR
 	hides_from_examine = C_EARS
-	seal_hair = 1
 	acid_survival_time = 8 MINUTES
 
 	setupProperties()
@@ -1468,7 +1463,7 @@ TYPEINFO(/obj/item/clothing/head/that/gold)
 	desc = "The hat of a not-so-funny-clown."
 	icon_state = "jester"
 	item_state = "jester"
-	seal_hair = 1
+	c_flags = COVERSHAIR
 
 /obj/item/clothing/head/party
 	name = "party hat"
@@ -2316,7 +2311,7 @@ ABSTRACT_TYPE(/obj/item/clothing/head/elephanthat)
 	desc = "For a more bull-headed approach."
 	icon_state = "minotaur"
 	item_state = "minotaur"
-	seal_hair = 1
+	c_flags = COVERSHAIR
 
 TYPEINFO(/obj/item/clothing/head/mushroomcap)
 	random_subtypes = list(
@@ -2515,21 +2510,21 @@ ABSTRACT_TYPE(/obj/item/clothing/head/mushroomcap)
 	desc = "A visor with teal spikes dragging behind the mask, vaguely reminiscent of an extinct alien race."
 	icon_state = "weirdohat"
 	item_state = "weirdohat"
-	seal_hair = 1
+	c_flags = COVERSHAIR
 
 /obj/item/clothing/head/lighthat
 	name = "light mitre"
 	desc = "A golden mitre pointing tall, proudly touting the strength of its faith and its light"
 	icon_state = "lighthat"
 	item_state = "lighthat"
-	seal_hair = 1
+	c_flags = COVERSHAIR
 
 /obj/item/clothing/head/bushhat
 	name = "druid mask"
 	desc = "Flowers, grass, and other flora completely cover the face of this mask. You can almost hear the roar of earthen creatures calling from inside the shrubbery"
 	icon_state = "bushhat"
 	item_state = "bushhat"
-	seal_hair = 1
+	c_flags = COVERSHAIR
 
 /obj/item/clothing/head/rabbithat
 	name = "Rabbit Costume Hat"
@@ -2539,7 +2534,7 @@ ABSTRACT_TYPE(/obj/item/clothing/head/mushroomcap)
 	inhand_image_icon = 'icons/mob/inhand/hand_headgear.dmi'
 	icon_state = "rabbithat"
 	item_state = "rabbithat"
-	seal_hair = TRUE
+	c_flags = COVERSHAIR
 
 // Mx Blorbo's lovable visage.
 
@@ -2551,7 +2546,7 @@ ABSTRACT_TYPE(/obj/item/clothing/head/mushroomcap)
 	inhand_image_icon = 'icons/mob/inhand/hand_headgear.dmi'
 	icon_state = "blorbohat"
 	item_state = "blorbohat"
-	seal_hair = TRUE
+	c_flags = COVERSHAIR
 
 /obj/item/clothing/head/chompskyhat
 	name = "Gnome hat"

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -19,12 +19,11 @@
 /obj/item/clothing/head/helmet/space
 	name = "space helmet"
 	icon_state = "space"
-	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE
+	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE | COVERSHAIR
 	see_face = FALSE
 	item_state = "s_helmet"
 	desc = "Helps protect against vacuum."
 	hides_from_examine = C_EARS|C_MASK|C_GLASSES
-	seal_hair = 1
 
 	setupProperties()
 		..()
@@ -46,7 +45,7 @@
 		icon_state = "space-fish"
 		desc = "You're about 90% sure this isn't just a regular fishbowl."
 		item_state = "s_helmet"
-		seal_hair = 0
+		c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE
 
 /obj/item/clothing/head/helmet/space/engineer
 	name = "engineering space helmet"
@@ -272,11 +271,9 @@
 	name = "light space helmet"
 	desc = "A lightweight space helmet."
 	icon_state = "spacelight-civ"
-	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE
 	see_face = FALSE
 	item_state = "s_helmet"
 	hides_from_examine = C_EARS|C_MASK // Light space suit helms have transparent fronts
-	seal_hair = 1
 	acid_survival_time = 5 MINUTES
 
 	setupProperties()
@@ -351,8 +348,7 @@
 			name = "commander's cap"
 			icon_state = "syndie_commander"
 			desc = "A terrifyingly tall, black & red cap, typically worn by a Syndicate Nuclear Operative Commander. Maybe they're trying to prove something to the Head of Security?"
-			seal_hair = 0
-			see_face = TRUE
+			c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE
 
 		infiltrator
 			icon_state = "syndie_specialist-infiltrator"
@@ -634,8 +630,7 @@ obj/item/clothing/head/helmet/hardhat/security/hos
 	name = "elite helmet"
 	icon_state = "helmet-sec-elite"
 	desc = "Better protection from getting your head bashed in."
-	c_flags = COVERSEYES | COVERSMOUTH | BLOCKCHOKE
-	seal_hair = 1
+	c_flags = COVERSEYES | COVERSMOUTH | BLOCKCHOKE | COVERSHAIR
 	item_state = "helmet-sec-elite"
 
 	setupProperties()
@@ -1115,7 +1110,7 @@ TYPEINFO(/obj/item/clothing/head/helmet/space/mining_combat)
 	item_state = "buckethat"
 	inhand_image_icon = 'icons/mob/inhand/hand_headgear.dmi'
 	block_vision = 1
-	seal_hair = 1
+	c_flags = COVERSEYES | BLOCKCHOKE | COVERSHAIR
 	var/bucket_type = /obj/item/reagent_containers/glass/bucket
 	hides_from_examine = C_EARS|C_MASK|C_GLASSES
 
@@ -1159,10 +1154,9 @@ TYPEINFO(/obj/item/clothing/head/helmet/space/mining_combat)
 /obj/item/clothing/head/helmet/firefighter
 	name = "firefighter helm"
 	desc = "For fighting fires."
-	c_flags = COVERSEYES | BLOCKCHOKE
+	c_flags = COVERSEYES | BLOCKCHOKE | COVERSHAIR
 	icon_state = "firefighter"
 	item_state = "firefighter"
-	seal_hair = 1
 
 	setupProperties()
 		..()

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -11,7 +11,6 @@ ABSTRACT_TYPE(/obj/item/clothing/suit)
 	wear_layer = MOB_ARMOR_LAYER
 	var/fire_resist = T0C+100
 	/// If TRUE the suit will hide whoever is wearing it's hair
-	var/over_hair = FALSE
 	w_class = W_CLASS_NORMAL
 	var/restrain_wearer = 0
 	var/bloodoverlayimage = 0
@@ -784,11 +783,10 @@ TYPEINFO(/obj/item/clothing/suit/hazard/paramedic/armored)
 	w_class = W_CLASS_TINY
 	throw_speed = 2
 	throw_range = 10
-	c_flags = COVERSEYES | COVERSMOUTH | ONBACK
+	c_flags = COVERSEYES | COVERSMOUTH | COVERSHAIR | ONBACK
 	hides_from_examine = C_UNIFORM|C_GLOVES|C_SHOES|C_GLASSES|C_EARS|C_MASK
 	body_parts_covered = TORSO|ARMS
 	see_face = FALSE
-	over_hair = TRUE
 	wear_layer = MOB_FULL_SUIT_LAYER
 	var/eyeholes = FALSE //Did we remember to cut eyes in the thing?
 	var/cape = FALSE
@@ -893,15 +891,13 @@ TYPEINFO(/obj/item/clothing/suit/hazard/paramedic/armored)
 			src.icon_state = "bedcape[src.bcolor ? "-[bcolor]" : null]"
 			src.item_state = src.icon_state
 			see_face = TRUE
-			over_hair = FALSE
-			src.c_flags = ONBACK
+			src.c_flags &= ~COVERSHAIR
 			wear_layer = MOB_BACK_LAYER + 0.2
 		else
 			src.icon_state = "bedsheet[src.bcolor ? "-[bcolor]" : null][src.eyeholes ? "1" : null]"
 			src.item_state = src.icon_state
 			see_face = FALSE
 			src.c_flags = initial(src.c_flags)
-			over_hair = TRUE
 			wear_layer = MOB_OVER_TOP_LAYER
 
 	proc/cut_eyeholes()
@@ -1768,9 +1764,8 @@ TYPEINFO(/obj/item/clothing/suit/space/industrial/salvager)
 	item_state = "cultist"
 	see_face = FALSE
 	magical = 1
-	over_hair = TRUE
 	wear_layer = MOB_FULL_SUIT_LAYER
-	c_flags = COVERSEYES | COVERSMOUTH
+	c_flags = COVERSEYES | COVERSMOUTH | COVERSHAIR
 	body_parts_covered = TORSO|LEGS|ARMS
 	hides_from_examine = C_UNIFORM
 
@@ -1809,10 +1804,9 @@ TYPEINFO(/obj/item/clothing/suit/space/industrial/salvager)
 	item_state = "flockcultistt"
 	see_face = FALSE
 	wear_layer = MOB_FULL_SUIT_LAYER
-	c_flags = COVERSEYES | COVERSMOUTH
+	c_flags = COVERSEYES | COVERSMOUTH | COVERSHAIR
 	body_parts_covered = TORSO|LEGS|ARMS
 	hides_from_examine = C_UNIFORM
-	over_hair = TRUE
 
 	setupProperties()
 		..()
@@ -2573,7 +2567,7 @@ ABSTRACT_TYPE(/obj/item/clothing/suit/sweater_vest)
 	wear_image_icon = 'icons/mob/clothing/overcoats/worn_suit_gimmick.dmi'
 	icon_state = "burnedrobe"
 	item_state = "burnedrobe"
-	over_hair = TRUE
+	c_flags = COVERSHAIR
 	wear_layer = MOB_FULL_SUIT_LAYER
 	body_parts_covered = TORSO|LEGS|ARMS
 	hides_from_examine = C_UNIFORM
@@ -2585,7 +2579,7 @@ ABSTRACT_TYPE(/obj/item/clothing/suit/sweater_vest)
 	wear_image_icon = 'icons/mob/clothing/overcoats/worn_suit_gimmick.dmi'
 	icon_state = "greenrobe"
 	item_state = "greenrobe"
-	over_hair = TRUE
+	c_flags = COVERSHAIR
 	wear_layer = MOB_FULL_SUIT_LAYER
 	body_parts_covered = TORSO|LEGS|ARMS
 	hides_from_examine = C_UNIFORM

--- a/code/obj/item/kendo.dm
+++ b/code/obj/item/kendo.dm
@@ -7,7 +7,7 @@
 	desc = "\improper 面 : A light padded helmet with a grilled faceplate to protect the user in a kendo match."
 	icon_state = "men"
 	item_state = "men"
-	seal_hair = 1
+	c_flags = COVERSEYES | COVERSHAIR
 
 	setupProperties()
 		..()

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -312,7 +312,7 @@
 		else if (src.head && src.head.wear_image_icon)
 			actual_head.overlays += image(src.head.wear_image_icon, src.head.icon_state, layer = MOB_HEAD_LAYER2)
 
-		if(!(src.head && src.head.seal_hair))
+		if(!(src.head && src.head.c_flags & COVERSHAIR))
 			if(src.donor_appearance?.mob_appearance_flags & HAS_HUMAN_HAIR || src.donor?.hair_override)
 				src.head_image_cust_one.pixel_x = 0
 				src.head_image_cust_one.pixel_y = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[clothing][code-quality]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
whether or not clothing covers hair used to be determined by 3 variables depending on the clothing type (2 of these were for suits and both were always the same). Now it is only 1 c_flag

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
better code
also fixes a bug that caused chameleon adeptus mechanicus suits to not hide hair unlike regular admech suits


## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested hats and suits with noticeable hair. Special attention was given to chameleon hat and suit, dinosaur pajamas (toggle able hood) and bedsheet (can be made into a cape) 
<img width="100" height="104" alt="image" src="https://github.com/user-attachments/assets/d3d9f1dd-b0dc-404c-bec4-dfe4ad80839a" />
<img width="81" height="87" alt="image" src="https://github.com/user-attachments/assets/459e97a0-db61-4b41-9178-2ff11a9612ba" />
<img width="70" height="78" alt="image" src="https://github.com/user-attachments/assets/4c89ec67-db9c-4bbc-8f34-fa0ef38ffb21" />
<img width="74" height="78" alt="image" src="https://github.com/user-attachments/assets/45a6ef37-530b-4d05-a15e-6435ae82600c" />


