### PR TITLE
Mechcomp components plated in materials have an action bar when secured/loosened

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -559,15 +559,7 @@ TYPEINFO(/obj/item/mechanics)
 				work_time = clamp(work_time, 1 SECONDS, 10 SECONDS)
 				//now we set the action bar in motion
 				user.visible_message(SPAN_NOTICE("[user] begins tampering with [src]."))
-				var/datum/action/bar/icon/callback/action_bar = new /datum/action/bar/icon/callback(
-					user,
-					src,
-					work_time,
-					/obj/item/mechanics/proc/wrench_action,
-					\list(user, W),
-					W.icon,
-					W.icon_state,)
-				actions.start(action_bar, user)
+				SETUP_GENERIC_ACTIONBAR(user, src, work_time, PROC_REF(wrench_action), list(user, W), W.icon, W.icon_state, null, INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION | INTERRUPT_MOVE)
 			else
 				src.wrench_action(user)
 			return TRUE

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -469,6 +469,71 @@ TYPEINFO(/obj/item/mechanics)
 	proc/rotate()
 		src.set_dir(turn(src.dir, -90))
 
+	proc/check_wrenching_conditions(var/mob/user)
+		//We need only to check conditions when the object is non-wrenched. Because else it can always be loosened
+		if(src.level == OVERFLOOR)
+			if(!isturf(src.loc) && !(IN_CABINET)) // allow items to be deployed inside housings, but not in other stuff like toolboxes
+				boutput(user, SPAN_ALERT("[src] needs to be on the ground  [src.cabinet_banned ? "" : "or in a component housing"] for that to work."))
+				return FALSE
+			if (IN_CABINET && istype(src, /obj/item/mechanics/movement))
+				var/obj/item/storage/mechanics/cabinet = src.stored?.linked_item
+				if (cabinet.amount_of_prevent_move_comps > 0)
+					boutput(user, SPAN_ALERT("[src] is not allowed since an anchored component is preventing cabinet movement."))
+					return FALSE
+			if(IN_CABINET && src.cabinet_banned)
+				boutput(user,SPAN_ALERT("[src] is not allowed in component housings."))
+				return FALSE
+			if(!IN_CABINET && src.cabinet_only)
+				boutput(user,SPAN_ALERT("[src] is not allowed outside of component housings."))
+				return FALSE
+		return TRUE
+
+
+	proc/wrench_action(var/mob/user, var/obj/item/used_wrench)
+		// we need to check if the component didn't moved during our action bar and all other conditions are still true
+		if (!in_interact_range(src, user) || !can_act(user) || !src.check_wrenching_conditions(user))
+			return
+		switch(level)
+			if(UNDERFLOOR) //Level 1 = wrenched into place
+				boutput(user, "You detach the [src] from the [istype(src.stored?.linked_item,/obj/item/storage/mechanics) ? "housing" : "underfloor"] and deactivate it.")
+				logTheThing(LOG_STATION, user, "detaches a <b>[src]</b> from the [istype(src.stored?.linked_item,/obj/item/storage/mechanics) ? "housing" : "underfloor"] and deactivates it at [log_loc(src)].")
+				level = OVERFLOOR
+				anchored = UNANCHORED
+				if (src.cabinet_prevent_move && IN_CABINET)
+					var/obj/item/storage/mechanics/cabinet = src.stored?.linked_item
+					cabinet.amount_of_prevent_move_comps--
+				clear_owner()
+				loosen()
+				if(src.material && src.material.getMaterialFlags() & MATERIAL_CRYSTAL)
+					user.visible_message(SPAN_NOTICE("[src] breaks under the strain of the operation."))
+					var/turf/target_turf = get_turf(src)
+					var/obj/item/raw_material/shard/new_shard = new /obj/item/raw_material/shard(target_turf)
+					new_shard.setMaterial(src.material)
+					playsound(target_turf, pick('sound/impact_sounds/Glass_Shatter_1.ogg','sound/impact_sounds/Glass_Shatter_2.ogg','sound/impact_sounds/Glass_Shatter_3.ogg'), 100, 1)
+					qdel(src)
+			if(OVERFLOOR) //Level 2 = loose
+				if (IN_CABINET && src.cabinet_prevent_move)
+					var/obj/item/storage/mechanics/cabinet = src.stored?.linked_item
+					cabinet.amount_of_prevent_move_comps++
+					if (cabinet.amount_of_prevent_move_comps == 1 && cabinet.unanchor_movement_comps() > 0)
+						boutput(user, SPAN_ALERT("The cabinet unanchored all movement components!"))
+				boutput(user, "You attach the [src] to the [istype(src.stored?.linked_item,/obj/item/storage/mechanics) ? "housing" : "underfloor"] and activate it.")
+				logTheThing(LOG_STATION, user, "attaches a <b>[src]</b> to the [istype(src.stored?.linked_item,/obj/item/storage/mechanics) ? "housing" : "underfloor"]  at [log_loc(src)].")
+				level = UNDERFLOOR
+				anchored = ANCHORED
+				set_owner(user)
+				secure()
+		var/turf/T = src.loc
+		if(isturf(T))
+			hide(T.intact)
+		else
+			hide()
+		if (!src.dont_disconnect_on_change)
+			SEND_SIGNAL(src,COMSIG_MECHCOMP_RM_ALL_CONNECTIONS)
+		if(src && !QDELETED(src))
+			src.material_trigger_when_attacked(used_wrench, user, 1)
+		return TRUE
+
 	attackby(obj/item/W, mob/user)
 		if (ispryingtool(W))
 			if (can_rotate)
@@ -478,60 +543,33 @@ TYPEINFO(/obj/item/mechanics)
 					boutput(user, "You must unsecure the [src] in order to rotate it.")
 			return TRUE
 		else if(iswrenchingtool(W))
-			switch(level)
-				if(UNDERFLOOR) //Level 1 = wrenched into place
-					boutput(user, "You detach the [src] from the [istype(src.stored?.linked_item,/obj/item/storage/mechanics) ? "housing" : "underfloor"] and deactivate it.")
-					logTheThing(LOG_STATION, user, "detaches a <b>[src]</b> from the [istype(src.stored?.linked_item,/obj/item/storage/mechanics) ? "housing" : "underfloor"] and deactivates it at [log_loc(src)].")
-					level = OVERFLOOR
-					anchored = UNANCHORED
-					if (src.cabinet_prevent_move && IN_CABINET)
-						var/obj/item/storage/mechanics/cabinet = src.stored?.linked_item
-						cabinet.amount_of_prevent_move_comps--
-					clear_owner()
-					loosen()
-				if(OVERFLOOR) //Level 2 = loose
-					if(!isturf(src.loc) && !(IN_CABINET)) // allow items to be deployed inside housings, but not in other stuff like toolboxes
-						boutput(user, SPAN_ALERT("[src] needs to be on the ground  [src.cabinet_banned ? "" : "or in a component housing"] for that to work."))
-						return FALSE
-					if (IN_CABINET && istype(src, /obj/item/mechanics/movement))
-						var/obj/item/storage/mechanics/cabinet = src.stored?.linked_item
-						if (cabinet.amount_of_prevent_move_comps > 0)
-							boutput(user, SPAN_ALERT("[src] is not allowed since an anchored component is preventing cabinet movement."))
-							return
-					if(IN_CABINET && src.cabinet_banned)
-						boutput(user,SPAN_ALERT("[src] is not allowed in component housings."))
-						return
-					if(!IN_CABINET && src.cabinet_only)
-						boutput(user,SPAN_ALERT("[src] is not allowed outside of component housings."))
-						return
-					if(src.one_per_tile)
-						for(var/obj/item/mechanics/Z in src.loc)
-							if (Z.type == src.type && Z.level == UNDERFLOOR)
-								boutput(user,SPAN_ALERT("No matter how hard you try, you are not able to think of a way to fit more than one [src] on a single tile."))
-								return
-					if(anchored)
-						boutput(user,SPAN_ALERT("[src] is already attached to something somehow."))
-						return
-					if (IN_CABINET && src.cabinet_prevent_move)
-						var/obj/item/storage/mechanics/cabinet = src.stored?.linked_item
-						cabinet.amount_of_prevent_move_comps++
-						if (cabinet.amount_of_prevent_move_comps == 1 && cabinet.unanchor_movement_comps() > 0)
-							boutput(user, SPAN_ALERT("The cabinet unanchored all movement components!"))
-					boutput(user, "You attach the [src] to the [istype(src.stored?.linked_item,/obj/item/storage/mechanics) ? "housing" : "underfloor"] and activate it.")
-					logTheThing(LOG_STATION, user, "attaches a <b>[src]</b> to the [istype(src.stored?.linked_item,/obj/item/storage/mechanics) ? "housing" : "underfloor"]  at [log_loc(src)].")
-					level = UNDERFLOOR
-					anchored = ANCHORED
-					set_owner(user)
-					secure()
-
-			var/turf/T = src.loc
-			if(isturf(T))
-				hide(T.intact)
+			if(src.material && src.material.getProperty("density") > 0)
+				if(!src.check_wrenching_conditions(user))
+					//we need to check the wrenching conditions manually here, else you get an action bar even though the action actually doesn't work
+					return TRUE
+				//work time calculation, 0.8 seconds per density, half when you have training, half for wrenching in, double for crystal material since loosening it breaks it.
+				var/work_time = src.material.getProperty("density") * 0.8 SECONDS
+				if(src.level == OVERFLOOR)
+					work_time *= 0.5
+				if(src.material.getMaterialFlags() & MATERIAL_CRYSTAL)
+					work_time *= 2
+				if(user.traitHolder && (user.traitHolder.hasTrait("carpenter") || user.traitHolder.hasTrait("training_engineer")))
+					work_time *= 0.5
+				// now, let's keep the result in reasonable values, even if you are untrained and should have no business working with this
+				work_time = clamp(work_time, 1 SECONDS, 10 SECONDS)
+				//now we set the action bar in motion
+				user.visible_message(SPAN_NOTICE("[user] begins tampering with [src]."))
+				var/datum/action/bar/icon/callback/action_bar = new /datum/action/bar/icon/callback(
+					user,
+					src,
+					work_time,
+					/obj/item/mechanics/proc/wrench_action,
+					\list(user, W),
+					W.icon,
+					W.icon_state,)
+				actions.start(action_bar, user)
 			else
-				hide()
-
-			if (!src.dont_disconnect_on_change)
-				SEND_SIGNAL(src,COMSIG_MECHCOMP_RM_ALL_CONNECTIONS)
+				src.wrench_action(user)
 			return TRUE
 		return ..()
 


### PR DESCRIPTION
[game objects][balance][Materials]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Mechcomp components plated in material now have an action bar when being tried to loosen/fasten with a wrench.

The duration of the action bar is equal to `Material density * 0.8 Seconds`. This is modifed by different means:
- The duration is halved when the component is fastened
- The duration is halved if the user has engineering/carpenter training
- The duration is doubled if the material is a crystal material, but the component will shatter on being loosened
- The duration will be clamped in an area between 1 and 10 seconds.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently, mechcomp is very frail. Components can be very easily accessed because every action on them is instant and can't be interrupted. For building and testing mechcomp, this is a very desireable trait.

However, when mechcomp interfaces with crew, this frailty often leads to it being very easily dismantled. This resulted into the concern by different people that antag usage is very limited. Once your pressure plate is tapped once with a wrench, your rube goldberg machine falls apart.

This PR enables engineers to make mechcomp much more resilient against tampering by other crewmembers. By plating single objects that interface with crew and hiding the rest, you are able to have more counterplay against people running at your mechcomp with wrenches.

Tying the action bar duration to engineer/carpenter training also allows engineers to be the best option at combating mechcomp by antags. Not only does their training half the duration of the operation, access to magboots also enables them to not be shoved away as easily.

If antags want additional safety against tampering, plating in crystal material allows much higher safety for the tradeoff of destroying your equipment once dismantled.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/b45d3fff-be02-40b3-aa98-db27e1d88e54

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(*)Plating mechcomp in materials makes them take much more time to loosen/fasten. Carefull of crystal material, since components plated in these shatter upon being loosened, but are much more durable to tampering.
```
