### PR TITLE
Pressure pads at default send the name of the item that triggered them

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -2975,7 +2975,7 @@ TYPEINFO(/obj/item/mechanics/miccomp)
 
 	Crossed(atom/movable/AM as mob|obj)
 		..()
-		if (level == OVERFLOOR || HAS_ATOM_PROPERTY(AM, PROP_ATOM_FLOATING))
+		if (level == OVERFLOOR || HAS_ATOM_PROPERTY(AM, PROP_ATOM_FLOATING) || istype(AM, /obj/item/dummy))
 			return
 		return_if_overlay_or_effect(AM)
 		if (limiter && (ticker.round_elapsed_ticks < limiter))


### PR DESCRIPTION
[Feature]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This Pr changes pressure pads. They will send out the name of the item that triggered them. It's old functionality can be used by toggling signal replacing, akin to relay and delay components.

Also, this PR fixes #24834

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This allows mechcomp that reacts to certain users or items. Have your chicken factory teleport out roosters but keep the hens available. Have a conveyor belt that filters out items. Have doors close when someone tries to walk through them, but do that only for that particular staffie you dislike.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Right now, it will spam "dummy" when you click with the multitool on mechcomp near pressure sensors, but thats a seperate bug with pressure sensors i wanna fix in a different PR

https://github.com/user-attachments/assets/798f95b6-e7d7-4261-8dd2-beb3684ad01b

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Pressure sensors by default give out the name of the object that triggered them as signal. You can override that signal, if you like.
```
