### PR TITLE
introduces the "nocrossing" property and apply it to `/obj/item/dummy`

### DIFF
--- a/_std/macros/atom_properties.dm
+++ b/_std/macros/atom_properties.dm
@@ -323,6 +323,8 @@ To remove:
 #define PROP_ATOM_FLOCK_THING(x) x("flock_thing", APPLY_ATOM_PROPERTY_SIMPLE, REMOVE_ATOM_PROPERTY_SIMPLE)
 #define PROP_ATOM_FLOATING(x) x("floating", APPLY_ATOM_PROPERTY_SIMPLE, REMOVE_ATOM_PROPERTY_SIMPLE)
 #define PROP_ATOM_FLOTSAM(x) x("flotsam", APPLY_ATOM_PROPERTY_SIMPLE, REMOVE_ATOM_PROPERTY_SIMPLE)
+// This will prevent the atom from ever calling Crossed()
+#define PROP_ATOM_NOCROSSING(x) x("nocrossing", APPLY_ATOM_PROPERTY_SIMPLE, REMOVE_ATOM_PROPERTY_SIMPLE)
 /// Thing will redirect clicks to a fluid on its tile when clicked by a relevant item (beaker mop etc)
 #define PROP_ATOM_DO_LIQUID_CLICKS(x) x("do_liquid_clicks", APPLY_ATOM_PROPERTY_SIMPLE, REMOVE_ATOM_PROPERTY_SIMPLE)
 ///for tracking if a borg/cyborg frame was a roundstart one, for stats purposes

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -540,7 +540,7 @@ TYPEINFO(/atom/movable)
 		if(isturf(src.loc)) // call it on the area too
 			src.loc.loc.Entered(src, null)
 			for(var/atom/A in src.loc)
-				if(A != src)
+				if(A != src && !HAS_ATOM_PROPERTY(src, PROP_ATOM_NOCROSSING))
 					A.Crossed(src)
 
 
@@ -1104,7 +1104,7 @@ TYPEINFO(/atom/movable)
 				covered_turf.pass_unstable -= src.pass_unstable
 				covered_turf.passability_cache = null
 		for(var/atom/A in oldloc)
-			if(A != src)
+			if(A != src && !HAS_ATOM_PROPERTY(src, PROP_ATOM_NOCROSSING))
 				A.Uncrossed(src)
 
 	// area.Exited called if we are on turfs and changing areas or if exiting a turf into a non-turf (just like Move does it internally)
@@ -1119,7 +1119,7 @@ TYPEINFO(/atom/movable)
 				covered_turf.pass_unstable += src.pass_unstable
 				covered_turf.passability_cache = null
 		for(var/atom/A in newloc)
-			if(A != src)
+			if(A != src && !HAS_ATOM_PROPERTY(src, PROP_ATOM_NOCROSSING))
 				A.Crossed(src)
 
 	// area.Entered called if we are on turfs and changing areas or if entering a turf from a non-turf (just like Move does it internally)

--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -1739,7 +1739,7 @@
 				sfx_count = 0
 
 			var/turf/T = get_turf(M)
-			if (T.active_liquid)
+			if (T.active_liquid && !HAS_ATOM_PROPERTY(M, PROP_ATOM_NOCROSSING))
 				T.active_liquid.Crossed(M)
 
 		else

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -900,7 +900,7 @@ TYPEINFO(/mob/living)
 			return
 
 	var/turf/T = get_turf(src)
-	if (T.active_liquid && src.lying)
+	if (T.active_liquid && src.lying && !HAS_ATOM_PROPERTY(src, PROP_ATOM_NOCROSSING))
 		T.active_liquid.Crossed(src)
 		src.visible_message(SPAN_ALERT("[src] splashes around in [T.active_liquid]!</b>"), SPAN_NOTICE("You splash around in [T.active_liquid]."))
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1382,7 +1382,7 @@
 		src.shoes = null
 		src.update_clothing()
 		var/turf/T = get_turf(src)
-		if(T?.active_liquid)
+		if(T?.active_liquid && !HAS_ATOM_PROPERTY(src, PROP_ATOM_NOCROSSING))
 			T.active_liquid.Crossed(src)
 	else if (W == src.belt)
 		W.unequipped(src)

--- a/code/mob/living/life/stuns_lying.dm
+++ b/code/mob/living/life/stuns_lying.dm
@@ -80,7 +80,7 @@
 			if (owner.lying && !owner.buckled && !HAS_ATOM_PROPERTY(owner, PROP_MOB_SUPPRESS_LAYDOWN_SOUND))
 				var/turf/T = get_turf(owner)
 				var/sound_to_play = 'sound/misc/body_thud.ogg'
-				if (T?.active_liquid && T.active_liquid.my_depth_level <= 3)
+				if (T?.active_liquid && T.active_liquid.my_depth_level <= 3 && !HAS_ATOM_PROPERTY(owner, PROP_ATOM_NOCROSSING))
 					T.active_liquid.Crossed(owner)
 					sound_to_play = 'sound/misc/splash_2.ogg'
 				else if(T?.active_liquid)

--- a/code/modules/disposals/crusher.dm
+++ b/code/modules/disposals/crusher.dm
@@ -181,7 +181,8 @@ ABSTRACT_TYPE(/obj/machinery/crusher)
 		qdel(src)
 		return
 	for (var/atom/movable/AM in T) //heh
-		src.Crossed(AM)
+		if(!HAS_ATOM_PROPERTY(AM, PROP_ATOM_NOCROSSING))
+			src.Crossed(AM)
 
 TYPEINFO(/obj/machinery/crusher/instant)
 	mats = null

--- a/code/modules/fluids/air.dm
+++ b/code/modules/fluids/air.dm
@@ -44,7 +44,8 @@
 		var/i = 0
 		for(var/atom/movable/A in range(0,src))
 			if (src.disposed) return
-			src.Crossed(A)
+			if(!HAS_ATOM_PROPERTY(A, PROP_ATOM_NOCROSSING))
+				src.Crossed(A)
 			i++
 			if (i > 40)
 				break

--- a/code/modules/fluids/fluid_groups.dm
+++ b/code/modules/fluids/fluid_groups.dm
@@ -535,7 +535,7 @@
 				F.last_depth_level = my_depth_level
 				for(var/obj/O in F.loc)
 					LAGCHECK(LAG_MED)
-					if (O?.submerged_images)
+					if (O?.submerged_images && !HAS_ATOM_PROPERTY(O, PROP_ATOM_NOCROSSING))
 						F.Crossed(O)
 
 				depth_changed = 1

--- a/code/obj/item/misc_junk.dm
+++ b/code/obj/item/misc_junk.dm
@@ -141,6 +141,10 @@ TYPEINFO(/obj/item/disk)
 	burn_possible = FALSE
 	item_function_flags = IMMUNE_TO_ACID
 
+	New()
+		..()
+		APPLY_ATOM_PROPERTY(src, PROP_ATOM_NOCROSSING, "dummy")
+
 	disposing()
 		disposed = FALSE
 		..()

--- a/code/obj/machinery/floorflusher.dm
+++ b/code/obj/machinery/floorflusher.dm
@@ -333,7 +333,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/floorflusher, proc/flush)
 		FLICK("floorflush_a", src)
 		src.icon_state = "floorflush_o"
 		for(var/atom/movable/AM in src.loc)
-			src.Crossed(AM) // try to flush them
+			if(!HAS_ATOM_PROPERTY(AM, PROP_ATOM_NOCROSSING))
+				src.Crossed(AM) // try to flush them
 		SPAWN(0.7 SECONDS)
 			opening = FALSE
 


### PR DESCRIPTION
[bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR introduces the "nocrossing" atom property. This prevents the atom in question from ever firing `Crossed`.

This propertie is applied to the `/obj/item/dummy` object which is used for the test_click-check.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This dummy would call Crossed each time things get clicked. And a dummy item should not do that. This means people would need to account for that each time they use crossed(). Which isn't happening, as we can see in #24834. This PR fixes #24834.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

This fucks around with a few mechanics, but i hope i tested the main ones

https://github.com/user-attachments/assets/3431211f-e780-4cca-819d-16c2050b50ec

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
