### PR TITLE
Makes HPD orderable and mechscannable

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -986,6 +986,17 @@
 	time = 90 SECONDS
 	category = "Tool"
 
+/datum/manufacture/placespipes
+	name = "Handheld Pipe Dispencer"
+	item_requirements = list("metal_superdense" = 12,
+							 "crystal_dense" = 6,
+							 "conductive_high" = 6,
+							 "energy_high" = 6)
+	item_outputs = list(/obj/item/places_pipes)
+	create = 1
+	time = 90 SECONDS
+	category = "Tool"
+
 /datum/manufacture/RCDammo
 	name = "Compressed Matter Cartridge"
 	item_requirements = list("dense" = 30)

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -966,6 +966,15 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate/wooden
 	containername = "RCD Replacement"
 
+/datum/supply_packs/placespipes
+	name = "Handheld-pipe-dispenser replacement"
+	desc = "Contains one handheld-pipe-dispenser."
+	category = "Basic Materials"
+	contains = list(/obj/item/places_pipes)
+	cost = PAY_DONTBUYIT
+	containertype = /obj/storage/crate/wooden
+	containername = "HPD Replacement"
+
 /datum/supply_packs/buddy
 	name = "Thinktronic Build Your Own Buddy Kit"
 	desc = "Assemble your very own working Robuddy, one part per week."

--- a/code/obj/item/handheld_dispenser/dispenser.dm
+++ b/code/obj/item/handheld_dispenser/dispenser.dm
@@ -1,3 +1,8 @@
+TYPEINFO(/obj/item/places_pipes)
+	mats = list("metal_superdense" = 12,
+				"crystal_dense" = 6,
+				"conductive_high" = 6,
+				"energy_high" = 6)
 /obj/item/places_pipes
 	name = "handheld pipe dispenser"
 	desc = "A neat tool to quickly lay down pipes onto the floor."

--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -655,6 +655,7 @@
 		/datum/manufacture/multitool,
 		/datum/manufacture/t_scanner,
 		/datum/manufacture/RCD,
+		/datum/manufacture/placespipes,
 		/datum/manufacture/RCDammo,
 		/datum/manufacture/RCDammomedium,
 		/datum/manufacture/RCDammolarge,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds HPD to cargo order list, engineering department's manufacturer and makes it mechscannable.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Only CE, RD, some borgs and willing miscreants get access to the toy. A lot of the time it gathers dust, forgotten. More pipes for the masses = more fun!

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Ran the game with my changes, made sure that the items can be mechscanned, manufactured and ordered. 

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)emmenthal
(+)HPD now can be mechscanned, produced at the engineering manufacturer and ordered from cargo.
