### PR TITLE
Gives Chemical Barrels Help Messages

### DIFF
--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -432,7 +432,7 @@ TYPEINFO(/obj/reagent_dispensers/watertank/fountain)
 
 /obj/reagent_dispensers/chemicalbarrel
 	name = "chemical barrel"
-	desc = "For storing medical chemicals and less savory things. It can be labeled with a pen."
+	desc = "For storing medical chemicals and less savory things."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "barrel-blue"
 	amount_per_transfer_from_this = 25

--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -439,6 +439,13 @@ TYPEINFO(/obj/reagent_dispensers/watertank/fountain)
 	p_class = 3
 	rc_flags = RC_SCALE | RC_SPECTRO | RC_VISIBLE
 	flags = FLUID_SUBMERGE | OPENCONTAINER | ACCEPTS_MOUSEDROP_REAGENTS
+	HELP_MESSAGE_OVERRIDE({"\
+		Click the barrel with an <b>empty hand</b> to flip the barrel's funnel into a spout or vice versa. \
+		Use a <b>reagent container</b> to add/remove reagents from the barrel, depending on the funnel/spout. \
+		Use a <b>pen</b> to add a label to the barrel. \
+		Use a <b>wrench</b> to open or close the barrel's lid. \
+		Use a <b>synthetic pustule</b> on the barrel to squeeze its contents into the barrel.\
+	"})
 	var/base_icon_state = "barrel-blue"
 	var/funnel_active = TRUE //if TRUE, allows players pouring liquids from beakers with just one click instead of clickdrag, for convenience
 	var/image/fluid_image = null


### PR DESCRIPTION
## About the PR:
Chemical barrels have given a help message that appears on-examine:
> Click the barrel with an **empty hand** to flip the barrel's funnel into a spout or vice versa. Use a **reagent container** to add/remove reagents from the barrel, depending on the funnel/spout. Use a **pen** to add a label to the barrel. Use a **wrench** to open or close the barrel's lid. Use a **synthetic pustule** on the barrel to squeeze its contents into the barrel.

Notably does not include the barrel's interaction with wood, which I thought would be best to keep hidden.


## Why Is This Needed?
It is now easier to see a barrel's various interactions at a glance.


## Testing: