### PR TITLE
Deconstructable safes

### DIFF
--- a/code/datums/components/tool/deconstructing.dm
+++ b/code/datums/components/tool/deconstructing.dm
@@ -59,6 +59,11 @@ TYPEINFO(/datum/component/deconstructing)
 			var/decon_time = (decon_complexity * 2.5 SECONDS * src.complexity_mult) + src.base_duration
 			actions.start(new/datum/action/bar/icon/deconstruct_obj(target,decon_tool,decon_time), user)
 		else
+			if (istype(O, /obj/item/storage/secure/ssafe)) //checks if secure safes are unlocked before attempting to deconstruct them.
+				var/obj/item/storage/secure/Oa = target
+				if(Oa.locked)
+					boutput(user, SPAN_ALERT("You cannot deconstruct [target] while it is locked."))
+					return ATTACK_PRE_DONT_ATTACK
 			user.showContextActions(O.decon_contexts, O, src.contextLayout)
 			boutput(user, SPAN_ALERT("You need to use some tools on [target] before it can be deconstructed."))
 		return ATTACK_PRE_DONT_ATTACK

--- a/code/obj/item/storage/secure_safe.dm
+++ b/code/obj/item/storage/secure_safe.dm
@@ -28,6 +28,8 @@ ABSTRACT_TYPE(/obj/item/storage/secure)
 	w_class = W_CLASS_NORMAL
 	burn_possible = FALSE
 	var/random_code = FALSE // sets things to already have a randomized code on spawning
+	//Enables deconstruction of safes
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS | DECON_CROWBAR
 
 /obj/item/storage/secure/New()
 	..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows players to deconstruct secure safes, so long as they are unlocked. This change also affects secure briefcases, but as you can scan and print frames of them this seems like acceptable behavior.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The staff quarters on Kondaru could be refurbished into new areas, but one major problem is that the 17(!) safes located in the area will stick out like sore thumbs. There are likely other maps this will come into play on, but Kondaru was my main focus. Allowing the safes to be deconstructed when unlocked allows for more customization. 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Deconstructed several pre-placed safes located on the station, along with a player built safe. Deconstructed a door, speaker, fabricator, several vending machines to ensure existing deconstructable items function as intended. Tested safes located in Mars azone, they were not able to be deconstructed both locked and unlocked.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kelguroth
(*) Added ability to deconstruct secure containers so long as they are unlocked.
```
