### PR TITLE
Make Uplinks Detomatix proof

### DIFF
--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -1217,7 +1217,7 @@
 		return 1
 
 	proc/explode()
-		if (src.bombproof)
+		if (src.bombproof || src.uplink)
 			if (ismob(src.loc))
 				boutput(src.loc, SPAN_ALERT("<b>ALERT:</b> An attempt to run malicious explosive code on your PDA has been blocked."))
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes any PDA with an uplink immune to PDA bombs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having all of your antag gear removed as a traitor or spy thief because someone decided to randomly pda bomb you doesn't feel particularly good, even if the attack was targeted you shouldn't be able to remotely destroy an uplink with no way of the victim knowing who did it. I don't see this being particularly metagameable because they could also just have their messenger off, have been signal jammed, or gotten a new pda between you bombing them and rescanning for PDAs.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="524" height="61" alt="image" src="https://github.com/user-attachments/assets/917749a5-7701-401a-91d3-fe9329276236" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)PDAs containing uplinks are now immune to detomatix bombings.
```
