### PR TITLE
Fix conversion chamber verb "move_inside"  not performing logging or …

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -430,6 +430,9 @@ TYPEINFO(/obj/machinery/recharge_station)
 	if (src.occupant)
 		boutput(usr, SPAN_ALERT("\The [src] is already occupied!"))
 		return
+	if(ishuman(usr))
+		src.move_human_inside(usr, usr)
+		return
 	usr.remove_pulling()
 	usr.set_loc(src)
 	src.occupant = usr


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If a human uses the "move_inside" verb on a conversion chamber, call move_human_inside(usr, usr) 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
so logging and ghost messaging is performed.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="664" height="24" alt="image" src="https://github.com/user-attachments/assets/b484a4b1-6e90-46a5-a09e-8c5f36e7220f" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
