### PR TITLE
Water coolers use slightly more detailed reagent view

### DIFF
--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -227,6 +227,7 @@ TYPEINFO(/obj/reagent_dispensers/watertank/fountain)
 	icon_state = "coolerbase"
 	anchored = ANCHORED
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_CROWBAR
+	rc_flags = RC_SPECTRO | RC_FULLNESS | RC_VISIBLE
 	capacity = 500
 	_health = 250
 	_max_health = 250


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[CHEMISTRY] [OBJECTS] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Examining a water cooler will now output its reagent color, reagent state, and approximate reagent level. Water coolers are also now compatible with spectroscopic scanner goggles.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Parity with reagent container item functionality, namely the water cooler bottle
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="557" height="716" alt="Screenshot (87)" src="https://github.com/user-attachments/assets/4cea43c0-0390-4883-b780-0dae37084b29" />
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
