### PR TITLE
Lizard tail clothing & handcuffs coloring fix

### DIFF
--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -506,7 +506,7 @@
 		if(src.handcuffs)
 			handcuff_img.color = src.handcuffs.color
 			handcuff_img.alpha = src.handcuffs.alpha
-			handcuff_img.filters = src.handcuffs.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.belt)
+			handcuff_img.filters = src.handcuffs.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.handcuffs)
 		src.AddOverlays(handcuff_img, "handcuffs")
 	else
 		src.ClearSpecificOverlays("handcuffs")
@@ -539,7 +539,7 @@
 			if(tail_clothing)
 				human_tail_image.color = tail_clothing.color
 				human_tail_image.alpha = tail_clothing.alpha
-				human_tail_image.filters = tail_clothing.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.belt)
+				human_tail_image.filters = tail_clothing.filters.Copy() + src.mutantrace?.apply_clothing_filters(tail_clothing)
 			src.tail_standing.overlays += human_tail_image
 			src.tail_standing_oversuit.overlays += human_tail_image
 			src.update_tail_overlays()


### PR DESCRIPTION
## About the PR
- Worn suit colors now affect lizard tail overlays
- Equipped handcuffs now have the same color as the handcuffs themselves

## Why's this needed?
- Fixes #17594 
- Fixes a similar issue with handcuffs

## Testing
<img width="146" height="108" alt="Screenshot 2025-10-09 195611" src="https://github.com/user-attachments/assets/315ee066-a401-43b1-95e2-774fa6dd2f75" />
