### PR TITLE
make it so highlights can't crash the chat

### DIFF
--- a/browserassets/src/js/browserOutput.js
+++ b/browserassets/src/js/browserOutput.js
@@ -824,6 +824,15 @@ $(function () {
           actualTerms +
           '</span>'
       );
+      // Check for invalid regexes in saved config
+      for (var t = 0; t < savedTerms.length; t++) {
+        var testTerm = savedTerms[t];
+        try {
+          new RegExp(testTerm);
+        } catch (err) {
+          savedTerms[t] = 'INVALID REGEX';
+        }
+      }
       opts.highlightTerms = savedTerms;
     }
   }
@@ -1315,11 +1324,18 @@ $(function () {
   $('body').on('submit', '#highlightTermForm', function (e) {
     e.preventDefault();
 
+    // Validate and replace invalid regexes
+    // Don't allow people to crash their own chat
     opts.highlightTerms = [];
     for (var count = 0; count < opts.highlightLimit; count++) {
       var term = $('#highlightTermInput' + count).val();
       if (term !== null && /\S/.test(term)) {
-        opts.highlightTerms.push(term);
+        try {
+          new RegExp(term);
+          opts.highlightTerms.push(term);
+        } catch (err) {
+          opts.highlightTerms.push('INVALID REGEX');
+        }
       }
     }
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #24654 and fixes #24252 and fixes #21474 and fixes #19397 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

we shouldn't let people crash their chat permanently

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

i wrote shit like `\bai\` in my highlight input and it got turned into `INVALID REGEX`
