### PR TITLE
Fix respawn event syndie jobs losing antag status on spawn

### DIFF
--- a/code/datums/jobs/operatives/jobs_syndicate.dm
+++ b/code/datums/jobs/operatives/jobs_syndicate.dm
@@ -24,11 +24,13 @@ ABSTRACT_TYPE(/datum/job/special/syndicate)
 
 	special_setup(var/mob/living/carbon/human/M)
 		..()
-		M.mind?.add_generic_antagonist(ROLE_SYNDICATE_AGENT, src.name, source = ANTAGONIST_SOURCE_ADMIN)
 		SPAWN(0) //Let the ID actually spawn
 			var/obj/item/card/id/ID = M.get_id()
 			if(istype(ID))
 				ID.icon_state = "id_syndie" //Syndie ID normally starts with basic sprite
+		SPAWN(2) //Ghost respawn panel has a SPAWN(1) that clears all antag roles. Apply specialist role if no other role was picked
+			if(!M.mind?.is_antagonist())
+				M.mind?.add_generic_antagonist(ROLE_SYNDICATE_AGENT, src.name, source = ANTAGONIST_SOURCE_ADMIN)
 
 /datum/job/special/syndicate/weak
 	name = "Junior Syndicate Operative"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes syndicate specialist jobs having their special antag status removed immediately by the ghost spawn panel by placing the antag status behind a semi-evil SPAWN(2) to go after the ghost spawn panel's SPAWN(1) antagonist role wipe.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The syndie jobs should always have their antag role regardless of how they're spawned, they're blatantly clear syndies.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="519" height="274" alt="image" src="https://github.com/user-attachments/assets/2396a237-6ff3-4b5e-94cf-13dccfbfeb41" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

