### PR TITLE
Prevent lying mobs from auto-grabbing items

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1749,6 +1749,8 @@ TYPEINFO(/mob/living)
 
 /// makes mob auto pick up the highest weight item on a turf. if multiple have that weight, last one in the order of contents var is picked
 /mob/living/proc/auto_pickup_item(atom/target_loc)
+	if (src.lying)
+		return
 	var/turf/T = get_turf(target_loc)
 	if (!T)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check for lying in the code for auto-grabbing (space+leftclick) items, to prevent people from grabbing items while laying down
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being able to grab items while laying down is, at least to my knowledge, an oversight and not an intended mechanic
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Layed down while space-clicking a folded folding chair, didn't pick it up despite my clicks registering
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->