### PR TITLE
fix #24896

### DIFF
--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -88,6 +88,7 @@
 		if ((isscrewingtool(I) || istype(I, /obj/item/pen)) && !src.pinhole)
 			src.pinhole = TRUE
 			src.block_vision = FALSE
+			setProperty("disorient_resist_eye", 2) // matches eyepatch with pinhole
 			boutput(user, SPAN_NOTICE("You poked two holes into the blindfold, now you can pretend that you can see without seeing"))
 		else
 			. = ..()
@@ -466,6 +467,7 @@ TYPEINFO(/obj/item/clothing/glasses/visor)
 
 	attackby(obj/item/W, mob/user)
 		if ((isscrewingtool(W) || istype(W, /obj/item/pen)) && !src.pinhole)
+			setProperty("disorient_resist_eye", 2) // You still have something on your eye and taking up a slot
 			if( equipper && equipper.glasses == src )
 				var/obj/item/organ/eye/theEye = equipper.drop_organ((src.icon_state == "eyepatch-L") ? "left_eye" : "right_eye")
 				src.pinhole = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

fix #24896

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

fixes deadly blindfold (also eyepatch while i'm here) powergaming where you could see through it but still just not be affected by flashes
still useful for intimidation i suppose

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

i mean it worked locally
