### PR TITLE
Limit checking for unlikely chemical reactions

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -431,6 +431,9 @@ var/global
 	list/datum/chemical_reaction/chem_reactions_by_id = list() //This sure beats processing the monster above if I want a particular reaction. =I
 	list/list/datum/chemical_reaction/chem_reactions_by_result = list() // Chemical reactions indexed by result ID
 
+	/// A single reaction is only in this list once, hopefully keyed by its least likely reagent, keeping the list of possible reactions small
+	list/limited_chem_reactions = list()
+
 	//SpyGuy: The reagents cache is now an associative list
 	list/reagents_cache = list()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a small optimization to chemical reactions where the possible reactions list is built from a more limited chem reactions list, containing each reaction only once keyed off its hopefully-least likely reagent. Basically makes it so that when you add water to an empty bucket, the reaction for holy water isn't even considered because it's not the reagent the reaction is keyed by. `append_possible_reactions` can then use += instead of |= to build the list, speeding it up too. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's free performance

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spawned a few sets of junk using 
```dm 
/proc/spawn_a_bunch_of_reagent_buckets(var/amt)
	var/loc = get_step(usr, 0)
	for(var/i in 1 to amt)
		var/obj/item/reagent_containers/glass/bucket/B = new /obj/item/reagent_containers/glass/bucket(loc)
		var/obj/item/reagent_containers/glass/bucket/B2 = new /obj/item/reagent_containers/glass/bucket(loc)
		while (prob(66))
			var/datum/reagent/R = pick(reagents_cache)
			B.reagents.add_reagent(R, rand(1, 20))
			B2.reagents.add_reagent(R, rand(1, 20))

/proc/spawn_a_bunch_of_reacting_reagent_buckets(var/amt)
	var/loc = get_step(usr, 0)
	for(var/i in 1 to amt)
	    // spawn two so we get the same reaction for both buckets
		var/obj/item/reagent_containers/glass/bucket/B = new /obj/item/reagent_containers/glass/bucket(loc)
		var/obj/item/reagent_containers/glass/bucket/B2 = new /obj/item/reagent_containers/glass/bucket(loc)
		// pick a random reaction
		var/datum/chemical_reaction/CR = chem_reactions_by_id[pick(chem_reactions_by_id)]
		if (CR.required_reagents)
			for (var/R in CR.required_reagents)
				B.reagents.add_reagent(R, CR.required_reagents[R])
				B2.reagents.add_reagent(R, CR.required_reagents[R])
```
These are the results for the definitely-reacting stuff, the best-case scenario for old code where something eventually definitely reacts.
<img width="976" height="36" alt="image" src="https://github.com/user-attachments/assets/ddd20582-af18-4ffd-b6fa-ff8cb7b238e2" />
<img width="968" height="40" alt="image" src="https://github.com/user-attachments/assets/3af9f25c-4627-47e0-9c3a-60ca77a1baed" />

A bit more limited testing on the random reagent stuff, where stuff mostly does not react
<img width="1244" height="38" alt="image" src="https://github.com/user-attachments/assets/350dce8b-a100-45ae-98aa-7002a417788b" />

Testing was done by adding a new var  `var/newbehavior = 0` on the reagents holder, and then in New() i had 
```dm
		var/static/apr_i = 0
		apr_i++
		src.newbehavior = apr_i % 2
```
I redirected handle_reactions and append/remove possible reactions based on newbehavior truthiness. The test procs created two buckets so the same reaction would happen in different behavior reagent containers. 

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Naksu
(+)Slight performance tweak for chemistry reactions. Report issues if you encounter any!
```
