### PR TITLE
Change the second "command" to "command_2" in guardbuddy code, to allow for guardbuddy targeting again

### DIFF
--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -2972,8 +2972,8 @@ TYPEINFO(/obj/item/device/guardbot_module)
 				if (target_name && target_name != "")
 					src.target_names = list(target_name)
 
-			if (confList["command_2"])
-				switch(lowertext(confList["command"]))
+			if (confList["command"])
+				switch(lowertext(confList["command_2"]))
 					if ("add_target")
 						if(confList["acc_code"] != netpass_heads)
 							return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Command] [C-Bug]
## About the PR 
Fixes a feature in Guardbuddies that was effectivly disabled, because of lines 2889-2894 failing to make command2 into base command. This PR fixes it by manualy making the command down at the problem area into command_2.

## Why's this needed?
It fixes a bug I found when code diving for specific targeting for guardbuddies

## Testing
Used "command=configure;command2=add_target;data=[self];acc_code=[Head pass]" and it not work, then applied the change and used the packet "command=configure;command_2=add_target;data=[self];acc_code=[Head pass]"
<img width="472" height="426" alt="{13178955-313A-4DC2-AC36-ED41CE29AFB9}" src="https://github.com/user-attachments/assets/de612190-ae77-462b-b69e-9ed6c43c7565" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->