### PR TITLE
HOTFIX: Removes wraith ability to trigger the lawbringer explosion

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1570,6 +1570,10 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 			//you must be holding/wearing the weapon
 			//this check makes it so that someone can't stun you, stand on top of you and say "I am the law" to kill you
 			if (src in M.contents)
+				// This is to check if someone is the gun, prevents them from speaking "I am the Law" into the gun while the gun. This was triggered by a Wraith event that happened.
+				if (islivingobject(M))
+					boutput(usr, SPAN_ALERT("<b>You cannot speak into the gun.</b>"))
+					return 1;
 				if (M.job != "Head of Security" || src.emagged)
 					src.cant_self_remove = 1
 					playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
During a round one of our fine officers was killed in action with their own lawbringer when a wraith possessed it and apparently spoke as the gun...

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wraith possession should not be able to speak as a gun. This does not prevent them from firing it but the fine speech function needed to trigger it should not able to be spoken as the gun itself. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="2416" height="1094" alt="Screenshot 2025-10-14 023409" src="https://github.com/user-attachments/assets/e65ec1d1-f84a-4790-8aba-1a7954d8ce16" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
