### PR TITLE
Getting interrupted no longer closes your chatbox

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1640,9 +1640,6 @@ TYPEINFO(/mob/living)
 					enteredtext = ";" + enteredtext
 				winset(client, "[window_type]window.say-input", "text=\"\"")
 				if (isnull(client)) return
-				if (isnull(client)) return
-				src.cancel_typing(window_type)
-				src.cancel_emote_typing(window_type)
 				found_text = TRUE
 				break
 	if (found_text)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
See title, when you get -BLUGH interrupted your chatbox will now stay open.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I'm kind of on the fence about this which is why I'm PRing it, in theory closing the chatbox makes sense because you've been interrupted and want to respond immediately, but in practice all this usually does is make the last few key presses of the input go as game inputs and people often open various random menus they don't mean to by typing M, P, Y etc.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I tested that it doesn't close the chatbox and it doesn't.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Getting interrupted no longer closes your chatbox.
```
