### PR TITLE
Add various secure crates to the crate manufacturer

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -3437,53 +3437,68 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 	time = 10 SECONDS
 	category = "Miscellaneous"
 
-/datum/manufacture/packingcrate
-	name = "Random Packing Crate"
-	item_requirements = list("wood" = 1)
-	item_outputs = list(/obj/storage/crate/packing)
-	create = 1
-	time = 10 SECONDS
-	category = "Miscellaneous"
-
-/datum/manufacture/wooden
+/datum/manufacture/crate/wooden
 	name = "Wooden Crate"
 	item_requirements = list("wood" = 1)
 	item_outputs = list(/obj/storage/crate/wooden)
-	create = 1
-	time = 10 SECONDS
-	category = "Miscellaneous"
 
-/datum/manufacture/medical
+/datum/manufacture/crate/wooden/packing
+	name = "Random Packing Crate"
+	item_outputs = list(/obj/storage/crate/packing)
+
+/datum/manufacture/crate/medical
 	name = "Medical Crate"
-	item_requirements = list("metal" = 1)
 	item_outputs = list(/obj/storage/crate/medical)
-	create = 1
-	time = 10 SECONDS
-	category = "Miscellaneous"
 
-/datum/manufacture/biohazard
+/datum/manufacture/crate/biohazard
 	name = "Biohazard Crate"
-	item_requirements = list("metal" = 1)
 	item_outputs = list(/obj/storage/crate/biohazard)
-	create = 1
-	time = 10 SECONDS
-	category = "Miscellaneous"
 
-/datum/manufacture/classcrate
+/datum/manufacture/crate/class
 	name = "Class Crate"
-	item_requirements = list("metal" = 1)
 	item_outputs = list(/obj/storage/crate/classcrate)
-	create = 1
-	time = 10 SECONDS
-	category = "Miscellaneous"
 
-/datum/manufacture/freezer
+/datum/manufacture/crate/freezer
 	name = "Freezer Crate"
-	item_requirements = list("metal" = 1)
 	item_outputs = list(/obj/storage/crate/freezer)
-	create = 1
-	time = 10 SECONDS
-	category = "Miscellaneous"
+
+/datum/manufacture/crate/secure
+	name = "Secure Crate (Access: None)"
+	item_requirements = list("metal" = 1, "conductive" = 2)
+	item_outputs = list(/obj/storage/secure/crate)
+
+/datum/manufacture/crate/secure/secure_transfer
+	name = "Security Transfer Crate"
+	item_outputs = list(/obj/storage/secure/crate/gear/transfer)
+
+/datum/manufacture/crate/secure/confiscated_items
+	name = "Confiscated Items Crate"
+	item_outputs = list(/obj/storage/secure/crate/weapon/confiscated_items)
+
+/datum/manufacture/crate/secure/armory
+	name = "Armory Weapons Crate (Empty)"
+	item_outputs = list(/obj/storage/secure/crate/weapon/armory)
+
+/datum/manufacture/crate/secure/hazard
+	name = "Research Hazard Transport Crate"
+	item_outputs = list(/obj/storage/secure/crate/plasma/hazard)
+
+/datum/manufacture/crate/secure/engineering
+	name = "Secure Engineering Crate"
+	item_outputs = list(/obj/storage/secure/crate/eng/locked)
+
+/datum/manufacture/crate/secure/medical
+	name = "Medical Transport Crate"
+	item_outputs = list(/obj/storage/secure/crate/medical)
+
+/datum/manufacture/crate/secure/hydroponics
+	name = "Hydroponics Transport Crate"
+	item_outputs = list(/obj/storage/secure/crate/bee/locked)
+
+/datum/manufacture/crate/secure/syndicate
+	name = "Unmarked Syndicate Crate"
+	item_outputs = list(/obj/storage/secure/crate/gear/syndicate)
+
 /******************** GUNS *******************/
 
 /datum/manufacture/alastor

--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -581,14 +581,24 @@
 	free_resources = list(/obj/item/material_piece/steel = 1,
 		/obj/item/material_piece/organic/wood = 1)
 	accept_blueprints = FALSE
-	available = list(/datum/manufacture/crate,
-		/datum/manufacture/packingcrate,
-		/datum/manufacture/wooden,
-		/datum/manufacture/medical,
-		/datum/manufacture/biohazard,
-		/datum/manufacture/freezer)
+	available = list(
+		/datum/manufacture/crate,
+		/datum/manufacture/crate/wooden,
+		/datum/manufacture/crate/wooden/packing,
+		/datum/manufacture/crate/medical,
+		/datum/manufacture/crate/biohazard,
+		/datum/manufacture/crate/freezer,
+		/datum/manufacture/crate/secure,
+		/datum/manufacture/crate/secure/secure_transfer,
+		/datum/manufacture/crate/secure/confiscated_items,
+		/datum/manufacture/crate/secure/armory,
+		/datum/manufacture/crate/secure/hazard,
+		/datum/manufacture/crate/secure/engineering,
+		/datum/manufacture/crate/secure/medical,
+		/datum/manufacture/crate/secure/hydroponics,
+		)
 
-	hidden = list(/datum/manufacture/classcrate)
+	hidden = list(/datum/manufacture/crate/class, /datum/manufacture/crate/secure/syndicate)
 
 /obj/machinery/manufacturer/zombie_survival
 	name = "\improper Uber-Extreme Survival Manufacturer"

--- a/code/obj/storage/secure_crates.dm
+++ b/code/obj/storage/secure_crates.dm
@@ -179,6 +179,10 @@
 					carton.ourEgg.blog += blog
 				return 1
 
+	locked
+		name = "Hydroponics Transfer crate"
+		req_access = list(access_hydro)
+
 /obj/storage/secure/crate/eng
 	name = "Engineering crate"
 	desc = "A yellow crate."
@@ -186,6 +190,10 @@
 	density = 1
 	icon_opened = "engcrate-open"
 	icon_closed = "engcrate"
+
+	locked
+		name = "Secure Engineering crate"
+		req_access = list(access_engineering)
 
 	explosives
 		name = "engineering explosive crate"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds various secure crates to the crate manufacturer, and repaths the other crate recipes to a common parent for less code duplication. The syndicate locked crate is a hidden recipe like the class crate, but I'm not so sure on this one.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Secure crates like these are varied in their presence across maps and them being printable in the crate manufacturer makes sense. This allows players to make secure crates for most any use, and possibly even any access if the accesspro can reprogram crates?

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="1199" height="450" alt="image" src="https://github.com/user-attachments/assets/3ef7d83a-dd43-4ba8-9e2c-5f7c39bb4fc7" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Cargo's crate manufacturer is now capable of printing locked secure crates. Be careful not to fabricate one around yourself.
```
