### PR TITLE
Fix job of the day not appearing in jobs panel

### DIFF
--- a/code/modules/admin/job_manager.dm
+++ b/code/modules/admin/job_manager.dm
@@ -13,21 +13,29 @@
 		ui = new(user, src, "JobManager")
 		ui.open()
 
+#define JOB_DATA list(list(name = job.name, type = job.job_category, count = countJob(job.name), limit = job.limit))
 /datum/job_manager/ui_data(mob/user)
 	var/list/staple_job_data = list()
 	var/list/special_job_data = list()
 	var/list/categorised_special_job_data = list()
 	var/list/hidden_job_data = list()
-	for (var/datum/job/job in job_controls.staple_jobs)
-		staple_job_data += list(list(name = job.name, type = job.job_category, count = countJob(job.name), limit = job.limit))
+	var/list/staple_job_categories = list(JOB_COMMAND, JOB_SECURITY, JOB_RESEARCH, JOB_MEDICAL, JOB_ENGINEERING, JOB_CIVILIAN)
 	var/list/special_job_categories = list(JOB_NANOTRASEN, JOB_SYNDICATE, JOB_HALLOWEEN)// If adding more, make sure to add the category in JobManager.tsx
+	for (var/datum/job/job in job_controls.staple_jobs)
+		if(!(job.job_category in staple_job_categories))// If its not in this list its not a staple job so should be sorted under special jobs
+			if(job.job_category in special_job_categories)
+				categorised_special_job_data += JOB_DATA
+			else
+				special_job_data += JOB_DATA
+			continue
+		staple_job_data += JOB_DATA
 	for (var/datum/job/job in job_controls.special_jobs)
 		if(job.job_category in special_job_categories)
-			categorised_special_job_data += list(list(name = job.name, type = job.job_category, count = countJob(job.name), limit = job.limit))
+			categorised_special_job_data += JOB_DATA
 			continue
-		special_job_data += list(list(name = job.name, type = job.job_category, count = countJob(job.name), limit = job.limit))
+		special_job_data += JOB_DATA
 	for (var/datum/job/job in job_controls.hidden_jobs)
-		hidden_job_data += list(list(name = job.name, type = job.job_category, count = countJob(job.name), limit = job.limit))
+		hidden_job_data += JOB_DATA
 	. = list(
 		"stapleJobs" = staple_job_data,
 		"specialJobs" = special_job_data,
@@ -35,6 +43,7 @@
 		"hiddenJobs" = hidden_job_data,
 		"allowSpecialJobs" = job_controls.allow_special_jobs
 	)
+#undef JOB_DATA
 
 /datum/job_manager/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes jobs added to the controller's staple_jobs not appearing anywhere in the job controller by ensuring all jobs sorted into staple_job_data are one of the staple job categories that the panel expects to receive. This applies to whatever daily job is currently active and pod pilots and commanders in the pod wars gamemode.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
All jobs in the controller should show somewhere in the job panel, staple job data only expects to receive one of 6 categories and it disregards everything else.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="484" height="390" alt="image" src="https://github.com/user-attachments/assets/e213b962-2f96-4595-9f3b-0cf478da5a0d" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

