### PR TITLE
Conga lines 2

### DIFF
--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -305,43 +305,9 @@
 								src.emote("wheeze")
 								boutput(src, SPAN_ALERT("You flop over, too winded to continue running!"))
 
-						var/list/pulling = list()
-						if (src.pulling)
-							if ((BOUNDS_DIST(old_loc, src.pulling) > 0 && BOUNDS_DIST(src, src.pulling) > 0) || !isturf(src.pulling.loc) || src.pulling == src) // fucks sake
-								src.remove_pulling()
-							else
-								var/can_pull = TRUE
-								if (ismob(src.pulling))
-									var/mob/M = src.pulling
-									for(var/obj/item/grab/grab_grabbed_by in M.grabbed_by)
-										if (grab_grabbed_by.assailant != src && grab_grabbed_by.state > GRAB_PASSIVE)
-											can_pull = FALSE
-											src.remove_pulling()
-											break
-								if (can_pull)
-									pulling += src.pulling
-						for (var/obj/item/grab/G in src.equipped_list(check_for_magtractor = 0))
-							var/can_pull = TRUE
-							if (G.affecting)
-								for(var/obj/item/grab/grab_grabbed_by in G.affecting.grabbed_by)
-									if (grab_grabbed_by.assailant != src && grab_grabbed_by.state > G.state)
-										can_pull = FALSE
-										break
-								if (can_pull)
-									pulling += G.affecting
-
-						for (var/atom/movable/A in pulling)
-							if (GET_DIST(src, A) == 0) // if we're moving onto the same tile as what we're pulling, don't pull
-								continue
-							if (A == src || A == pushing)
-								continue
-							if (!isturf(A.loc) || A.anchored)
-								continue // whoops
-							A.animate_movement = SYNC_STEPS
-							A.glide_size = glide
-							step(A, get_dir(A, old_loc))
-							A.glide_size = glide
-							A.OnMove(src)
+						var/list/chain = list()
+						chain.Add(src)
+						src.do_pulling(old_loc, glide, chain)
 			else
 				if(!src.dir_locked) //in order to not turn around and good fuckin ruin the emote animation
 					src.set_dir(move_dir)
@@ -362,3 +328,49 @@
 						return
 					src.last_resist = world.time + 20
 					G.do_resist()
+
+/mob/proc/do_pulling(var/turf/old_loc, var/glide, var/list/chain)
+	var/list/pulling = list()
+	if (src.pulling)
+		if ((BOUNDS_DIST(old_loc, src.pulling) > 0 && BOUNDS_DIST(src, src.pulling) > 0) || !isturf(src.pulling.loc) || src.pulling == src) // fucks sake
+			src.remove_pulling()
+		else
+			var/can_pull = TRUE
+			if (ismob(src.pulling))
+				var/mob/M = src.pulling
+				for(var/obj/item/grab/grab_grabbed_by in M.grabbed_by)
+					if (grab_grabbed_by.assailant != src && grab_grabbed_by.state > GRAB_PASSIVE)
+						can_pull = FALSE
+						src.remove_pulling()
+						break
+			if (can_pull)
+				pulling += src.pulling
+	for (var/obj/item/grab/G in src.equipped_list(check_for_magtractor = 0))
+		var/can_pull = TRUE
+		if (G.affecting)
+			for(var/obj/item/grab/grab_grabbed_by in G.affecting.grabbed_by)
+				if (grab_grabbed_by.assailant != src && grab_grabbed_by.state > G.state)
+					can_pull = FALSE
+					break
+			if (can_pull)
+				pulling += G.affecting
+
+	for (var/atom/movable/A in pulling)
+		if (GET_DIST(src, A) == 0) // if we're moving onto the same tile as what we're pulling, don't pull
+			continue
+		if (A == src || A == pushing)
+			continue
+		if (!isturf(A.loc) || A.anchored)
+			continue // whoops
+		if (chain.Find(A))
+			continue // no loops
+		A.animate_movement = SLIDE_STEPS
+		A.glide_size = glide
+		var/turf/pulled_old_loc = A.loc
+		step(A, get_dir(A, old_loc))
+		A.glide_size = glide
+		A.OnMove(src)
+		if (istype(A, /mob/))
+			chain.Add(A)
+			var/mob/M = A
+			M.do_pulling(pulled_old_loc, glide, chain)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Actions][Feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
sequel to #20064
You now pull others when you are pulled (and with grabs)
~~this currently includes pins which i think is really funny and balanced enough by requiring 2 people but that can go if people disagree~~ this behavior is not from this pr and works the same on master
also fixes the teleporting when pulling things in a different direction to the one you are moving in

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fun

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spawned a bunch of assistants, possessed them and made them pull eachother

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
```
(u)Valtsu0
(*)You now pull while being pulled, allowing you to form conga lines
```
