### PR TITLE
Refactor Midas Touch into a targetable ability

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -1372,7 +1372,6 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 		logTheThing(LOG_COMBAT, owner, "uses [name] to transmute [log_object(target)] into [material_id] at [log_loc(owner)].")
 		src.owner.visible_message(SPAN_ALERT("[src.owner] touches [target], turning it to [material_id]!"))
 		target.setMaterial(getMaterial(material_id))
-		return 1
 
 /datum/bioEffect/power/midas/pickle
 	name = "Pickle Touch"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactors midas touch into a targetable ability with a common proc for transmuting a thing to a material ID instead of copypasting between misfire and non-misfire casting.
Allows midas touch to be varedited to override the material or the types it can transmute.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Casting the ability as a targetable is easier to use than a list of all objects within range
Makes much more sense that you can't touch your internal organs to turn them to gold if they're still in your body.
Lets me allow pickles to pickle turfs and mobs.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Midas touch works as expected I can transmute things in my inventory and around me, but not if they're too far away.
Varediting to different types such as /turf, /mob and /atom/movable works as expected and transmutes those things
<img width="454" height="699" alt="image" src="https://github.com/user-attachments/assets/4c538b11-1cb1-4056-a7c1-ee31a02938ff" />

In testing I found that a genetic power misfiring will also perform the non-misfire act (also tested with healing touch), I've elected to ignore that this issue is present in this PR and fix it in a seperate PR
<img width="470" height="71" alt="image" src="https://github.com/user-attachments/assets/ae357a51-1528-4ca3-86cd-201f08652a24" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+) The Midas Touch gene is now a targetable ability, meaning you cannot turn anything you can't click on gold (e.g. your internal organs)
```
