### PR TITLE
Spy thief in cryo warning

### DIFF
--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -1124,11 +1124,15 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 				src.menu_message += "<B>Current Bounties (Next Refresh at : [refresh_time_formatted]):</B>"
 				for(var/datum/bounty_item/B in game.active_bounties)
 					var/atext = ""
-					var/item_destroyed = FALSE // If the bounty required a specific item and was destroyed
-					if (B.reveal_area && B.item && !B.claimed)
+					var/unavailable_text = null // Why the specific bounty can't be redeemed (Claimed, Destroyed or In Cryo)
+					if (B.claimed)
+						unavailable_text = "CLAIMED"
+					else if (B.reveal_area && B.item)
 						var/item_area = get_area(B.item)
 						if(!item_area) // Also includes if there's no item because if there's no item then it has no area
-							item_destroyed = TRUE
+							unavailable_text = "DESTROYED"
+						else if ((locate(/obj/cryotron) in get_turf(B.item)) && !isturf(B.item.loc)) //There's gotta be a better way to check for this
+							unavailable_text = "IN CRYOGENIC STORAGE"
 						else
 							atext = "<br>(Last Seen : [item_area])"
 					var/rtext = ""
@@ -1138,7 +1142,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 						else
 							rtext = "<br><b>Reward</b> : Not available. Deliver [req_bounties()] more bounties."
 
-					src.menu_message += "<small><br><br><tr><td><b>[B.name]</b>[rtext][atext]<br>[(B.claimed) ? "(<b>CLAIMED</b>)" : (item_destroyed) ? "(<b>DESTROYED</b>)" : "(Deliver : <b>[B.delivery_area ? B.delivery_area : "Anywhere"]</b>) [B.photo_containing ? "" : "<a href='byond://?src=\ref[src];action=print;bounty=\ref[B]'>Print</a>"]"]</td></tr></small>"
+					src.menu_message += "<small><br><br><tr><td><b>[B.name]</b>[rtext][atext]<br>[(unavailable_text) ? "(<b>[unavailable_text]</b>)" : "(Deliver : <b>[B.delivery_area ? B.delivery_area : "Anywhere"]</b>) [B.photo_containing ? "" : "<a href='byond://?src=\ref[src];action=print;bounty=\ref[B]'>Print</a>"]"]</td></tr></small>"
 
 		src.menu_message += "<HR>"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Spy thieves will now receive a warning when an item is in the cryotron, rather than just in the room with the cryotron.

Please tell me there's a better way to find if X item is in X thing through any amount of layers

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sometimes people drop their trinkets (or themselves) in the same room as the cryotron so this helps inform you if the bounty is possible or not before you go after it.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. --> 
<img width="251" height="353" alt="image" src="https://github.com/user-attachments/assets/870fae44-4e16-402a-8a57-8071ba8ec5da" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Spy thieves will now be informed if a target bounty is in cryogenic storage
```
