### PR TITLE
Fix observing admins via chat right click + observing admin alarm bells

### DIFF
--- a/code/datums/browserOutput.dm
+++ b/code/datums/browserOutput.dm
@@ -279,6 +279,8 @@ var/global
 			if(src.owner.holder)
 				src.owner.holder.playeropt(targetMob)
 		if ("observe")
+			if(!isadmin(src.owner) && isadmin(targetMob) && !targetMob.client?.player_mode)
+				return // no
 			if (istype(src.owner.mob, /mob/dead/target_observer))
 				var/mob/dead/target_observer/obs = src.owner.mob
 				if (!obs.locked)

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -732,6 +732,11 @@ TYPEINFO(/mob/dead/observer)
 
 
 /mob/dead/observer/proc/insert_observer(var/atom/target)
+	var/mob/targetMob = target
+	if(istype(targetMob) && isadmin(targetMob) && !targetMob.client?.player_mode && !isadmin(src)) //Activate the alarm bells
+		logTheThing(LOG_DEBUG, src, "observes non-player mode admin [constructName(target)]") //They shouldn't be here unless forced manually
+		message_admins("[key_name(src)] starts observing non-player mode admin [key_name(target)]")
+		boutput(targetMob.client, SPAN_ALERT("<b>[key_name(src)] IS OBSERVING YOU!! If you didn't do this, kick them out!</b>"))
 	var/mob/dead/target_observer/newobs = new /mob/dead/target_observer
 	src.set_loc(newobs)
 	newobs.attach_hud(hud)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stops non-admins spectating non-player mode admins via the right click chat "observe" command
Adds alarm bells (debug log, message admins, boutput target client) for when someone does observe an admin so the observed admin can detonate the user if they didn't force them to observe them (which is meant to be the only way to observe an admin)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The clown is too powerful, they cannot know our secrets. If someone is observing a non-player mode admin, the target admin should know.
<img width="600" height="177" alt="image" src="https://github.com/user-attachments/assets/4cff6efc-6573-4c98-acb7-496aa1091bad" />

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Made isadmin() return TRUE for stirstir, after deadminning myself could not observe stirstir via chat right click menu, could observe via clicking as observer (click check directly checks for a holder so this was expected), doing so caused the debug log entry to show up in the debug log (but i couldn't see the other messages on the count of being deadminned but I presume they work as they didn't runtime.)
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

