### PR TITLE
Give the clown civilian radio access

### DIFF
--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -351,6 +351,7 @@
 	desc = "Anybody using this headset is unlikely to be taken seriously."
 	icon_override = "clown"
 	icon_tooltip = "Clown"
+	secure_frequencies = list("c" = R_FREQ_CIVILIAN)
 
 /obj/item/device/radio/headset/ghost_buster
 	name = "\improper Ghost Buster's headset"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives the clown's headset access to the civilian radio channel

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The civilian radio is really underused and now that multiple clowns are common via RoleControl or the Blue Clown the clowns need somewhere to scheme that isn't the public general channel, clunky PDA messaging or confusing changing the radio channel to an arbitrary frequency that only the clowns are told. This will also let solo clowns beg botany for banana peels or the chef for cream pies and will hopefully increase civilian channel usage by showing people it exists because the clown used it

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="509" height="158" alt="image" src="https://github.com/user-attachments/assets/a1f502bc-4d00-425d-9baf-59e08428635e" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Clowns have been granted access to the Civilian radio channel for scheming with each other and begging the botanists for banana peels.
```
