### PR TITLE
lets pickles be refined into pickle clumps

### DIFF
--- a/code/modules/cooking/food_and_drink/snacks.dm
+++ b/code/modules/cooking/food_and_drink/snacks.dm
@@ -2258,6 +2258,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/soup)
 	bites_left = 2
 	heal_amt = 1
 	initial_reagents = list("juice_pickle"=5)
+	mat_changename = "pickle"
+	default_material = "pickle"
 
 	trash
 		name = "trash pickle"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

adds the ability to make pickle clumps from pickles made from the food processor

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

cause sometimes i really wanna plate the station in pickle but i can't because the pickle jars got emptied out 3 rounds ago and no one's rolled this map all day so i cant do the bit when i want to

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/039c29f3-1fc3-4283-ada1-dfe2b046e8e7


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bork
(+)pickles from the food processor can be refined into pickle clumps
```
