### PR TITLE
Make curl fail on 404s in `install_byond.sh`

### DIFF
--- a/tools/ci/install_byond.sh
+++ b/tools/ci/install_byond.sh
@@ -11,9 +11,9 @@ else
   rm -rf "$HOME/BYOND"
   mkdir -p "$HOME/BYOND"
   cd "$HOME/BYOND"
-  if ! curl --connect-timeout 2 --max-time 10 "https://spacestation13.github.io/byond-builds/${BYOND_MAJOR_VERSION}/${BYOND_MAJOR_VERSION}.${BYOND_MINOR_VERSION}_byond_linux.zip" -o byond.zip -A "GoonstationCI/2.0"; then
+  if ! curl --fail --connect-timeout 2 --max-time 10 "https://spacestation13.github.io/byond-builds/${BYOND_MAJOR_VERSION}/${BYOND_MAJOR_VERSION}.${BYOND_MINOR_VERSION}_byond_linux.zip" -o byond.zip -A "GoonstationCI/2.0"; then
       echo "Mirror download failed, falling back to byond.com"
-      if ! curl --connect-timeout 2 --max-time 10 "http://www.byond.com/download/build/${BYOND_MAJOR_VERSION}/${BYOND_MAJOR_VERSION}.${BYOND_MINOR_VERSION}_byond_linux.zip" -o byond.zip -A "GoonstationCI/2.0"; then
+      if ! curl --fail --connect-timeout 2 --max-time 10 "http://www.byond.com/download/build/${BYOND_MAJOR_VERSION}/${BYOND_MAJOR_VERSION}.${BYOND_MINOR_VERSION}_byond_linux.zip" -o byond.zip -A "GoonstationCI/2.0"; then
           echo "BYOND download failed too :("
           exit 1
       fi


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If curl hits a 404 currently, it'll download the 404 page as byond.zip and then the unzip fails. Adding `--fail` causes it to return a non-zero exit code on a 404, allowing for the intended detection of failure.
