### PR TITLE
Emagged/Syndie borgs are considered "Other Antagonists" in the end of…

### DIFF
--- a/code/modules/antagonists/syndicate_cyborg/emagged_cyborg.dm
+++ b/code/modules/antagonists/syndicate_cyborg/emagged_cyborg.dm
@@ -2,6 +2,7 @@
 	id = ROLE_EMAGGED_ROBOT
 	display_name = "emagged cyborg"
 	antagonist_icon = "emagged"
+	succinct_end_of_round_antagonist_entry = TRUE
 	remove_on_death = TRUE
 	remove_on_clone = TRUE
 	keep_equipment_on_death = TRUE

--- a/code/modules/antagonists/syndicate_cyborg/syndicate_cyborg.dm
+++ b/code/modules/antagonists/syndicate_cyborg/syndicate_cyborg.dm
@@ -2,6 +2,7 @@
 	id = ROLE_SYNDICATE_ROBOT
 	display_name = "\improper Syndicate cyborg"
 	antagonist_icon = "syndieborg"
+	succinct_end_of_round_antagonist_entry = TRUE
 	remove_on_death = TRUE
 	remove_on_clone = TRUE
 	keep_equipment_on_death = TRUE


### PR DESCRIPTION
… round summary

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes Emagged and Syndicate cyborgs to appear in the smaller "Other antagonists" section at the bottom of the antagonist list, rather than with their own dropdown containing no extra information

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lots of emagged/syndieborgs are decently common and this can cause a massively inflated antagonist summary list. Other convertable antagonists show in this bottom tab to avoid this issue and syndicate and emagged cyborgs are often more common than say, a mindhack army.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="584" height="259" alt="image" src="https://github.com/user-attachments/assets/f8d81517-adaa-4ae9-86c8-69e3e45a2854" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Emagged and Syndicate cyborgs will now appear in the other/minor antagonists section of the round summary, rather than as main antagonists.
```
