### PR TITLE
Makes scrap weapons + nanofab weapons contraband 4

### DIFF
--- a/code/WorkInProgress/MarqStuff.dm
+++ b/code/WorkInProgress/MarqStuff.dm
@@ -649,7 +649,7 @@
 	spread_angle = 40
 	force = 5
 	can_dual_wield = 0
-	contraband = 0
+	contraband = 3
 	move_triggered = 1
 	var/spread_base = 40
 	var/max_draw = 3

--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -1332,6 +1332,7 @@ Returns:
 	desc = "An ancient solution to the ancient problem of wanting to stab somebody, but not wanting them to be able to stab you back."
 	force = 10
 	throwforce = 20
+	contraband = 4
 	color = "#ffffff"
 	icon = 'icons/obj/items/weapons.dmi'
 	icon_state = "spear"

--- a/code/obj/item/scrapweapons.dm
+++ b/code/obj/item/scrapweapons.dm
@@ -129,6 +129,7 @@ ABSTRACT_TYPE(/obj/item/scrapweapons/weapons)
 /obj/item/scrapweapons/weapons
 	name = "youshouldntseemee scrapweapon"
 	force = 5
+	contraband = 4
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Any scrap weapon (not their components), and the spear is contraband 4. This means that holding them in your hand will now set off security alarms, trigger beepsky, and show the contraband sechud indicator. The bow is only contraband 3.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nanotrasen probably doesn't want their employees carrying weapons everywhere. Thematically it makes sense you'd have to hide them a little bit in your backpack or something.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I just opened goonstation and grabbed the items I changed. 
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(*)Due to caveman rumors Nanotrasen has now decided to make scrap weapons and the spear contraband level 4, and the bow contraband level 3.