### PR TITLE
Mild buff to scrap weapons

### DIFF
--- a/code/obj/item/scrapweapons.dm
+++ b/code/obj/item/scrapweapons.dm
@@ -142,7 +142,7 @@ ABSTRACT_TYPE(/obj/item/scrapweapons/weapons)
 	item_state = "spear"
 	w_class = W_CLASS_NORMAL
 	hit_type = DAMAGE_BLUNT
-	force = 6
+	force = 7
 	throwforce = 10
 	custom_suicide = 1
 	attack_verbs = "impales"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
All scrap weapons have had their base weapon damage increased by 1, and the plasmaglass variants have had their damage increased by 2.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The makeshift weapons feel a bit weak compared to standard station equipment which is far more available. This makes them a bit stronger. Also widens the gap between the normal and plasmaglass variants because plasmaglass is way harder to obtain.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I beat up some monkeys with a spear, felt fine? Hard to test combat changes by yourself though.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(*)Makeshift weapons have had their damage slightly buffed.
```
