### PR TITLE
If a hotspot is pinned it will change color on the trench map

### DIFF
--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -91,12 +91,15 @@
 		var/list/hotspots = list()
 
 		for (var/datum/sea_hotspot/S in hotspot_groups)
-			if (S.can_drift == 1) // draws the hotspots on the trench map and changes color if it is pinned
-				S.hotspot_color = "hotspot"
-			else
-				S.hotspot_color = "pinned_hotspot"
 
-			hotspots += {"<div class='[S.hotspot_color]' style='bottom: [S.center.y * 2]px; left: [S.center.x * 2]px; width: [S.radius * 4 + 2]px; height: [S.radius * 4 + 2]px; margin-left: -[S.radius * 2]px; margin-bottom: -[S.radius * 2]px;'></div>"}
+			var/hotspot_color
+
+			if (S.can_drift == 1) // draws the hotspots on the trench map and changes color if it is pinned
+				hotspot_color = "hotspot"
+			else
+				hotspot_color = "pinned_hotspot"
+
+			hotspots += {"<div class='[hotspot_color]' style='bottom: [S.center.y * 2]px; left: [S.center.x * 2]px; width: [S.radius * 4 + 2]px; height: [S.radius * 4 + 2]px; margin-left: -[S.radius * 2]px; margin-bottom: -[S.radius * 2]px;'></div>"}
 
 		src.map_html = {"
 <!doctype html>
@@ -264,6 +267,8 @@
 
 				S.move_center_to(get_step(S.center.turf(), S.drift_dir))
 
+				generate_map_html() //updates the map when hotspot gets stomped
+
 	proc/colorping_at_turf(var/turf/T)
 		for (var/datum/sea_hotspot/S in hotspot_groups)
 			if(S.get_tile_heat(T))
@@ -302,8 +307,6 @@
 	var/d = 0
 
 	var/last_colorping = 0
-
-	var/hotspot_color
 
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [ENGINEERING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This will update the trench map to show wether or not a hotspot is pinned with a different color. Also makes the trench map update whenever a hotspot is stomped
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There is virtually no feedback on if a hotspot is pinned or not
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
<img width="630" height="671" alt="image" src="https://github.com/user-attachments/assets/65bb57d7-835e-480e-8056-df777beb5a1e" />

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Phoi
(+)Changes trench map to update hotspot color based on wether it is pinned or not 
(+)Adds pinned hotspot color to key
```

