### PR TITLE
Adds the handheld pipe dispenser to the science manufacturer

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -997,6 +997,9 @@
 	time = 90 SECONDS
 	category = "Tool"
 
+/datum/manufacture/places_pipes/science
+	item_outputs = list(/obj/item/places_pipes/research)
+
 /datum/manufacture/RCDammo
 	name = "Compressed Matter Cartridge"
 	item_requirements = list("dense" = 30)

--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -280,6 +280,8 @@
 		/datum/manufacture/chembarrel,
 		/datum/manufacture/chembarrel/yellow,
 		/datum/manufacture/chembarrel/red,
+		/datum/manufacture/places_pipes/science,
+		/datum/manufacture/RCDammo,
 		/datum/manufacture/condenser,
 		/datum/manufacture/fractionalcondenser,
 		/datum/manufacture/dropper_funnel,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The science variant of the pipe dispenser can now be made at the same cost as the engineering one in the science manufacturer. It can now also print small matter cartridges to refill the dispenser.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Science does gas and fluid stuff, they should probably have the means to make the gas and fluid tool.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Thats what it do yugi
<img width="1107" height="427" alt="image" src="https://github.com/user-attachments/assets/7094e754-5a5a-4aa0-b8d4-91a38434c56a" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(+)The handheld pipe dispenser is now manufacturable from the science manufacturer.
```
