### PR TITLE
Fixed impact pad stand extension animation not playing

### DIFF
--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -3732,7 +3732,7 @@ TYPEINFO(/obj/machinery/networked/test_apparatus)
 						src.visible_message("<b>[src.name]</b> extends its stand.")
 						src.set_density(1)
 						src.setup_base_icon_state = "impactstand"
-						FLICK("impactpad-extend",src)
+						FLICK("impactstand-extend",src)
 						src.UpdateIcon()
 						playsound(src.loc, 'sound/effects/pump.ogg', 50, 1)
 					else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL]-->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FIX] [SCIENCE]
## About the PR
The impact pad in the artifact lab has animations for both extending and retracting the stand for smaller items, but until now the animation was only played when the stand retracted. This PR is a very minor fix that makes the animation play correctly in both directions.

## Why's this needed?
The animation only working one way is a little jarring when working in the lab.

## Testing
I raised and lowered the stand several times, then did several tests with artifacts to make sure the pad still functioned just to be safe.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Hawke
(+)The impact pad's stand now properly plays the extension animation.
```
