### PR TITLE
Gives borgs the *raisehand emote

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -608,7 +608,7 @@ TYPEINFO(/mob/living/silicon/robot)
 						maptext_out = "<I>raises [thing]</I>"
 					else
 						message = "<b>[used_name]</b> raises [his_or_her(src)] distinct lack of hands."
-						maptext_out = "<I>raises a lack of hands</I>"
+						maptext_out = "<I>raises [his_or_her(src)] lack of hands</I>"
 				else
 					message = "<b>[used_name]</b> tries to move [his_or_her(src)] arm."
 					maptext_out = "<I>tries to move [his_or_her(src)] arm</I>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets borgs *raisehand, allowing them to show off their selected tool, or the fact that they don't have hands.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gives cyborg players a quick way to communicate what tool they're using.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="349" height="218" alt="saw" src="https://github.com/user-attachments/assets/0fe147a4-37e8-4d76-b63a-6d4586bf8926" />
<img width="318" height="177" alt="nohands" src="https://github.com/user-attachments/assets/b1d7a9a5-3ef8-49b9-a758-aac835f381d2" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Smearfo
(+)Cyborgs can now *raisehand.
```
