### PR TITLE
Fixes wrestling bell runtime + Spawn new hammer if destroyed

### DIFF
--- a/code/obj/item/wrestlingbell.dm
+++ b/code/obj/item/wrestlingbell.dm
@@ -44,9 +44,9 @@
 		RegisterSignal(src.hammer, COMSIG_MOVABLE_MOVED, PROC_REF(hammer_move))
 
 	disposing()
-		if (hammer)
-			qdel(hammer)
-			hammer = null
+		if (src.hammer)
+			qdel(src.hammer)
+			src.hammer = null
 		..()
 
 	process()
@@ -57,7 +57,7 @@
 		..()
 
 	update_icon()
-		if (hammer && hammer.loc == src)
+		if (src.hammer && src.hammer.loc == src)
 			icon_state = "wrestlingbell1"
 		else
 			icon_state = "wrestlingbell0"
@@ -66,7 +66,11 @@
 		if (isAI(user) || isintangible(user) || isobserver(user) || !in_interact_range(src, user)) return
 		user.lastattacked = get_weakref(src)
 		..()
-		if(hammer.loc != src)
+		if(!hammer || QDELETED(src.hammer))
+			boutput(user, "The wrestling bell grows a new tiny hammer. Nature is beautiful.")
+			src.hammer = new /obj/item/tinyhammer/wrestling(src)
+			src.hammer.parent = src
+		if(src.hammer.loc != src)
 			return //if someone else has it, don't put it in user's hand
 		user.put_in_hand_or_drop(src.hammer)
 		src.hammer.parent = src
@@ -96,7 +100,7 @@
 				src.put_back_hammer()
 
 	proc/put_back_hammer()
-		if (src.hammer)
+		if (src.hammer && !QDELETED(src.hammer))
 			playsound(src.loc, 'sound/impact_sounds/Generic_Click_1.ogg', 50)
 			src.hammer.force_drop(sever=TRUE)
 			src.hammer.set_loc(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Clicking on a wrestling bell that's had its tiny hammer destroyed causes a runtime, I've added a qdelete check to fix that. The bell will also grow a new tiny hammer if it has none, which shouldn't generally happen.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtime bad, perma-broken bell after hammer destruction also bad.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I've tested this a few times, seems to work. There's still some weirdness like if you deep fry the tiny hammer, the real one will be set_loc'd out from the deep fried hammer's contents effectively enabling infinite deep fried hammers. Things like that require someone to build a new machine next to the bell though so I think it's fine for now. I imagine deep frying might be re-done to work like electroplating one day anyway.
