### PR TITLE
Fixes #24846 - Non-Player Speech Is No Longer Screened For Links

### DIFF
--- a/code/modules/speech/trees/speech_module_tree.dm
+++ b/code/modules/speech/trees/speech_module_tree.dm
@@ -151,10 +151,11 @@
 		logTheThing(LOG_ADMIN, message.speaker, "[message.speaker] tried to say \"[message.original_content]\" but it was garbled into \"[message.content]\", which is uncool by the following effects: [jointext(modifier_ids, ", ")]. The uncool words were garbled.")
 		message.content = replacetext(message.content, global.phrase_log.uncool_words, pick("urr", "blargh", "der", "hurr", "pllt"))
 
-	// Check for URLs if we're an IC channel, let people paste wiki links at each other in LOOC if they want to
-	if (!global.SpeechManager.GetSayChannelInstance(message.output_module_channel).allows_urls && global.url_regex.Find(message.content))
+	// Check for URLs if we're an IC channel, let people paste wiki links at each other in LOOC if they want to.
+	if ((message.flags & SAYFLAG_SPOKEN_BY_PLAYER) && !global.SpeechManager.GetSayChannelInstance(message.output_module_channel).allows_urls && global.url_regex.Find(message.content))
 		if (ismob(message.speaker))
-			boutput(message.speaker, "<span class='notice'><b>Web/BYOND links are not allowed in ingame chat.</b></span>")
+			boutput(message.speaker, SPAN_NOTICE("<b>Web/BYOND links are not allowed in ingame chat.</b>"))
+
 		return
 
 	// Apply sayflag message manipulation.


### PR DESCRIPTION
## About The PR:
Fixes #24846 by checking for the `SAYFLAG_SPOKEN_BY_PLAYER` flag when screening messages for links, allowing non-player atoms to send links over chat.


## Testing:
<img width="442" height="22" alt="image" src="https://github.com/user-attachments/assets/b04994f0-bf52-4265-baba-5b765ca6455d" />