### PR TITLE
Fixes Gunbots Not Being Able To Use Internal Radios

### DIFF
--- a/code/datums/critter_mobs/equipment.dm
+++ b/code/datums/critter_mobs/equipment.dm
@@ -134,7 +134,7 @@
 
 		intercom
 			after_setup(var/datum/hud/hud)
-				var/obj/item/device/radio/intercom/O = new(holder)
+				var/obj/item/device/radio/headset/O = new(holder)
 				equip(O)
 				// it's a built in radio, they can't take it off.
 				O.cant_self_remove = TRUE
@@ -142,7 +142,7 @@
 
 			syndicate
 				after_setup(var/datum/hud/hud)
-					var/obj/item/device/radio/intercom/syndicate/S = new(holder)
+					var/obj/item/device/radio/headset/syndicate/S = new(holder)
 					equip(S)
 					// it's a built in radio, they can't take it off.
 					S.cant_self_remove = TRUE

--- a/code/mob/living/critter/gunbot/gunbot.dm
+++ b/code/mob/living/critter/gunbot/gunbot.dm
@@ -3,7 +3,7 @@ TYPEINFO(/mob/living/critter/robotic/gunbot)
 				"conductive_high" = 12,
 				"dense" = 6)
 	start_speech_modifiers = list(SPEECH_MODIFIER_MOB_MODIFIERS, SPEECH_MODIFIER_ACCENT_ERROR)
-	start_speech_outputs = list(SPEECH_OUTPUT_SPOKEN_LOCAL)
+	start_speech_outputs = list(SPEECH_OUTPUT_SPOKEN_LOCAL, SPEECH_OUTPUT_EQUIPPED)
 
 /mob/living/critter/robotic/gunbot
 	name = "robot"


### PR DESCRIPTION
## About The PR:
Fixes gunbots and their subtypes not being able to use their internal radios due to the radios being typed as intercoms and the gunbots themselves lacking an `EQUIPPED` speech output.


## Testing:
<img width="542" height="53" alt="image" src="https://github.com/user-attachments/assets/cb628852-7c2f-4b76-b65d-1a70ceff56f7" />