### PR TITLE
Clears pushing on conga line

### DIFF
--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -368,9 +368,9 @@
 		A.glide_size = glide
 		var/turf/pulled_old_loc = A.loc
 		step(A, get_dir(A, old_loc))
-		A.glide_size = glide
 		A.OnMove(src)
 		if (istype(A, /mob/))
 			chain.Add(A)
 			var/mob/M = A
+			M.pushing = null
 			M.do_pulling(pulled_old_loc, glide, chain)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently, if you push someone, you cannot pull them until you move yourself. This means that if someone pushes someone behind them in a conga line. they have to move themselves before the conga line can be made again. This fixes this.

also removes duplicate line

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes bug
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
possessed assistants and made them push and pull eachother
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
