### PR TITLE
Removes panic buttons from secoff etc pouches

### DIFF
--- a/code/obj/item/storage/ammo_pouches.dm
+++ b/code/obj/item/storage/ammo_pouches.dm
@@ -212,7 +212,7 @@
 	icon_state = "ammopouch-ntsc"
 	health = 6
 	w_class = W_CLASS_SMALL
-	slots = 4
+	slots = 5
 	opens_if_worn = TRUE
 	prevent_holding = list(/obj/item/storage)
 	spawn_contents = list(/obj/item/handcuffs/ = 1,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
See title, leaves the big box of them in security. Also reduces pouch capacities by 1 so they're still full.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Further attempt to reduce security swarm effect. Leaving them in security lets people pick them up if they think they'll need them, before going into danger, or hand them out to VIPs who need protection.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="76" height="401" alt="image" src="https://github.com/user-attachments/assets/c736998d-b54b-46be-b8dd-519328f1e9db" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Security roles no longer start with a panic button in their pouch.
```
