### PR TITLE
Health implants only send PDA alerts to medical/chaplain

### DIFF
--- a/code/datums/jobs/jobs_command.dm
+++ b/code/datums/jobs/jobs_command.dm
@@ -25,7 +25,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	receives_miranda = TRUE
 	can_roll_antag = FALSE
 	world_announce_priority = ANNOUNCE_ORDER_CAPTAIN
-	receives_implants = list(/obj/item/implant/health/security/anti_mindhack)
+	receives_implants = list(/obj/item/implant/health/security/anti_mindhack/command)
 	wiki_link = "https://wiki.ss13.co/Captain"
 
 	slot_card = /obj/item/card/id/gold
@@ -96,7 +96,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	receives_disk = /obj/item/disk/data/floppy/sec_command
 	badge = /obj/item/clothing/suit/security_badge
 	show_in_id_comp = FALSE
-	receives_implants = list(/obj/item/implant/health/security/anti_mindhack)
+	receives_implants = list(/obj/item/implant/health/security/anti_mindhack/command)
 	items_in_backpack = list(/obj/item/device/flash)
 	wiki_link = "https://wiki.ss13.co/Head_of_Security"
 

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -327,9 +327,11 @@ THROWING DARTS
 	icon_state = "implant-b"
 	impcolor = "b"
 	scan_category = IMPLANT_SCAN_CATEGORY_HEALTH
-	var/healthstring = ""
 	uses_radio = 1
 	mailgroups = list(MGD_MEDBAY, MGD_MEDRESEACH, MGD_SPIRITUALAFFAIRS)
+
+	var/healthstring = ""
+	var/affected = "CREW"
 
 	implanted(mob/M, mob/I)
 		..()
@@ -425,21 +427,12 @@ THROWING DARTS
 			if(cl_implant.owner != src.owner || !cl_implant.scanned_here)
 				continue
 			cloner_areas += "[cl_implant.scanned_here]"
-		var/message = "DEATH ALERT: [src.owner] in [myarea], " //youre lucky im not onelining this
-		if (he_or_she(src.owner) == "they")
-			message += "they " + (length(cloner_areas) ? "were clone-scanned in [jointext(cloner_areas, ", ")]." : "do not have a cloning implant.")
-		else
-			message += he_or_she(src.owner) + " " + (length(cloner_areas) ? "was clone-scanned in [jointext(cloner_areas, ", ")]." : "does not have a cloning implant.")
-
+		var/message = "[affected] DEATH ALERT: [src.owner] in [myarea]. [length(cloner_areas) ? "Clone implant detected." : "No cloning implant detected."]"
 		src.send_message(message, MGA_DEATH, "HEALTH-MAILBOT")
 
 /obj/item/implant/health/security
 	name = "health implant - security issue"
-
-	death_alert()
-		mailgroups.Add(MGD_SECURITY)
-		..()
-		mailgroups.Remove(MGD_SECURITY)
+	affected = "SECURITY"
 
 /obj/item/implant/health/security/anti_mindhack
 	name = "mind protection health implant"
@@ -450,6 +443,10 @@ THROWING DARTS
 		. = ..()
 		src.on_remove(src.owner)
 		qdel(src)
+
+/obj/item/implant/health/security/anti_mindhack/command
+	name = "health implant - command issue"
+	affected = "COMMAND"
 
 /obj/item/implant/emote_triggered/freedom
 	name = "freedom implant"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[medical][station systems][balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The security mailgroup is no longer alerted when security health implants trigger a death alert.

Instead, the death alerts add a prefix to the message based on the type of health implant:
* Printable health implants say "CREW"
* Security implants say "SECURITY"
* Command members that recieve health implants by default (Captain/HoS) now get a new implant sub-type that says "COMMAND"

The report also strips the clone scan location, just noting whether they had a cloning implant or not.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Encourage/require more communication between medical and security teams to deal with death on station.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="1072" height="87" alt="Screenshot 2025-11-02 111517" src="https://github.com/user-attachments/assets/a4482585-6a20-4d57-a6fb-2d7e1a317e74" />
<img width="1134" height="88" alt="Screenshot 2025-11-02 111529" src="https://github.com/user-attachments/assets/5f2e8a03-0a1d-41fe-8319-b061de0b107b" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Death alerts only send messages to the medical and spiritualaffairs mailgroups and include the type of health implant that triggered the alert.
(+)Death alerts only indicate if the person has a clone implant, not the location of the cloner. Rejoice, mindhackers!
```