### PR TITLE
Fix addict trait nicotine addiction being unsatisfiable

### DIFF
--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -364,7 +364,7 @@
 	proc/metabolised_addictive_reagent(var/datum/reagent/reagent, var/rate, var/mult)
 		// The minimum rate means that patches with less than ~1 unit of the addictive reagent usually won't work to satisfy addiction.
 		// This is useful because dose logic is very binary and exploitable by microdosing with ludicrously small volumes.
-		if (reagent.addiction_severity < src.severity || rate < 0.04 * mult)
+		if (rate < 0.04 * mult)
 			return
 		if (src.associated_reagent == reagent.name)
 			src.last_reagent_dose = TIME
@@ -373,7 +373,7 @@
 				src.stage = 1
 				src.stage_satisfied = FALSE
 			return
-		else if (!src.tick_satisfied)
+		else if (reagent.addiction_severity >= src.severity && !src.tick_satisfied)
 			src.tick_satisfied = TRUE
 			src.addiction_meter += src.depletion_rate * 2
 			if (!src.stage_satisfied && src.stage > 1)
@@ -381,7 +381,7 @@
 				src.stage_satisfied = TRUE
 
 	proc/ingested_addictive_reagent(var/datum/reagent/reagent, var/volume)
-		if (reagent.addiction_severity < src.severity || volume < 0.1)
+		if (volume < 0.1)
 			return
 		if (src.associated_reagent == reagent.name)
 			src.last_reagent_dose = TIME
@@ -390,7 +390,7 @@
 				boutput(src.affected_mob, SPAN_NOTICE("<b>That's the good stuff! But how long can it last?</b>"))
 				src.stage = 1
 				src.stage_satisfied = FALSE
-		else if (src.stage > 1 && !src.stage_satisfied)
+		else if (reagent.addiction_severity >= src.severity && src.stage > 1 && !src.stage_satisfied)
 			src.stage -= 1
 			src.stage_satisfied = TRUE
 			// don't want every addiction spamming this message whenever any addictive reagent is taken


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Moves the addiction severity check back a bit so it doesn't stop associated reagents satisfying the addiction in cases where the severity of the reagent and the severity of the addiction don't match. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This fixes a bug where a nicotine addiction from the 'addict' trait couldn't be satisfied by consuming nicotine. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Applied a nicotine addiction from the addict trait and smoked a cigarette. Also took meth to make sure other addictive drugs still worked to satisfy addictions properly.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

