### PR TITLE
Removes starting cash, starting bonus paid to bank account instead

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -638,7 +638,7 @@
 
 /datum/trait/pawnstar
 	name = "Pawn Star"
-	desc = "You sold your trinket before you departed for the station. You start with a bonus of 25% of your starting cash in your inventory."
+	desc = "You sold your trinket before you departed for the station. You start with a bonus of 25% of your starting money in your bank account."
 	id = "pawnstar"
 	icon_state = "pawnP"
 	points = 0

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -812,19 +812,10 @@ Equip items from body traits.
 	src.mind?.remembered_pin = C.pin
 
 	if (JOB.wages > 0)
-		var/cashModifier = 1
-		if (src.traitHolder && src.traitHolder.hasTrait("pawnstar"))
-			cashModifier = 1.25
-
-		var/obj/item/currency/spacecash/S = new /obj/item/currency/spacecash
-		S.setup(src,round(JOB.wages * cashModifier))
-
-		if (isnull(src.get_slot(SLOT_R_STORE)))
-			src.equip_if_possible(S, SLOT_R_STORE)
-		else if (isnull(src.get_slot(SLOT_L_STORE)))
-			src.equip_if_possible(S, SLOT_L_STORE)
-		else
-			src.equip_if_possible(S, SLOT_IN_BACKPACK)
+		var/startingBonusModifier = 1
+		if (src.traitHolder?.hasTrait("pawnstar"))
+			startingBonusModifier += 0.25
+		C.money += round(JOB.wages * startingBonusModifier)
 	else
 		var/shitstore = rand(1,3)
 		switch(shitstore)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR is intended as an alternative to #25079.

Starting cash no longer spawns in a player's inventory. The starting bonus you would usually be paid, including the 25% Pawn Star bonus, now starts in the player's bank account. Pens and water bottles may still spawn randomly in your right pocket if possible only if your job is not paid any wage, as per prior behaviour.

Pawn Stars trait description updated to match behaviour.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

As an alternative to #25079, this PR would not necessitate any player input to get rid of starting cash on a given character slot as it'd be fully automatic. Access to cash wouldn't be impeded for those who have access to a bank account as withdrawing physical cash is trivial with a PDA.

At present, I anticipate that the biggest pinch point would be for new users who aren't as familiar with using card-based payments. Cash on its own presents challenges due to it requiring two hands to separate stacks, so I don't currently believe that this would be too much of an issue.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

Tested by loading in a character with a bank account and comparing money on card to job wages. Confirmed to work with Pawn Star's 25% bonus.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DisturbHerb
(*)HR has finally discovered how to pay employees' starting bonuses into their bank accounts instead of giving them untraceable physical cash.
```
