### PR TITLE
Rework Addict trait addictions list

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1061,7 +1061,7 @@ TYPEINFO(/datum/trait/partyanimal)
 	points = 2
 	afterlife_blacklisted = TRUE
 	var/selected_reagent = "ethanol"
-	var/addictive_reagents = list("LSD", "space_drugs", "methamphetamine", "ethanol", "nicotine", "caffeine", "morphine", "cold_medicine",
+	var/addictive_reagents = list("space_drugs", "methamphetamine", "ethanol", "nicotine", "caffeine", "morphine", "cold_medicine",
 									 "crank", "krokodil")
 	var/do_addiction = FALSE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changed up the list of potential drug addictions of the Addict trait to emphasise accessibility and theme.

The new list is:
- Space Drugs
- Meth
- Ethanol
- Nicotine
- Caffeine
- Morphine
- Robustissin
- Crank
- Krokodil

Reasonings:
- removed psilocybin, LSD and cat drugs because they are non-addictive, and were in fact broken. Because of the way addiction works, the withdrawal symptoms of non-addictive drugs cannot be satisfied by consuming the associated reagent.
- removed bath salts, because it's a difficult reagent to obtain in any given round.
- added caffeine, because it's widely available.
- added crank and krokodil, because they are available in the space diner as well as via chemistry, and are sort of the quintessential back-alley drugs after bath salts.
- added morphine, because it's available from botany, medbay, chemistry, the space diner, and other traders.
- added robustissin, because it's available from medbay and I thought there should be another reason for addicts to go begging or stealing reasonably benign drugs from doctors. 
- kept ethanol and nicotine because they are widely available.
- kept space drugs because it is easily synthesised.
- kept meth because it is available from the space diner, botany, and chemistry. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Addict is actually quite broken, almost half the drugs on the list are non-addictive and thus do not quell withdrawal symptoms. 

A frequent complaint about the trait is that sometimes the drugs are difficult to obtain, which seems like it can be reasonably attributed to the inclusion of bath salts. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Set the trait to apply addictions immediately and then spammed adding and removing the addict trait with admin commands, and checked health each time for oddities. 

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Egregorious
(+)The list of possible addictions from the addict trait has been reworked. 
```
