### PR TITLE
Fix animated ingredients' icons appearing as every frame in oven UI

### DIFF
--- a/code/modules/cooking/kitchen_submachines.dm
+++ b/code/modules/cooking/kitchen_submachines.dm
@@ -503,7 +503,7 @@ TYPEINFO(/obj/submachine/chef_oven)
 			return
 		var/list/contained = list()
 		for (var/obj/item/I in src.contents)
-			contained += icon2base64(getFlatIcon(I), "chef_oven-\ref[src]")
+			contained += icon2base64(getFlatIcon(I,no_anim=TRUE), "chef_oven-\ref[src]")
 		return contained
 
 	proc/get_content_names()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Does what it says on the tin, quick one line change that makes animated ingredients appear as their first frame instead of every frame.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug bad

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested, doesn't seem like something that would break.
Before:
<img width="194" height="178" alt="jMwbbTdqct" src="https://github.com/user-attachments/assets/a6a8e62d-cf28-4ab7-8db0-db22e850519e" />
After:
<img width="133" height="70" alt="twxzIYDch5" src="https://github.com/user-attachments/assets/2cc2d5e0-ba16-498c-aab1-71cbe8fe1ff8" />


