### PR TITLE
Elvis Monkeys No Longer Cause Simian Rage Cascades That Crash The Server

### DIFF
--- a/code/modules/speech/modules/listen/effects/monkey.dm
+++ b/code/modules/speech/modules/listen/effects/monkey.dm
@@ -5,7 +5,8 @@
 	var/mob/living/carbon/human/npc/monkey/monkey = src.parent_tree.listener_parent
 	if (!istype(monkey) || !isalive(monkey) || !ismob(message.speaker) || !(message.flags & (SAYFLAG_LOUD_SINGING | SAYFLAG_BAD_SINGING)))
 		return
-	if (message.speaker == monkey)
+
+	if ((message.speaker == monkey) || !ishuman(message.speaker) || ismonkey(message.speaker) || !prob(50))
 		return
 
 	SPAWN(0.5 SECONDS)


### PR DESCRIPTION
## About The PR:
Monkeys no longer become angered by loud or bad singing if the singer is another monkey or is non-human. This fixes a bug wherein two monkeys with the Elvis accent would enter into a loop of angering each other, with the anger speech of the first monkey (mutated into song by the accent), which contains an exclamation mark causing the singing to be marked as loud, angering the other monkey, in turn causing them to irately remark about the first monkey's awful vocalisations, and so forth.


## Testing:
Monkeys in the monkeydome were forced to loudly sing, with no instances of other monkeys becoming enraged.
A human mob singing loudly still causes monkeys to become angered, as expected.