### PR TITLE
Adjust chemfire atmos interactions to be more reasonable

### DIFF
--- a/code/modules/atmospherics/FEA_fire.dm
+++ b/code/modules/atmospherics/FEA_fire.dm
@@ -101,6 +101,9 @@
 #endif
 	/// Volume to expose to other atoms. Also used while [/atom/movable/hotspot/var/bypassing] is FALSE to act on a volume of gas on our turf.
 	var/volume = 125
+	/// How much the volume of this hotspot is scaled by when affecting gas temperature
+	/// Importantly this is ONLY gas temperature and not other "expose" effects like objects being caught in the fire
+	var/atmos_heating_mult = 1
 	/// Our temperature.
 	var/temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST
 	/// If we've just spawned then don't process yet, wait a cycle.
@@ -156,7 +159,9 @@
 			src.temperature = location.air.temperature
 	else
 		bypassing = FALSE
-		var/datum/gas_mixture/affected = location.air.remove_ratio(src.volume/max((location.air.volume/5),1))
+		var/affected_volume = src.volume/max((location.air.volume/5),1)
+		affected_volume *= src.atmos_heating_mult
+		var/datum/gas_mixture/affected = location.air.remove_ratio(affected_volume)
 
 		affected.temperature = src.temperature
 		if( affected.react() & CATALYST_ACTIVE)
@@ -395,6 +400,8 @@
 	plane = PLANE_NOSHADOW_BELOW
 	layer = OBJ_LAYER - 0.2 // so that part of the fire appears behind objects. 0.2 to account for vending machine, etc layering
 	blend_mode = BLEND_DEFAULT
+	//chemical fires heat things up less than the air itself being on fire, this makes sense I think
+	atmos_heating_mult = 1/20
 
 	var/fire_color = CHEM_FIRE_RED
 

--- a/code/procs/fireflash.dm
+++ b/code/procs/fireflash.dm
@@ -39,8 +39,8 @@
 				continue
 
 		// create hotspots
-		var/atom/movable/hotspot/hotspot = T.add_hotspot(temp - GET_DIST(center_turf, T) * falloff, 15, chemfire)
-		T.hotspot_expose(temp - GET_DIST(center_turf, T) * falloff, 15)
+		var/atom/movable/hotspot/hotspot = T.add_hotspot(temp - GET_DIST(center_turf, T) * falloff, 400, chemfire)
+		T.hotspot_expose(temp - GET_DIST(center_turf, T) * falloff, 400)
 
 		if (!QDELETED(hotspot))
 			created_hotspots += hotspot


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes adding a hotspot to an airgroup immediately suspend its group processing and makes chemfires heat up air specifically 20x less.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Looking into blob balance issues from this thread https://forum.ss13.co/showthread.php?tid=24681 I realised that flamethrowers have an issue where 80% of the time they have zero effect on atmos because they're not enough to suspend group processing and then when they *do* have an effect they have such a high volume (3.2x higher than an atmos fire) that they instantly skyrocket the temperature up to ~1200C.

I know this will cause some extra server load so it might be worth testmerging but I do think there being a FIRE in the room is a good reason to want to start actually processing cell-level atmos again. It shouldn't have any effect on atmos fires since if gas in the air is on fire the room is already definitely not group processing.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Firing a single flamethrower shot now brings the temperature up to about 100C, then quickly dissipates back down and *eventually* resumes group processing (the logic for this could still use some work, larger airgroups can take a VERY long time to resume group processing)
<img width="816" height="282" alt="image" src="https://github.com/user-attachments/assets/17ca0865-2bf1-422f-94c0-cb8b03b538ba" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Chemical fires now heat up the air less but much more consistently.
```
