### PR TITLE
Switched the pickup verb to use tgui_input_list

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -3368,7 +3368,8 @@ TYPEINFO(/mob)
 			items += I
 	if (items.len)
 		var/atom/A = tgui_input_list(src, "What do you want to pick up?", "", items, start_with_search = TRUE)
-		src.client?.Click(A, get_turf(A))
+		if (A)
+			src.client?.Click(A, get_turf(A))
 
 /mob/proc/can_eat(var/atom/A)
 	return 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## It switches pickup verb to use tgui_input_list <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

## Because the default DM prompt gui prompt doesn't allow you to search by default making pickup less viable than the mouse and click. <!-- Describe why you think this should be added to the game. -->

## I compiled it. Kept starting the game by hitting ready then going to server and hitting `start now`. From there I would press P. Eventually, i figured out a way for it to popup.
<img width="556" height="434" alt="image" src="https://github.com/user-attachments/assets/bf74b548-f07e-44e0-afb6-250054602ae8" />
  <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Updated the pickup verb (default hotkey: p) to use TGUI. <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Albassort
(*)Updated the pickup verb (default hotkey: p) to use TGUI. Now you can fuzzy search items!
```
