### PR TITLE
Fix animated oven result icons

### DIFF
--- a/code/modules/cooking/kitchen_submachines.dm
+++ b/code/modules/cooking/kitchen_submachines.dm
@@ -527,7 +527,7 @@ TYPEINFO(/obj/submachine/chef_oven)
 
 		for(var/I in possible.ingredients)
 			var/atom/item_path = I
-			src.output_icon = icon2base64(getFlatIcon(I, no_anim=TRUE), "chef_oven-\ref[src]")
+			src.output_icon = icon2base64(getFlatIcon(item_path, no_anim=TRUE), "chef_oven-\ref[src]")
 			src.possible_recipe_names += "[initial(item_path.name)][possible.ingredients[I] > 1 ? " x[possible.ingredients[I]]" : ""]"
 
 		if (ispath(possible.output))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Does the same as #25122, I didn't think to replicate it for the other parts of the UI.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug bad.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested using #25161, seems to work.