### PR TITLE
Buff csaber swipe attack

### DIFF
--- a/code/modules/items/specials/ItemSpecials.dm
+++ b/code/modules/items/specials/ItemSpecials.dm
@@ -750,14 +750,12 @@
 					playsound(master, 'sound/effects/flame.ogg', 50, FALSE)
 		return
 
-	csaber //no stun and less damage than normal csaber hit ( see sword/attack() )
+	csaber
 
-		damageMult = 0.54
+		damageMult = 0.8
 
 		onAdd()
 			if(master)
-				//cooldown = master.click_delay
-				overrideStaminaDamage = master.stamina_damage * 0.9
 				var/obj/item/sword/saber = master
 				if (istype(saber))
 					swipe_color = get_hex_color_from_blade(saber.bladecolor)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stamina damage mult: 0.9 -> 1
Brute damage mult: 0.54 -> 0.8
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Did you know the csaber specifically is the only weapon in the game to do half damage on special attack? Why is this? I don't know!
I don't see this thing used too much recently so a buff is probably fine and being punished that much for daring to use a special attack feels very bad.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)The cyalume saber's swipe special attack now does full stamina damage and 0.8x base damage instead of 0.54x.
```
