### PR TITLE
Material Texture Fixes & Code cleanup

### DIFF
--- a/code/WorkInProgress/IconProcs.dm
+++ b/code/WorkInProgress/IconProcs.dm
@@ -102,6 +102,33 @@ icon
 		Higher value means brighter color
  */
 
+/// Use another icon as a cut-out for the original icon
+proc/GetMaskedIcon(var/icon/original, var/icon/mask_base)
+	RETURN_TYPE(/icon)
+	var/icon/mask = icon(mask_base)
+	mask.MapColors(1,1,1, 1,1,1, 1,1,1, 1,1,1)
+	mask.Blend(original, ICON_MULTIPLY)
+	return mask
+
+proc/GetTexturedIcon(var/icon/I, var/texture)
+	RETURN_TYPE(/icon)
+	if(isfile(I))
+		I = icon(I) // Management needs you to find the difference between these two icons: "It's the same icon." - Byond
+	if(!I || !texture)
+		return null
+
+	var/icon_height = I.Height()
+	var/icon_width = I.Width()
+	var/icon/tex
+	if(icon_height <= 32 && icon_width <= 32)
+		tex = icon('icons/effects/atom_textures_32.dmi', texture)
+	else if(icon_height <= 64 && icon_width <= 64)
+		tex = icon('icons/effects/atom_textures_64.dmi', texture)
+	else
+		return null
+
+	return GetMaskedIcon(tex, I)
+
 proc/ReadRGB(rgb)
 	if(!rgb) return
 

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -77,7 +77,6 @@ TYPEINFO(/atom)
 	var/list/name_suffixes = null
 	var/num_allowed_prefixes = 10
 	var/num_allowed_suffixes = 5
-	var/image/worn_material_texture_image = null
 
 	/// Whether the last material applied updated appearance. Used for re-applying material appearance on icon update
 	var/material_applied_appearance = FALSE
@@ -868,97 +867,20 @@ TYPEINFO(/atom/movable)
 		hits = "\the [self.real_name]"
 	user.visible_message(SPAN_COMBAT("<B>[user] hits [hits] with [W]!</B>"))
 
-//This will looks stupid on objects larger than 32x32. Might have to write something for that later. -Keelin
+/// Note: Texture is only applied if the object is 64x64 or smaller
 /atom/proc/setTexture(var/texture, var/blendMode = BLEND_MULTIPLY, var/key = "texture")
 	var/image/I = isnull(texture) ? null : getTexturedImage(src, texture, blendMode)//, key)
 	src.UpdateOverlays(I, key)
 
-	if(isitem(src) && key == "material")
-		worn_material_texture_image = isnull(texture) ? null : getTexturedWornImage(src, texture, blendMode)
-	return
-
-/proc/getTexturedIcon(var/atom/A, var/texture = "damaged")//, var/key = "texture")
+/proc/getTexturedImage(var/atom/A, var/texture = "damaged", var/blendMode = BLEND_MULTIPLY)
 	if (!A)
 		return
-	var/icon/tex = null
-
-	//Try to find an appropriately sized icon.
-	if(istype(A, /atom/movable))
-		var/atom/movable/M = A
-		if(A.texture_size == 32 || ((M.bound_height == 32 && M.bound_width == 32) && !A.texture_size))
-			tex = icon('icons/effects/atom_textures_32.dmi', texture)
-		else if(A.texture_size == 64 || ((M.bound_height == 64 && M.bound_width == 64) && !A.texture_size))
-			tex = icon('icons/effects/atom_textures_64.dmi', texture)
-		else
-			tex = icon('icons/effects/atom_textures_32.dmi', texture)
-	else if (isicon(A))
-		var/icon/I = A
-		if(I.Height() > 32)
-			tex = icon('icons/effects/atom_textures_64.dmi', texture)
-		else
-			tex = icon('icons/effects/atom_textures_32.dmi', texture)
-	else
-		if(A.texture_size == 32)
-			tex = icon('icons/effects/atom_textures_32.dmi', texture)
-		else if(A.texture_size == 64)
-			tex = icon('icons/effects/atom_textures_64.dmi', texture)
-		else
-			tex = icon('icons/effects/atom_textures_32.dmi', texture)
-
-	var/icon/mask = null
-	mask = new(isicon(A) ? A : A.icon)
-	mask.MapColors(1,1,1, 1,1,1, 1,1,1, 1,1,1)
-	mask.Blend(tex, ICON_MULTIPLY)
-	//mask is now a cut-out of the texture shaped like the object.
-	return mask
-
-/proc/getTexturedImage(var/atom/A, var/texture = "damaged", var/blendMode = BLEND_MULTIPLY)//, var/key = "texture")
-	if (!A)
+	var/mask = GetTexturedIcon(A.icon, texture) // mask is a cut-out of the texture shaped like the object.
+	if(!mask)
 		return
-	var/mask = getTexturedIcon(A, texture)
-	//mask is now a cut-out of the texture shaped like the object.
 	var/image/finished = image(mask,"")
 	finished.blend_mode = blendMode
 	return finished
-
-/proc/getTexturedWornImage(var/obj/item/A, var/texture = "damaged", var/blendMode = BLEND_MULTIPLY)
-	if (!A)
-		return
-	var/icon/tex = null
-
-	//Try to find an appropriately sized icon.
-	if(istype(A, /atom/movable))
-		var/atom/movable/M = A
-		if(A.texture_size == 32 || ((M.bound_height == 32 && M.bound_width == 32) && !A.texture_size))
-			tex = icon('icons/effects/atom_textures_32.dmi', texture)
-		else if(A.texture_size == 64 || ((M.bound_height == 64 && M.bound_width == 64) && !A.texture_size))
-			tex = icon('icons/effects/atom_textures_64.dmi', texture)
-		else
-			tex = icon('icons/effects/atom_textures_32.dmi', texture)
-	else if (isicon(A))
-		var/icon/I = A
-		if(I.Height() > 32)
-			tex = icon('icons/effects/atom_textures_64.dmi', texture)
-		else
-			tex = icon('icons/effects/atom_textures_32.dmi', texture)
-	else
-		if(A.texture_size == 32)
-			tex = icon('icons/effects/atom_textures_32.dmi', texture)
-		else if(A.texture_size == 64)
-			tex = icon('icons/effects/atom_textures_64.dmi', texture)
-		else
-			tex = icon('icons/effects/atom_textures_32.dmi', texture)
-
-	if (A?.wear_image) //Wire: Fix for: Cannot read null.icon
-		var/icon/mask = null
-		mask = icon(A.wear_image.icon, A.wear_image.icon_state)
-		mask.MapColors(1,1,1, 1,1,1, 1,1,1, 1,1,1)
-		mask.Blend(tex, ICON_MULTIPLY)
-		var/image/finished = image(mask,"")
-		finished.blend_mode = blendMode
-		return finished
-
-	return null
 
 /// Override mouse_drop instead of this. Call this instead of mouse_drop, but you probably shouldn't!
 /atom/MouseDrop(atom/over_object, src_location, over_location, src_control, over_control, params)

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -508,8 +508,13 @@
 			handcuff_img.alpha = src.handcuffs.alpha
 			handcuff_img.filters = src.handcuffs.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.handcuffs)
 		src.AddOverlays(handcuff_img, "handcuffs")
+		if (src.handcuffs.worn_material_texture_image)
+			src.handcuffs.worn_material_texture_image.layer = src.handcuffs.wear_image.layer + 0.1
+			src.AddOverlays(src.handcuffs.worn_material_texture_image, "material_handcuffs")
+		else
+			src.ClearSpecificOverlays("material_handcuffs")
 	else
-		src.ClearSpecificOverlays("handcuffs")
+		src.ClearSpecificOverlays("handcuffs", "material_handcuffs")
 
 /mob/living/carbon/human/proc/update_implants()
 	for (var/I in implant_images)
@@ -524,7 +529,7 @@
 #undef wear_sanity_check
 #undef inhand_sanity_check
 
-/mob/living/carbon/human/proc/update_tail_clothing(var/icon_state, var/obj/tail_clothing)
+/mob/living/carbon/human/proc/update_tail_clothing(var/icon_state, var/obj/item/tail_clothing)
 	src.tail_standing = SafeGetOverlayImage("tail", 'icons/mob/human.dmi', "blank", MOB_TAIL_LAYER1)
 	src.tail_standing.overlays.len = 0
 	src.tail_standing_oversuit = SafeGetOverlayImage("tail_oversuit", 'icons/mob/human.dmi', "blank", MOB_OVERSUIT_LAYER1)
@@ -542,6 +547,12 @@
 				human_tail_image.filters = tail_clothing.filters.Copy() + src.mutantrace?.apply_clothing_filters(tail_clothing)
 			src.tail_standing.overlays += human_tail_image
 			src.tail_standing_oversuit.overlays += human_tail_image
+			if(tail_clothing.worn_material_texture_image)
+				// If the original object has a material texture, apply it
+				var/icon/masked_tail_tex = GetTexturedIcon(human_tail_image.icon, tail_clothing.material.getTexture())
+				var/image/tail_tex_image = image(masked_tail_tex, icon_state)
+				tail_tex_image.layer = human_tail_image.layer + 0.1
+				src.tail_standing_oversuit.overlays += tail_tex_image
 			src.update_tail_overlays()
 			return
 

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -15,6 +15,7 @@ ABSTRACT_TYPE(/obj/item)
 	var/wear_state = null
 	var/image/wear_image = null
 	var/wear_image_icon = 'icons/mob/clothing/belt.dmi'
+	var/image/worn_material_texture_image = null
 	var/wear_layer = MOB_CLOTHING_LAYER
 	var/image/inhand_image = null
 	var/inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
@@ -1873,3 +1874,16 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 /obj/item/proc/should_suppress_attack(var/object, mob/user, params)
 	return flags & SUPPRESSATTACK
 
+/obj/item/proc/getTexturedWornImage(var/texture = "damaged", var/blendMode = BLEND_MULTIPLY)
+	if (!src.wear_image || !texture)
+		return null
+	var/icon/mask = GetTexturedIcon(icon(src.wear_image.icon, src.wear_image.icon_state), texture)
+	var/image/finished = image(mask,"")
+	finished.blend_mode = blendMode
+	return finished
+
+/obj/item/setTexture(var/texture, var/blendMode = BLEND_MULTIPLY, var/key = "texture")
+	..()
+	if(key != "material")
+		return
+	src.worn_material_texture_image = src.getTexturedWornImage(texture, blendMode)

--- a/code/obj/nuclearreactor/reactorcomponents.dm
+++ b/code/obj/nuclearreactor/reactorcomponents.dm
@@ -86,7 +86,8 @@ ABSTRACT_TYPE(/obj/item/reactor_component)
 						if(BLEND_MULTIPLY) icon_mode = ICON_MULTIPLY
 						if(BLEND_INSET_OVERLAY) icon_mode = ICON_OVERLAY
 
-					src.cap_icon.Blend(getTexturedIcon(src.cap_icon, mat1.getTexture()), icon_mode)
+					var/icon/tex = GetTexturedIcon(src.cap_icon, mat1.getTexture())
+					src.cap_icon.Blend(tex, icon_mode)
 
 				if(length(setcolor) > 4) //ie, if it's a color matrix
 					src.cap_icon.MapColors(arglist(setcolor))


### PR DESCRIPTION
## About the PR
- Fixes material textures breaking non-standard sized icons
- Icons larger than the available 64x64 textures no longer have a material texture applied
- Material textures now applied to lizard tail clothing and handcuffs
- Cleans up related procs to make more sense

## Why's this needed?
- The material visual changes made textured materials more common, making issues with them more prevalent

## Testing
<img width="574" height="359" alt="Screenshot 2025-11-15 073049" src="https://github.com/user-attachments/assets/1a280197-e0b4-4a90-b5f3-99a9cad730f8" />

