### PR TITLE
Adds the cosmetic Muscly gene

### DIFF
--- a/code/modules/medical/genetics/bioEffects/useless.dm
+++ b/code/modules/medical/genetics/bioEffects/useless.dm
@@ -311,6 +311,15 @@
 	id = "muscly"
 	msgGain = "Damn, where do you work out?"
 	msgLose = "You feel like you worked out at a library."
+	occur_in_genepools = 0
+	probability = 0
+	scanner_visibility = 0
+	can_research = 0
+	can_make_injector = 0
+	can_copy = 0
+	can_reclaim = 0
+	can_scramble = 0
+	curable_by_mutadone = 0
 	var/filter = null
 	var/tmp/obj/effect/rt/muscly/distort = new
 	var/size = 20


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a cosmetic gene that makes the owner _**SWOLE.**_ In actuality, it copies the effect applied by the Muscly Belt (`/obj/item/storage/belt/muscly`) without the character needing to wear the belt or have filters/procs applied. Won't appear in genepools and cannot be researched, since it's meant entirely as a joke and warps the character's appearance.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Entirely for the enjoyment of admins wanting to goof around. A few admins expressed a desire for this one, so here I am to make nightmares come true.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Gave myself the gene through the bioeffect manager and removed it in order to make sure the effect applied and unapplied correctly.

<img width="747" height="456" alt="Muscly Man" src="https://github.com/user-attachments/assets/d70772ad-cbc4-4ac5-b78b-4b1f962f2cce" />

[A-ADMIN] [C-QoL]