### PR TITLE
Dowsing Rods give sound and text notification when placed on a turf that can be pinned

### DIFF
--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -578,10 +578,8 @@ TYPEINFO(/obj/item/heat_dowsing)
 					if (src.loc == center)
 						true_center += 1
 
-					if (BOUNDS_DIST(src, H.center.turf()) == 0) //variable for determining wether to play a sound if turf is able to be pinned
+					if (BOUNDS_DIST(src, H.center.turf()) == 0) //variable for determining whether to play a sound if turf is able to be pinned
 						pinnable_spot = TRUE
-					else
-						pinnable_spot = FALSE
 
 					var/d = GET_DIST(src.loc,center)
 					if (d < dist_last)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Engineering] [C-QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a sound when a Dowsing rod is placed on a turf that if stomped will pin the Hotspot. currently uses sound/machines/found.ogg
Also slaps a text onto the end of the normal text it spits out when on a pinnable turf currently "Location able to be pinned"
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hotspots can be pinned in a 3x3 area around the true center by default, but there is no way of telling this except through luck or already knowing where the true center is.
This will give much needed feedback and help when the hotspot is inside a station wall.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/316433c0-175c-41bd-90a2-1984af3c2409
<img width="519" height="19" alt="Screenshot 2025-11-16 202134" src="https://github.com/user-attachments/assets/16738cd0-4cd2-4bd2-bd07-bf4046d1bbb1" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Phoi
(+)Adds sound notification to dowsing rod when placed on a pinnable turf
(+)Adds text onto the pre-existing message when dowsing rod is placed on a pinnable turf
```