### PR TITLE
Increase Nonhuman mode antag scaling

### DIFF
--- a/code/datums/gamemodes/arcfiend.dm
+++ b/code/datums/gamemodes/arcfiend.dm
@@ -11,11 +11,7 @@
 	has_werewolves = 0
 	major_threats = list(ROLE_WRAITH)
 
-#ifdef RP_MODE
-	num_enemies_divisor = 20
-#else
-	num_enemies_divisor = 15
-#endif
+	num_enemies_divisor = 12
 
 /datum/game_mode/mixed/arcfiend/announce()
 	boutput(world, "<B>The current game mode is - Arcfiend!</B>")

--- a/code/datums/gamemodes/changeling.dm
+++ b/code/datums/gamemodes/changeling.dm
@@ -10,11 +10,7 @@
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 
-#ifdef RP_MODE
-	var/const/pop_divisor = 20
-#else
-	var/const/pop_divisor = 15
-#endif
+	var/const/pop_divisor = 12
 
 /datum/game_mode/changeling/announce()
 	boutput(world, "<B>The current game mode is - Changeling!</B>")

--- a/code/datums/gamemodes/vampire.dm
+++ b/code/datums/gamemodes/vampire.dm
@@ -11,11 +11,7 @@
 	has_werewolves = 0
 	major_threats = list(ROLE_WRAITH)
 
-#ifdef RP_MODE
-	num_enemies_divisor = 20
-#else
-	num_enemies_divisor = 15
-#endif
+	num_enemies_divisor = 12
 
 /datum/game_mode/mixed/vampire/announce()
 	boutput(world, "<B>The current game mode is - Vampire!</B>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Decreases the pop divisor on the Changeling, Vampire and Arcfiend modes from 20/15 to 12, the same as the Intrigue/Mixed(RP) mode

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These modes have significantly less antagonists than other modes and can lead to things like 1 ling at 35 pop when if the mode was intrigue with several of these antagonists you'd get almost double the amount of antags, this brings the scaling in line with what would happen if Intrigue rolled only these antagonists.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

None, numbers change with antag scaling that I can't test locally.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Antagonist scaling in the Changeling, Vampire and Arcfiend gamemodes has been increased to be the same as Intrigue.
```
