### PR TITLE
Removes zipping people up on toilets, and zipping up on toilets in general

### DIFF
--- a/code/obj/item/toilets.dm
+++ b/code/obj/item/toilets.dm
@@ -104,11 +104,6 @@ TYPEINFO(/obj/item/storage/toilet)
 
 	for(var/mob/M in src.loc)
 		if (M.buckled)
-			if (M != user)
-				user.visible_message(SPAN_NOTICE("[M] is zipped up by [user]. That's... that's honestly pretty creepy."))
-			else
-				user.visible_message(SPAN_NOTICE("[M] zips up."), SPAN_NOTICE("You zip up."))
-//			boutput(world, "[M] is no longer buckled to [src]")
 			reset_anchored(M)
 			M.buckled = null
 			src.add_fingerprint(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes zipping up and zipping others up when interacting with the toilet they are on.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Forgot this was even in the game until recently, it's kinda gross and I don't think reflects the culture of goonstation now. Also, we can't piss or shit WHY ARE WE UNZIPPING IN THE FIRST PLACE.
`SPAN_NOTICE("[M] is zipped up by [user]. That's... that's honestly pretty creepy."`
Yucky.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Just removed the offending lines, the rest stays as normal (clicking the toilet unbuckling and flushing)
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->