### PR TITLE
Unlock Snaily Softserve's dir

### DIFF
--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -3357,7 +3357,6 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	voice_name = "Snaily Softserve"
 	memory = "i love being a snail..."
 	appearance_flags = KEEP_TOGETHER | PIXEL_SCALE
-	dir_locked = 1
 	player_can_spawn_with_pet = FALSE
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Self explanatory. I think it was me who locked the dir cause I thought it wouldn't look as awkward as having a slightly misaligned bow but I tested it and it's fine.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Snaily is frozen please help her, she's meant to be soft serve. Fixes #25174.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Yes.
