### PR TITLE
Pipes that cannot rupture are no longer able to rupture 🤯 

### DIFF
--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -105,7 +105,7 @@
 /// Ruptures the pipe, with varying levels of leakage.
 /obj/machinery/atmospherics/pipe/proc/rupture(pressure)
 	if(!can_rupture)
-		return // if we can't rupture, then pass.
+		return // nah, don't feel like it.
 
 	var/new_rupture
 


### PR DESCRIPTION
## About the PR

Pipes that attempt to rupture while having `can_rupture` set to `FALSE` no longer perform any rupture logic.

## Why's this needed?

ex_act on pipes directly call rupture instead of checking can_rupture.
Instead of adjusting ex_act to read a var off the target I prefer to add a guard clause in the rupture proc itself.

Closes #24702
Closes #24974
Closes #24621 
Closes #24113
