### PR TITLE
Change ancient heavy silicon arms to have same health

### DIFF
--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -1438,7 +1438,7 @@ proc/do_clamp(atom/movable/clamped, mob/clamper, obj/item/clamp)
 		desc = "A massive clamping arm from an ancient lifter construct."
 		icon_state = "r_arm-ancient3"
 		appearanceString = "ancient3"
-		max_health = 300
+		max_health = 350
 		weight = 0.5
 		handlistPart = "armR-heavy"
 		add_to_tools = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Silicons] [C-Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
changes ancient actuator right arm to have the same max health as it's left counterpart
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #25108
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
before
<img width="230" height="42" alt="image" src="https://github.com/user-attachments/assets/27018024-488d-43ce-abcf-08642fb4b78c" />

after
<img width="233" height="46" alt="image" src="https://github.com/user-attachments/assets/43deba02-c769-47fb-8766-7de29fa54a79" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

