### PR TITLE
Makes "Strong Willed" and "Addictive Personality" mutually exclusive 

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -27,6 +27,7 @@
 		"nohair",
 		"nowig",
 		"infrared",
+		"addiction",
 	)
 
 	var/list/traitData = list()
@@ -1098,12 +1099,14 @@ TYPEINFO(/datum/trait/partyanimal)
 	desc = "You are more resistant to addiction."
 	id = "strongwilled"
 	icon_state = "nosmoking"
+	category = list("addiction")
 	points = -1
 
 /datum/trait/addictive_personality // different than addict because you just have a general weakness to addictions instead of starting with a specific one
 	name = "Addictive Personality"
 	desc = "You are less resistant to addiction."
 	id = "addictive_personality"
+	category = list("addiction")
 	icon_state = "syringe"
 	points = 1
 


### PR DESCRIPTION
[A-Traits] [C-Bug]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
prevents "Strong Willed" (decreased likelihood of getting addicted to chems) and "Addictive Personality" (increased likelihood of getting addicted to chems) traits from being taken together

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
they cancel each other out so there's no real reason for you to be able to take them both
fixes #25226 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
before

<img width="608" height="254" alt="image" src="https://github.com/user-attachments/assets/3eb2356e-0975-4f68-83ce-61cd4b3fdc35" />


after

<img width="608" height="179" alt="image" src="https://github.com/user-attachments/assets/da6a2cec-84fe-43c4-8c00-09693193a574" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

