### PR TITLE
Fix trench mining volume weirdness

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -1561,6 +1561,7 @@ TYPEINFO(/turf/simulated/floor/plating/airless/asteroid)
 #ifdef UNDERWATER_MAP
 	fullbright = 0
 	luminosity = 3
+	special_volume_override = 0.62 // without this, the rock floors in the trench attenuate incorrectly and become very loud
 #else
 	luminosity = 1
 #endif


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Set `special_volume_override` on asteroid floors to match the regular sea floors when on an underwater map. 

This prevents the asteroid floors located in the trench increasing the volume of sounds which occur on their tile, and destroying miner's eardrums. 

It's a hacky solution, but no more so than is already being done for brightness. Water maps should really get their own special rock floor tiles to use. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This fixes a bug where mining in the trench is super loud. 

fixes #16900

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Drove around in a sub and observed that the rock floors and the sea floors are at the same volume level. 

https://github.com/user-attachments/assets/a5b6fb5d-8e79-428a-a601-786100fc289b

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

