### PR TITLE
Prevent null exception when contraband falls from burning storage

### DIFF
--- a/code/datums/components/contraband.dm
+++ b/code/datums/components/contraband.dm
@@ -70,7 +70,7 @@ TYPEINFO(/datum/component/contraband)
 	src.contraband_logic(owner, user, slot_mult)
 
 /datum/component/contraband/proc/removed(obj/item/owner, mob/user)
-	if(user != null)
+	if(user)
 		REMOVE_ATOM_PROPERTY(user, PROP_MOVABLE_VISIBLE_GUNS, src)
 		REMOVE_ATOM_PROPERTY(user, PROP_MOVABLE_VISIBLE_CONTRABAND, src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[A-Game-Objects] [C-Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes incredibly niche bug where if a contraband item is in a box when it is set alight and destroyed, a runtime exception will be thrown because when the contraband item goes to remove the "contains contraband" property from the box, it attempts to access a null entity (the box does not exist, for it is destroyed)

accomplished by making the atom property check only fire if there actually is a user to fire at (not null)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
needed to save the sanity of poor innocent contributors who have errors unrelated to their PR and think its their fault
this *shouldn't* affect gameplay in any way because behavior was as expected even when bug was present

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/bf965b55-ef22-4572-b329-e486b634d1a0

note lack of "Cannot read null.atom_properties" error in console log when box finishes burning and is deleted
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->