### PR TITLE
Adds brown satchels/backpacks to uniform manufacturers

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2686,15 +2686,6 @@ ABSTRACT_TYPE(/datum/manufacture/aiModule)
 	time = 10 SECONDS
 	category = "Clothing"
 
-/datum/manufacture/backpack_studded
-	name = "Studded Backpack"
-	item_requirements = list("fabric" = 8,
-							 "metal" = 1)
-	item_outputs = list(/obj/item/storage/backpack/empty/studdedblack)
-	create = 1
-	time = 10 SECONDS
-	category = "Clothing"
-
 /datum/manufacture/satchel
 	name = "Satchel"
 	item_requirements = list("fabric" = 8)
@@ -2731,15 +2722,6 @@ ABSTRACT_TYPE(/datum/manufacture/aiModule)
 	name = "Brown Satchel"
 	item_requirements = list("fabric" = 8)
 	item_outputs = list(/obj/item/storage/backpack/satchel/empty/brown)
-	create = 1
-	time = 10 SECONDS
-	category = "Clothing"
-
-/datum/manufacture/satchel_studded
-	name = "Studded Satchel"
-	item_requirements = list("fabric" = 8,
-							 "metal" = 1)
-	item_outputs = list(/obj/item/storage/backpack/satchel/empty/studdedblack)
 	create = 1
 	time = 10 SECONDS
 	category = "Clothing"

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -258,14 +258,6 @@
 	item_state = "bp_studded"
 	satchel_variant = /obj/item/storage/backpack/satchel/studdedblack
 
-/obj/item/storage/backpack/empty/studdedblack
-	name = "studded backpack"
-	desc = "Made of sturdy synthleather and covered in metal studs. Much edgier than the standard issue bag."
-	icon_state = "bp_studded"
-	item_state = "bp_studded"
-	satchel_variant = /obj/item/storage/backpack/satchel/studdedblack
-	spawn_contents = list()
-
 /obj/item/storage/backpack/itabag
 	name = "pink itabag"
 	desc = "Comes in cute pastel shades. Within the heart-shaped window, you can see buttons and stickers of Heisenbee!"

--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -475,8 +475,6 @@
 		/datum/manufacture/patch,
 		/datum/manufacture/towel,
 		/datum/manufacture/tricolor,
-		/datum/manufacture/backpack_studded,
-		/datum/manufacture/satchel_studded,
 		/datum/manufacture/hat_ltophat)
 
 /// cogwerks - a gas extractor for the engine


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds brown and studded satchels/backpacks to uniform manufacturers. The studded variants cost some metal, and can only be printed if the fabricator is hacked.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These are usually spacebux purchases, but I've always found it odd that there's no way (that I know of) to obtain them besides that. Thought it'd be neat if there was.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="887" height="215" alt="1" src="https://github.com/user-attachments/assets/7db475c7-5998-4b2d-ae97-ad28f5e1a72e" />
Hacked:
<img width="899" height="279" alt="2" src="https://github.com/user-attachments/assets/380fbdb3-10c2-4a36-922a-dc6ea4e43613" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
```changelog
(u)Microoowaaave
(+)Added brown satchels/backpacks to uniform manufacturers.
```
