### PR TITLE
Removes the need for wirecutters when unstacking cable coils

### DIFF
--- a/code/obj/item/cable_coil.dm
+++ b/code/obj/item/cable_coil.dm
@@ -103,6 +103,25 @@ obj/item/cable_coil/abilities = list(/obj/ability_button/cable_toggle)
 	after_stack(atom/movable/O as obj, mob/user as mob, var/added)
 		boutput(user, SPAN_NOTICE("You finish coiling cable."))
 
+	attack_hand(mob/user)
+		if((user.r_hand == src || user.l_hand == src) && src.amount > 1)
+			var/splitnum = round(input("How many cables do you want to take from the stack?","Stack of [src.amount]",1) as num)
+			if(!in_interact_range(src, user) || !isnum_safe(splitnum))
+				return
+			splitnum = round(clamp(splitnum, 0, src.amount))
+			if(amount == 0)
+				return
+			var/obj/item/cable_coil/new_stack = split_stack(splitnum)
+			if (!istype(new_stack))
+				boutput(user, SPAN_ALERT("Invalid entry, try again."))
+				return
+			user.put_in_hand_or_drop(new_stack)
+			new_stack.add_fingerprint(user)
+			boutput(user, SPAN_NOTICE("You take [splitnum] cables from the stack, leaving [src.amount] cables behind."))
+			tgui_process.update_uis(src)
+		else
+			..(user)
+
 	custom_suicide = 1
 	suicide(var/mob/user as mob)
 		if (!src.user_can_suicide(user))
@@ -275,21 +294,11 @@ obj/item/cable_coil/dropped(mob/user)
 	if (conductor)
 		. += "Its conductive layer is made out of [conductor]."
 
-/obj/item/cable_coil/attackby(obj/item/W, mob/user)
-	if (issnippingtool(W) && src.amount > 1)
-		var/cut_amount = round(input("How long of a wire do you wish to cut?","Length of [src.amount]",1) as num)
-		if (!in_interact_range(src, user))
-			boutput(user, "You're too far away from the cable that you're trying to cut from!")
-			return
-		var/obj/item/cable_coil/cable = src.split_stack(cut_amount)
-		if (istype(cable))
-			user.put_in_hand_or_drop(cable) //Hey, split_stack, Why is the default location for the new item src.loc which is *very likely* to be a damn mob?
-			boutput(user, "You cut a piece off the [base_name].")
-		return
-
+obj/item/cable_coil/attackby(obj/item/W, mob/user)
 	if (check_valid_stack(W))
 		stack_item(W)
 		if(!user.is_in_hands(src))
+			user.u_equip(src)
 			user.put_in_hand(src)
 		boutput(user, "You join the cable coils together.")
 


### PR DESCRIPTION
## About the PR
This PR allows players to unstack cable coils by using an empty hand on the stack instead of requiring wirecutters. 

Also happens to fix a bug that caused a user's pocket inventory to be considered both empty and in-use if the user stacks coil from there. Previously, users could not put newly-stacked coils back into their pocket without dropping the coils or swapping hands, as the game would begin laying coils rather than placing the coils into the pocket. By adding `user.u_equip(src)` to the `attackby` proc, this glitch is eliminated.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, cables can be stacked by hand, but in order to _unstack_ them, a user must use wirecutters on the stack. This is not mentioned anywhere (such as a help message in the description), nor does it make sense to require the extra step when the player can already do the reverse action by hand. 

## Testing
Gathered several coils from an electrical toolbox and tested various functions like stacking, unstacking, laying coils and then stacking onto the pile in use, and ensuring the item is unequipped from the player's pockets if stacked from there.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

```changelog
(u)Driftered
(*)Cable coils can now be unstacked by hand.
```

[A-GAME OBJECTS] [C-CODE QUALITY]