### PR TITLE
adds bricks to hacked general fabricators

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1113,6 +1113,14 @@
 	time = 5 SECONDS
 	category = "Tool"
 
+/datum/manufacture/brick
+	name = "Brick"
+	item_requirements = list("rock" = 100)
+	item_outputs = list(/obj/item/brick)
+	create = 1
+	time = 10 SECONDS
+	category = null
+
 /******************** Medical **************************/
 
 /datum/manufacture/scalpel

--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -82,7 +82,8 @@
 		/datum/manufacture/stapler,
 		/datum/manufacture/bagpipe,
 		/datum/manufacture/fiddle,
-		/datum/manufacture/whistle)
+		/datum/manufacture/whistle,
+		/datum/manufacture/brick)
 
 /obj/machinery/manufacturer/general/grody
 	name = "grody manufacturer"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Feature] [Game-Objects]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds bricks to general fabricators at the cost of 10 rocks, if they are hacked

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bricks are not renewable in any way shape or form, which means the only source of bricks is from map specific spawns or random rooms. this means playing impromptu brick dodgeball in the hall with the angry staffies is all up to chance

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://file.garden/Z5gQkrJ7CWwAEOa2/videos/bricks%20bricks%20and%20more%20god%20fucking%20damned%20bricks.mp4

## Changelog 

```changelog
(u)Red Screen of Death
(+)General manufacturers can now make bricks when hacked.
```
