### PR TITLE
Possibly fix permanent hallucinations

### DIFF
--- a/code/datums/components/hallucinations.dm
+++ b/code/datums/components/hallucinations.dm
@@ -380,6 +380,7 @@ ABSTRACT_TYPE(/datum/component/hallucination)
 	UnregisterFromParent()
 		UnregisterSignal(src.parent, COMSIG_ITEM_PICKUP)
 		UnregisterSignal(src.parent, COMSIG_ITEM_DROPPED)
+		src.viewer_client.images -= src.current_image
 
 	proc/on_pickup_drop()
 		SPAWN(0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Manually remove the hallucinated image from the viewer client when the hallucination component becomes unregistered. 

This was literally just the first thing I tried and it seemed to work so I didn't look deeper into it. I don't know enough about how `client` works to say whether this is a hacky solution or not. It doesn't look like the component was removing the hallucinated image at all, I guess it was relying on some weird Byond bug purging the client's images list, and that got fixed or something, I have no idea. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

fixes #24977

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Spawn target dummy; take LSD; wait for a hallucination to occur; flush LSD; wait for hallucination to fall off; observe that dummy returns to normal after a while. 

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->