### PR TITLE
Fix sylvester missing hat on kondaru

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -28165,7 +28165,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/mob/living/critter/small_animal/turtle/sylvester,
+/mob/living/critter/small_animal/turtle/sylvester/HoS,
 /turf/simulated/floor/carpet/red,
 /area/station/security/hos)
 "dkL" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
4 character change: Adds "/HoS" to the end of the sylvester spawn on kondaru

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So the proper sylvester spawns with his beret and HoS requirement to remove it.
Fixes #25282


## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="203" height="201" alt="image" src="https://github.com/user-attachments/assets/68f64cdd-08a4-4422-8d90-8f1d256d6774" />