### PR TITLE
Admin "Respawn Self" works like other respawns

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -4559,6 +4559,10 @@ var/global/noir = 0
 	var/mob/new_player/M = new()
 
 	M.key = usr.client.key
+	M.adminspawned = 1
+	M.client.player.dnr = FALSE //reset DNR in case we cryoed to get here
+	M.client.player.claimed_rewards = list() // reset claimed medal rewards
+	M.mind.purchased_bank_item = null
 
 	usr.remove()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The admin "Respawn Self" command (the one that sends you back to the menu) resets DNR, purchased spacebux item and claimed medals just like how respawning from the timer would.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Respawning someone should reset DNR the same way it works with every other respawn.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Set DNR, respawned self, set DNR again (it didn't remove DNR it activated it)

