### PR TITLE
changelings get hivemind member maptext

### DIFF
--- a/code/modules/speech/modules/speech/outputs/hivechat.dm
+++ b/code/modules/speech/modules/speech/outputs/hivechat.dm
@@ -61,9 +61,9 @@
 			src.role = " (MASTER)"
 
 	message.maptext_css_values["color"] = "#e2a059"
-	message.maptext_css_values["font-size"] = "5px"
+	message.maptext_css_values["font-size"] = "6px"
 	message.maptext_variables["maptext_x"] += prob(50) ? 28 : -28
-	message.maptext_variables["maptext_y"] -= rand(24, 32)
+	message.maptext_variables["maptext_y"] -= rand(12, 24)
 
 	if (isabomination(changeling_ability_holder.owner) && istype(message.speaker, /mob/dead/target_observer/hivemind_observer))
 		message.speaker.say(message.content, message_params = list("output_module_override" = SPEECH_OUTPUT_SPOKEN_HIVEMIND))
@@ -102,9 +102,9 @@
 		mind_ref = "\ref[mob_speaker.mind]"
 
 	message.maptext_css_values["color"] = "#e2a059"
-	message.maptext_css_values["font-size"] = "5px"
+	message.maptext_css_values["font-size"] = "6px"
 	message.maptext_variables["maptext_x"] += prob(50) ? 28 : -28
-	message.maptext_variables["maptext_y"] -= rand(24, 32)
+	message.maptext_variables["maptext_y"] -= rand(12, 24)
 
 	message.format_speaker_prefix = {"\
 		<span class='game hivesay'>\

--- a/code/modules/speech/modules/speech/outputs/spoken/hivemind.dm
+++ b/code/modules/speech/modules/speech/outputs/spoken/hivemind.dm
@@ -8,10 +8,10 @@
 	if (!istype(mob_speaker))
 		return
 
+	message.message_size_override = "6px"
 	message.maptext_css_values["color"] = living_maptext_color(message.speaker.name)
-	message.maptext_css_values["font-size"] = "5px"
 	message.maptext_variables["maptext_x"] += prob(50) ? 28 : -28
-	message.maptext_variables["maptext_y"] -= rand(24, 32)
+	message.maptext_variables["maptext_y"] -= rand(12, 24)
 
 	message.message_origin = mob_speaker.target
-	message.speaker_to_display = "Congealed [mob_speaker]"
+	message.speaker_to_display = "[pick("Congealed", "Subsumed", "Absorbed")] [mob_speaker]"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
when speaking, members of a changeling hivemind residing in the host now show floating maptext visible to the to the host and other hivemind members
this maptext appears smaller than normal maptext, and is offset to the side and below.

when in abomination form, hivemind members in the changeling output text similarly

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
talk with the voices in your head

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/a6b6da90-cdfe-454e-932c-0a58221295b5


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)Changeling hivemind members now show floating maptext to the host
```
