### PR TITLE
Radios always show the frequency's default colour

### DIFF
--- a/code/modules/speech/modules/listen/modifiers/radio_formatting.dm
+++ b/code/modules/speech/modules/listen/modifiers/radio_formatting.dm
@@ -58,7 +58,9 @@
 
 	message.format_verb_prefix = {"\
 		</span> \
+		<span class='radio [default_frequency_class(display_frequency)]'>\
 		<b>\[[format_frequency(display_frequency)]\]</b> \
+		</span>\
 		<span class='message'>\
 	"}
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Radio frequencies from heard radio messages will always be coloured in the frequency's default, e.g. a syndicate headset talking on the general frequency will show the [145.9] in the general green colour.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some headsets have special class overrides for certain frequencies which can be especially confusing if you don't have the frequencies memorised or read the frequency, instead relying on the colour of the chat message. This can cause problems when a syndicate operative thinks a message on the syndicate line was on general and vice versa.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Standard NTSC headset working as usual
<img width="259" height="154" alt="image" src="https://github.com/user-attachments/assets/9c22d518-2b09-45ed-8a35-b8e510caf05c" />
Syndicate headset on the syndicate, unknown, AI and general frequencies
<img width="266" height="159" alt="image" src="https://github.com/user-attachments/assets/b745707e-c907-4b16-b6b3-c97d499aa5c8" />
Pod pilot headsets
<img width="326" height="190" alt="image" src="https://github.com/user-attachments/assets/88c2a53e-1947-4af0-b01a-22284a7c9f71" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Radio frequencies before radio messages will now always be highlighted in that frequency's default colour.
```
