### PR TITLE
Refactor Trichochromatic Shift

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -553,11 +553,11 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 	desc = "Swap the colors of your hair around."
 	icon_state = "polymorphism"
 	needs_hands = FALSE
-	targeted = 0
+	targeted = FALSE
 
-	cast()
+	cast_genetics(atom/target, misfire)
 		if (..())
-			return 1
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
 
 		var/mob/living/carbon/human/H
 		if (ishuman(owner))
@@ -583,6 +583,7 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 
 			H.visible_message(SPAN_NOTICE("<b>[H.name]</b>'s hair changes colors!"))
 			H.update_colorful_parts()
+		return CAST_ATTEMPT_SUCCESS
 
 /* / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / */
 /* / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Refactors Colorshift to use a different miscast implementation, explicit returns, and "booleans".

This is a part of a larger refactor https://github.com/goonstation/goonstation/pull/24987.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Genetics abilities have a lot of copy-pasted code, which is seemingly encouraged by the way misfire mechanics are handled. This way genetic abilities have more control over how they want to implement miscasts.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Add bioeffect 'colorshift', spam it a few times. 

https://github.com/user-attachments/assets/52a0487e-1632-451b-963a-d4918f8e6f3d

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

