### PR TITLE
Refactor telepathy

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -605,24 +605,25 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 	desc = "Transmit psychic messages to others."
 	icon_state = "telepathy"
 	needs_hands = FALSE
-	targeted = 1
+	targeted = TRUE
+	do_logs = FALSE //Handle logs ourselves
 
-	cast(atom/target)
+	cast_genetics(atom/target, misfire)
 		if (..())
-			return 1
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
 
 		if (istype(target, /obj/item/reagent_containers/food/snacks/pancake))
 			dothepixelthing(target)
 			src.holder.owner.visible_message(SPAN_ALERT(SPAN_BOLD("[src.holder.owner] blows up the pancakes with their mind!")), SPAN_ALERT("You blow up the pancakes with your mind!"))
 			src.holder.owner.bioHolder?.RemoveEffect("telepathy")
-			return
+			return CAST_ATTEMPT_SUCCESS
 
 		var/mob/living/carbon/recipient = null
 		if (iscarbon(target))
 			recipient = target
 		else if (ismob(target) && !iscarbon(target))
 			boutput(owner, SPAN_ALERT("You can't transmit to [target] as they are too different from you mentally!"))
-			return 1
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
 		else
 			var/turf/T = get_turf(target)
 			for (var/mob/living/carbon/C in T.contents)
@@ -631,76 +632,41 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 
 		if (!recipient)
 			boutput(owner, SPAN_ALERT("There's nobody there to transmit a message to."))
-			return 1
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
 
 		if (recipient.bioHolder.HasEffect("psy_resist"))
 			boutput(owner, SPAN_ALERT("You can't contact [recipient.name]'s mind at all!"))
-			return 1
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
 
 		if(isghostcritter(owner))
 			boutput(owner, SPAN_ALERT("You can't contact [recipient.name]'s mind with your spectral brain!"))
-			return 1
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
 
 		if(!recipient.client || recipient.stat)
 			boutput(owner, SPAN_ALERT("You can't seem to get through to [recipient.name] mentally."))
-			return 1
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
 
 		var/msg = copytext( adminscrub(input(usr, "Message to [recipient.name]:","Telepathy") as text), 1, MAX_MESSAGE_LEN)
 		if (!msg)
-			return 1
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
 		phrase_log.log_phrase("telepathy", msg)
 
 		var/psyname = "A psychic voice"
 		if (recipient.bioHolder.HasOneOfTheseEffects("telepathy","empath"))
 			psyname = "[owner.name]"
 
+		if (misfire)
+			msg = uppertext(msg)
+			owner.visible_message(SPAN_ALERT("<b>[owner]</b> puts [his_or_her(owner)] fingers to [his_or_her(owner)] temples and stares at [target] really hard."))
+			owner.say(msg)
+			logTheThing(LOG_TELEPATHY, owner, "TELEPATHY misfire to [constructTarget(recipient,"telepathy")]: [msg]")
+
 		boutput(recipient, "<span style='color: #BD33D9'><b>[psyname]</b> echoes, \"<i>[msg]</i>\"</span>")
 		boutput(owner, "<span style='color: #BD33D9'>You echo \"<i>[msg]</i>\" to <b>[recipient.name]</b>.</span>")
 
 		logTheThing(LOG_TELEPATHY, owner, "TELEPATHY to [constructTarget(recipient,"telepathy")]: [msg]")
 
-		return
-
-	cast_misfire(atom/target)
-		if (..())
-			return 1
-
-		var/mob/living/carbon/recipient = null
-		if (iscarbon(target))
-			recipient = target
-		else if (ismob(target) && !iscarbon(target))
-			boutput(owner, SPAN_ALERT("You can't transmit to [target] as they are too different from you mentally!"))
-			return 1
-		else
-			var/turf/T = get_turf(target)
-			for (var/mob/living/carbon/C in T.contents)
-				recipient = C
-				break
-
-		if (!recipient)
-			boutput(owner, SPAN_ALERT("There's nobody there to transmit a message to."))
-			return 1
-
-		if (recipient.bioHolder.HasEffect("psy_resist"))
-			boutput(owner, SPAN_ALERT("You can't contact [recipient.name]'s mind at all!"))
-			return 1
-
-		if(!recipient.client || recipient.stat)
-			boutput(recipient, SPAN_ALERT("You can't seem to get through to [recipient.name] mentally."))
-			return 1
-
-		var/msg = copytext( adminscrub(input(usr, "Message to [recipient.name]:","Telepathy") as text), 1, MAX_MESSAGE_LEN)
-		if (!msg)
-			return 1
-		phrase_log.log_phrase("telepathy", msg)
-		msg = uppertext(msg)
-
-		owner.visible_message(SPAN_ALERT("<b>[owner]</b> puts [his_or_her(owner)] fingers to [his_or_her(owner)] temples and stares at [target] really hard."))
-		owner.say(msg)
-
-		logTheThing(LOG_TELEPATHY, owner, "TELEPATHY misfire to [constructTarget(recipient,"telepathy")]: [msg]")
-
-		return
+		return CAST_ATTEMPT_SUCCESS
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Refactors Telepathy to use a different miscast implementation, explicit returns, and "booleans".

Telepathy sends a telepathic message on miscast as well as forces the user to say the message out loud, which is technically a bug caused by the previous implementation double-casting on miscasts, but has been rolled in to avoid changes in behaviour. 

This is a part of a larger refactor https://github.com/goonstation/goonstation/pull/24987.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Genetics abilities have a lot of copy-pasted code, which is seemingly encouraged by the way misfire mechanics are handled. This way genetic abilities have more control over how they want to implement miscasts.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Add bioeffect 'telepathy'. Test regular cast on self; set stability to 0 to test miscast on self. 

https://github.com/user-attachments/assets/fdf9947f-ef61-4400-bcf1-45ba4cdf318b


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->