### PR TITLE
Fixes paper juggling constantly reading the paper (#25366)

### DIFF
--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -326,7 +326,8 @@
 			var/obj/item/item1 = pick(juggled_items)
 			juggled_items -= item1
 			var/obj/item/item2 = pick(juggled_items)
-			item2.Attackby(item1, src, silent = TRUE)
+			if(!istype(item2, /obj/item/paper))
+				item2.Attackby(item1, src, silent = TRUE)
 
 	//Attaching a limb that didn't originally belong to you can do stuff
 	if(!isdead(src) && prob(2) && src.limbs)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #25366 
Not a too good of a fix;
When someone juggles more than one item, there is a chance for items to hit each other every life cycle. When papers are involved in the juggle, it constantly opens the paper window. This fix checks if the hit item is an object type of paper and skips that one. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugfix

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
**Before:**

https://github.com/user-attachments/assets/1968a489-4da9-4794-9f8a-7c54c97a592f


**After:**

https://github.com/user-attachments/assets/9ab3d218-456f-472f-b66d-66a4f5a57210

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ribbie
(+)Fixes juggling paper with multiple items.
```
