### PR TITLE
Cogmap 2 Missing Security Pod Equipment 

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -20625,26 +20625,25 @@
 /turf/simulated/floor/orangeblack,
 /area/station/maintenance/inner/central)
 "bnp" = (
-/obj/table/auto,
-/obj/item/hand_labeler,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/shipcomponent/mainweapon/phaser,
-/obj/item/shipcomponent/mainweapon/taser,
-/obj/item/crowbar,
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/caution/north{
 	dir = 1
 	},
 /area/station/hangar/sec)
 "bnq" = (
-/obj/table/auto,
 /obj/random_item_spawner/tools,
+/obj/item/storage/toolbox/mechanical,
+/obj/table/auto,
 /turf/simulated/floor/caution/north{
 	dir = 1
 	},
 /area/station/hangar/sec)
 "bnr" = (
 /obj/machinery/light/small,
-/obj/reagent_dispensers/fueltank,
+/obj/table/auto,
+/obj/item/shipcomponent/mainweapon/phaser,
+/obj/item/hand_labeler,
+/obj/item/crowbar,
 /turf/simulated/floor/caution/north{
 	dir = 1
 	},
@@ -20663,6 +20662,23 @@
 "bnt" = (
 /obj/machinery/camera/directional/south{
 	pixel_x = -10
+	},
+/obj/storage/crate,
+/obj/item/shipcomponent/secondary_system/tractor_beam{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/shipcomponent/secondary_system/tractor_beam{
+	pixel_x = -6;
+	pixel_y = -5
+	},
+/obj/item/shipcomponent/mainweapon/taser{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/shipcomponent/mainweapon/taser{
+	pixel_x = 6;
+	pixel_y = 2
 	},
 /turf/simulated/floor/caution/north{
 	dir = 1
@@ -70638,6 +70654,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
+"tTw" = (
+/obj/storage/crate,
+/obj/item/shipcomponent/secondary_system/tractor_beam{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/shipcomponent/secondary_system/tractor_beam{
+	pixel_x = -6;
+	pixel_y = -5
+	},
+/obj/item/shipcomponent/mainweapon/taser{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/shipcomponent/mainweapon/taser{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/security/checkpoint/podbay)
 "tTK" = (
 /obj/machinery/door/poddoor/pyro/shutters{
 	density = 0;
@@ -104926,7 +104962,7 @@ mzz
 bLp
 rbn
 fjS
-bQe
+tTw
 xyL
 bQe
 bQe
@@ -130277,7 +130313,7 @@ bit
 bkp
 bko
 bkp
-bnu
+bnv
 boW
 bqH
 bsu
@@ -130579,7 +130615,7 @@ biu
 bkp
 bkq
 blS
-bnv
+bnu
 boX
 bqI
 bsv


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[mapping] [security] [qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Hello! This is my first PR to Goonstation (though I have experience contributing to other SS13 codebases). Starting simple with a mapping PR, I've added missing pod tractor beams and mounted tasers to the security pod bays in Cogmap2. The main security podbay has also had its tables ever so slightly rearranged for compositional balance/aesthetic.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These items are present on nearly ever other map and (especially in the case of tractor beams) difficult to obtain outside of roundstart spawns.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

I checked to see if the items appeared where I placed them:
<details><summary>Main Security Pod Bay Screenshot</summary>
<img width="858" height="573" alt="image" src="https://github.com/user-attachments/assets/0562526e-0b22-4b38-a631-6918140b0f08" />
</details>

<details><summary>Other Security Pod Bay Screenshot</summary>
<img width="964" height="955" alt="image" src="https://github.com/user-attachments/assets/2541013b-36a2-46bb-8fb1-5b26d15af0ab" />
</details>

_Crates are present under pod equipment in the above screenshots._
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)QuiteLiterallyAnything
(+)Added missing pod tractor beams and tasers to the security pod bays in Cogmap 2.
```
