### PR TITLE
Enable stickers to be placed onto borg-arm-assemblies and make sticker-throws guaranteed

### DIFF
--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -649,7 +649,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm)
 		parent_assembly.applier_icon_prefix = "robot_arm"
 		if (!parent_assembly.target)
 			// trigger-robotarm-Assembly + pie -> trigger-robotarm-pie-assembly
-			parent_assembly.AddComponent(/datum/component/assembly, list(/obj/item/reagent_containers/food/snacks/pie), TYPE_PROC_REF(/obj/item/assembly, add_target_item), TRUE)
+			parent_assembly.AddComponent(/datum/component/assembly, list(/obj/item/reagent_containers/food/snacks/pie, /obj/item/sticker), TYPE_PROC_REF(/obj/item/assembly, add_target_item), TRUE)
 
 	proc/assembly_application(var/manipulated_arm, var/obj/item/assembly/parent_assembly, var/obj/assembly_target)
 		var/mob/mob_target = null
@@ -666,23 +666,23 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm)
 				SPAN_ALERT("<b>[parent_assembly.name]'s [src] flips you off! How rude...</b>"))
 		else
 			var/atom/throw_target = mob_target
-			var/obj/item/pie_to_throw = parent_assembly.target
+			var/obj/item/item_to_throw = parent_assembly.target
 			//if no target is found, we throw at a random turf which is 6 tiles away instead
 			if(!throw_target)
 				throw_target = get_ranged_target_turf(current_turf, pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST), 6 * 32)
 			else
-				throw_target.visible_message(SPAN_ALERT("<b>[parent_assembly.name]'s [src] launches [pie_to_throw] at [throw_target]!</b>"),\
-				SPAN_ALERT("<b>[parent_assembly.name]'s [src] launches [pie_to_throw] at you!</b>"))
+				throw_target.visible_message(SPAN_ALERT("<b>[parent_assembly.name]'s [src] launches [item_to_throw] at [throw_target]!</b>"),\
+				SPAN_ALERT("<b>[parent_assembly.name]'s [src] launches [item_to_throw] at you!</b>"))
 			parent_assembly.remove_until_minimum_components()
 			//after the pie is removed from the assembly and positioned at the ground, lets launch it!
 			if(mob_target && get_turf(mob_target) == current_turf)
 				//if the pie and the person is on the same tile, we gotta make them meet directly
 				var/datum/thrown_thing/simulated_throw = new
 				simulated_throw.user = parent_assembly.last_armer
-				simulated_throw.thing = pie_to_throw
-				pie_to_throw.throw_impact(throw_target, simulated_throw)
+				simulated_throw.thing = item_to_throw
+				item_to_throw.throw_impact(throw_target, simulated_throw)
 			else
-				pie_to_throw.throw_at(throw_target, 6, 2, thrown_by = parent_assembly.last_armer)
+				item_to_throw.throw_at(throw_target, 6, 2, thrown_by = parent_assembly.last_armer)
 
 /// ----------- ---------------------------------------------- -----------
 

--- a/code/obj/item/stickers.dm
+++ b/code/obj/item/stickers.dm
@@ -30,6 +30,29 @@
 			src.icon_state = pick(src.random_icons)
 		pixel_y = rand(-8, 8)
 		pixel_x = rand(-8, 8)
+		RegisterSignal(src, COMSIG_ITEM_ASSEMBLY_ITEM_SETUP, PROC_REF(assembly_setup))
+		RegisterSignal(src, COMSIG_ITEM_ASSEMBLY_ITEM_REMOVAL, PROC_REF(assembly_removal))
+
+/// ----------- Trigger/Applier/Target-Assembly-Related Procs -----------
+
+	proc/assembly_setup(var/manipulated_pie, var/obj/item/assembly/parent_assembly, var/mob/user, var/is_build_in)
+		if (is_build_in && parent_assembly.target == src)
+			//we want to handle the overlay over vis_content here
+			parent_assembly.target_overlay_invisible = TRUE
+			//we scale down the sticker and position it properly on the robot arm
+			src.pixel_x = 6
+			src.pixel_y = -6
+			src.transform *= 0.85
+			src.vis_flags |= (VIS_INHERIT_ID | VIS_INHERIT_PLANE |  VIS_INHERIT_LAYER)
+			parent_assembly.vis_contents += src
+
+	proc/assembly_removal(var/manipulated_pie, var/obj/item/assembly/parent_assembly, var/mob/user)
+		//we reset the transformations and the vis_flags here
+		src.vis_flags &= ~(VIS_INHERIT_ID | VIS_INHERIT_PLANE |  VIS_INHERIT_LAYER)
+		src.transform = null
+		parent_assembly.vis_contents -= src
+
+/// ----------------------------------------------
 
 	afterattack(var/atom/A as mob|obj|turf, var/mob/user as mob, reach, params)
 		if (!A)
@@ -84,7 +107,7 @@
 
 	throw_impact(atom/A, datum/thrown_thing/thr)
 		..()
-		if (prob(50) && !src.active)
+		if (!src.active)
 			A.visible_message(SPAN_ALERT("[src] lands on [A] sticky side down!"))
 			src.stick_to(A,rand(-5,5),rand(-8,8))
 


### PR DESCRIPTION
[Feature][Game Objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR enables stickers to be placed onto robot-arm-assemblies, like pies.

Like pies, these stickers will be thrown onto the nearest target in the area.

To make this feature properly useable, the sticking chance on being thrown was set to 100%, up from 50%. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This feature was inspired by the forum thread: https://forum.ss13.co/showthread.php?tid=24790

It also expands the use of robot arm assembies, which are kinda lacking right now.

I don't expect much balance implications from making sticker throws guaranteed. Spy stickers are very rarely used and contraband stickers are almost never used for criming. Making the throw guaranteed could potentially push these uses in a good way.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/d24892b6-f820-4761-83c9-4b2995a47ab3

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Stickers can be placed onto robot-arm assemblies
(+)Stickers, when thrown onto someone/something, will guarantee stick onto said object/person
```
