### PR TITLE
mousetrap rollers will respect the size of the assembly used to build them

### DIFF
--- a/code/obj/item/mousetrap.dm
+++ b/code/obj/item/mousetrap.dm
@@ -316,7 +316,7 @@
 			src.frame = new_frame
 		else
 			src.frame = new /obj/item/pipebomb/frame
-		src.w_class = max(new_payload.w_class, W_CLASS_TINY)
+		src.w_class = max(src.payload.w_class, W_CLASS_TINY)
 		src.frame.set_loc(src)
 		src.frame.master = src
 		// mousetrap roller + wrench -> disassembly


### PR DESCRIPTION
[Game Obects][Balance]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR will make it so that mousetrap rollers will at least have the size of the assembly used to build them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

We don't want pocket-sized single tank bombs, don't we? Putting them into mousetrap rollers made them tiny sized, this Pr changes this.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

I made a mousetrap/igniter/plasma tank assembly roller and a mousetrap/igniter one. the first didn't fit in my belt, the second one did.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Mousetrap rollers respect the size of the assembly used to build them.
```
