### PR TITLE
increases the size class of compatible pies with robot-arm assemblies

### DIFF
--- a/code/modules/cooking/food_and_drink/pies.dm
+++ b/code/modules/cooking/food_and_drink/pies.dm
@@ -32,7 +32,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/pie)
 /// ----------- Trigger/Applier/Target-Assembly-Related Procs -----------
 
 /obj/item/reagent_containers/food/snacks/pie/proc/assembly_check(var/manipulated_pie, var/obj/item/second_part, var/mob/user)
-	if (src.w_class > W_CLASS_TINY) // Transfer valve bomb pies are a thing. Shouldn't fit in a backpack, much less a box.
+	if (src.w_class > W_CLASS_SMALL)
 		boutput(user, SPAN_NOTICE("[src] is way too large. You can't find any way to balance it on the arm."))
 		return TRUE
 


### PR DESCRIPTION
[Balance][Game-Objects]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes small item-pies compatible with robot-arm-assemblies.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

the use case of robot arm assemblies is very limited. There are few items that are actually tiny and have a noticeable effect when thrown in pies. Increasing the size of throwable items to small should give people more room for shenanigans. The old restriction was there to disable things like TTV-pies fitting in pocket sized assemblies. This isn't a thing anyway, since assemblies now properly scale their size with the parts used.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Spaceman now learned to properly balance small item pies onto robot-arm assemblies, up from tiny-only. 
```
