### PR TITLE
Makes Food processor sever limbs before deleting them to prevent ghost limb issues.

### DIFF
--- a/code/obj/artifacts/artifact_machines/food_processor.dm
+++ b/code/obj/artifacts/artifact_machines/food_processor.dm
@@ -103,15 +103,8 @@
 				if (!convertable_limbs.len) //avoid runtiming once all limbs are converted
 					continue
 				var/obj/item/parts/limb_to_replace = pick(convertable_limbs)
-				switch(limb_to_replace.slot)
-					if ("l_arm")
-						qdel(humanuser.limbs.get_limb("l_arm"))
-					if ("r_arm")
-						qdel(humanuser.limbs.get_limb("r_arm"))
-					if ("l_leg")
-						qdel(humanuser.limbs.get_limb("l_leg"))
-					if ("r_leg")
-						qdel(humanuser.limbs.get_limb("r_leg"))
+				humanuser.sever_limb(limb_to_replace.slot)
+				qdel(limb_to_replace)
 				convertable_limbs -= limb_to_replace
 				humanuser.update_body()
 				src.biomatter += 2


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Science][Bug][Minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As shown in issues like #25396 and #25395, a person rescued from a Food Processor would have their limbs become completely useless, despite still being attached. This severs the limb before deleting it, hopefully resolving this issue.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ghost limbs bad.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Artifact still functions as normal during test in my own environment, unable to test the ghost limb issue.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kanthes
(+)Prevents the Food Processor from giving people ghost-limbs that couldn't interact with anything.
```
