### PR TITLE
Fix unspeakable words with certain accents

### DIFF
--- a/code/datums/regex.dm
+++ b/code/datums/regex.dm
@@ -18,5 +18,5 @@
 		string = splicetext(string, src.index, src.next, replacement_string)
 		src.next += (length(replacement_string) - length(src.match))
 
-	callback.arguments.Cut(1,2)
+	callback.arguments.Cut(1, 2)
 	return string


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fix certain words being lost to the aether when using accents that want to replace those words. 

Removes the inserted argument in `/regex/proc/ReplaceWithCallback` before returning. This fixes a bug where callback arguments would accumulate across multiple iterations when callbacks were reused, which caused runtimes by passing nonsense args and preventing accents from converting words correctly. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

fixes #25346
fixes #25268
fixes #25401

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

- add bioeffect 'loud_voice' and 'accent_hacker'
- spam talk with words 'yes', 'no', 'okay', 'die', 'kill', 'toolbox'
- observe that words are properly converted

<img width="492" height="565" alt="Screenshot 2025-12-27 124216" src="https://github.com/user-attachments/assets/cd6c98a5-084d-4957-881e-6c1c5caa2ab9" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

