### PR TITLE
Maptext Callbacks

### DIFF
--- a/code/modules/maptext/maptext_images/message.dm
+++ b/code/modules/maptext/maptext_images/message.dm
@@ -23,4 +23,7 @@
 
 		global.oscillate_colors(src, message.maptext_animation_colours)
 
+	for (var/datum/callback/callback as anything in message.maptext_callbacks)
+		callback.Invoke(message, src)
+
 	. = ..()

--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -96,6 +96,8 @@
 	)
 	/// A list of colours for the maptext to oscillate through. Use the "start_colour" value to determine the colour to animate from to `maptext_css_values["color"]`.
 	var/list/maptext_animation_colours = null
+	/// A list of callback datums to be invoked with the message itself as the first argument and any maptext images created by this message as the second argument.
+	var/list/datum/callback/maptext_callbacks = null
 	/// A prefix that should only be displayed on the maptext.
 	var/maptext_prefix = null
 	/// A suffix that should only be displayed on the maptext.
@@ -449,6 +451,7 @@
 	copy.maptext_css_values = src.maptext_css_values?.Copy()
 	copy.maptext_variables = src.maptext_variables?.Copy()
 	copy.maptext_animation_colours = src.maptext_animation_colours?.Copy()
+	copy.maptext_callbacks = src.maptext_callbacks?.Copy()
 	copy.maptext_prefix = src.maptext_prefix
 	copy.maptext_suffix = src.maptext_suffix
 

--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -96,7 +96,7 @@
 	)
 	/// A list of colours for the maptext to oscillate through. Use the "start_colour" value to determine the colour to animate from to `maptext_css_values["color"]`.
 	var/list/maptext_animation_colours = null
-	/// A list of callback datums to be invoked with the message itself as the first argument and any maptext images created by this message as the second argument.
+	/// A list of callback datums to be invoked, with the message itself as the first argument and the maptext image created by this message as the second argument.
 	var/list/datum/callback/maptext_callbacks = null
 	/// A prefix that should only be displayed on the maptext.
 	var/maptext_prefix = null


### PR DESCRIPTION
## About The PR:
Message datums now have a `maptext_callbacks` list, containing callback datums to be executed when the message creates a maptext image.

This allows for maptext images to be animated and for other effects to be applied to them, not restricted by what you can do with CSS properties.

Example usage: messages displayed to clients will be made to translate back and forth.
```
/datum/listen_module/effect/display_to_client
	id = LISTEN_EFFECT_DISPLAY_TO_CLIENT

/datum/listen_module/effect/display_to_client/process(datum/say_message/message)
	message.maptext_callbacks ||= list()
	message.maptext_callbacks += CALLBACK(src, PROC_REF(example_proc))
	boutput(src.parent_tree.listener_parent, message.format_for_output(src.parent_tree.listener_parent))

/datum/listen_module/effect/display_to_client/proc/example_proc(datum/say_message/message, image/maptext/maptext)
	animate(maptext, time = 1 SECOND, loop = -1, pixel_x = 10, flags = ANIMATION_PARALLEL)
	animate(time = 1 SECOND, pixel_x = -10)
```


## Why Is This Needed?
By request of @pgmzeta.


## Testing:
The example above was tested, with the results as expected.