### PR TITLE
Make multitool-assemblies be improved by adding power cells to them.

### DIFF
--- a/code/obj/item/device/multitool.dm
+++ b/code/obj/item/device/multitool.dm
@@ -19,8 +19,8 @@ TYPEINFO(/obj/item/device/multitool)
 	m_amt = 50
 	g_amt = 20
 	custom_suicide = TRUE
-	var/spark_power = 5000 //! The amount of power needed to cause an upgraded spark in a cell-assembly
-	var/max_spark_power_usage = 20000 //! The amount of power consumed at maximum power.
+	var/spark_power = 2000 //! The amount of power needed to cause an upgraded spark in a cell-assembly
+	var/max_spark_power_usage = 8000 //! The amount of power consumed at maximum power.
 
 	New()
 		..()


### PR DESCRIPTION
[Feature][Game Objects]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes it so that multitool-assemblies can be improved by adding power cells onto them.

Depending on the power of the cell used, the area and the effect of the electric effect is increased.

For every 5k of charge on the cell, the power of the elecflash is increased by 1, up to 6 at 8k Charge. at 2k and 4k energy, the range increase by 1. 

Erebite cells cause an explosion without triggering the assemblies effect.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Adding cells to assemblies should help increasing their power. A bigger cell on the multitool does this mainly be increasing the shock and effective range on the assembly. a High powered cell causes a stamina drain akin to getting defibbed.

Their main use will likely be lighting fires. Due to the increased range you can place them further away from welding fuel tanks or other igniteable sources. And the larger shock does cause a better heatup than the small shock from the unmodified multitool.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/ec668e47-b751-44ee-8a73-7c75cbf52326


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Multitool assemblies can be modified by adding a large power cell onto them. This drains the power cell to increase the area and the effect of the flash produced.
```
