### PR TITLE
Coffins are Made of Wood

### DIFF
--- a/code/obj/storage/closets.dm
+++ b/code/obj/storage/closets.dm
@@ -165,6 +165,7 @@ TYPEINFO(/obj/storage/closet/coffin)
 	volume = 70
 	auto_close = FALSE
 	can_leghole = FALSE
+	default_material = "wood"
 
 	wood
 		icon_closed = "woodcoffin"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes coffins be made of wood.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Coffins are made of wood. More specifically, not having `default_material` set to `"wood"` means that coffins deconstruct to steel. Needless to say, _coffins are not made of steel_.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<details><summary>Before:</summary>
<img width="795" height="840" alt="coffin_test_1" src="https://github.com/user-attachments/assets/940a59a4-98a2-423e-a584-ae2b94f394c9" />
</details>
<details><summary>After:</summary>
<img width="767" height="818" alt="coffin_test_2" src="https://github.com/user-attachments/assets/bc2506e5-4667-499d-b991-98ca040fa39c" />
</details>
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)QuiteLiterallyAnything
(+)Coffins are now made of wood (and deconstruct to it).
```
