### PR TITLE
Allows ABCUs to be Put in Pod Cargo Holds

### DIFF
--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -114,6 +114,9 @@
 				src.deactivate()
 
 			if("Lock")
+				if(!isturf(src.loc))
+					boutput(user, SPAN_ALERT("The machine cannot lock into place here."))
+					return
 				if (src.building)
 					boutput(user, SPAN_ALERT("Lock status can't be changed with a build in progress."))
 					return

--- a/code/modules/transport/pods/secondary_system.dm
+++ b/code/modules/transport/pods/secondary_system.dm
@@ -155,7 +155,8 @@
 	/obj/machinery/nuclearbomb,
 	/obj/bomb_decoy,
 	/obj/gold_bee,
-	/obj/reagent_dispensers/beerkeg)
+	/obj/reagent_dispensers/beerkeg,
+	/obj/machinery/abcu)
 
 	hud_state = "cargo"
 	f_active = 1


### PR DESCRIPTION
[Game Objects] [QoL]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows ABCUs to be put in pod cargo holds. I've also added an `isturf()` check to ABCU locking logic so that it doesn't runtime (or somehow succeed) when told to lock while inside something.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
ABCUs are often used in space, and pods are a common means by which players transport things to space. Their sprite is also very rectangular and similar to a crate, so it is rather intuitive to imagine that they would fit in a cargo hold.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
On a debug build of the codebase I spawned an ABCU, selected a blueprint, put it in a pod, made sure I couldn't activate it while in the pod, took it out of the pod, and made sure it still worked when used regularly.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)QuiteLiterallyAnything
(+)ABCUs can now be placed in pod cargo holds.
```
