### PR TITLE
Slight Adjustment to Pod Fuel Tank Attachment

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -182,7 +182,7 @@
 				return
 
 		if (istype(W, /obj/item/tank/plasma))
-			if(src.fueltank)
+			if(src.fueltank || !src.atmostank)
 				src.open_parts_panel(user)
 			else
 				logTheThing(LOG_VEHICLE, usr, "replaces [src.name]'s engine fuel supply with [W] [log_atmos(W)] at [log_loc(src)].")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QoL] [Vehicles]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes hitting a fuel-tankless pod with a plasma tank automatically insert said plasma tank as the pod's fuel tank (under the condition that the pod does not also lack an atmos tank).
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If a pod has no fuel tank then any player hitting it with a plasma tank likely intends to refuel it (especially if the pod also has an atmos tank). Skipping UI interaction in this circumstance seems to be a given.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
On a debug build of the codebase I took a pod's fuel tank out, put it back in using the new method, and flew the pod around a bit. Everything worked as expected.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)QuiteLiterallyAnything
(+)Plasma tanks may now be quickly inserted into pods lacking a fuel tank via hit.
```
