### PR TITLE
Lets Handspiders Snap

### DIFF
--- a/code/mob/living/critter/changeling_critters.dm
+++ b/code/mob/living/critter/changeling_critters.dm
@@ -187,6 +187,7 @@ TYPEINFO(/mob/living/critter/changeling)
 			. += 7
 
 	specific_emotes(var/act, var/param = null, var/voluntary = 0)
+		var/message
 		switch (act)
 			if ("scream")
 				if (src.emote_check(voluntary, 50))
@@ -195,7 +196,6 @@ TYPEINFO(/mob/living/critter/changeling)
 			if("flip")
 				if(src.emote_check(voluntary, 50))
 					var/list/mob/living/possible_targets = list()
-					var/message
 					//Check if we have any nearby mobs
 					for(var/mob/living/L in oview(1))
 						possible_targets += L
@@ -221,6 +221,10 @@ TYPEINFO(/mob/living/critter/changeling)
 						message = "<B>[src]</B> does a flip!"
 
 					return message
+			if ("snap","snapfingers","fingersnap","click","clickfingers")
+				message = "The <b>[src.name]</b> snaps [his_or_her(src)] fingers."
+				playsound(src.loc, src.sound_fingersnap, 50, TRUE, channel=VOLUME_CHANNEL_EMOTE)
+				return message
 		return null
 
 	specific_emote_type(var/act)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows handspiders to snap.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Its entire thing is being a hand and the fact that it can't snap is sad :(
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
On a debug build of the codebase I spawned in a handspider, assumed control of it, and snapped successfully. I was then briefly confused/worried by my unknowing discovery of the fact that admins have no emote cooldown. Everything else worked as expected though.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)QuiteLiterallyAnything
(+)Handspiders can now snap.
```
