### PR TITLE
Headset EMP Improvement

### DIFF
--- a/code/modules/speech/modules/listen/effects/radio.dm
+++ b/code/modules/speech/modules/listen/effects/radio.dm
@@ -3,7 +3,7 @@
 
 /datum/listen_module/effect/radio/process(datum/say_message/message)
 	var/obj/item/device/radio/radio = src.parent_tree.listener_parent
-	if (!istype(radio) || radio.bricked)
+	if (!istype(radio) || radio.bricked || radio.emp)
 		return
 
 	var/signal_frequency

--- a/code/obj/item/device/radios/_radio.dm
+++ b/code/obj/item/device/radios/_radio.dm
@@ -94,6 +94,10 @@ TYPEINFO(/obj/item/device/radio)
 	var/wires = WIRE_SIGNAL | WIRE_RECEIVE | WIRE_TRANSMIT
 	/// The build status of this radio, determining whether it can be attached to other objects, and other objects attached to it.
 	var/b_stat = FALSE
+	/// The radio has malfunctioned due to an EMP
+	var/emp = FALSE
+	/// The message that should be displayed when attempting to use a radio that is under the effects of an EMP.
+	var/emp_msg = "The radio buzzes softly. Hopefully it kicks back on soon."
 
 /obj/item/device/radio/New()
 	. = ..()
@@ -173,6 +177,10 @@ TYPEINFO(/obj/item/device/radio)
 /obj/item/device/radio/ui_interact(mob/user, datum/tgui/ui)
 	if (src.bricked)
 		user.show_text(src.bricked_msg, "red")
+		return
+
+	if (src.emp)
+		user.show_text(src.emp_msg, "red")
 		return
 
 	ui = tgui_process.try_update_ui(user, src, ui)

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -46,12 +46,14 @@
 
 	emp_act()
 		. = ..()
+		src.emp = TRUE
 		src.visible_message(SPAN_ALERT("[src] sparks and goes silent!")) // Alert the wearer that their headset is busted
 
 		// After a certain amount of time, toggle speaker back on
 		SPAWN(90 SECONDS)
-			if (!src.speaker_enabled)
-				src.visible_message(SPAN_NOTICE("[src]'s speaker automatically toggles back on!"))
+			if (src.emp)
+				src.visible_message(SPAN_NOTICE("[src] automatically toggles back on!"))
+				src.emp = FALSE
 				src.toggle_speaker(initial_speaker_enabled)
 
 	proc/install_radio_upgrade(var/obj/item/device/radio_upgrade/R)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a descriptive message when your headset is affected by an EMP. Headset speakers now automatically toggle back on after 90 seconds (same timer as security cameras when hit with EMPs).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Getting your headset hit by an EMP is cool and can be utilized by antags if timed properly. The issue is that there was formerly no message to indicate specifically that your headset had been turned off, which just led to people both new and veteran either forgetting or not realizing that they needed to turn their headset on again to hear radios. With the addition of proper EMP storms and the much more common likelihood of headsets getting nailed every so often, I think it's a good QoL change to have them automatically toggle back on (if not done so manually) after a set amount of time.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Ensured EMPs trigger the headset message, and made sure the headset speaker turns on after a set amount of time.

<img width="563" height="445" alt="{C28B3976-9482-4F4E-980A-D9CA73089240}" src="https://github.com/user-attachments/assets/8acab6c5-1030-417d-bb5b-3774bf1dde96" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TheGeneralJay
(*)Headsets now malfunction fully and cannot be turned on manually for a set duration after an EMP. They will automatically toggle back on after the duration is up.
```
