### PR TITLE
Message Groups

### DIFF
--- a/code/modules/speech/modules/listen/effects/display_to_client.dm
+++ b/code/modules/speech/modules/listen/effects/display_to_client.dm
@@ -2,4 +2,4 @@
 	id = LISTEN_EFFECT_DISPLAY_TO_CLIENT
 
 /datum/listen_module/effect/display_to_client/process(datum/say_message/message)
-	boutput(src.parent_tree.listener_parent, message.format_for_output(src.parent_tree.listener_parent))
+	boutput(src.parent_tree.listener_parent, message.format_for_output(src.parent_tree.listener_parent), message.group)

--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -82,6 +82,8 @@
 	var/relay_flags = null
 	/// If FALSE, this message will not be permitted to be retransmitted, regardless of the flags present in `relay_flags`.
 	var/can_relay = TRUE
+	/// The browser output group of this message. Messages in the same group will be bundled as if their contents were identical.
+	var/group = ""
 
 	// Maptext Variables:
 	/// The CSS values for the maptext, stored as an associative list, i.e: "font-weight" = "bold".
@@ -446,6 +448,7 @@
 	copy.atom_listeners_to_be_excluded = src.atom_listeners_to_be_excluded?.Copy()
 	copy.relay_flags = src.relay_flags
 	copy.can_relay = src.can_relay
+	copy.group = src.group
 
 	// Maptext Variables:
 	copy.maptext_css_values = src.maptext_css_values?.Copy()


### PR DESCRIPTION
## About The PR:
Message datums now have a `group` variable, passed to `boutput`'s `group` argument when the message it output to a client.


## Why Is This Needed?
By request of @pgmzeta.


## Testing:
Vending machines were made to output messages to the "test" group, and message grouping worked as expected.