### PR TITLE
Moves a Single Light Switch

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -14706,7 +14706,6 @@
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "aTq" = (
-/obj/machinery/light_switch/north,
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -65353,6 +65352,10 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/blue/side,
 /area/station/medical/medbay/surgery/storage)
+"pdK" = (
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "peI" = (
 /obj/shrub,
 /obj/machinery/firealarm/directional/north,
@@ -101935,7 +101938,7 @@ aOo
 aPB
 aQZ
 aWh
-tTd
+pdK
 aUM
 aWh
 aZm


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Mapping] [Fix]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR moves a singular light switch in Cog2's ranch one tile to the left.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This light switch can be flipped from both sides of the door it resides along. This isn't good because it controls the lights of a minor access-restricted area.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<details><summary>Expand for screenshot. . .</summary>
<img width="614" height="606" alt="image" src="https://github.com/user-attachments/assets/a93108c9-cfe9-440a-9346-3664ce98a56b" />
</details>
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->