### PR TITLE
Makes Glass Recycler UI Appear Less Often

### DIFF
--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -134,7 +134,7 @@ TYPEINFO(/obj/machinery/glass_recycler)
 			user.visible_message(SPAN_NOTICE("[user] inserts [W] into [src]."))
 			user.u_equip(W)
 			qdel(W)
-			tgui_process.try_update_ui(user, src)
+			tgui_process.update_uis(src)
 			var/sound = pick('sound/impact_sounds/Glass_Shatter_1.ogg', 'sound/impact_sounds/Glass_Shatter_2.ogg', 'sound/impact_sounds/Glass_Shatter_3.ogg')
 			playsound(src.loc, sound, 40, 0, 0.1)
 			return TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects] [QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR replaces a single `ui_interact()` call which makes glass recyclers open their UI any time glass is added to them. A more direct ~`tgui_process.try_update_ui()`~ `tgui_process.update_uis()` call has been added instead.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It is currently impossible to add glass to a glass recycler without its UI opening. This is unnecessary as it is often the case that a player may desire to simply add glass to a recycler without also dispensing glass from it. 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
On a debug build of the codebase I spawned a glass recycler and added glass to it. Its UI appeared to update and function properly when both unopened and never previously opened. When opened its glass count appeared to increment slower, so I added the previously mentioned ~`try_update_ui()`~ `update_uis()` call.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
