### PR TITLE
hpd now returns 1 (one) matter unit or 200 (two hundred) energy to borgs when deconstructing

### DIFF
--- a/code/obj/item/handheld_dispenser/dispenser.dm
+++ b/code/obj/item/handheld_dispenser/dispenser.dm
@@ -212,7 +212,7 @@ TYPEINFO(/obj/item/places_pipes)
 	if (S?.cell)
 		S.cell.give(src.silicon_cost_multiplier)
 	else
-		resources += (src.resources < src.max_resources) ? 1 : 0
+		resources += (src.resources + 1 <= src.max_resources) ? 1 : 0
 	if (!issilicon(user))
 		src.inventory_counter.update_number(src.resources)
 	src.tooltip_rebuild = TRUE


### PR DESCRIPTION
[FEATURE][QOL]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
title. it also returns 200 energy to borgs, making it a very shitty charging method.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
its nice to have when changing pipes.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
i deconstructed something. it returned a matter unit. i deconstructed when full, it did not go over 50.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```
(u)cringe
(+)hpd is now 1% efficient when deconstructing, returning 1 matter unit or 200 charge.
```
