### PR TITLE
Speech Code Fixes For 25470

### DIFF
--- a/code/modules/speech/modules/listen/effects/microphone.dm
+++ b/code/modules/speech/modules/listen/effects/microphone.dm
@@ -6,11 +6,9 @@
 	if (!istype(microphone) || !microphone.on || !CAN_RELAY_MESSAGE(message, SAY_RELAY_MICROPHONE))
 		return
 
-	// if held, it must be in active hand to be heard through
-	if (ismob(microphone.loc))
-		var/mob/mob_speaker = message.original_speaker
-		if (istype(mob_speaker) && mob_speaker.equipped() != microphone)
-			return NO_MESSAGE
+	// If held, the microphone must be in the speaker's active hand to receive the message.
+	if (ismob(microphone.loc) && (astype(message.original_speaker, /mob)?.equipped() != microphone))
+		return
 
 	var/feedback = FALSE
 	var/cause_fault = FALSE

--- a/code/modules/speech/modules/listen/modifiers/phone_formatting.dm
+++ b/code/modules/speech/modules/listen/modifiers/phone_formatting.dm
@@ -12,16 +12,9 @@
 	if (!istype(handset))
 		return
 
-
-	// if held, it must be in active hand to be heard through
-	if (ismob(handset.loc))
-		var/mob/mob_speaker = message.original_speaker
-		if(mob_speaker.equipped() != handset)
-			return NO_MESSAGE
-
-
-	// Create a text reference to the speaker's mind, if they have one.
-
+	// If held, the handset must be in the speaker's active hand to receive the message.
+	if (ismob(handset.loc) && (astype(message.original_speaker, /mob)?.equipped() != handset))
+		return NO_MESSAGE
 
 	message.flags |= SAYFLAG_NO_MAPTEXT
 	message.flags &= ~(SAYFLAG_WHISPER | SAYFLAG_NO_SAY_VERB)
@@ -31,6 +24,7 @@
 	message.atom_listeners_to_be_excluded = null
 	FORMAT_MESSAGE_FOR_RELAY(message, SAY_RELAY_PHONE)
 
+	// Create a text reference to the speaker's mind, if they have one.
 	var/mind_ref = ""
 	if (ismob(message.original_speaker))
 		var/mob/mob_speaker = message.original_speaker

--- a/code/modules/speech/modules/speech/modifiers/megaphone.dm
+++ b/code/modules/speech/modules/speech/modifiers/megaphone.dm
@@ -9,8 +9,7 @@
 
 	var/mob/mob_speaker = message.message_origin
 	var/obj/item/megaphone/megaphone = mob_speaker.equipped()
-
-	if (!megaphone)
+	if (!istype(megaphone))
 		return
 
 	message.maptext_css_values["font-family"] = ((megaphone.maptext_size >= 12) ? "'PxPlus IBM VGA9'" : "'Small Fonts'")


### PR DESCRIPTION
## About The PR:
Replaces an `if (!...)` check with an `if (!istype(...))` check, which otherwise permits non-megaphone objects to pass and cause runtimes.

Also fixes a misplaced comment and shortens an active hand check using `astype`.