### PR TITLE
Fixes engineering space helmets not covering hair/blocking chokeholds

### DIFF
--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -51,7 +51,6 @@
 	name = "engineering space helmet"
 	desc = "Comes equipped with a built-in flashlight."
 	icon_state = "espace0"
-	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH
 	see_face = FALSE
 	item_state = "s_helmet"
 	var/on = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [CLOTHING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR removes a line of code that made engineering space helmets not inherit the `COVERSHAIR` and `NOCHOKE` clothing flags from their parent object.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I can only assume that them not having it was an oversight. Fixes #24967 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="447" height="285" alt="image" src="https://github.com/user-attachments/assets/aa0b4ece-9d41-4fad-8349-ae53f6a0cd2e" />
