### PR TITLE
Fix not being able to pour from headless mobs using an aggressive grab

### DIFF
--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -139,15 +139,6 @@
 
 		UpdateIcon()
 
-	afterattack(atom/target, mob/user, reach, params)
-		. = ..()
-		if (state >= GRAB_AGGRESSIVE && !istype(target,/turf))
-			if (src.affecting?.is_open_container() && src.affecting?.reagents && target.is_open_container(TRUE))
-				logTheThing(LOG_CHEMISTRY, user, "transfers chemicals from [src.affecting] [log_reagents(src.affecting)] to [target] at [log_loc(user)].")
-				var/trans = src.affecting.reagents.trans_to(target, 10)
-				if (trans)
-					boutput(user, SPAN_NOTICE("You dump [trans] units of the solution from [src.affecting] to [target]."))
-
 	attack(atom/target, mob/user)
 		if (check())
 			return
@@ -587,6 +578,15 @@
 
 	if (BOUNDS_DIST(src, M) > 0)
 		return 0
+
+	// attempt to pour into the object instead, putting it here because i dont know whether its open by its type
+	if (G.state >= GRAB_AGGRESSIVE && !istype(src,/turf))
+		if (M.is_open_container() && M.reagents && src.is_open_container(TRUE))
+			logTheThing(LOG_CHEMISTRY, user, "transfers chemicals from [M] [log_reagents(M)] to [src] at [log_loc(user)].")
+			var/trans = M.reagents.trans_to(src, 10)
+			if (trans)
+				boutput(user, SPAN_NOTICE("You dump [trans] units of the solution from [M] to [src]."))
+				return 0
 
 	user.visible_message(SPAN_ALERT("<B>[M] has been smashed against [src] by [user]!</B>"))
 	logTheThing(LOG_COMBAT, user, "smashes [constructTarget(M,"combat")] against [src]")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[PLAYER ACTIONS] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

In a previous PR back in 2023, #14252, I added the ability to pour from open container mobs into open containers hit with the grab object. Since then, the method that i had used to implement this no longer gets called and is nonfunctional

My solution to fix this was to move it to a place where it does get called, inside grab smash code.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Being able to use skeletons as a beaker with legs can potentially lead to comedy and should not be bugged.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="599" height="78" alt="image" src="https://github.com/user-attachments/assets/109f32dd-94b0-42e5-b9ad-fc97546d2b96" />

tested by spawning a clown on devtest, filling with chemicals, turning them into a skeleton, removing their head, and pouring their chems into a beaker by hitting the beaker with the aggressive grab

