### PR TITLE
Macho Healing Clarification

### DIFF
--- a/code/modules/antagonists/macho_man/abilities/heal.dm
+++ b/code/modules/antagonists/macho_man/abilities/heal.dm
@@ -7,37 +7,37 @@
 		if (isalive(holder.owner) && !holder.owner.transforming)
 			// This proc's actual target (if found). This should probably be `atom/target` typecasted to a
 			// mob, but as of writing this comment I'm just trying to fix something else rather than refactor.
-			var/mob/living/H
-			for (var/obj/item/grab/G in holder.owner)
-				if (isliving(G.affecting))
+			var/mob/living/living_target
+			for (var/obj/item/grab/grab_item in holder.owner)
+				if (isliving(grab_item.affecting))
 					holder.owner.verbs -= /mob/living/carbon/human/machoman/verb/macho_heal
-					H = G.affecting
-					if (H.lying)
-						H.lying = 0
-						H.remove_stuns()
-						H.set_clothing_icon_dirty()
-					H.transforming = 1
+					living_target = grab_item.affecting
+					if (living_target.lying)
+						living_target.lying = 0
+						living_target.remove_stuns()
+						living_target.set_clothing_icon_dirty()
+					living_target.transforming = 1
 					holder.owner.transforming = 1
-					holder.owner.set_dir(get_dir(holder.owner, H))
-					H.set_dir(get_dir(H, holder.owner))
-					holder.owner.visible_message(SPAN_ALERT("<B>[holder.owner] gently picks up [H]!</B>"))
+					holder.owner.set_dir(get_dir(holder.owner, living_target))
+					living_target.set_dir(get_dir(living_target, holder.owner))
+					holder.owner.visible_message(SPAN_ALERT("<B>[holder.owner] gently picks up [living_target]!</B>"))
 					playsound(holder.owner.loc, pick(snd_macho_rage), 50, 0, 0, holder.owner.get_age_pitch())
-					var/dir_offset = get_dir(holder.owner, H)
+					var/dir_offset = get_dir(holder.owner, living_target)
 					switch(dir_offset)
 						if (NORTH)
-							H.pixel_y = -24
-							H.layer = holder.owner.layer - 1
+							living_target.pixel_y = -24
+							living_target.layer = holder.owner.layer - 1
 						if (SOUTH)
-							H.pixel_y = 24
-							H.layer = holder.owner.layer + 1
+							living_target.pixel_y = 24
+							living_target.layer = holder.owner.layer + 1
 						if (EAST)
-							H.pixel_x = -24
-							H.layer = holder.owner.layer - 1
+							living_target.pixel_x = -24
+							living_target.layer = holder.owner.layer - 1
 						if (WEST)
-							H.pixel_x = 24
-							H.layer = holder.owner.layer - 1
+							living_target.pixel_x = 24
+							living_target.layer = holder.owner.layer - 1
 					for (var/i = 0, i < 5, i++)
-						H.pixel_y += 2
+						living_target.pixel_y += 2
 						sleep(0.3 SECONDS)
 					holder.owner.transforming = 0
 					holder.owner.bioHolder.AddEffect("fire_resist") // This is added just for the outline???
@@ -45,24 +45,24 @@
 					playsound(holder.owner.loc, 'sound/voice/heavenly.ogg', 50)
 					holder.owner.visible_message(SPAN_ALERT("<b>[holder.owner] closes [his_or_her(holder.owner)] eyes in silent macho prayer!</b>"))
 					sleep(4 SECONDS)
-					for (var/mob/N in viewers(holder.owner, null))
-						N.flash(3 SECONDS)
-						if (N.client)
-							shake_camera(N, 6, 16)
-							N.show_message(SPAN_ALERT("<b>A blinding light envelops [holder.owner]!</b>"), 1)
+					for (var/mob/bystander in viewers(holder.owner, null))
+						bystander.flash(3 SECONDS)
+						if (bystander.client)
+							shake_camera(bystander, 6, 16)
+							bystander.show_message(SPAN_ALERT("<b>A blinding light envelops [holder.owner]!</b>"), 1)
 
 					playsound(holder.owner.loc, 'sound/weapons/flashbang.ogg', 50, 1)
-					qdel(G)
+					qdel(grab_item)
 					holder.owner.transforming = 0
 					holder.owner.bioHolder.RemoveEffect("fire_resist")
 					holder.owner.verbs += /mob/living/carbon/human/machoman/verb/macho_heal
 					random_brute_damage(holder.owner, 25)
 					holder.owner.UpdateDamageIcon()
 					SPAWN(0)
-						if (H)
-							H.pixel_x = 0
-							H.pixel_y = 0
-							H.transforming = 0
-							H.full_heal()
-			if(!H) // If the proc doesn't assign a target.
+						if (living_target)
+							living_target.pixel_x = 0
+							living_target.pixel_y = 0
+							living_target.transforming = 0
+							living_target.full_heal()
+			if(!living_target)
 				boutput(holder.owner, SPAN_ALERT("You must have a target grabbed if you want to heal them!"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug] [Player Actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Closes #25480 

This PR clarifies that targets of a macho man's healing ability must be grabbed. 

While making this small change, I noticed a few other issues with Faustian macho men in particular. I haven't fixed any of those other issues for the sake of atomization, but I will note that Faustian macho men apparently get a full heal ability with no cooldown. _They can revive an infinite number of dead people at a rate of around seven seconds per person._ 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This PR resolves a minor semi-false issue and makes the use of an ability more intuitive.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
On a debug build of the codebase I spawned a Faustian macho man contract and signed it. I then spawned a human, punched it, and attempted to heal it without grabbing. The message added by this PR appeared as expected, and the bold formatting worked when viewed in the healing ability's description. Attempting to properly heal the target worked as well.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->