### PR TITLE
Fix for In-Hand Paper Bin Weirdness

### DIFF
--- a/code/modules/writing/paper.dm
+++ b/code/modules/writing/paper.dm
@@ -614,7 +614,9 @@
 
 /obj/item/paper_bin/mouse_drop(mob/user as mob)
 	if (user == usr && !user.restrained() && !user.stat && (user.contents.Find(src) || in_interact_range(src, user)))
-		if (!user.put_in_hand(src))
+		if(src.loc == user)
+			user.drop_item(src) // Drop because `put_in_hand(src)` will keep an invisible paper bin in offhand otherwise. I have no idea why.
+		if(!user.put_in_hand(src))
 			return ..()
 
 /obj/item/paper_bin/attack_hand(mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug] [Game Objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #25491

This PR makes using a paper bin in hand do nothing if the bin lacks paper. Paper bins will also not link themselves to unoccupied hands upon being swapped between hands multiple times. Additionally, full paper bins may be properly swapped in hand via click-dragging as presumably intended.

~~This took me nearly three hours of code tweaking to get right.~~
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So far as the linked issue goes, using an empty paper bin in hand will currently produce a weird visual effect that's effectively a "ghost" paper bin. I've found that this particular portion of the issue is caused by the paper bin `attack_self()` proc. Using GitHub's Git blame view I was able to trace the last relevant (non-refactor) change of this proc to commit ffeeb36e4f3a9a584df9b027f7bb530d83ffb040, which was for dispensing paper rather than having the bin swap in hand. The swapping part seems to have been unintentional, so this PR does not preserve it.

Other paper bin hand handling procs call `put_in_hand(src)`/`put_in_hand_or_drop(src)` directly, and for some reason that seems to summon ghost paper bins whenever `src` is in hand. ~~In exorcising these specters, have I too not become haunted?~~
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
On a debug build of the codebase I spawned a paper bin and manipulated it in hand in every possible way I could think of. I also tested cyborg paper bins to make sure nothing had transferred to them either. Everything worked as expected.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->