### PR TITLE
Voluntarily leaving the hivemind sets DNR

### DIFF
--- a/code/mob/dead/hivemind_observer.dm
+++ b/code/mob/dead/hivemind_observer.dm
@@ -127,8 +127,10 @@ TYPEINFO(/mob/dead/target_observer/hivemind_observer)
 	usr = src
 
 	if(world.time >= can_exit_hivemind_time && hivemind_owner && hivemind_owner.master != src)
-		boutput(src, SPAN_ALERT("You have parted with the hivemind."))
-		src.mind?.remove_antagonist(ROLE_CHANGELING_HIVEMIND_MEMBER)
+		if(tgui_alert(src, "This will automatically set DNR. Continue?", "DNR Confirmation", list("Yes", "No")) == "Yes")
+			boutput(src, SPAN_ALERT("You have parted with the hivemind."))
+			src.mind?.remove_antagonist(ROLE_CHANGELING_HIVEMIND_MEMBER)
+			src.mind?.get_player()?.dnr = TRUE
 	else
 		boutput(src, SPAN_ALERT("You are not able to part from the hivemind at this time. You will be able to leave in [(can_exit_hivemind_time/10 - world.time/10)] seconds."))
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a confirmation dialog when leaving the hivemind, and tie it to setting the player as DNR.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People keep popping out of the hivemind instantly and at *best* act like nothing happened. More often than not, they have an axe to grind.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Difficult to test locally

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Leaving a changeling hivemind voluntarily will set DNR.
```
