### PR TITLE
Werewolf Feed Objective Formatting

### DIFF
--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -927,10 +927,7 @@ ABSTRACT_TYPE(/datum/objective/madness)
 
 	set_up()
 		target_feed_count = max(min(10, (ticker.minds.len - 1)), 1)
-		if(target_feed_count > 0)
-			explanation_text = "Feed on at least [target_feed_count] crew [(target_feed_count > 1) ? "members" : "member"]."
-		else
-			explanation_text = "Become the ultimate lone wolf."
+		explanation_text = "Feed on at least [target_feed_count] crew [(target_feed_count > 1) ? "members" : "member"]."
 
 	check_completion()
 		if (feed_count >= target_feed_count)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #25502 

This PR adjusts werewolf feed objective text to account for low player counts. 

~~_**Please note,**_ this PR does not prevent players from receiving a medal for feeding on less than one person.~~ This PR ~~also~~ doesn't fix similar issues with other antagonist objectives.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This fixes an issue and makes an objective reasonably possible.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
On a debug build of the codebase I spawned as a human, turned myself into a werewolf, and ghosted. I did this two more times to ensure that the objective text appeared as expected. 
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->