### PR TITLE
hit cruiser area code with hammers

### DIFF
--- a/code/modules/transport/cruisers/cruisers.dm
+++ b/code/modules/transport/cruisers/cruisers.dm
@@ -848,21 +848,33 @@
 
 	Entered(var/atom/movable/A, atom/oldloc)
 		. = ..()
-		if(!src.is_upper || !ismob(A))
+		if( !ismob(A) || !src.ship)
 			return
 		var/mob/user = A
-		src.ship.subscribe_interior(user)
-		user.set_eye(src.ship)
+
+		// make absolutely SURE they stay synced
+		if (!src.is_upper)
+			src.ship.unsubscribe_interior(user)
+			user.set_eye(null)
+		else
+			src.ship.subscribe_interior(user)
+			user.set_eye(src.ship)
 
 	Exited(atom/movable/A)
 		. = ..()
-		if(!ismob(A))
+		if( !ismob(A) || !src.ship)
 			return
 		if(get_area(A) == src)
 			return
 		var/mob/user = A
-		src.ship.unsubscribe_interior(user)
-		user.set_eye(null)
+
+		// make absolutely SURE they stay synced
+		if (src.is_upper || !istype(get_area(A),/area/cruiser))
+			src.ship.unsubscribe_interior(user)
+			user.set_eye(null)
+		else
+			src.ship.subscribe_interior(user)
+			user.set_eye(src.ship)
 
 /area/cruiser/syndicate/lower
 	name = "Syndicate cruiser interior"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes up some of the area entering / exiting logic for cruisers to hopefully make it more successful at properly removing / adding interior overlays

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
<img width="814" height="379" alt="image" src="https://github.com/user-attachments/assets/f4bcb9e7-0d19-4e12-bd7b-8b7925848ba2" />
cruiser out of body experiences bad

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested by spawning a cruiser on devtest and hopping in and out of the control pods, climbing up and down the ladders to try and desync the overlays.
![cruisertest](https://github.com/user-attachments/assets/457a319d-1d63-4439-8b9b-1ad1ee7ebd2f)


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->