### PR TITLE
Plague Rat Feeding Fix

### DIFF
--- a/code/modules/antagonists/wraith/critters/abilities/plaguerat.dm
+++ b/code/modules/antagonists/wraith/critters/abilities/plaguerat.dm
@@ -47,7 +47,7 @@ ABSTRACT_TYPE(/datum/targetable/critter/plague_rat)
 
 		if (!isturf(P.loc))
 			boutput(P, SPAN_ALERT("You can't feed while in [istype(P.loc,/obj/dummy/disposalmover) ? "a disposal pipe" : "\the [P.loc]"]."))
-			return FALSE
+			return CAST_ATTEMPT_FAIL_NO_COOLDOWN
 
 		for (var/obj/decal/cleanable/C in T)
 			for (var/D in decal_list)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug] [Player Actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Related to and may be considered a fix for issue #25499. (Final judgement on whether or not this PR should close that issue is left to maintainers.) 

This PR prevents plague rats from feeding on detritus while inside things.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I wasn't able to directly reproduce issue #25499 or locate its main cause. I did, however, notice that plague rats can feed on waste while inside pipes, closets, and similar objects. They can only do this when the ability is bound to a key, so I assume it's an exploit. 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
On a debug build of the codebase I spawned a plague rat and placed some blood beside a disposals chute and closet. The blood could not be fed on from inside either, and the message indicating such to players appeared as appropriate.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
