### PR TITLE
Buttbot Movement Fix

### DIFF
--- a/code/modules/robotics/bot/buttbot.dm
+++ b/code/modules/robotics/bot/buttbot.dm
@@ -122,7 +122,7 @@ TYPEINFO(/obj/machinery/bot/buttbot)
 				src.navigate_to(A, BUTTBOT_MOVE_SPEED, 0, 15)
 				break
 	else
-		step_rand(src, BUTTBOT_MOVE_SPEED)
+		src.navigate_to(get_step_rand(src), BUTTBOT_MOVE_SPEED)
 
 /obj/machinery/bot/buttbot/process(mult)
 	if(src.exploding)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug] [AI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #25495
Fixes #11008

This PR makes un-emagged buttbot movement rely on `navigate_to()` rather than just Dream Maker's inbuilt `step_rand()` proc. 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Using an engine proc with no other checks can (and in this case does) cause bugs such as those described in the issues above. If the debug define `CHECK_MORE_RUNTIMES` is enabled then buttbots will `CRASH()` when told to move in lockers..
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
On a debug build of the codebase I spawned a buttbot and checked if it would move properly both when inside and not inside a closet.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->