### PR TITLE
Swaps 'Backgrounds' to 'Scenarios'

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -916,7 +916,7 @@ ABSTRACT_TYPE(/datum/trait/job)
 	desc = "You spawn hidden away on-station without an ID, PDA, or entry in NT records."
 	id = "stowaway"
 	icon_state = "stowaway"
-	category = list("scenario")
+	category = list("spawn scenario")
 	points = 0
 	unselectable = TRUE
 
@@ -925,7 +925,7 @@ ABSTRACT_TYPE(/datum/trait/job)
 	desc = "You spawn in a pod off-station with a Space GPS, Emergency Oxygen Tank, Breath Mask and proper protection, but you have no PDA and your pod cannot open wormholes."
 	id = "pilot"
 	icon_state = "pilot"
-	category = list("scenario")
+	category = list("spawn scenario")
 	points = 0
 
 
@@ -934,7 +934,7 @@ ABSTRACT_TYPE(/datum/trait/job)
 	desc = "You always sleep through the start of the shift, and wake up in a random bed."
 	id = "sleepy"
 	icon_state = "sleepy"
-	category = list("scenario")
+	category = list("spawn scenario")
 	points = 0
 	spawn_delay = 10 SECONDS
 
@@ -966,7 +966,7 @@ TYPEINFO(/datum/trait/partyanimal)
 	desc = "You don't remember much about last night, but you know you had a good time."
 	id = "partyanimal"
 	icon_state = "partyanimal"
-	category = list("scenario")
+	category = list("spawn scenario")
 	points = 0
 	spawn_delay = 3 SECONDS
 


### PR DESCRIPTION
<!-- [A-Traits] [C-QoL] -->
## About the PR
Renames the 'Background' trait category to 'Scenario'

## Why's this needed?
Baby's first PR. I don't think this change is strictly necessary but it did cause confusion for me returning to the game. Basically, there are a few uncategorised traits which would be described as backgrounds but don't go in backgrounds, which was confusing, until someone mentioned that backgrounds actually all change where you spawn and that traits in same categories are mutually exclusive of eachother
Changing 'Backgrounds' to 'Scenarios' accomplishes three things:
- Removes the confusion around traits that should be considered backgrounds not being backgrounds, and how some background traits are not really backgrounds.
- Makes potentially game-altering traits like Pilot appear further down in the trait list, so new players are less likely just to pick them due to first choice bias.
- Very clearly indicates the common theme between the Scenario traits, that they are starting scenarios.

Once again, this is very fluff but I just want to test out making a PR.

## Testing
<img width="591" height="464" alt="image" src="https://github.com/user-attachments/assets/89c3c18f-0d0a-4a22-b5ba-86069312add1" />
<img width="1899" height="973" alt="image" src="https://github.com/user-attachments/assets/1990582d-6b53-4e38-85f4-29b788c8f220" />
<img width="1910" height="979" alt="image" src="https://github.com/user-attachments/assets/ef334031-2d94-47b9-b84a-072a5d8b20ea" />
<img width="878" height="736" alt="image" src="https://github.com/user-attachments/assets/b538ff7c-6645-4d77-8d8e-c44aa7092cc4" />

Traits show up in menu, no problem spawning as them.

## Changelog
```changelog
(u)Pirate-Rob
(+)Renamed the 'Background' trait category to 'Scenario'.
```
