### PR TITLE
Additional ChemiCompiler Measurement Instructions

### DIFF
--- a/code/modules/chemistry/chemicompiler_core.dm
+++ b/code/modules/chemistry/chemicompiler_core.dm
@@ -154,7 +154,7 @@
 
 
 /datum/chemicompiler_core/proc/parseCBF(string, button)
-	var/list/tokens = list(">", "<", "+", "-", ".",",", "\[", "]", "{", "}", "(", ")", "^", "'", "$", "@", "#", "*")
+	var/list/tokens = list(">", "<", "+", "-", ".",",", "T", "A", "V", "N", "\[", "]", "{", "}", "(", ")", "^", "'", "$", "@", "#", "*")
 	var/l = length(string)
 	var/list/inst = new
 	var/token
@@ -227,10 +227,22 @@
 				if(".") //buffer text
 					textBuffer += ascii2text(data[dp+1])
 					loopUsed += 19
-				if(",") //load volume of sx into ax
+				if ("T") // Load temperature of sx into ax.
 					loopUsed += 9
 					var/datum/chemicompiler_executor/E = src.holder
-					ax = E.reagent_volume(sx)
+					ax = E.reagent_temperature(sx)
+				if ("A", ",") // Load aggregate (total) volume of sx into ax.
+					loopUsed += 9
+					var/datum/chemicompiler_executor/E = src.holder
+					ax = E.reagent_aggregate_volume(sx)
+				if ("V") // Load volume of individual reagent from sx into ax.
+					loopUsed += 9
+					var/datum/chemicompiler_executor/E = src.holder
+					ax = E.reagent_volume(sx, src.data[src.dp + 1])
+				if ("N") // Load number of reagents in sx into ax.
+					loopUsed += 9
+					var/datum/chemicompiler_executor/E = src.holder
+					ax = E.no_of_reagents(sx)
 				if("\[") //start loop
 					if(data[dp + 1] == 0)
 						count = 1
@@ -273,7 +285,7 @@
 					tgui_process.update_uis(E.holder)
 				if("$") //heat
 					loopUsed = 30
-					var/heatTo = (273 - tx) + ax
+					var/heatTo = (T0C - tx) + ax
 					heatReagents(sx, heatTo)
 				if("@") //transfer
 					loopUsed = tx > 10 ? 45 : 30 //output is more expensive
@@ -644,19 +656,77 @@
 	if (core.statusChangeCallback)
 		return call(holder, core.statusChangeCallback)(oldStatus, newStatus)
 
-/datum/chemicompiler_executor/proc/reagent_volume(rid)
+/datum/chemicompiler_executor/proc/reagent_temperature(reservoir_id)
 	if(!istype(src.holder))
 		qdel(src)
 		return
-	if(rid < 1 || rid > 10)
-		beepCode(1, 1) // Invalid reservoir id
-		return 0
-	if(!istype(reservoirs[rid], /obj/item/reagent_containers/glass))
-		beepCode(3, 1) // No reservoir loaded in specified position
-		return 0
-	var/obj/item/reagent_containers/holder = reservoirs[rid]
+
+	if ((reservoir_id < 1) || (reservoir_id > 10))
+		src.err(CC_ERROR_INVALID_SX)
+		return FALSE
+
+	var/obj/item/reagent_containers/holder = src.reservoirs[reservoir_id]
+	if (!istype(holder, /obj/item/reagent_containers/glass))
+		src.err(CC_ERROR_INVALID_CONTAINER_SX)
+		return FALSE
+
 	tgui_process.update_uis(src.holder)
-	return holder.reagents.total_volume
+	return round(holder.reagents.total_temperature - T0C, 1)
+
+/datum/chemicompiler_executor/proc/reagent_aggregate_volume(reservoir_id)
+	if(!istype(src.holder))
+		qdel(src)
+		return
+
+	if ((reservoir_id < 1) || (reservoir_id > 10))
+		src.err(CC_ERROR_INVALID_SX)
+		return FALSE
+
+	var/obj/item/reagent_containers/holder = src.reservoirs[reservoir_id]
+	if (!istype(holder, /obj/item/reagent_containers/glass))
+		src.err(CC_ERROR_INVALID_CONTAINER_SX)
+		return FALSE
+
+	tgui_process.update_uis(src.holder)
+	return round(holder.reagents.total_volume, 1)
+
+/datum/chemicompiler_executor/proc/reagent_volume(reservoir_id, reagent_index)
+	if(!istype(src.holder))
+		qdel(src)
+		return
+
+	if ((reservoir_id < 1) || (reservoir_id > 10))
+		src.err(CC_ERROR_INVALID_SX)
+		return FALSE
+
+	var/obj/item/reagent_containers/holder = src.reservoirs[reservoir_id]
+	if (!istype(holder, /obj/item/reagent_containers/glass))
+		src.err(CC_ERROR_INVALID_CONTAINER_SX)
+		return FALSE
+
+	if (!src.index_check(reservoir_id, reagent_index))
+		src.err(CC_ERROR_INDEX_INVALID)
+		return FALSE
+
+	tgui_process.update_uis(src.holder)
+	return round(holder.reagents.get_reagent_amount(holder.reagents.reagent_list[reagent_index]), 1)
+
+/datum/chemicompiler_executor/proc/no_of_reagents(reservoir_id)
+	if(!istype(src.holder))
+		qdel(src)
+		return
+
+	if ((reservoir_id < 1) || (reservoir_id > 10))
+		src.err(CC_ERROR_INVALID_SX)
+		return FALSE
+
+	var/obj/item/reagent_containers/holder = src.reservoirs[reservoir_id]
+	if (!istype(holder, /obj/item/reagent_containers/glass))
+		src.err(CC_ERROR_INVALID_CONTAINER_SX)
+		return FALSE
+
+	tgui_process.update_uis(src.holder)
+	return length(holder.reagents.reagent_list)
 
 /datum/chemicompiler_executor/proc/get_ui_data()
 	. = core.get_ui_data()


### PR DESCRIPTION
## About the PR:
Adds three new measurement instructions to the ChemiCompiler and a further instruction analogue to `,`:

> **`T`**
> Measures the t̲emperature of the reagents in reservoir sx and stores the value in the Amount register (ax). Value rounded to the nearest degree Celsius.

> **`A`**
> Measures the a̲ggregate (total) volume of the reagents in reservoir sx and stores the value in the Amount register (ax). Value rounded to the nearest unit.

> **`V`**
> Measures the v̲olume of reagent number *ptr in reservoir sx and stores the value in the Amount register (ax). Value rounded to the nearest unit.

> **`N`**
> Measures the n̲umber of reagents in reservoir sx and stores the value in the Amount register (ax).

As stated, `,` is analogous to `A` and has been retained for the purposes of backwards compatibility.


## Why Is This Needed?
While the chemistry system has progressed, with new chemical reactions involving a time element, the ChemiCompiler has not been adequately kept up to date. It has no method of measuring the current state of reactions involving a time element, thus leaving any script attempting to account for reaction rates at the mercy of the lag-compensated tick rate.


## Testing:
An example script was created to continuously heat a bath of ethanol and ammonia until it had completely reacted into diethylamine:
```brainfuck
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++>+}[<'>$*****N^-]
```

<details>
<summary> Explanation</summary>

#### 1. Memory initialisation:
```brainfuck
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++>+}
```
Sets up the registers and memory for the second part of the script. Note the target temperature stored in memory cell `00x`.

Final state:
```
sx:001 tx:000 ax:000
         V
00x200 01x001
```

#### 2. The Heating Loop:
```brainfuck
[<'>$*****N^-]
```
While the number of reagents in the first reservoir is inequal to 1, continuously heat that reservoir to 200 °C.

Instruction-wise explanation:
```brainfuck
[			;If the current cell has a value of 0, skip the loop.
	<'>		;Sets ax to the target temperature and returns to the current cell.
	$		;Heats the sx reservoir to ax - tx degrees Celsius.
	*****	;Waits several ticks for the reaction to process.
	N		;Writes the number of reagents in the sx reservoir to ax.
	^-		;Writes ax to the current memory cell, and subtracts 1.
]			;If the current cell has a value of 0, breaks the loop.
```

</details>


## Changelog:
```changelog
(u)Mr. Moriarty
(*)Four new measurement instructions have been added to the ChemiCompiler. See minor changelog for details.
(+)T: Measures the temperature of the reagents in reservoir sx and stores the value in the Amount register (ax). Value rounded to the nearest degree Celsius.
(+)A: Measures the aggregate (total) volume of the reagents in reservoir sx and stores the value in the Amount register (ax). Value rounded to the nearest unit.
(+)V: Measures the volume of reagent number *ptr in reservoir sx and stores the value in the Amount register (ax). Value rounded to the nearest unit.
(+)N: Measures the number of reagents in reservoir sx and stores the value in the Amount register (ax).
```