### PR TITLE
Tractor Beam Target Anchoring Checks

### DIFF
--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -37,7 +37,7 @@
 		This fine piece of machinery can construct entire rooms from blueprints."
 	density = 1
 	opacity = 0
-	anchored = UNANCHORED
+	anchored = UNANCHORED // Set to ANCHORED_ALWAYS when locked.
 	processing_tier = PROCESSING_FULL
 	event_handler_flags = NO_MOUSEDROP_QOL
 
@@ -353,7 +353,7 @@
 
 	proc/activate(mob/user)
 		src.locked = TRUE
-		src.anchored = ANCHORED
+		src.anchored = ANCHORED_ALWAYS
 		src.invalid_count = 0
 		for(var/datum/tileinfo/T in src.current_bp.roominfo)
 			var/turf/pos = locate(text2num(T.posx) + src.x,text2num(T.posy) + src.y, src.z)

--- a/code/modules/transport/pods/secondary_system.dm
+++ b/code/modules/transport/pods/secondary_system.dm
@@ -644,7 +644,7 @@ ABSTRACT_TYPE(/obj/item/shipcomponent/secondary_system/thrusters)
 	run_component()
 		if(settingup)
 			return
-		if(src.target.anchored)
+		if(src.target.anchored == ANCHORED_ALWAYS)
 			deactivate()
 			return
 		if(target in view(src.seekrange,ship.loc))
@@ -707,7 +707,7 @@ ABSTRACT_TYPE(/obj/item/shipcomponent/secondary_system/thrusters)
 		return
 
 	proc/tractor_drag(obj/machinery/vehicle/holding_ship, atom/previous_loc, direction)
-		if(src.target.anchored)
+		if(src.target.anchored == ANCHORED_ALWAYS)
 			deactivate()
 			return
 		if (QDELETED(src.target) || GET_DIST(holding_ship, src.target) > src.seekrange)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [VEHICLES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #25537

I was only able to reproduce #25537 by tractor beaming an ABCU _before_ locking it. This doesn't line up with the steps described in the issue, but I believe it's safe to assume that's what was meant by it.

This PR adds two `if(src.target.anchored)` checks to tractor beams so that they will no longer move objects anchored after initially being caught by a beam. 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Tractor beams can cause a lot of buggy behavior (such as that described in the linked issue) when moving anchored objects.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
On a debug build of the codebase I spawned an ABCU, caught it with a pod tractor beam, and failed to pull it after locking. I also verified that tractor beams still worked under more regular circumstances.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->