### PR TITLE
Changeling Speed Regeneration Clarification

### DIFF
--- a/code/modules/antagonists/changeling/abilities/regeneration.dm
+++ b/code/modules/antagonists/changeling/abilities/regeneration.dm
@@ -160,7 +160,7 @@
 
 /datum/targetable/changeling/regeneration
 	name = "Speed Regeneration"
-	desc = "Regenerate your health quickly and rather loudly. <b>Does not work while on fire</b>."
+	desc = "Regenerate your health quickly and rather loudly. <b>Doesn't work well with fire or burns</b>."
 	icon_state = "speedregen"
 	human_only = 1
 	cooldown = 900


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Player Actions] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Inspired by #25538

This PR adds a bit of text to the changeling speed regeneration ability's description clarifying that the ability does not work well with fire or burns.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This aspect of the ability isn't explicitly described in-game, and it can be a rather frustrating fact to discover mid-usage. 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<details><summary>Expand for screenshot of the new description as seen in-game. . .</summary>
<img width="606" height="229" alt="image" src="https://github.com/user-attachments/assets/048578f0-79fb-4952-9a0d-41b3b434a4be" />
</details>
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
