### PR TITLE
Neon Janitorial Blinds Fix

### DIFF
--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -30667,8 +30667,7 @@
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle{
-	dir = 8;
-	id = "robotics"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/janitor/office)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #25533

This PR makes a singular improperly set blinds object in Neon's janitorial office work.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This set of blinds appears to be erroneously linked to a potentially nonexistent switch in robotics. This is likely caused by map editor prefabs (I think that's the right term).
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I loaded Neon on a debug build of the codebase, went to the janitorial office, and verified that the blinds worked when their switch was flipped.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->