### PR TITLE
Adds two new death and damage related traits

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1290,10 +1290,10 @@ TYPEINFO(/datum/trait/partyanimal)
 	id = "suddendeath"
 	points = 2
 
-/datum/trait/glassjoe
-	name = "Glass Joe"
+/datum/trait/glassjaw
+	name = "Glass Jaw"
 	desc = "There is a very teensy tiny chance for any damage received (brute, burn, toxin, oxy) to be multiplied by 100."
-	id = "glassjoe"
+	id = "glassjaw"
 	points = 0
 
 /datum/trait/carpenter

--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -162,7 +162,7 @@
 		if (!isdead(src))
 			H.emote(pick("wheeze", "cough", "sputter"))
 
-	if (src.traitHolder?.hasTrait("glassjoe") && prob(0.02))
+	if (src.traitHolder?.hasTrait("glassjaw") && prob(0.02))
 		amount *= 100
 
 	src.oxyloss = max(0,src.oxyloss + amount)

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -331,7 +331,7 @@
 		brute *= 3
 		burn *= 3
 
-	if (src.traitHolder?.hasTrait("glassjoe") && prob(0.02)) // h e h
+	if (src.traitHolder?.hasTrait("glassjaw") && prob(0.02)) // h e h
 		brute *= 100
 		burn *= 100
 		tox *= 100


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the Critical Existence Failure trait(stole name from tvtropes), which instantly kills you upon hitting crit and is +2 points. Adds the Glass Jaw trait, which has a 0.02 percent chance to multiply any brute, burn, tox, and oxy by 100, and is worth 0 points.
No icons because I can't really think of any and also aseprite no worky right currently.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
death and injury is fun! lets people make pathetically weak beings.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
monkey died with critical existence failure upon hitting crit.
monkey got slammed with damage with the glass jaw trait.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)cringe
(*)there are now two new death and damage related traits. one kills you instantly, the other hurts a LOT.
```
