### PR TITLE
Add purchaser name to crates ordered with personal funds

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -8,20 +8,18 @@
 	var/datum/supply_packs/object = null
 	var/orderedby = null
 	var/comment = null
-	var/whos_id = null
+	var/used_personal_funds = FALSE
 	var/address = null
 	var/console_location = null
 
 	proc/create(var/mob/orderer)
 		var/obj/storage/S = object.create(orderer)
 
-		if(!isnull(whos_id))
-			S.name = "[S.name], Ordered by [whos_id:registered], [comment ? "([comment])":"" ]"
-		else
-			S.name = "[S.name] [comment ? "([comment])":"" ]"
+		var/show_purchaser = !isnull(src.orderedby) && src.used_personal_funds
+		S.name = "[S.name][show_purchaser ? " (Purchased by [src.orderedby])" : ""][src.comment ? " ([src.comment])" : "" ]"
 
-		if(comment)
-			S.delivery_destination = comment
+		if(src.comment)
+			S.delivery_destination = src.comment
 
 		object.exhaustion += 1
 		if(object.exhaustion > 10)

--- a/code/obj/machinery/computer/QM_order.dm
+++ b/code/obj/machinery/computer/QM_order.dm
@@ -204,6 +204,7 @@
 						O.address = account["pda_net_id"]
 					O.orderedby = usr.name
 					O.console_location = src.console_location
+					O.used_personal_funds = TRUE
 					var/obj/storage/S = O.create(usr)
 					shippingmarket.receive_crate(S)
 					logTheThing(LOG_STATION, usr, "ordered a [P.name] at [log_loc(src)].")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[LOGISTICS][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When someone makes a QM order using funds from their personal account, their name will be added to the crate that is shipped in the form of `(Purchased by [player_name])`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Quartermasters that aren't paying 100% attention to the constant stream of cargo mailbot messages will often get confused when a random unlabeled crate shows up that none of them ordered. This can lead to orders made by crew members getting mishandled, such as being sold off to the shipping market, being delivered to the wrong place, or (unintentionally) getting robbed of contents.

This change allows quartermasters to differentiate between orders purchased by cargo and orders purchased by crewmates using their personal accounts, so that cargo can easily coordinate who/where the package should be delivered to.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="548" height="232" alt="image" src="https://github.com/user-attachments/assets/8801b14a-464a-4051-b415-880404776c80" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CodeJester
(*)Orders made using a crew members's personal account will now add their name to the shipped crate.
```
