### PR TITLE
Dance Shoe Speed Bounding

### DIFF
--- a/code/datums/abilities/dancing.dm
+++ b/code/datums/abilities/dancing.dm
@@ -9,7 +9,7 @@
 
 /// The maximum time per count available when a player adjusts dance speed.
 /// The lower bound is just zero.
-#define COUNT_HIGHER_BOUND 5 SECONDS
+#define COUNT_HIGHER_BOUND 2 SECONDS
 
 #define BEAT_COUNT(_X) (AH.time_per_count * _X)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug] [Runtime] [Player Actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #25572 

This PR both corrects a division by zero runtime error and resolves the linked issue by bounding dance speed to reasonable BPMs.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
After reproducing issue #25572, I discovered that the bug only occurs when `time_per_count` equals zero. I don't know exactly why it happens, but it's accompanied with a division by zero runtime error. Realistically speaking, dancing at a time per count equal to zero shouldn't even be possible-- that would just be standing. Dancing at a negative BPM also doesn't make sense, so this PR just limits player adjustments on `time_per_count` such that they're always greater than zero.

Dancing with a very slow time per count can allow players to maintain a prolonged and subtle sprite shift that is both potentially advantageous in combat and antithetical to the concept of dancing. (Not to mention that it's difficult to return from since you have to spam the "faster" button to get it back to a reasonable speed.) Aside from that, it also leads BPM towards zero (though it might not actually ever reach it due to the nature of whatever decaying function may be said to represent its slowing decrease).
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
On a debug build of the codebase I spawned a pair of dancing dress shoes and verified that the bounds worked as expected when speed was adjusted.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
