### PR TITLE
Remove req_access_txt from Cogmap2

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -10723,8 +10723,7 @@
 /obj/machinery/bot/guardbot/old/tourguide{
 	beacon_freq = 1443;
 	desc = "A PR-4 Robuddy. These are pretty old, you didn't know there were any still around!  This one has a little name tag on the front labeled 'Murray'";
-	name = "Murray";
-	req_access_txt = ""
+	name = "Murray"
 	},
 /obj/machinery/navbeacon/tour/cog2/tour11,
 /turf/simulated/floor/carpet{
@@ -10763,8 +10762,7 @@
 "aHk" = (
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
-	opacity = 0;
-	req_access_txt = ""
+	opacity = 0
 	},
 /turf/unsimulated/floor/shuttle/white{
 	dir = 4
@@ -11664,8 +11662,7 @@
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
 	name = "Cockpit";
-	opacity = 0;
-	req_access_txt = ""
+	opacity = 0
 	},
 /turf/unsimulated/floor/shuttle/yellow{
 	dir = 4
@@ -12534,8 +12531,7 @@
 "aMX" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
-	opacity = 0;
-	req_access_txt = ""
+	opacity = 0
 	},
 /turf/unsimulated/floor/shuttle/red{
 	dir = 4
@@ -24754,8 +24750,7 @@
 	density = 0;
 	icon_state = "glass_open";
 	id = "pt_laser";
-	name = "Beamline Interlock";
-	req_access_txt = "54"
+	name = "Beamline Interlock"
 	},
 /obj/securearea{
 	desc = "This hazard stripe marks a high-intensity beamline.";
@@ -24764,6 +24759,7 @@
 	layer = 2.5;
 	name = "Beamline"
 	},
+/obj/mapping_helper/access/impossible,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -24782,9 +24778,9 @@
 	density = 0;
 	icon_state = "glass_open";
 	id = "pt_laser";
-	name = "Beamline Interlock";
-	req_access_txt = "54"
+	name = "Beamline Interlock"
 	},
+/obj/mapping_helper/access/impossible,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -24802,12 +24798,12 @@
 	density = 0;
 	icon_state = "glass_open";
 	id = "pt_laser";
-	name = "Beamline Interlock";
-	req_access_txt = "54"
+	name = "Beamline Interlock"
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 1
 	},
+/obj/mapping_helper/access/impossible,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -25338,9 +25334,9 @@
 	density = 0;
 	icon_state = "glass_open";
 	id = "pt_laser";
-	name = "Beamline Interlock";
-	req_access_txt = "54"
+	name = "Beamline Interlock"
 	},
+/obj/mapping_helper/access/impossible,
 /turf/simulated/floor/blueblack,
 /area/station/hallway/primary/west)
 "bCc" = (
@@ -25356,12 +25352,12 @@
 	density = 0;
 	icon_state = "glass_open";
 	id = "pt_laser";
-	name = "Beamline Interlock";
-	req_access_txt = "54"
+	name = "Beamline Interlock"
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
 	dir = 1
 	},
+/obj/mapping_helper/access/impossible,
 /turf/simulated/floor/blueblack,
 /area/station/hallway/primary/west)
 "bCd" = (
@@ -29972,10 +29968,10 @@
 /area/station/maintenance/east)
 "bOR" = (
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	req_access_txt = "1"
+	dir = 4
 	},
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/access/security,
 /turf/simulated/floor,
 /area/station/maintenance/east)
 "bOS" = (
@@ -53788,14 +53784,14 @@
 /area/station/turret_protected/ai_upload)
 "eTK" = (
 /obj/machinery/door/airlock/pyro/external{
-	name = "Engineering Dock";
-	req_access_txt = "40"
+	name = "Engineering Dock"
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/access/engineering,
 /turf/simulated/floor,
 /area/station/hangar/engine)
 "eTX" = (
@@ -58142,12 +58138,12 @@
 "iQb" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/classic{
-	name = "Clown's Quarters";
-	req_access_txt = "12"
+	name = "Clown's Quarters"
 	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/mapping_helper/access/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown{
 	name = "Clown's Quarters"
@@ -60388,9 +60384,7 @@
 	level = 2
 	},
 /obj/disposalpipe/segment/mail/vertical,
-/obj/machinery/door/airlock/pyro/external{
-	req_access_txt = "40"
-	},
+/obj/machinery/door/airlock/pyro/external,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
@@ -60400,6 +60394,7 @@
 	cycle_id = "westsubstation";
 	name = "West Substation"
 	},
+/obj/mapping_helper/access/engineering,
 /turf/simulated/floor/caution/northsouth,
 /area/station/engine/substation/west)
 "kKC" = (
@@ -62162,9 +62157,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	level = 2
 	},
-/obj/machinery/door/airlock/pyro/external{
-	req_access_txt = "40"
-	},
+/obj/machinery/door/airlock/pyro/external,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
@@ -62174,6 +62167,7 @@
 	cycle_id = "eastsubstation";
 	name = "East Substation"
 	},
+/obj/mapping_helper/access/engineering,
 /turf/simulated/floor/caution/northsouth,
 /area/station/engine/substation/east)
 "mmR" = (
@@ -62682,8 +62676,7 @@
 	name = "Beamline"
 	},
 /obj/machinery/door/airlock/pyro/external{
-	name = "Pod Bay";
-	req_access_txt = "0"
+	name = "Pod Bay"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
@@ -63950,9 +63943,9 @@
 	density = 0;
 	icon_state = "glass_open";
 	id = "pt_laser";
-	name = "Beamline Interlock";
-	req_access_txt = "54"
+	name = "Beamline Interlock"
 	},
+/obj/mapping_helper/access/impossible,
 /turf/simulated/floor/blueblack,
 /area/station/hallway/primary/west)
 "nPU" = (
@@ -66286,10 +66279,10 @@
 "pVH" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
-	name = "Emergency Storage B";
-	req_access_txt = "12"
+	name = "Emergency Storage B"
 	},
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/access/maint,
 /turf/simulated/floor,
 /area/station/storage/emergency2)
 "pWw" = (
@@ -66604,8 +66597,7 @@
 "qkZ" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
-	name = "Technical Storage";
-	req_access_txt = "23"
+	name = "Technical Storage"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -68221,9 +68213,7 @@
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "rHQ" = (
-/obj/machinery/door/airlock/pyro/external{
-	req_access_txt = "40"
-	},
+/obj/machinery/door/airlock/pyro/external,
 /obj/disposalpipe/segment/mail/bent/south,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
@@ -68236,6 +68226,7 @@
 	cycle_id = "westsubstation";
 	name = "West Substation"
 	},
+/obj/mapping_helper/access/engineering,
 /turf/simulated/floor,
 /area/station/engine/substation/west)
 "rIh" = (
@@ -68371,9 +68362,7 @@
 /turf/simulated/floor/blue/checker,
 /area/station/medical/medbay/pharmacy)
 "rRJ" = (
-/obj/machinery/door/airlock/pyro/external{
-	req_access_txt = "40"
-	},
+/obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/firedoor_spawn,
 /obj/decal/stripe_delivery,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -68385,6 +68374,7 @@
 	cycle_id = "eastsubstation";
 	name = "East Substation"
 	},
+/obj/mapping_helper/access/engineering,
 /turf/simulated/floor,
 /area/station/engine/substation/east)
 "rSI" = (
@@ -70419,9 +70409,9 @@
 /area/station/science/artifact)
 "tFo" = (
 /obj/machinery/door/airlock/pyro/glass{
-	name = "Research Outpost";
-	req_access_txt = "24"
+	name = "Research Outpost"
 	},
+/obj/mapping_helper/access/research,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/hangar/science)
 "tFI" = (
@@ -70552,8 +70542,7 @@
 "tOj" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
-	name = "Research Outpost";
-	req_access_txt = "24"
+	name = "Research Outpost"
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/cable{
@@ -74733,8 +74722,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	req_access_txt = ""
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-8"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces existing access varedits on Cog2 with the appropriate mappinghelpers.
Changes PTL Interlock doors from Special Club to Impossible access. There is no way to get this access so its functionally the same.

You may recognise this PR from #23991 which I fucked up and then did other stuff. But I'm back in my quest to destroy req_access_txt once and for all.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
req_access_txt varedits bad. Access spawners good. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
All edited doors work as expected.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
