### PR TITLE
Varditable wasp implants

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -825,11 +825,15 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 	do_effect(power)
 		// enjoy your wasps
 		for (var/i in 1 to power)
-			var/mob/living/critter/small_animal/wasp/W = new src.wasp_type(get_turf(src))
-			W.lying = TRUE // So wasps dont hit other wasps when being flung
-			W.throw_at(get_edge_target_turf(get_turf(src), pick(alldirs)), rand(1,3 + round(power / 16)), 2)
-			SPAWN(1 SECOND)
-				W.lying = FALSE
+			var/throw_type = THROW_NORMAL
+			var/mob/M = new src.wasp_type(get_turf(src))
+			if(ismob(M))
+				M.lying = TRUE // So wasps dont hit other wasps when being flung
+				SPAWN(1 SECOND)
+					M.lying = FALSE
+			else
+				throw_type = THROW_PHASE
+			M.throw_at(get_edge_target_turf(get_turf(src), pick(alldirs)), rand(1,3 + round(power / 16)), 2, throw_type = throw_type)
 
 		SPAWN(1)
 			src.owner?.gib()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes wasp implant's mobs summoned on death and applied faction to be variables.
If the wasp implant's summoned thing is not a mob, instead throw it with throw_phase (as objects cant lie down)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Admin crimes.
Potential for other summoning revenge implants (though ideally you'd genericise the wasp implant first)

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="685" height="680" alt="image" src="https://github.com/user-attachments/assets/035c56e4-8bfb-41b4-b3fa-74854deb6452" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
