### PR TITLE
Fixes Spatial Hashmap Z-Order Not Updating With `world.maxz`

### DIFF
--- a/_std/defines/component_defines/_component_defines_integral.dm
+++ b/_std/defines/component_defines/_component_defines_integral.dm
@@ -9,7 +9,7 @@
 
 #define SEND_COMPLEX_SIGNAL(target, sigtype, arguments...) SEND_SIGNAL(target, sigtype[2], ##arguments)
 
-#define GLOBAL_SIGNAL global_signal_holder // dummy datum that exclusively exists to hold onto global signals
+#define GLOBAL_SIGNAL (global.global_signal_holder ||= new()) // dummy datum that exclusively exists to hold onto global signals
 
 /**
 	* `target` to use for signals that are global and not tied to a single datum.

--- a/_std/defines/component_defines/component_defines_global.dm
+++ b/_std/defines/component_defines/component_defines_global.dm
@@ -10,6 +10,10 @@
 /// When a client is calling New() (GLOBAL_SIGNAL, client)
 #define COMSIG_GLOBAL_CLIENT_NEW "global_client_new"
 
+// ---- z-levels ----
+	/// When `world.maxz` is incremented.
+	#define COMSIG_GLOBAL_MAXZ_INCREMENTED "global_maxz_incremented"
+
 // ---- cargo pads ----
 
 	/// When a cargo pad is destroyed, deconstructed, or turned off

--- a/code/modules/worldgen/mapgen/RoomMaze.dm
+++ b/code/modules/worldgen/mapgen/RoomMaze.dm
@@ -62,7 +62,7 @@
 			LAGCHECK(LAG_MED)
 
 	proc/connect_nodes_by_spatial_distance(datum/bsp_tree/tree)
-		var/datum/spatial_hashmap/manual/spatial_map = new(depth = 1, cell_size = src.room_size * 2, name = "Room Maze Nodes")
+		var/datum/spatial_hashmap/manual/spatial_map = new(depth = 1, track_world_maxz = FALSE, cell_size = src.room_size * 2, name = "Room Maze Nodes")
 
 		var/center_x
 		var/center_y

--- a/code/world/initialization/1_preMapLoad.dm
+++ b/code/world/initialization/1_preMapLoad.dm
@@ -125,9 +125,6 @@
 	Z_LOG_DEBUG("Preload", "Generating access name lookup") // ^^
 	generate_access_name_lookup()
 
-	// no log because this is functionally instant
-	global_signal_holder = new
-
 	Z_LOG_DEBUG("Preload", "Loading saved gamemode...")
 	world.load_mode()
 

--- a/code/world/world.dm
+++ b/code/world/world.dm
@@ -143,6 +143,9 @@
 	// the space filling this z-level will be somewhat broken (which you will hopefully replace with whatever it is you want to replace it with).
 	if (!isnum(new_maxz) || new_maxz <= src.maxz)
 		return src.maxz
+
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOBAL_MAXZ_INCREMENTED, new_maxz)
+
 	for (var/zlevel = world.maxz+1; zlevel <= new_maxz; zlevel++)
 		#ifdef CHECK_MORE_RUNTIMES
 		in_replace_with++


### PR DESCRIPTION
## About The PR:
Fixes the z-order of spatial hashmaps not keeping track of increases in `world.maxz`, resulting in allocated z-levels not receiving their own hashmap layer.
Also fixes `GLOBAL_SIGNAL` not being available during initialisation. This fix is temporary until `Genesis()` is fixed.


## Testing:
Tested by spawning an extradimensional locker and observing that the allocated interior region had sound. Additionally, on inspection, `client_hashmap` had an additional layer not present prior to the locker being spawned.