### PR TITLE
Using a DetGadget hat now puts the controller in the users hands instead of dumping it on the floor.

### DIFF
--- a/code/mob/living/critter/scuttlebot.dm
+++ b/code/mob/living/critter/scuttlebot.dm
@@ -26,14 +26,17 @@
 	var/obj/item/clothing/head/det_hat/linked_hat = null
 	var/mob/living/carbon/human/controller = null //Who's controlling us? Lets keep track so we can put them back in their body
 
-	New()
+	New(var/loc, var/mob/living/carbon/human/creator = null)
 		..()
 		//Comes with the goggles
-		src.spawn_goggles()
+		src.spawn_goggles(creator)
 
-	proc/spawn_goggles()
+	proc/spawn_goggles(var/mob/living/carbon/human/creator = null)
 		var/obj/item/clothing/glasses/scuttlebot_vr/R = new /obj/item/clothing/glasses/scuttlebot_vr(src.loc)
 		R.connected_scuttlebot = src
+		//If a person transformed the hat (most cases), let's be nice and put the controller in their hand.
+		if(creator)
+			creator.put_in_hand_or_eject(R)
 
 	setup_hands()
 		..()

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -417,11 +417,11 @@ TYPEINFO(/obj/item/clothing/head/det_hat/gadget)
 		if(!(src in user.equipped_list())) //lagspikes can allow a doubleinput here. or something
 			return
 		user.visible_message(SPAN_COMBAT("<b>[user] turns [his_or_her(user)] DetGadget hat into a spiffy scuttlebot!</b>"))
-		var/mob/living/critter/robotic/scuttlebot/weak/S = new /mob/living/critter/robotic/scuttlebot/weak(get_turf(src))
+		user.drop_item()
+		var/mob/living/critter/robotic/scuttlebot/weak/S = new /mob/living/critter/robotic/scuttlebot/weak(get_turf(src), user)
 		if (src.inspector == TRUE)
 			S.make_inspector()
 		S.linked_hat = src
-		user.drop_item()
 		src.set_loc(S)
 		user.update_inhands()
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Clothing][Security][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes the DetGadget hat attempt to put the scuttlebot controller in the hand of the hats user, instead of throwing it on the floor underneath the created scuttlebot.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's really awkward to fish out the controller of the DetGadget scuttlebot after spawning it, as it spawns underneath the scuttlebot itself.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
Tested on a local server with both an item and in hand and empty hands.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kanthes
(+)Using a DetGadget hat to create a scuttlebot now puts the controller in the user's hand instead of on the floor.
```
