### PR TITLE
Fixes Dancing Shoe Ability Persistence

### DIFF
--- a/code/WorkInProgress/AzrunStuff.dm
+++ b/code/WorkInProgress/AzrunStuff.dm
@@ -1395,6 +1395,7 @@ ADMIN_INTERACT_PROCS(/turf/unsimulated/floor, proc/sunset, proc/sunrise, proc/se
 		..()
 
 	unequipped(var/mob/user)
+		user.remove_ability_holder(/datum/abilityHolder/dancing)
 		if (ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if (H.hud)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Bug] [Player Actions] [Game Objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #25568

This PR has dancing shoes remove their mob's dancing ability holder when taken off.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This type of ability holder only appears to be added by dancing shoes. Never removing it leaves players with dancing abilities even without dancing shoes.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
On a debug build of the codebase I spawned dancing shoes, put them on, danced, removed them, and found that the abilities disappeared as expected. 
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
