### PR TITLE
Formats Diplomat and Tourist Species Selection

### DIFF
--- a/code/datums/jobs/special/jobs_random.dm
+++ b/code/datums/jobs/special/jobs_random.dm
@@ -198,13 +198,13 @@ ABSTRACT_TYPE(/datum/job/special/random)
 			return
 		SPAWN(0)
 			var/selection = null
-			var/list/options = list("Lizard" = /datum/mutantrace/lizard,
-									"Skeleton" = /datum/mutantrace/skeleton,
-									"Ithillid" = /datum/mutantrace/ithillid,
-									"Martian" = /datum/mutantrace/martian,
-									"Amphibian" = /datum/mutantrace/amphibian,
-									"Blob" = /datum/mutantrace/blob,
-									"Cow" = /datum/mutantrace/cow)
+			var/list/options = list(/datum/mutantrace/lizard::name = /datum/mutantrace/lizard,
+									/datum/mutantrace/skeleton::name  = /datum/mutantrace/skeleton,
+									/datum/mutantrace/ithillid::name = /datum/mutantrace/ithillid,
+									/datum/mutantrace/martian::name = /datum/mutantrace/martian,
+									/datum/mutantrace/amphibian::name = /datum/mutantrace/amphibian,
+									/datum/mutantrace/blob::name  = /datum/mutantrace/blob,
+									/datum/mutantrace/cow::name = /datum/mutantrace/cow)
 
 			selection = tgui_input_list(M,"Pick a Mutantrace. Cancel to be Human.","Pick a Mutantrace. Cancel to be Human.",options)
 			var/datum/mutantrace/morph = options[selection]

--- a/code/datums/jobs/special/jobs_special.dm
+++ b/code/datums/jobs/special/jobs_special.dm
@@ -512,13 +512,13 @@ ABSTRACT_TYPE(/datum/job/daily)
 			return
 		SPAWN(0)
 			var/selection = null
-			var/list/options = list("Lizard" = /datum/mutantrace/lizard,
-									"Skeleton" = /datum/mutantrace/skeleton,
-									"Ithillid" = /datum/mutantrace/ithillid,
-									"Martian" = /datum/mutantrace/martian,
-									"Amphibian" = /datum/mutantrace/amphibian,
-									"Blob" = /datum/mutantrace/blob,
-									"Cow" = /datum/mutantrace/cow)
+			var/list/options = list(/datum/mutantrace/lizard::name = /datum/mutantrace/lizard,
+									/datum/mutantrace/skeleton::name  = /datum/mutantrace/skeleton,
+									/datum/mutantrace/ithillid::name = /datum/mutantrace/ithillid,
+									/datum/mutantrace/martian::name = /datum/mutantrace/martian,
+									/datum/mutantrace/amphibian::name = /datum/mutantrace/amphibian,
+									/datum/mutantrace/blob::name  = /datum/mutantrace/blob,
+									/datum/mutantrace/cow::name = /datum/mutantrace/cow)
 
 			selection = tgui_input_list(M,"Pick a Mutantrace. Cancel to be Human.","Pick a Mutantrace. Cancel to be Human.",options)
 			var/datum/mutantrace/morph = options[selection]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR formats the species selection listing that players are shown when spawning as a diplomat or tourist. Code-wise this is done by simply making the `options` list associative with species names as indexes. 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the list shows mutantrace type paths instead of mutantrace names. Type paths are (at least momentarily) difficult to parse if you don't know Dream Maker, and they're generally not supposed to be player facing.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<details><summary>Before:</summary>

<img width="365" height="390" alt="Before_Naming" src="https://github.com/user-attachments/assets/1287f198-c443-4d10-9822-b18319af557f" />

</details>
<details><summary>After:</summary>

<img width="365" height="390" alt="After_Naming" src="https://github.com/user-attachments/assets/8194b86e-f884-483e-8b4b-480e1a233dba" />
</details>

On a debug build of the codebase I verified that the menu appeared as expected and functioned properly for both tourists and diplomats.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
