### PR TITLE
Prevent queued forcefeed actionbars from bypassing bites_left on food items

### DIFF
--- a/code/datums/actions/actions.dm
+++ b/code/datums/actions/actions.dm
@@ -1557,7 +1557,10 @@
 		if(BOUNDS_DIST(owner, consumer) > 0 || !consumer || !owner || (mob_owner.equipped() != food && mob_owner.equipped() != drink))
 			interrupt(INTERRUPT_ALWAYS)
 			return
-		if (food.bites_left)
+		if (!isnull(food))
+			if (!food.bites_left)
+				interrupt(INTERRUPT_ALWAYS)
+				return
 			food.take_a_bite(consumer, mob_owner)
 		else
 			drink.take_a_drink(consumer, mob_owner)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a bites_left check in the code for forcefeeding people food items.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, forcefeeding food to people ignores bites_left, so if you queue multiple forcefeeds, you can continue forcefeeding someone an item after it's gone. This can result in reagent duplication (bad).

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
[Clicked on a monkey multiple times with a donk-pocket in hand, and only ended up feeding it to the monkey once. Reagent scanned the monkey to confirm that only 10 units of omnizine were present.]
(https://www.youtube.com/watch?v=VndzLnfHhKc)
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->