### PR TITLE
Makes hard candies (and fruitcake) crunchier

### DIFF
--- a/code/modules/cooking/food_and_drink/bread.dm
+++ b/code/modules/cooking/food_and_drink/bread.dm
@@ -122,6 +122,7 @@
 
 /obj/item/reagent_containers/food/snacks/breadloaf/fruit_cake
 	name = "fruitcake"
+	crunchy = TRUE
 	desc = "The most disgusting dessert ever devised. Legend says there's only one of these in the galaxy, passed from location to location by vengeful deities."
 	icon = 'icons/obj/foodNdrink/food_dessert.dmi'
 	icon_state = "cake_fruit"
@@ -250,6 +251,7 @@
 
 	fruit_cake
 		name = "slice of fruit cake"
+		crunchy = TRUE
 		desc = "The most despicable dessert ever sliced. According to legend, a vengeful deity invented sliced bread solely to allow the distribution of these miniature monstrosities to unsuspecting crewmembers."
 		icon_state = "fruitcakeslice"
 		real_name = "fruitcake \"bread\""

--- a/code/modules/cooking/food_and_drink/candy.dm
+++ b/code/modules/cooking/food_and_drink/candy.dm
@@ -54,6 +54,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy)
 
 /obj/item/reagent_containers/food/snacks/candy/candy_cane
 	name = "candy cane"
+	crunchy = TRUE
 	desc = "Holiday treat and aid to limping gingerbread men everywhere."
 	real_name = "candy cane"
 	icon = 'icons/misc/xmas.dmi'
@@ -259,6 +260,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy/jellybean)
 
 /obj/item/reagent_containers/food/snacks/candy/lollipop
 	name = "lollipop"
+	crunchy = TRUE
 	desc = "How many licks does it take to get to the center? No one knows, they just bite the things."
 	icon = 'icons/obj/foodNdrink/food_candy.dmi'
 	icon_state = "lpop-0"
@@ -429,6 +431,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy/jellybean)
 
 /obj/item/reagent_containers/food/snacks/candy/candyheart
 	name = "candy heart"
+	crunchy = TRUE
 	desc = "Can you find the perfect phrase for that special someone?"
 	icon_state = "heart"
 	bites_left = 1
@@ -555,6 +558,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy/wrapped_candy/taffy
 
 /obj/item/reagent_containers/food/snacks/candy/hard_candy
 	name = "hard candy"
+	crunchy = TRUE
 	desc = "A piece of hard candy."
 	real_name = "hard candy"
 	icon_state = "hardcandy-nowrap"
@@ -619,6 +623,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy/wrapped_candy/taffy
 
 /obj/item/reagent_containers/food/snacks/candy/wrapped_candy/hard
 	name = "wrapped hard candy"
+	crunchy = TRUE //probably not necessary here since i don't think you can normally eat it while it's wrapped but matter eater exists so whatever
 	desc = "A piece of wrapped hard candy."
 	real_name = "hard candy"
 	icon_state = "hardcandy"
@@ -645,6 +650,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy/wrapped_candy/taffy
 
 /obj/item/reagent_containers/food/snacks/candy/rock_candy
 	name = "rock candy"
+	crunchy = TRUE
 	desc = "Rock candy on a stick. Hard as a rock, hopefully doesn't taste like one."
 	real_name = "rock candy"
 	icon_state = "rockcandy-0"
@@ -677,6 +683,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/candy/wrapped_candy/taffy
 
 /obj/item/reagent_containers/food/snacks/candy/swirl_lollipop
 	name = "swirly lollipop"
+	crunchy = TRUE
 	desc = "A giant colorful lollipop in the shape of a swirl."
 	real_name = "swirly lollipop"
 	icon_state = "lpop-rainbow"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE] [CATERING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets crunchy to true on fruitcakes and various hard candies, giving them Cool Sounds which are currently only in use by food processor artifacts.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We have a variable to make things crunchy, so it makes sense to apply it to things which should be crunchy.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spawned in every food item which was affected by this change and ate them all.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)nova2053
(+)Hard candies (including lollipops, candy canes, and candy hearts) are now considerably more crunchy.
```
