### PR TITLE
Hacking a manufacturer is permanent and causes malfunctions

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -870,6 +870,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 	emag_act(mob/user, obj/item/card/emag/E)
 		if (!src.hacked)
 			src.hacked = TRUE
+			src.malfunction = TRUE
 			if(user)
 				boutput(user, SPAN_NOTICE("You remove the [src]'s product locks!"))
 			return TRUE
@@ -962,6 +963,9 @@ TYPEINFO(/obj/machinery/manufacturer)
 		else if (isscrewingtool(W))
 			if (!src.panel_open)
 				src.panel_open = TRUE
+			else if (src.hacked)
+				boutput(user, SPAN_ALERT("The maintenance panel is jammed!"))
+				return
 			else
 				src.panel_open = FALSE
 			boutput(user, "You [src.panel_open ? "open" : "close"] the maintenance panel.")
@@ -1540,8 +1544,6 @@ TYPEINFO(/obj/machinery/manufacturer)
 		var/wireIndex = APCWireColorToIndex[wireColor]
 		src.wires &= ~wireFlag
 		switch(wireIndex)
-			if(WIRE_EXTEND)
-				src.hacked = FALSE
 			if(WIRE_SHOCK)
 				src.time_left_electrified = 0
 			if(WIRE_MALF)
@@ -1560,7 +1562,8 @@ TYPEINFO(/obj/machinery/manufacturer)
 			if(WIRE_SHOCK)
 				src.time_left_electrified = 0
 			if(WIRE_MALF)
-				src.malfunction = FALSE
+				if(!src.hacked) //Hacking permanently breaks it.
+					src.malfunction = FALSE
 			if(WIRE_POWER)
 				src.power_wire_cut = FALSE
 				src.check_power_status()
@@ -1571,11 +1574,13 @@ TYPEINFO(/obj/machinery/manufacturer)
 		var/wireIndex = APCWireColorToIndex[wireColor]
 		switch(wireIndex)
 			if(WIRE_EXTEND)
-				src.hacked = !src.hacked
+				src.hacked = TRUE
+				src.malfunction = TRUE
 			if (WIRE_SHOCK)
 				src.time_left_electrified = 30
 			if (WIRE_MALF)
-				src.malfunction = !src.malfunction
+				if(!src.hacked) //Hacking permanently breaks it.
+					src.malfunction = !src.malfunction
 			if (WIRE_POWER)
 				if(!src.is_disabled())
 					src.shock(user, 100)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Hacked fabricators cannot have their maintenance panel closed.
Hacking a fabricator to show the extended recipe list now cannot be repaired without replacing the entire fabricator.
Hacked fabricators now also malfunction irreparably.

Emags will also cause the fabricator to malfunction, but don't require you to open the panel to do so, reducing the chance of getting caught (although opening the panel will prevent it being closed again).

For reference malfunctioning fabricators:
- Shred inserted blueprints (75% chance)
- Take longer to print things
- Consume more power
- Every so often may flip out with any of the following effects:
   - Eject a random item inserted (materials, disks)(15%)(Only if not printing)
   - Delete random items from the queue (20% overall, 33% per item (does not include first item in queue))
   - Pause current print (5%) (Only if printing)
   - Double active power consumption (9.5%) (Only if printing)
   - Set speed to a random amount (10%)
   - Electrify itself for 5 seconds (5%)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently theres no downside to just hacking a manufacturer at roundstart, hacking should be something non-antags only need to do in emergencies, or that antags use to obtain contraband.

Having the fabricator permanently visibly hacked gives security a chance to investigate for example, why the HoP would hack their own fabricator (its to print a sec radio) or why the general fabricator in tool storage is hacked (the chaplain was printing more .22 ammo)

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Properly could repair malfunctioning fabricators if not hacked, could not repair hacked fabricators and could not close their maintenance panel. UI showed that the fabricator was malfunctioning.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Hacking a fabricator now cannot be repaired, causes the fabricator to malfunction and stops the maintenance panel being closed.
```
