### PR TITLE
Fix newer ban notes not receiving ban formatting

### DIFF
--- a/code/modules/admin/playernotes.dm
+++ b/code/modules/admin/playernotes.dm
@@ -65,6 +65,10 @@
 			var/list/row_classes = list()
 			var/noteReason = playerNote.note
 
+			var/list/legacyData
+			if (length(playerNote.legacy_data))
+				legacyData = json_decode(playerNote.legacy_data)
+
 			var/gameAdminCkey = playerNote.game_admin?.player?.ckey
 			if (!gameAdminCkey && ("game_admin_ckey" in legacyData))
 				gameAdminCkey = legacyData["game_admin_ckey"]
@@ -77,10 +81,6 @@
 			else if (new_ban_regex.Find(noteReason))
 				row_classes += "ban"
 				noteReason = new_ban_regex.Replace(noteReason, "<b>BANNED</b> from <b>$1</b> by <b>[gameAdminCkey]</b> &mdash; $2<br><blockquote>$3</blockquote>")
-
-			var/list/legacyData
-			if (length(playerNote.legacy_data))
-				legacyData = json_decode(playerNote.legacy_data)
 
 			var/id = playerNote.server_id
 			if (!id && ("oldserver" in legacyData))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes newer ban notes not showing up in red with the ban formatting in the notes viewer.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
New bans have a different format to old ones so need a different regex

## Testing
Tested via a TM on dev and a note on myself using the old formatting, both it and another recent testing ban showed up with the correct ban formatting.