### PR TITLE
RP deaths trigger respawn timers regardless of DNR

### DIFF
--- a/code/datums/hud/ghost_observer.dm
+++ b/code/datums/hud/ghost_observer.dm
@@ -14,6 +14,8 @@
 
 	proc/get_respawn_timer()
 		RETURN_TYPE(/atom/movable/screen/respawn_timer)
+		if(master.mind?.get_player()?.joined_observer)
+			return null
 		if(isnull(src.respawn_timer))
 			src.respawn_timer = new
 			src.add_object(src.respawn_timer)

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1234,8 +1234,13 @@ TYPEINFO(/mob)
 	if (src.suicide_alert)
 		message_attack("[key_name(src)] died shortly after spawning.")
 		src.suicide_alert = 0
-	if(src.ckey && !src.mind?.get_player()?.dnr && !src.mind?.get_player()?.joined_observer)
+	if(src.ckey && !src.mind?.get_player()?.joined_observer)
+		#ifdef RP_MODE // you can always respawn (into a new character) on RP
 		respawn_controller.subscribeNewRespawnee(src.ckey)
+		#else
+		if(!src.mind?.get_player()?.dnr)
+			respawn_controller.subscribeNewRespawnee(src.ckey)
+		#endif
 	// stop piloting pods or whatever
 	src.movement_controller_list = list()
 	// stop pulling shit!!

--- a/code/mob/dead/hivemind_observer.dm
+++ b/code/mob/dead/hivemind_observer.dm
@@ -129,6 +129,9 @@ TYPEINFO(/mob/dead/target_observer/hivemind_observer)
 	if(world.time >= can_exit_hivemind_time && hivemind_owner && hivemind_owner.master != src)
 		if(tgui_alert(src, "This will automatically set DNR. Continue?", "DNR Confirmation", list("Yes", "No")) == "Yes")
 			boutput(src, SPAN_ALERT("You have parted with the hivemind."))
+			#ifdef RP_MODE
+			respawn_controller.subscribeNewRespawnee(src.ckey)
+			#endif
 			src.mind?.remove_antagonist(ROLE_CHANGELING_HIVEMIND_MEMBER, set_dnr=TRUE)
 	else
 		boutput(src, SPAN_ALERT("You are not able to part from the hivemind at this time. You will be able to leave in [(can_exit_hivemind_time/10 - world.time/10)] seconds."))


### PR DESCRIPTION
[rp][fuck][bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Ensure respawn timer is added on death when in RP
* Force respawn timer when manually leaving hivemind on RP
* Fixes some ways of getting a respawn timer back as a joined observer

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fix #24351
fix #25046
fix #25497
fix #25579
fix #25639
fix #25643

make sure people on rp get to respawn appropriately

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
tested respawn times locally but limited ways to test hiveminds. 

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)RP: Setting DNR should no longer block respawn timers from appearing.
```