### PR TITLE
Rubber items use synthrubber as their default material

### DIFF
--- a/code/modules/items/gimmick/plushies.dm
+++ b/code/modules/items/gimmick/plushies.dm
@@ -342,6 +342,7 @@ TYPEINFO(/obj/submachine/claw_machine)
 	desc = "Talk and fidget things out. It'll be okay."
 	icon_state = "stress_ball"
 	throw_range = 10
+	default_material = "synthrubber_yellow"
 
 /obj/item/toy/plush/small/stress_ball/attack_self(mob/user as mob)
 	animate_door_squeeze(src) //squish

--- a/code/modules/power/cablecolors.dm
+++ b/code/modules/power/cablecolors.dm
@@ -3,7 +3,7 @@
 /obj/item/cable_coil/_color/name = ""+#_color+" cable coil";\
 /obj/item/cable_coil/_color/base_name = ""+#_color+" cable coil";\
 /obj/item/cable_coil/_color/stack_type = /obj/item/cable_coil/_color;\
-/obj/item/cable_coil/_color/spawn_insulator_name = ""+#_color+" synthrubber";\
+/obj/item/cable_coil/_color/spawn_insulator_name = ""+"synthrubber_"+#_color;\
 /obj/item/cable_coil/_color/cable_obj_type = /obj/cable/_color;\
 /obj/item/cable_coil/_color/cut;\
 /obj/item/cable_coil/_color/cut/icon_state = "coil2";\
@@ -14,9 +14,9 @@
 /obj/cable/_color;\
 /obj/cable/_color/name = ""+#_color+" power cable";\
 /obj/cable/_color/color = _hexcolor;\
-/obj/cable/_color/insulator_default = ""+#_color+" synthrubber";\
+/obj/cable/_color/insulator_default = ""+"synthrubber_"+#_color;\
 /datum/material/rubber/synthrubber/_color;\
-/datum/material/rubber/synthrubber/_color/mat_id = ""+#_color+" synthrubber";\
+/datum/material/rubber/synthrubber/_color/mat_id = ""+"synthrubber_"+#_color;\
 /datum/material/rubber/synthrubber/_color/name = ""+#_color+" synthrubber";\
 /datum/material/rubber/synthrubber/_color/desc = ""+"A type of synthetic rubber. This one is "+#_color+".";\
 /datum/material/rubber/synthrubber/_color/color = _hexcolor;\

--- a/code/modules/writing/paper.dm
+++ b/code/modules/writing/paper.dm
@@ -692,6 +692,7 @@
 	stamina_damage = 0
 	stamina_cost = 0
 	rand_pos = 1
+	default_material = "synthrubber"
 	var/special_mode = null
 	var/is_reassignable = 1
 	var/assignment = null
@@ -768,6 +769,7 @@
 		name = "\improper captain's rubber stamp"
 		desc = "The Captain's rubber stamp for stamping important documents. Ooh, it's the really fancy National Notary 'Congressional' model with the fine ebony handle."
 		icon_state = "stamp-cap"
+		default_material = "synthrubber_green"
 		special_mode = "Captain"
 		is_reassignable = 0
 		assignment = "stamp-cap"
@@ -775,6 +777,7 @@
 		name = "\improper head of personnel's rubber stamp"
 		desc = "The Head of Personnel's rubber stamp for stamping important documents. Looks like one of those fancy National Notary 'Continental' models with the kingwood handle."
 		icon_state = "stamp-hop"
+		default_material = "synthrubber_blue"
 		special_mode = "Head of Personnel"
 		is_reassignable = 0
 		assignment = "stamp-hop"
@@ -789,6 +792,7 @@
 		name = "\improper chief engineer's rubber stamp"
 		desc = "The Chief Engineer's rubber stamp for stamping important documents. Looks like one of those fancy National Notary 'St. Mary' models with the ironwood handle."
 		icon_state = "stamp-ce"
+		default_material = "synthrubber_yellow"
 		special_mode = "Chief Engineer"
 		is_reassignable = 0
 		assignment = "stamp-ce"
@@ -796,6 +800,7 @@
 		name = "\improper medical director's rubber stamp"
 		desc = "The Medical Director's rubber stamp for stamping important documents. Looks like one of those fancy National Notary 'St. Anne' models with the rosewood handle."
 		icon_state = "stamp-md"
+		default_material = "synthrubber_blue"
 		special_mode = "Medical Director"
 		is_reassignable = 0
 		assignment = "stamp-md"
@@ -803,6 +808,7 @@
 		name = "\improper research director's rubber stamp"
 		desc = "The Research Director's rubber stamp for stamping important documents. Looks like one of those fancy National Notary 'St. John' models with the purpleheart handle."
 		icon_state = "stamp-rd"
+		default_material = "synthrubber_purple"
 		special_mode = "Research Director"
 		is_reassignable = 0
 		assignment = "stamp-rd"
@@ -810,6 +816,7 @@
 		name = "\improper clown's rubber stamp"
 		desc = "The Clown's rubber stamp for stamping whatever important documents they've gotten their hands on. It doesn't seem very legit."
 		icon_state = "stamp-honk"
+		default_material = "synthrubber_hotpink"
 		special_mode = "Clown"
 		is_reassignable = 0
 		assignment = "stamp-honk"
@@ -817,6 +824,7 @@
 		name = "\improper centcom executive rubber stamp"
 		desc = "Some bureaucrat from Centcom probably lost this. Dang, is that National Notary's 'Admiral Sampson' model with the exclusive blackwood handle?"
 		icon_state = "stamp-centcom"
+		default_material = "synthrubber_blue"
 		special_mode = "Centcom"
 		is_reassignable = 0
 		assignment = "stamp-centcom"
@@ -824,6 +832,7 @@
 		name = "\improper mime's rubber stamp"
 		desc = "The Mime's rubber stamp for stamping whatever important documents they've gotten their hands on. It doesn't seem very legit."
 		icon_state = "stamp-mime"
+		default_material = "synthrubber_white"
 		special_mode = "Mime"
 		is_reassignable = 0
 		assignment = "stamp-mime"
@@ -831,6 +840,7 @@
 		name = "\improper chaplain's rubber stamp"
 		desc = "The Chaplain's rubber stamp for stamping whatever important documents they've gotten their hands on. It's the National Notary 'Chesapeake' model in varnished oak."
 		icon_state = "stamp-chap"
+		default_material = "synthrubber_black"
 		special_mode = "Chaplain"
 		is_reassignable = 0
 		assignment = "stamp-chap"
@@ -838,6 +848,7 @@
 		name = "\improper quartermaster's rubber stamp"
 		desc = "The Quartermaster's rubber stamp for stamping whatever important documents they've gotten their hands on. A classic National Notary 'Eastport' model in oiled black walnut."
 		icon_state = "stamp-qm"
+		default_material = "synthrubber_yellow"
 		special_mode = "Quartermaster"
 		is_reassignable = 0
 		assignment = "stamp-qm"

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -220,6 +220,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	name = "cleaning gloves"
 	icon_state = "long_gloves"
 	item_state = "long_gloves"
+	default_material = "synthrubber_yellow"
 	protective_temperature = 550
 	material_prints = "synthetic silicone rubber fibers"
 	fingertip_color = "#ffff33"
@@ -291,6 +292,8 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	icon_state = "latex"
 	item_state = "lgloves"
 	desc = "Thin, disposable medical gloves used to help prevent the spread of germs."
+	default_material = "latex"
+	material_amt = 0.5
 	protective_temperature = 310
 	scramble_prints = 1
 	fingertip_color = "#f3f3f3"

--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -289,6 +289,7 @@ TYPEINFO(/obj/item/clothing/shoes/industrial)
 	name = "galoshes"
 	desc = "Rubber boots that prevent slipping on wet surfaces."
 	icon_state = "galoshes"
+	default_material = "synthrubber_yellow"
 	c_flags = NOSLIP
 	step_sound = "step_rubberboot"
 	step_priority = STEP_PRIORITY_LOW
@@ -404,6 +405,7 @@ TYPEINFO(/obj/item/clothing/shoes/industrial)
 	name = "flippers"
 	desc = "A pair of rubber flippers that improves swimming ability when worn."
 	icon_state = "flippers"
+	default_material = "synthrubber_blue"
 	laces = LACES_NONE
 	step_sound = "step_flipflop"
 	step_priority = STEP_PRIORITY_LOW

--- a/code/obj/item/misc_junk.dm
+++ b/code/obj/item/misc_junk.dm
@@ -159,6 +159,7 @@ TYPEINFO(/obj/item/disk)
 	icon_state = "rubber_chicken"
 	item_state = "rubber_chicken"
 	w_class = W_CLASS_SMALL
+	default_material = "synthrubber_yellow"
 	stamina_damage = 10
 	stamina_cost = 5
 	stamina_crit_chance = 3
@@ -294,6 +295,7 @@ TYPEINFO(/obj/item/disk)
 	icon_state = "rubber_hammer"
 	c_flags = ONBELT
 	force = 0
+	default_material = "synthrubber_yellow"
 
 	New()
 		..()

--- a/code/obj/item/toys.dm
+++ b/code/obj/item/toys.dm
@@ -296,6 +296,7 @@ ADMIN_INTERACT_PROCS(/obj/item/rubberduck, proc/quack, proc/evil_quack)
 	w_class = W_CLASS_TINY
 	throw_speed = 3
 	throw_range = 15
+	default_material = "synthrubber_yellow"
 
 /obj/item/rubberduck/attack_self(mob/user as mob)
 	if (!ON_COOLDOWN(src,"quack",2 SECONDS))

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1544,7 +1544,7 @@ TYPEINFO(/turf/simulated/floor/grass)
 	mat_changedesc = 0
 	step_material = "step_outdoors"
 	step_priority = STEP_PRIORITY_MED
-	default_material = "synthrubber"
+	default_material = "synthrubber_green"
 	can_dig = TRUE
 
 	#ifdef SEASON_WINTER


### PR DESCRIPTION
## About the PR
- A bunch of items that should be made of synthrubber are now actually made of synthrubber.
- Same applies for latex and latex gloves.
- Changed the material IDs of colored synthrubber from `"color synthrubber"` to `"synthrubber_color"`.

## Why's this needed?
- More rubbery rubber ducks.
- Better naming for colored synthrubber IDs.

## Testing
<img width="434" height="294" alt="Screenshot 2026-01-18 180049" src="https://github.com/user-attachments/assets/8826dff3-73eb-4496-945b-84ca9f778c91" />
<img width="638" height="836" alt="Screenshot 2026-01-18 181635" src="https://github.com/user-attachments/assets/52335662-f38c-49d1-b995-c2e71830a901" />

## Changelog
```changelog
(u)LorrMaster
(+)A bunch of items that should be made of rubber now use synthrubber as their default material.
```
