### PR TITLE
Minor cleanup of world/Topic()'s "status"

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -1098,8 +1098,8 @@ var/global/list/mapNames = list(
 			return "south-east"
 	return "unknown[side ? " side" : null]"
 
+/// Fetches the map name from a given map ID. Returns null if none could be found
 /proc/getMapNameFromID(id)
 	for (var/map in mapNames)
 		if (id == mapNames[map]["id"])
 			return map
-	return 0

--- a/code/world/topic.dm
+++ b/code/world/topic.dm
@@ -35,6 +35,7 @@
 			response_body["mode"] = (ticker.hide_mode) ? "secret" : master_mode
 			response_body["round_duration"] = round(ticker.round_elapsed_ticks / (1 SECOND))
 		if(emergency_shuttle)
+			response_body["shuttle_online"] = emergency_shuttle.online
 			response_body["shuttle_direction"] = emergency_shuttle.direction
 			response_body["shuttle_location"] = emergency_shuttle.location
 			response_body["shuttle_timer"] = emergency_shuttle.timeleft()

--- a/code/world/topic.dm
+++ b/code/world/topic.dm
@@ -28,13 +28,16 @@
 		response_body["enter"] = enter_allowed
 		response_body["round_id"] = roundId
 
-		response_body["ai"] = config?.allow_ai
-		response_body["mode"] = ((ticker?.hide_mode) ? "secret" : master_mode)
-		response_body["round_duration"] = round(ticker?.round_elapsed_ticks / (1 SECOND))
-
-		response_body["shuttle_direction"] = emergency_shuttle?.direction
-		response_body["shuttle_location"] = emergency_shuttle?.location
-		response_body["shuttle_timer"] = emergency_shuttle?.timeleft()
+		// These can be all be null before current_state >= GAME_STATE_PREGAME
+		if(config)
+			response_body["ai"] = config.allow_ai
+		if(ticker)
+			response_body["mode"] = (ticker.hide_mode) ? "secret" : master_mode
+			response_body["round_duration"] = round(ticker.round_elapsed_ticks / (1 SECOND))
+		if(emergency_shuttle)
+			response_body["shuttle_direction"] = emergency_shuttle.direction
+			response_body["shuttle_location"] = emergency_shuttle.location
+			response_body["shuttle_timer"] = emergency_shuttle.timeleft()
 
 		response_body["station_name"] = station_name
 		response_body["map_name"] = getMapNameFromID(map_setting)

--- a/code/world/topic.dm
+++ b/code/world/topic.dm
@@ -26,11 +26,12 @@
 		response_body["gamestate"] = current_state
 		response_body["respawn"] = abandon_allowed
 		response_body["enter"] = enter_allowed
+		response_body["round_id"] = roundId
 
 		response_body["ai"] = config?.allow_ai
 		response_body["mode"] = ((ticker?.hide_mode) ? "secret" : master_mode)
 		response_body["round_duration"] = round(ticker?.round_elapsed_ticks / (1 SECOND))
-		
+
 		response_body["shuttle_direction"] = emergency_shuttle?.direction
 		response_body["shuttle_location"] = emergency_shuttle?.location
 		response_body["shuttle_timer"] = emergency_shuttle?.timeleft()

--- a/code/world/world.dm
+++ b/code/world/world.dm
@@ -162,10 +162,11 @@
 /world/proc/setupZLevel(new_zlevel)
 	global.zlevels += new/datum/zlevel("dyn[new_zlevel]", length(global.zlevels) + 1)
 
+/// Returns the number of unstealthed clients currently connected to the server
 /world/proc/total_player_count()
-	var/n = 0
-	for(var/client/C)
-		if (C.stealth && !C.fakekey) // stealthed admins don't count
+	var/total = 0
+	for(var/client/client in clients)
+		if (client.stealth && !client.fakekey) // stealthed admins don't count
 			continue
-		n++
-	return n
+		total++
+	return total


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INTERNAL] [CODE-QUALITY]

## About the PR

Migration PRs:
- https://github.com/goonstation/gooncogs/pull/33

Partially rewrites /world/Topic() so that:
- "status" is generally much cleaner
- "status" separates state and time from round info and shuttle info
- "status" now provides the round id
- "players" topic is replaced with "who" topic which returns a list of all visible players (and removes this behavior from "status")

<details>
<summary>API change summary:</summary>
status:

```diff
+ "round_id"

- "player[n]"

- "elapsed"
+ "round_time"
+ "gamestate"

- "shuttle_time"
+ "shuttle_online"
+ "shuttle_timer"
+ "shuttle_direction"
+ "shuttle_location"
```
topics:

```diff
- "players"
+ "who"
```
</details>

While I was here, I modified/documented a few relevant procs:
- Documented/cleaned `/world/proc/total_player_count` (behaviour unchanged)
- Documented `/proc/getMapNameFromId` and made it return `null` as to not mix types (returning `FALSE` instead of `null`) and cause errors. I've checked all uses and it won't break anything 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

## Testing
I have my own personal instance for calling SS13 topics, and I used it to test the API. It handles all cases regardless of gamestate, so this will not runtime during game setup or anything like that.

<details>
<summary>Testing evidence:</summary>

> GAME_STATE_WORLD_INIT
<img width="765" height="504" alt="image" src="https://github.com/user-attachments/assets/9560cfb1-6c8e-4c1e-a30c-f448e3d86542" />

> GAME_STATE_PREGAME
<img width="849" height="563" alt="image" src="https://github.com/user-attachments/assets/cc773229-5935-4a1c-bf24-cb5e5394b81c" />

</details>

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)finger
(+)Backend stuff regarding server information was modified. Goonhub/MedAss might fail to fetch servers while stuff gets migrated.
```
