### PR TITLE
Adds a shelterfrog spacebux purchase

### DIFF
--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -40,6 +40,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/space_diner,\
 	new /datum/bank_purchaseable/missile_arrival,\
 	new /datum/bank_purchaseable/lunchbox,\
+	new /datum/bank_purchaseable/shelterfrog,\
 
 	new /datum/bank_purchaseable/bird_respawn,\
 	new /datum/bank_purchaseable/critter_respawn,\
@@ -506,6 +507,23 @@ var/global/list/persistent_bank_purchaseables =	list(\
 					launch_with_missile(M)
 			..()
 			return TRUE
+
+	shelterfrog
+		name = "Shelterfrog"
+		cost = 7000
+		icon = 'icons/mob/shelterfrog.dmi'
+		icon_state = "body_m"
+		icon_dir = SOUTH
+
+		Create(var/mob/living/M)
+			if (ishuman(M))
+				var/mob/living/carbon/human/H = M
+				switch (H.mind.assigned_role) // Special mutantrace overrides
+					if ("Test Subject","Salvager")
+						return FALSE
+					else H.set_mutantrace(/datum/mutantrace/amphibian/shelter)
+				return 1
+			return 0
 
 	critter_respawn
 		name = "Alt Ghost Critter"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[INPUT WANTED] [MUTANTRACES] [EXPERIMENTAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

As it stands, this PR adds the currrently in limbo shelterfrog mutantrace as a spacebux purchase for 7000 spacebux. It does not rebalance shelterfrogs in any way, but it attempts to solve many of the issues caused by previous methods of sheltergrog overdose.

I am seeking feedback on this PR, as the re-implementation of shelterfrogs isn't a cut and dry issue. While having them be a spacebux purchase solves many of the issues that have been described, there is likely something I've missed. Additionally, it would also necessitate an addition to the server's nonhuman policy, as amphibians being considered nonhuman is one of the large issues that led to their removal. **I am fully aware that this PR may not be merged.**

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Having shelterfrogs as a spacebux purchase solves the issue of it revolving around secret content, and allows for shelterfrogs to be a bit more goofy in comparison to the formal mutantraces associated with traits. This should reduce the workload associated with adding a new mutantrace, as it is just re-implementing a pre-existing mutantrace in a manner I find to be more suitable.

This does not directly solve the issue of shelterfrogs being easily recognizable, but divorcing them from secret content should allow more players to use them, which could balance out in time to a healthily rotating cast of frog players rather than 1 or 2 stalwarts. Additionally, with the absence of sheltergrog withdrawal, this could pose balance concerns. However, I do believe this to be an appropriate solution to the issue at hand.

Again, I am seeking feedback on this PR. It is a proposed solution, not the end-all-be-all solution.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="301" height="603" alt="Screenshot 2026-01-20 222118" src="https://github.com/user-attachments/assets/4e28315d-684a-41d6-aced-44ff80c02666" />
<img width="369" height="242" alt="Screenshot 2026-01-20 221706" src="https://github.com/user-attachments/assets/80719e69-62c9-494f-8157-99b5da8c7d25" />
<img width="326" height="219" alt="Screenshot 2026-01-20 221720" src="https://github.com/user-attachments/assets/a12de443-e413-40e5-b15e-63455075e1ee" />
<img width="715" height="539" alt="Screenshot 2026-01-20 221806" src="https://github.com/user-attachments/assets/b2efa399-37d7-4849-8614-e994c2318245" />
<img width="693" height="122" alt="Screenshot 2026-01-20 221828" src="https://github.com/user-attachments/assets/d5031ab5-43de-4c0f-8032-b0a55d5bd6d7" />

As it stands, the shelterfrog purchase is disabled on test subject and salvager. This can be extended to more jobs as needed.



<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)SnugglyCactus
(*)Added shelterfrogs as a spacebux purchase.
```
