### PR TITLE
Fix for self observing sending you to 0,0

### DIFF
--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -733,6 +733,7 @@ TYPEINFO(/mob/dead/observer)
 
 /mob/dead/observer/proc/insert_observer(var/atom/target)
 	if(target == src) //cant observe self, or it nullspaces
+		boutput(src, SPAN_NOTICE("You cannot observe yourself, silly."))
 		return
 	var/mob/targetMob = target
 	if(istype(targetMob) && isadmin(targetMob) && !targetMob.client?.player_mode && !isadmin(src)) //Activate the alarm bells


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When you try to observe yourself, you get nullspaced. This PR fixes it by not letting you observe yourself.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #25675

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested in local instance by trying to;
Observe self and not getting nullspaced and getting the boutput message.
Observe NPCs and spawned mobs.
Going back to own corpse.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ribbie
(+)No more observing yourself.
```
