### PR TITLE
Agent IDs keep special icons

### DIFF
--- a/code/datums/jobs/operatives/jobs_syndicate.dm
+++ b/code/datums/jobs/operatives/jobs_syndicate.dm
@@ -30,6 +30,7 @@ ABSTRACT_TYPE(/datum/job/special/syndicate)
 			var/obj/item/card/id/ID = M.get_id()
 			if(istype(ID))
 				ID.icon_state = "id_syndie" //Syndie ID normally starts with basic sprite
+				ID.keep_icon = TRUE
 		SPAWN(2) //Ghost respawn panel has a SPAWN(1) that clears all antag roles. Apply specialist role if no other role was picked
 			if(!M.mind?.is_antagonist())
 				M.mind?.add_generic_antagonist(src.antag_role, src.name, source = ANTAGONIST_SOURCE_ADMIN)

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -327,8 +327,10 @@ TYPEINFO(/obj/item/card/emag)
 		switch (color)
 			if ("clown")
 				src.icon_state = "id_clown"
+				src.keep_icon = TRUE
 			if ("golden")
 				src.icon_state = "id_gold"
+				src.keep_icon = TRUE
 			if ("No band")
 				src.icon_state = "id_basic"
 			if ("civilian")
@@ -345,8 +347,10 @@ TYPEINFO(/obj/item/card/emag)
 				src.icon_state = "id_eng"
 			if ("nanotrasen")
 				src.icon_state = "id_nanotrasen"
+				src.keep_icon = TRUE
 			if ("syndicate")
 				src.icon_state = "id_syndie"
+				src.keep_icon = TRUE
 			else
 				return // Abort process.
 		src.registered = reg


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When an agent ID picks the Clown, Gold, NT or Syndicate icon, it will keep that icon like IDs that naturally have that sprite would.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
No giving away the clown's agent ID because the HoP made them a chef.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested a couple of the above icon options, couldn't change them. Checked the normal icon options, could. Checked the syndicate special roles, could not change icon.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Agent IDs that select the Clown, Gold, NT or Syndicate sprites will no longer lose their special icon at an ID computer.
```
