### PR TITLE
Enhanced feedback for hitting light fixtures

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -977,7 +977,7 @@ DEFINE_DELAYS(/obj/machinery/light/traffic_light/medical_pathology)
 		return TRUE
 
 /obj/machinery/light/proc/do_burn_out()
-	if(!src.current_lamp.light_status == LIGHT_OK)
+	if(src.current_lamp.light_status != LIGHT_OK)
 		return
 	var/original_brightness = src.light.brightness
 	playsound(src, 'sound/effects/snaptape.ogg', 30, TRUE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[ACTIONS] [GAME OBJECTS] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Hitting light fixtures will now play a glass hit sound effect and show an attack effect (like what happens when you hit a vending machine, mob, window, etc.). Changes the sound of light fixtures breaking. Also fixes a bug I found while testing where you could burn out an already burnt or broken light fixture.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the only feedback for hitting light fixtures is a message in the chat log unless the light fixture is also destroyed in the same hit.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="156" height="92" alt="Screenshot (349)" src="https://github.com/user-attachments/assets/e38e7b86-5428-4b7b-81cb-8d8a23ca6408" />
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

