### PR TITLE
Rework "DWAINE Superuser" credential into "Mainframe Administration"

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -460,7 +460,7 @@ var/list/access_all_actually = null
 		if(access_head_of_personnel)
 			return "Head of Personnel's Office"
 		if(access_dwaine_superuser)
-			return "DWAINE Superuser"
+			return "Mainframe Administration"
 		if(access_researchfoyer)
 			return "Research Foyer"
 		if(access_artlab)


### PR DESCRIPTION
## About the PR
Reworks the DWAINE Superuser credential into "Mainframe Administration", which includes access to the computer core (but not the robotics control computer)

## Why's this needed?
This separates access to the AI Upload and access to the physical mainframe, allowing for roles which do not have access to the former but do have access to the later.

## Testing

## Changelog
```changelog
(u)CodeDude
(+)Renamed the DWAINE Superuser credential "Mainframe Administration", and gave it access to the computer core.
```

## Todo
- [ ] Apply change to maps
- [ ] Properly test this PR