### PR TITLE
Adds Partially Hydrogenated Space-Soybean Oil as an associated reagent to Strange Soybean plants

### DIFF
--- a/code/modules/cooking/food_and_drink/plants.dm
+++ b/code/modules/cooking/food_and_drink/plants.dm
@@ -312,6 +312,11 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/plant)
 	bites_left = 3
 	heal_amt = 2
 	food_color = "#BBF33D"
+	initial_volume = 20 //Limiting this so there's a max of 10u of both grease and bad-grease
+
+	make_reagents() //explicitly don't invoke the parent or else we'll get 20u of regular grease.
+		src.reagents.add_reagent("grease",10)
+		src.reagents.add_reagent("badgrease",10)
 
 
 /obj/item/reagent_containers/food/snacks/plant/bean

--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -464,6 +464,7 @@ ABSTRACT_TYPE(/datum/plantmutation)
 	name = "Strange soybean"
 	name_prefix = "Strange "
 	crop = /obj/item/reagent_containers/food/snacks/plant/soy/soylent
+	assoc_reagents = list("badgrease")
 	iconmod = "Soylent"
 
 // Contusine Mutations


### PR DESCRIPTION
[HYDROPONICS][FEATURE]
## About the PR 
Makes 2 chamges:
1. soylenth "chartreuse" now always and only have 10 unit of soybeans oil and 10 unit of "badgrease" (Partially Hydrogenated Space-Soybean Oil ). Do not have milk or other chemiacles from plant.
2. Add "badgrease" as associated reagent to strange soybean plant

## Why's this needed? 
3 reason:
1. I donot see many botanists making/usering strange soybean. now it can be more interesting maybe
3. IF YOY HAVE STRAMGE SEED (leaker)- can now make plant with beff init. with the other botany things, can maybe make lots of peppeperoni! it is fun.
3, make sense, i think. soylet not look very good or tastey - in other medias, it is made of people! It can be nyasty.

i only change chartreuse tohave limited reagent because high potency of the plant wouldbe VERY damgerous (too much  badgrease is very not good). Can do splice into other plant toget he scaling badgrease if wanting scary grease lelves in fruit/vegetable . I can do chamge if others want scaling, it ok.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="977" height="611" alt="bean" src="https://github.com/user-attachments/assets/c2129e3f-f3c4-4eda-93a1-a5182ee52f1b" />
do splice, lookat non mutated and mutaated and look like expect.

## Changelog 

```changelog
(u)NibChocolateeny
(+)Strange Soybean plants and their questionable produce now contain Partially Hydrogenated Space-Soybean Oil. 
```
