### PR TITLE
Adds a new biological artifact bomb variant

### DIFF
--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -666,6 +666,8 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 			explosion_new(O, get_turf(O), self_destruct_strength, turf_safe=TRUE)
 
+			O.visible_message(SPAN_ALERT("<b>With a blinding light [O] cracks open, releasing its contents into the air.</b>"))
+
 			O.ArtifactDestroyed()
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[SCIENCE] [FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new biological variant of artifact bomb, similar to the chemical bomb but only using disease reagents. The bomb only uses aerosol propellant, and comes in two versions: wizard and eldritch. As the bomb works via disease reagent and not direct transmission, negative effects can be avoided via gas mask or internals. It also has a 50% chance to destroy itself in a minor explosion upon releasing it's payload.

Eldritch biological bombs can carry the following diseases as payloads:
- Beserker
- Rat plague
- Space Madness
- E coli
- Flu
- GBS

Wizard variants can carry the following;
- Clowning around
- Cluwning around
- Grave Fever
- Exploding Head Syndrome


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Adds the potential for larger scale infection incidents without the balance issues of further transmission between crew. Also a funny way to punish scientists that don't wear PPE around hazardous bomb artifacts. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->


<img width="2034" height="951" alt="Screenshot 2026-01-27 143245" src="https://github.com/user-attachments/assets/19f3ba7d-3d19-4bd7-9615-589dc1d9e777" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bamlord
(*)Added a new type of artifact bomb: biological
(+)The biological artifact bomb spews out a cloud of disease reagents.
```
