### PR TITLE
Refactor and fix incendiary mitochondria

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -859,34 +859,33 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 	desc = "Wreath yourself in burning flames."
 	icon_state = "immolate"
 	needs_hands = FALSE
-	targeted = 0
+	targeted = FALSE
 
-	cast()
+	cast_genetics(atom/target, misfire)
 		if (..())
-			return 1
+			return CAST_ATTEMPT_FAIL_CAST_FAILURE
 
-		playsound(owner.loc, 'sound/effects/mag_fireballlaunch.ogg', 50, 0)
+		if (misfire)
+			return src.do_misfire()
+
+		playsound(src.owner.loc, 'sound/effects/mag_fireballlaunch.ogg', 50, 0)
 
 		if (linked_power.power > 1)
-			owner.visible_message(SPAN_ALERT("<b>[owner.name]</b> erupts into a huge column of flames! Holy shit!"))
-			fireflash_melting(get_turf(owner), 3, 7000, 2000, chemfire = CHEM_FIRE_RED)
+			src.owner.visible_message(SPAN_ALERT("<b>[src.owner.name]</b> erupts into a huge column of flames! Holy shit!"))
+			fireflash_melting(get_turf(src.owner), 3, 7000, 2000, chemfire = CHEM_FIRE_RED)
 		else if (owner.is_heat_resistant())
-			owner.show_message(SPAN_ALERT("Your body emits an odd burnt odor but you somehow cannot bring yourself to heat up. Huh."))
-			return
+			src.owner.show_message(SPAN_ALERT("Your body emits an odd burnt odor but you somehow cannot bring yourself to heat up. Huh."))
+			return CAST_ATTEMPT_SUCCESS
 		else
-			owner.visible_message(SPAN_ALERT("<b>[owner.name]</b> suddenly bursts into flames!"))
-			owner.set_burning(100)
-		return
+			src.owner.visible_message(SPAN_ALERT("<b>[src.owner.name]</b> suddenly bursts into flames!"))
+			src.owner.set_burning(100)
+		return CAST_ATTEMPT_SUCCESS
 
-	cast_misfire()
-		if (..())
-			return 1
-
-		playsound(owner.loc, 'sound/effects/bamf.ogg', 50, 0)
-		owner.show_message(SPAN_ALERT("You accidentally expunge all heat from your body. Whoops!"))
-		owner.bodytemperature = 0
-
-		return
+	proc/do_misfire()
+		playsound(src.owner.loc, 'sound/effects/bamf.ogg', 50, 0)
+		src.owner.show_message(SPAN_ALERT("You accidentally expunge all heat from your body. Whoops!"))
+		src.owner.bodytemperature = 0
+		return CAST_ATTEMPT_SUCCESS
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Refactors Incendiary Mitochondria to use a different miscast implementation, explicit returns, srcs and "booleans".

Miscasting Incendiary Mitochondria will now expunge heat from the body only, instead of both expunging heat and then performing the regular cast. 

This is a part of a larger refactor https://github.com/goonstation/goonstation/pull/24987.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The behaviour caused by the miscast bug removed the personality of the miscast, because the heat expunge is completely mitigated by the immediate burning status. 

Genetics abilities have a lot of copy-pasted code, which is seemingly encouraged by the way misfire mechanics are handled. This way genetic abilities have more control over how they want to implement miscasts.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/b8c17bd4-7586-4c47-b5a6-bb93f2509117

Add bioeffect 'immolate'. Test regular cast; set stability to 0 to test miscast. 

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

