### PR TITLE
Made the Door Panel UI open upon unscrewing it

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -774,7 +774,7 @@ var/global/list/cycling_airlocks = list()
 	return
 
 /obj/machinery/door/airlock/proc/interact_panel(mob/user)
-	src.panel_open = !(src.panel_open)
+	src.panel_open = !src.panel_open
 	if (src.panel_open)
 		user.visible_message(SPAN_ALERT("[user] opens the maintenance panel on \the [src.name]."))
 		logTheThing(LOG_STATION, user, "opens the maintenance panel on \the [src.name] airlock/door at [log_loc(src)]")


### PR DESCRIPTION
[A-Engineering] [C-QoL]

## About the PR
Automatically opens the Door Panel UI when screwdriving it open.

## Why's this needed?
A nice QoL feature, you virtually always want to open the panel after unscrewing it.
Also adds a way to look at the panel without needing wirecutters/multitool/signaller.

## Testing 
I've screwed many things on the station and no problems came up.
I screwed many types of doors, and everything seemed to work perfectly. I even screwed them a second time to make sure nothing came up, and it was all fine.

## Changelog
```changelog
(u)Pirate-Rob
(+)Door Panel UI now automatically opens upon opening the panel with a screwdriver.
```
