### PR TITLE
Adds the Ejector Resistance artifact fault

### DIFF
--- a/code/obj/artifacts/artifacts.dm
+++ b/code/obj/artifacts/artifacts.dm
@@ -106,6 +106,18 @@
 		src.ArtifactTakeDamage(rand(5,20))
 		boutput(user, SPAN_ALERT("It seems to be a bit more damaged!"))
 
+	throw_at(atom/target, range, speed, list/params, turf/thrown_from, mob/thrown_by, throw_type = 1,
+			allow_anchored = UNANCHORED, bonus_throwforce = 0, datum/callback/end_throw_callback = null)
+		if(istype(thrown_by, /obj/machinery/mass_driver))
+			var/obj/machinery/mass_driver/thrown_by_ejector = thrown_by
+			if(thrown_by_ejector.id == "ejector_medsci" || thrown_by_ejector.id == "artlabgun")
+				var/datum/artifact/A = src.artifact
+				for(var/datum/artifact_fault/F in A.faults)
+					if(istype(F, /datum/artifact_fault/ejector_resistance))
+						SPAWN(1 SECOND)
+							src.loc = thrown_by_ejector.loc
+		..()
+
 /obj/machinery/artifact
 	name = "artifact large art piece"
 	icon = 'icons/obj/artifacts/artifacts.dmi'
@@ -212,6 +224,19 @@
 			var/obj/item/ITM = M
 			for (var/obj/machinery/networked/test_apparatus/impact_pad/I in src.loc.contents)
 				I.impactpad_senseforce(src, ITM)
+		..()
+
+	throw_at(atom/target, range, speed, list/params, turf/thrown_from, mob/thrown_by, throw_type = 1,
+			allow_anchored = UNANCHORED, bonus_throwforce = 0, datum/callback/end_throw_callback = null)
+		if(istype(thrown_by, /obj/machinery/mass_driver))
+			var/obj/machinery/mass_driver/thrown_by_ejector = thrown_by
+			//TODO: Check other maps to see if they have other IDs on their artlab mass drivers.
+			if(thrown_by_ejector.id == "ejector_medsci" || thrown_by_ejector.id == "artlabgun")
+				var/datum/artifact/A = src.artifact
+				if(/datum/artifact_fault/ejector_resistance in A.faults)
+					SPAWN(5 SECOND)
+						//TODO: Add a sound effect and chat message when it warps back.
+						src.loc = thrown_by_ejector.loc
 		..()
 
 /obj/item/artifact

--- a/code/obj/artifacts/faults.dm
+++ b/code/obj/artifacts/faults.dm
@@ -281,3 +281,12 @@ ABSTRACT_TYPE(/datum/artifact_fault/messager/)
 		boutput(user, SPAN_ALERT("The [cosmeticSource.name] stings you!"))
 		if (user.reagents)
 			user.reagents.add_reagent(poison_type,poison_amount)
+
+/datum/artifact_fault/ejector_resistance
+	type_name = "Ejector resistance"
+	trigger_prob = 5
+
+	//This fault doesn't have a deployment effect, instead happening as a check on the
+	deploy(var/obj/O,var/mob/living/user,var/atom/cosmeticSource)
+		if (..())
+			return

--- a/code/obj/machinery/mass_driver.dm
+++ b/code/obj/machinery/mass_driver.dm
@@ -28,6 +28,6 @@
 				boutput(M, SPAN_NOTICE("The mass driver lets out a screech, it mustn't be able to handle any more items."))
 			break
 		use_power(500)
-		O.throw_at(target, drive_range * src.power, src.power, throw_type=src.throw_type, params=src.throw_params)
+		O.throw_at(target, drive_range * src.power, src.power, thrown_by=src, throw_type=src.throw_type, params=src.throw_params)
 	FLICK("mass_driver1", src)
 	return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[SCIENCE][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds the Ejector Resistance fault, which makes the artifact teleport back to the turf it was thrown from when thrown from the artifact emergency ejector.

This PR notably does not prevent the artifact from being sold or transported via belt hell by identifying which ejector threw it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The panic in the eyes in scientists as the bomb they're ejecting keeps teleporting back.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested on a locally hosted server by spawning an artifact, manually adding the fault, and then ejecting it. A video demonstrating the functionality will be added later.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kanthes
(*)Adds the Ejector Resistance artifact fault
```
