### PR TITLE
Adds Computer maintenance panel you can open after unscrewing

### DIFF
--- a/code/modules/networks/computer3/buildandrepair.dm
+++ b/code/modules/networks/computer3/buildandrepair.dm
@@ -138,8 +138,6 @@ TYPEINFO(/obj/item/motherboard)
 		if (href_list["addPeriph"])
 			src.insert_periph(usr.equipped(),usr)
 
-			src.updateUsrDialog()
-
 		if(href_list["driveRemove"])
 			if(src.hd)
 				usr.put_in_hand_or_drop(src.hd)
@@ -423,5 +421,6 @@ TYPEINFO(/obj/item/motherboard)
 		src.peripherals.Add(P)
 		P.set_loc(src)
 		boutput(user, SPAN_NOTICE("You add \the [P] to the frame."))
+		src.updateUsrDialog()
 	else
 		boutput(user, SPAN_ALERT("There is no more room for peripheral cards."))


### PR DESCRIPTION
[A-Station-Systems][C-QoL]

## About the PR
Adds a maintenance panel you can open by clicking on computers in the last stage of their construction.
The panel allows you to take out and put in peripherals and harddrives.
You can't remove motherboards because from what I can tell there's no reason to, and they don't even get carried over to the final construction.

## Why's this needed?
While messing with computers, and particularly while learning how they work, you often have to disassemble a computer down to it's second or so stage before you can actually swap peripherals in and out, which is quite tedious to deconstruct and rebuild the pc multiple times, worse if you put back the wrong peripherals or missed one because you were forced to take them all out.
With this change, it'll be nice and easy to simply unscrew a pc, adjust peripherals/harddrives, and screw it back closed with no fuss. 

## Testing
<img width="1127" height="1026" alt="image" src="https://github.com/user-attachments/assets/8c6e4683-9da1-4234-afe8-976b396af0d5" />
I've tested on many computers around the station. I've swapped out harddrives and their programs remained correctly as expected. Swapping peripherals all works and reports correctly when checking periph view. Removing an id scanner from the frame while an ID is in it doesn't destroy the ID (you do have to click on the id scanner to get it out though, but it's always been like that). I also tested to make sure you can't pull things out while far away either.

## Changelog
```changelog
(u)Pirate-Rob
(+)Computers now have a maintenance panel you can access by unscrewing them, allowing you to change peripherals and harddrives.
```
