### PR TITLE
Refactor and fix Empathic Thought

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -754,7 +754,7 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 			return CAST_ATTEMPT_SUCCESS
 
 		if (misfire)
-			boutput(read, SPAN_ALERT("Somehow, you sense <b>[src.owner]</b> trying and failing to read your mind!"))
+			boutput(read, SPAN_ALERT("You sense <b>[src.owner]</b> trying and failing to read your mind!"))
 			boutput(src.owner, SPAN_ALERT("You are mentally overwhelmed by a huge barrage of worthless data!"))
 			src.owner.emote("scream")
 			src.owner.changeStatus("unconscious", 5 SECONDS)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Refactors Empathic Thought to use a different miscast implementation, explicit returns, srcs and "booleans".

Empathic Thought will properly fail to read mind on miscast, like the message says. 

Moves a null check when obtaining speech text forward to prevent an exception when targetting mobs without clients. 

This is a part of a larger refactor https://github.com/goonstation/goonstation/pull/24987.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It was ever so slightly easier to make the ability fail properly in order to suit the message than to reword it, and it doesn't feel like much of a balance decision either way so I just opted to go with the original intention. 

Genetics abilities have a lot of copy-pasted code, which is seemingly encouraged by the way misfire mechanics are handled. This way genetic abilities have more control over how they want to implement miscasts.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/7cc7c544-4bcd-4269-bc99-09a2fde8b774

Add bioeffect 'empath'. Test regular cast on a target dummy; set stability to 0 to test miscast on target dummy.
