### PR TITLE
Refactor Self Biomass Manipulation

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -937,11 +937,11 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 		return CAST_ATTEMPT_SUCCESS
 
 	proc/misfire()
-		if (!linked_power.safety && ishuman(owner))
+		if (!linked_power.safety && ishuman(src.owner))
 			// If unsynchronized, you drop a random organ. Hope it's not one of the important ones!
 			var/list/possible_drops = list("heart", "left_lung","right_lung","left_kidney","right_kidney",
 				"liver","spleen","pancreas","stomach","intestines","appendix","butt")
-			var/obj/item/organ/O = owner.organHolder?.drop_organ(pick(possible_drops))
+			var/obj/item/organ/O = src.owner.organHolder?.drop_organ(pick(possible_drops))
 			if (O)
 				logTheThing(LOG_COMBAT, src.owner, "dropped organ [O] due to misfire of unsynchronized power [name] at [log_loc(src.owner)].")
 				boutput(src.owner, SPAN_ALERT("You dissolve... mostly. Oops."))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Refactors Self Biomass Manipulation to use a different miscast implementation, explicit returns, srcs and "booleans".

This is a part of a larger refactor https://github.com/goonstation/goonstation/pull/24987.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Genetics abilities have a lot of copy-pasted code, which is seemingly encouraged by the way misfire mechanics are handled. This way genetic abilities have more control over how they want to implement miscasts.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/5b87aae5-ed93-40a4-8486-a89a96fb9aa6

Add bioeffect 'melt'. Test regular cast; set stability to 0 to test miscast.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
