### PR TITLE
kills buzztile

### DIFF
--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -2184,11 +2184,6 @@ Returns:
 	ex_act()
 		return
 
-/proc/gobuzz()
-	if(buzztile)
-		usr.set_loc(buzztile)
-	return
-
 /obj/item/beamtest
 	desc = "beamtest thingamobob"
 	name = "beamtest thingamobob"

--- a/code/global.dm
+++ b/code/global.dm
@@ -34,8 +34,6 @@ var/global
 
 	datum/datacore/data_core = null
 
-	turf/buzztile = null
-
 	atom/movable/screen/renderSourceHolder
 	obj/overlay/zamujasa/round_start_countdown/game_start_countdown	// Countdown clock for round start
 	list/globalImages = list() //List of images that are always shown to all players. Management procs at the bottom of the file.

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -339,14 +339,6 @@
 		name = "void"
 		desc = "Yep, this is fine."
 
-	#ifndef CI_RUNTIME_CHECKING
-	if(buzztile == null && prob(0.01) && src.z == Z_LEVEL_STATION) //Dumb shit to trick nerds.
-		buzztile = src
-		icon_state = "wiggle"
-		src.desc = "There appears to be a spatial disturbance in this area of space."
-		new/obj/item/device/key/random(src)
-	#endif
-
 	// // forbidden zone // //
 	update_icon() // HIGHLY ILLEGAL NEVER DO THIS, SPECIAL CASE IGNORE ME (for starlight)
 	// // do not pass go // //


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
kills the buzz tile (the wiggly tile a key spawns on)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
its utterly useless, it was nerd bait that serves no use. its also a bit imperformant by calling prob on a fuckton of tiles. you can't even see it with parallax.


## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
dreamchecker didnt complain

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
