### PR TITLE
Revert the ability to plant seeds in grass

### DIFF
--- a/code/obj/item/seeds.dm
+++ b/code/obj/item/seeds.dm
@@ -38,22 +38,6 @@ ADMIN_INTERACT_PROCS(/obj/item/seed, proc/admin_set_mutation)
 			if (charges > 1) name += " packet"
 		if (charges > 1) src.inventory_counter.update_number(src.charges)
 
-	afterattack(atom/target, mob/user, reach, params)
-		. = ..()
-		if (!isturf(target)) return
-		if (!user.find_tool_in_hand(TOOL_DIGGING))
-			return
-
-		var/turf/T = target
-		if (T.can_dig) // if we can dig it to make trenches, we can plant using it
-
-			var/datum/component/arable/A = T.AddComponent(/datum/component/arable/single_use)
-			A.auto_water = FALSE // disable auto watering
-			A.plant_seed(T,src,user)
-
-
-
-
 	HYPsetup_DNA(var/datum/plantgenes/passed_genes, var/obj/machinery/plantpot/harvested_plantpot, var/datum/plant/origin_plant, var/quality_status)
 		// If the crop is just straight up seeds. Don't need reagents, but we do
 		// need to pass genes and whatnot along like we did for fruit.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Partially reverts #25539, removing the ability to plant seeds anywhere.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Botany is designed around manipulating the stats and genes of limited numbers of plants to get good harvests, not just planting 50 of the same thing:
<img width="647" height="704" alt="image" src="https://github.com/user-attachments/assets/081a4fac-eefd-4b90-9c00-b4ef8192910c" />
<img width="240" height="445" alt="image" src="https://github.com/user-attachments/assets/a1827729-a4b4-415f-90b1-fbac8b95eff5" />
Also how are you planting seeds in astroturf!!
## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Reverted the ability to plant seeds outside of hydroponics trays.
```
