### PR TITLE
Emag Emag act

### DIFF
--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -52,6 +52,17 @@ TYPEINFO(/obj/item/card/emag)
 			return
 		hit_atom.emag_act(thr.user, src)
 
+	emag_act(mob/user, obj/item/card/emag/E)
+		. = ..()
+		if(!src.throw_return)
+			boutput(user, SPAN_ALERT("You run [E] over [src], causing an internal magnetisim feedback loop!"))
+			src.throw_return = TRUE
+			return
+
+	demag(mob/user)
+		. = ..()
+		src.throw_return = FALSE
+
 /obj/item/card/emag/attack_self(mob/user as mob)
 	if(ON_COOLDOWN(user, "showoff_item", SHOWOFF_COOLDOWN))
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an emag act to the emag that makes it act like a boomarang, an emagarang if you will

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Incredibly silly idea by crungnuts on discord. You can already throw the emag at things to emag them, this just lets you use it as a boomerang emag assuming you have 2.
<img width="352" height="80" alt="image" src="https://github.com/user-attachments/assets/8c421277-5d86-433b-9619-00b93706f425" />

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Emagged an emag, threw the emag, thing i threw the emag at got emagged and the emag returned to me.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Electromagnetic cards can now be emagged to make them return like boomerangs when thrown.
```
