### PR TITLE
fixes fluid pipes blowing up if theyre from map init

### DIFF
--- a/code/modules/fluids/fluid_pipe_machinery.dm
+++ b/code/modules/fluids/fluid_pipe_machinery.dm
@@ -54,8 +54,9 @@ ABSTRACT_TYPE(/obj/machinery/fluid_machinery/unary)
 /obj/machinery/fluid_machinery/unary/initialize()
 	for(var/obj/fluid_pipe/target in get_step(src, src.dir))
 		if(target.initialize_directions & get_dir(target,src))
-			src.network = target.network
-			src.network.machines += src
+			if(target.network)
+				src.network = target.network
+				src.network.machines += src
 			break
 
 /obj/machinery/fluid_machinery/unary/refresh_network(datum/flow_network/network)
@@ -433,14 +434,16 @@ ABSTRACT_TYPE(/obj/machinery/fluid_machinery/binary)
 /obj/machinery/fluid_machinery/binary/initialize()
 	for(var/obj/fluid_pipe/target in get_step(src, turn(src.dir, 180)))
 		if(target.initialize_directions & get_dir(target,src))
-			src.network1 = target.network
-			src.network1.machines += src
+			if(target.network)
+				src.network1 = target.network
+				src.network1.machines += src
 			break
 
 	for(var/obj/fluid_pipe/target in get_step(src, src.dir))
 		if(target.initialize_directions & get_dir(target,src))
-			src.network2 = target.network
-			src.network2.machines += src
+			if(target.network)
+				src.network2 = target.network
+				src.network2.machines += src
 			break
 
 /obj/machinery/fluid_machinery/binary/refresh_network(datum/flow_network/network)
@@ -569,20 +572,23 @@ ABSTRACT_TYPE(/obj/machinery/fluid_machinery/trinary)
 /obj/machinery/fluid_machinery/trinary/initialize()
 	for(var/obj/fluid_pipe/target in get_step(src, turn(src.dir, 180)))
 		if(target.initialize_directions & get_dir(target,src))
-			src.network1 = target.network
-			src.network1.machines += src
+			if(target.network)
+				src.network1 = target.network
+				src.network1.machines += src
 			break
 
 	for(var/obj/fluid_pipe/target in get_step(src, turn(src.dir, -90)))
 		if(target.initialize_directions & get_dir(target,src))
-			src.network2 = target.network
-			src.network2.machines += src
+			if(target.network)
+				src.network2 = target.network
+				src.network2.machines += src
 			break
 
 	for(var/obj/fluid_pipe/target in get_step(src, src.dir))
 		if(target.initialize_directions & get_dir(target,src))
-			src.network3 = target.network
-			src.network3.machines += src
+			if(target.network)
+				src.network3 = target.network
+				src.network3.machines += src
 			break
 
 /obj/machinery/fluid_machinery/trinary/refresh_network(datum/flow_network/network)

--- a/code/modules/fluids/fluid_pipes.dm
+++ b/code/modules/fluids/fluid_pipes.dm
@@ -223,8 +223,13 @@ ABSTRACT_TYPE(/obj/fluid_pipe)
 
 /// Accepts a pipe to merge with.
 /datum/flow_network/proc/merge_pipe(obj/fluid_pipe/fluid_pipe)
-	if(isnull(fluid_pipe.network))
+	if(QDELETED(fluid_pipe.network))
 		fluid_pipe.network = src
+		src.pipes += fluid_pipe
+		src.reagents.maximum_volume += fluid_pipe.capacity
+		if(fluid_pipe.default_reagent)
+			src.reagents.add_reagent(fluid_pipe.default_reagent, fluid_pipe.capacity)
+		
 		var/datum/component/reagent_overlay/other_target/fluid_component = fluid_pipe.GetComponent(/datum/component/reagent_overlay/other_target)
 		if(fluid_component)
 			var/states = fluid_component.reagent_overlay_states


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
i fix fluid pipes during map init by actually adding them to the network properly and telling machines to not try adding themselves to null (pipe may not have a network yet)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
it didnt blow up