### PR TITLE
changeling abomination form cannot be buckled

### DIFF
--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -87,7 +87,7 @@
 			return ..()
 
 	proc/can_buckle(var/mob/living/to_buckle, var/mob/user)
-		if (!istype(to_buckle) || isintangible(to_buckle) || isflockmob(to_buckle)) //no buckling AI-eyes
+		if (!istype(to_buckle) || isintangible(to_buckle) || isflockmob(to_buckle) || isabomination(to_buckle)) //no buckling AI-eyes
 			return FALSE
 		if (!ticker)
 			boutput(user, "You can't buckle anyone in before the game starts.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds a check for abomination form when buckling a mob

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
writhing mass of flesh stopped by lone chair ???

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested locally with infinite mode abom, trying several ways to buckle self and have other people buckle abom

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Changeling abomination form cannot buckle or be buckled into a chair.
```
