### PR TITLE
Allows harm to gunbots with welder

### DIFF
--- a/code/datums/critter_mobs/health/structure.dm
+++ b/code/datums/critter_mobs/health/structure.dm
@@ -3,7 +3,7 @@
 	associated_damage_type = "brute"
 
 	on_attack(var/obj/item/I, var/mob/M)
-		if (isweldingtool(I) && M.a_intent != "harm")
+		if (isweldingtool(I) && M.a_intent != INTENT_HARM)
 			if (I:try_weld(M,0))
 				if (damaged())
 					holder.visible_message(SPAN_NOTICE("[M] repairs some dents on [holder]!"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR allows you to harm gunbots using welders, by setting the intent to harm and then clicking on the gunbot.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The amount of salt that I'm exuding at this very moment is excruciating. Why. On earth. Would you heal. The enemy. During. A fight. This cannot stand. I cannot sit right here and allow that gunbot that I just healed get scott free from this STEAL, from this ROBBERY that just unfolded in front of my eyes.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

I beat a gunbot to death with a welder. I also healed one.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
## Changelogs...?

No need for changelogs. It's not a critical bug or anything.