### PR TITLE
ghostize does not prohibit respawns if DNR is set on RP only

### DIFF
--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -374,7 +374,15 @@ TYPEINFO(/mob/dead/observer)
 		if(istype(get_area(src), /area/afterlife))
 			qdel(src)
 
-		if(!(mind?.get_player()?.dnr || mind?.get_player()?.joined_observer))
+		var/do_respawn = TRUE
+		if(mind?.get_player()?.joined_observer)
+			do_respawn = FALSE
+		#ifndef RP_MODE
+		if(mind?.get_player()?.dnr)
+			do_respawn = FALSE
+		#endif
+
+		if (do_respawn)
 			respawn_controller.subscribeNewRespawnee(our_ghost.ckey)
 		var/datum/respawnee/respawnee = global.respawn_controller.respawnees[our_ghost.ckey]
 		if(istype(respawnee) && istype(our_ghost, /mob/dead/observer)) // target observers don't have huds


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[rp][player actions][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
On ghostize, only limit the respawn timer for DNRed parties if the server is NOT rp.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
On RP "DNR" means "don't revive me in this character", not "don't respawn me"
Fix #25826
Fix #18021
Fix #12951
Fix #19628


## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
With RP Mode enabled, Used ai Go Offline command, which sets DNR before calling ghostize, and got a respawn timer


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
