### PR TITLE
Hardhats and camera helmets no longer catch fire when you use the laser eyes gene

### DIFF
--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -515,6 +515,7 @@
 	icon_state = "hardhat0"
 	item_state = "hardhat0"
 	desc = "Protects your head from falling objects, and comes with a flashlight. Safety first!"
+	c_flags = null
 	var/on = 0
 	var/datum/component/loctargeting/simple_light/light_dir
 
@@ -657,6 +658,7 @@ TYPEINFO(/obj/item/clothing/head/helmet/camera)
 	desc = "A helmet with a built in camera."
 	icon_state = "camhat"
 	item_state = "camhat"
+	c_flags = null
 	var/obj/machinery/camera/camera = null
 	var/camera_tag = "Helmet Cam"
 	var/camera_network = CAMERA_NETWORK_PUBLIC


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the COVERSEYES flag from camera helmets and engineering hard hats. Everything else under the /obj/item/clothing/head/helmet path should be unaffected.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Judging by their sprites, camera helmets and hard hats do not actually cover eyes.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Equipped hard hats and camera helmets, used laser eye mutation, they didn't catch fire. Used a welding helmet with its visor down and it caught fire as expected. Used a welding helmet with its visor up and a chef hat and they didn't catch fire.
