### PR TITLE
Fixes #25740 - Speech Bubble Fix

### DIFF
--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -303,7 +303,7 @@
 		if ("!")
 			speech_bubble_icon = src.speaker.speech_bubble_icon_exclaim
 		else
-			var/number = text2num(src.content)
+			var/number = text2num(src.original_content)
 			if (number && (((number >= 0) && (number <= 20)) || number == 420))
 				speech_bubble_icon = "[number]"
 


### PR DESCRIPTION
## About The PR:
Fixes #25740 by applying `text2num()` to the original content of a message, as `content` will always have a mutable tag prepended, preventing `text2num()` from returning numbers. Heart bubbles never existed, however.


## Testing:
<img width="212" height="267" alt="image" src="https://github.com/user-attachments/assets/119ab6bf-3e59-47d8-bdb4-bf2b4bf27cd1" />