### PR TITLE
Increase the agent b output of molitz beta

### DIFF
--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -432,7 +432,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		var/datum/gas_mixture/payload = new /datum/gas_mixture
 
 		if(agent_b && air.toxins > MINIMUM_REACT_QUANTITY)
-			payload.oxygen_agent_b += 0.18 * owner.material_amt
+			payload.oxygen_agent_b += 0.5 * owner.material_amt
 			payload.oxygen = 15 * owner.material_amt
 			payload.temperature = T0C //reduced temp is supposeed to represent endothermic reaction
 			air.merge(payload) //add it to the target air


### PR DESCRIPTION
[Balance][Material]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR increases the agent b-output of molitz beta from 0.18 mol per release to 0.5 mol

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The extraction of agent b from molitz b is a fun atmos challenge. However, the amount of molitz b released per crystal requires the use of a metric fuckton of crystals for a good amount.

This means that pipeburns are the preferred method of reaching very high temperatures and many people don't bother with molitz beta. The geodes were a good step in the direction of pushing hellburns again and hopefully this change makes it more feasable for engineers to chuck in a few blocks of molitz beta in the burn chamber... or do a proper extraction setup.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Since it's a numerical change, i just compiled it and tried releasing some agent b. Nothing broke.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)The output of agent b of molitz beta crystals was increased by around 150%.
```
