### PR TITLE
Allows IV bags to be openned with snipping tools

### DIFF
--- a/code/modules/chemistry/tools/iv_drips.dm
+++ b/code/modules/chemistry/tools/iv_drips.dm
@@ -126,9 +126,9 @@
 			return
 
 	attackby(obj/A, mob/user)
-		if (iscuttingtool(A) && !(src.slashed))
+		if ((iscuttingtool(A) || issnippingtool(A)) && !(src.slashed))
 			src.slashed = 1
-			src.desc = "[src.desc] It has been sliced open with a scalpel."
+			src.desc = "[src.desc] It has been sliced open."
 			boutput(user, "You carefully slice [src] open.")
 			return
 		else if (iscuttingtool(A) && (src.slashed))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
IV bags can now be opened with snipping tools alongside cutting tools

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's unintuitive that a scapel can cut open an IV bag while scissors can't. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Works ingame yeah
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(+)IV bags can now be sliced open with snipping tools such as wirecutters or scissors.
```
