### PR TITLE
Deletes the mining transit shuttle on battle royale

### DIFF
--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -152,6 +152,8 @@ var/global/area/current_battle_spawn = null
 				qdel(machine)
 			if (/obj/deployable_turret/riot)
 				qdel(machine)
+			if (/obj/machinery/computer/transit_shuttle/mining)
+				qdel(machine)
 
 	for_by_tcl(circuitboard, /obj/item/circuitboard)
 		qdel(circuitboard)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You're not really meant to go off station
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
Not needed probably
## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

No
