### PR TITLE
Fixes access implants eating ID cards

### DIFF
--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -563,7 +563,7 @@
 /obj/machinery/computer/card/attackby(obj/item/I, mob/user)
 	//grab the ID card from an access implant if this is one
 	var/modify_only = 0
-	if (istypes(I, list(/obj/item/implantcase/access, /obj/item/implant/access))
+	if (istypes(I, list(/obj/item/implantcase/access, /obj/item/implant/access)))
 		if (!src.modify)
 			I = get_card_from(I)
 		else if (!src.scan)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #25809 by checking if a target ID is inserted before overriding it with an implant

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
- Inserted both an authentication and target IDs into an ID computer
- Hit the ID computer with an access implant
- The ID didn't vanish

Also tested all other ID/implant combinations to make sure no other similiar issues were created.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
