### PR TITLE
Fixes #24631 - Ghost "Teleport To" Command Fix

### DIFF
--- a/code/datums/browserOutput.dm
+++ b/code/datums/browserOutput.dm
@@ -245,7 +245,7 @@ var/global
 
 /// Called by js client on admin command via context menu
 /datum/chatOutput/proc/handleContextMenu(command, target)
-	if (!src.owner.holder && command != "observe" && command != "teleport") return // oopsy i'm so messy heehee
+	if (!src.owner.holder && command != "observe" && command != "ghostjump") return // oopsy i'm so messy heehee
 	var/datum/mind/targetMind = locate(target)
 	var/mob/targetMob
 	if (targetMind)
@@ -287,7 +287,7 @@ var/global
 					obs.set_observe_target(targetMob)
 			if(istype(src.owner.mob, /mob/dead/observer))
 				src.owner.mob:insert_observer(targetMob)
-		if ("teleport")
+		if ("ghostjump")
 			if (istype(src.owner.mob, /mob/dead/target_observer))
 				var/mob/dead/target_observer/obs = src.owner.mob
 				if (!obs.locked)


### PR DESCRIPTION
## About The PR:
Fixes #24631, which was caused by `"ghostjump"` being incorrectly termed `"teleport"` in `handleContextMenu()`.


## Testing:
The command now works as expected both as a player and as an admin.