### PR TITLE
Adds flavored vape cartridges to the game

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1342,6 +1342,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item)
 		product_list += new/datum/data/vending_product(/obj/item/decoration/ashtray, 5, cost=PAY_TRADESMAN/10)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/vape, 10, cost=PAY_TRADESMAN/2)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/ecig_refill_cartridge, 20, cost=PAY_TRADESMAN/5)
+		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/ecig_refill_cartridge/flavored, 10, cost=PAY_TRADESMAN/3)
 		product_list += new/datum/data/vending_product(/obj/item/item_box/medical_patches/nicotine, 5, cost=PAY_TRADESMAN/5)
 		product_list += new/datum/data/vending_product(/obj/item/paper, 20, cost=PAY_TRADESMAN/20)
 

--- a/code/obj/item/misc_junk.dm
+++ b/code/obj/item/misc_junk.dm
@@ -334,7 +334,7 @@ TYPEINFO(/obj/item/reagent_containers/vape)
 	c_flags = ONBELT
 	var/emagged = 0
 	var/last_used = 0
-	var/list/safe_smokables = list("nicotine", "THC", "CBD")
+	var/list/safe_smokables = list("nicotine", "THC", "CBD", "beff", "fizzy_banana", "beer", "menthol", "synaptizine", "cryostylane", "barbecue_sauce", "strawberry_milk")
 	var/datum/effects/system/bad_smoke_spread/smoke
 	var/range = 1
 
@@ -475,6 +475,17 @@ TYPEINFO(/obj/item/reagent_containers/vape)
 	item_state = "ecigrefill"
 	icon_state = "ecigrefill"
 	flags = TABLEPASS
+
+	flavored
+		name = "flavored E-cigarette refill pack"
+		desc = "A small black box full of flavors fun for the whole family"
+		var/list/flavors = list("beff", "fizzy_banana", "beer", "menthol", "synaptizine", "cryostylane", "barbecue_sauce", "strawberry_milk") // when changing make sure you adjust safe_whitelist on vapes
+		initial_reagents = null
+
+		New()
+			..()
+			src.reagents.add_reagent("nicotine", 25)
+			src.reagents.add_reagent(pick(flavors), 25)
 
 /obj/item/trophy
 	name = "trophy"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cigarette machines now sell 10 flavored vape cartridges that contain 25u nicotine alongside 25u of one of the following. beff, fizzy banana, beer, menthol, synaptizine, cryostylane, barbecue sauce, and strawberry milk. This costs 100 credits per cartridge.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I wish to become more obnoxious

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Purchased in game and analyzed with a reagant scanner
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ikea
(+)You can now find flavored vape cartridges in cigarette machines.
```
