### PR TITLE
Airlock autoclose directly relies on AI wire rather than control bein…

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -886,7 +886,7 @@ var/global/list/cycling_airlocks = list()
 	return 0
 
 /obj/machinery/door/airlock/autoclose()
-	if (src.wires & AIRLOCK_WIRE_AI_CONTROL)
+	if (!src.isWireCut(AIRLOCK_WIRE_AI_CONTROL))
 		if(!src.welded)
 			close(0, 1)
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes airlock autoclosing to be tied directly to the AI control wire rather than if AI access is disabled. This allows doors with AI access disabled by default to still autoclose. This includes:
- All "reinforced" airlocks (Arrivals, Syndicate(including listening post), Centcom)
- Doors with their AI access disabled via ion storm
- Any doors mapped with Ai access disablers (Armory) or varedited to have their AI access disabled.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Doors autoclosing should be considered the default behaviour and not tied to if the silicons have access. Silicon access would reasonably be denied by these airlocks while being designed to retain their autoclose functionality. You can still have an airlock that by default won't close by changing the autoclose variable to 0.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
From left to right: Syndicate airlock, Armory airlock with ai access disabler, Armory airlock without disabler. All closed automatically
<img width="264" height="263" alt="image" src="https://github.com/user-attachments/assets/e067ae60-2861-48f8-9434-4c2aea16153f" /><img width="263" height="266" alt="image" src="https://github.com/user-attachments/assets/bb83840c-4763-4da7-bdff-3d13e12a0824" />
Standard airlock with AI wire cut did not autoclose
<img width="135" height="230" alt="image" src="https://github.com/user-attachments/assets/736e677a-fa8f-444f-98d3-4f1838193a9d" /><img width="75" height="211" alt="image" src="https://github.com/user-attachments/assets/76780b13-6ac5-4588-a1fd-a8a45c3a4661" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Airlocks autoclosing is now only disabled if the AI wire was cut, rather than if AI control was disabled. This means airlocks with AI control disabled by default such as Armory, Arrivals and Syndicate will still autoclose.
```
