### PR TITLE
Change when hit twitch animations occur

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1099,7 +1099,12 @@ TYPEINFO(/mob)
 
 // for mobs without organs
 /mob/proc/TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss=FALSE)
-	hit_twitch(src)
+	if (src.nodamage || QDELETED(src)) return
+
+	if (brute > 0)
+		hit_twitch(src)
+	else if((burn > 0 || tox > 0) && isalive(src) && !src.hasStatus("paralysis"))
+		hit_twitch(src)
 	src.health -= max(0, brute)
 	src.health -= max(0, (src.bioHolder?.HasEffect("fire_resist") > 1) ? burn/2 : burn)
 

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -316,7 +316,15 @@
 /mob/living/carbon/human/TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss, var/bypass_reversal = FALSE)
 	if (src.nodamage || QDELETED(src)) return
 
-	hit_twitch(src)
+	if (brute > 0)
+		hit_twitch(src)
+	else if((burn > 0 || tox > 0) && isalive(src) && !src.hasStatus("paralysis"))
+		if (ischangeling(src))
+			var/datum/abilityHolder/changeling/C = get_ability_holder(/datum/abilityHolder/changeling)
+			if (!C || !C.in_fakedeath)
+				hit_twitch(src)
+		else
+			hit_twitch(src)
 
 	if (src.traitHolder && src.traitHolder.hasTrait("reversal") && !bypass_reversal)
 		src.HealDamage(zone, brute, burn, tox, TRUE)

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -17,8 +17,13 @@
 	if (src.hasStatus("paralysis"))
 		return //pls stop emoting :((
 
-	if (voluntary && (src.hasStatus("unconscious") || isunconscious(src)))
-		return
+	if (voluntary)
+		if (src.hasStatus("unconscious") || isunconscious(src))
+			return
+	else if (ischangeling(src))
+		var/datum/abilityHolder/changeling/C = src.get_ability_holder(/datum/abilityHolder/changeling)
+		if (C?.in_fakedeath)
+			return
 
 	if (src.bioHolder.HasEffect("revenant"))
 		src.visible_message(SPAN_ALERT("[src] makes [pick("a rude", "an eldritch", "a", "an eerie", "an otherworldly", "a netherly", "a spooky")] gesture!"), group = "revenant_emote")

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -918,10 +918,14 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 		src.was_harmed(thr.user, AM)
 
 /mob/living/critter/TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
-	if (brute > 0 || burn > 0 || tox > 0)
-		hit_twitch(src)
-	if (nodamage)
+	if (src.nodamage || QDELETED(src))
 		return
+
+	if (brute > 0)
+		hit_twitch(src)
+	else if((burn > 0 || tox > 0) && isalive(src) && !src.hasStatus("paralysis"))
+		hit_twitch(src)
+
 	var/datum/healthHolder/Br = get_health_holder("brute")
 	if (Br)
 		Br.TakeDamage(brute)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Brute damage always causes a hit twitch (as before)
* Burn and tox damage only causes hit twitches when someone is alive, not paralyzed, and not a changeling in fake death
* Changeling fakedeath prevents non-voluntary emotes.
* Adds some nodamage/QELETED checks for consistency

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hit twitches from fire and toxin damage don't make a lot of sense

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Dead bodies and the paralyzed only twitch if physically hit.
(*)Changeling "Regenerative Stasis" ability acts as dead for hit-twitches.
(+)Changeling "Regenerative Stasis" ability prevents forced emotes while faking death.
```
