### PR TITLE
Rearrange Cog1's Mining Magnet Area

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -42405,15 +42405,6 @@
 /turf/space,
 /area/space)
 "iie" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 15
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/yellow/side{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the mining nano-fab and telescope to the mining magnet control room.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Minor QoL changes are nice :) Having only the refining nano-fab in there was less useful, and the sheet extruder being blocked by 2 empty crates was odd.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Ran and tested the telescope and everything. All works.
<img width="575" height="534" alt="image" src="https://github.com/user-attachments/assets/4fcccfef-f6d1-44f1-b7db-89c2a4a924ea" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

