### PR TITLE
Cryotubes heat/cool chemicals in their corresponding beakers

### DIFF
--- a/code/modules/atmospherics/machinery/unary/cryo_cell.dm
+++ b/code/modules/atmospherics/machinery/unary/cryo_cell.dm
@@ -1,3 +1,6 @@
+#define CRYO_ATMOS_INTERACTION_TRESHOLD 1 MOLES
+#define CRYO_MOB_HEAL_TRESHOLD 10 MOLES
+
 TYPEINFO(/obj/machinery/atmospherics/unary/cryo_cell)
 	mats = list("cobryl" = 100,
 				"crystal" = 50,
@@ -63,7 +66,7 @@ TYPEINFO(/obj/machinery/atmospherics/unary/cryo_cell)
 		src.use_power(src.occupied_power_use, EQUIP)
 
 	if(src.air_contents)
-		if(src.beaker)
+		if(src.beaker && TOTAL_MOLES(src.air_contents) >= CRYO_ATMOS_INTERACTION_TRESHOLD)
 			// cryotubes cool people and the chemicals they keep in them
 			src.beaker.reagents.temperature_reagents(src.air_contents.temperature, exposed_volume = (600 + src.beaker.reagents.total_volume * 7.5), change_cap = 30)
 		src.ARCHIVED(temperature) = src.air_contents.temperature
@@ -377,7 +380,7 @@ TYPEINFO(/obj/machinery/atmospherics/unary/cryo_cell)
 		src.UpdateOverlays(null, "defib")
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/process_occupant()
-	if(TOTAL_MOLES(src.air_contents) < 10 MOLES)
+	if(TOTAL_MOLES(src.air_contents) < CRYO_MOB_HEAL_TRESHOLD)
 		return
 	if(ishuman(src.occupant))
 		if(isdead(src.occupant))
@@ -405,7 +408,7 @@ TYPEINFO(/obj/machinery/atmospherics/unary/cryo_cell)
 
 /// Slowly heats air_contents to 20C
 /obj/machinery/atmospherics/unary/cryo_cell/proc/heat_gas_contents()
-	if(TOTAL_MOLES(air_contents) < 1 MOLE)
+	if(TOTAL_MOLES(air_contents) < CRYO_ATMOS_INTERACTION_TRESHOLD)
 		return
 	var/air_heat_capacity = HEAT_CAPACITY(src.air_contents)
 	var/combined_heat_capacity = src.current_heat_capacity + air_heat_capacity
@@ -415,7 +418,7 @@ TYPEINFO(/obj/machinery/atmospherics/unary/cryo_cell)
 
 /// Leaks some gas out.
 /obj/machinery/atmospherics/unary/cryo_cell/proc/expel_gas()
-	if(TOTAL_MOLES(src.air_contents) < 1)
+	if(TOTAL_MOLES(src.air_contents) < CRYO_ATMOS_INTERACTION_TRESHOLD)
 		return
 	var/remove_amount = TOTAL_MOLES(src.air_contents)/100
 	var/datum/gas_mixture/expel_gas = air_contents.remove(remove_amount)
@@ -500,3 +503,6 @@ TYPEINFO(/obj/machinery/atmospherics/unary/cryo_cell)
 	icon = 'icons/obj/Cryogenic2.dmi'
 	layer = 3
 	icon_state = "defib-shock"
+
+#undef CRYO_ATMOS_INTERACTION_TRESHOLD
+#undef CRYO_MOB_HEAL_TRESHOLD


### PR DESCRIPTION
[Chemistry][Feature]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes it so beakers inserted in cryotubes adjust their temperature to the gas-temperature in the cryotube

Also, chemicals inserted in the cryotube cannot burn/frostburn people anymore

To facilitate this, cryotubes beakers are now pathed to glas items and they use defines for the mol thresholds

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This allows doctors to do chemical reactions that do require cooling without accessing the pharmacy and chemistry.

This is relevant for the parazamine-PR (#25944) and aranesp.

Also, terribly burning people with superhot chems inserted in the cryotube was always odd and even partially an abuse case. I hope loosing this functionality is worth having a hobo-esque chemistry tool for doctors.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->


https://github.com/user-attachments/assets/2ea0101f-8ba3-4f0e-aaea-a419ae04adf2

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Lord_Earthfire
(+)Cryotubes will adjust the temperature of chemicals inserted into them to the temperature of the cryotube
(+)Chemicals inserted into cryotubes cannot burn/frostburn their occupants anymore
```
