### PR TITLE
Increase baseline payout of prototypist requisitions

### DIFF
--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -572,9 +572,9 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 #define GOAL_MANUFACTURE 2
 #define GOAL_REFINEMENT 3
 
-//Prototypist contract; payout in cash is notably lower than usual on purpose, since you get "paid in items"
+//Prototypist contract; raw payout relative to effort is lower than usual, but you'll get a special item reward as partial barter
 /datum/req_contract/scientific/prototypist
-	payout = PAY_DOCTORATE
+	payout = PAY_DOCTORATE * 6
 	weight = 180
 
 	var/list/namevary = list("Prototyping Assistance","Cutting-Edge Endeavor","Investment Opportunity","Limited Run","Overhaul Project")
@@ -587,7 +587,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 
 	New()
 		src.name = pick(namevary)
-		src.payout += rand(0,80) * 10
+		src.payout += rand(0,35) * 50
 
 		///Identifier of the "prototypist", using defines set up above; associated with what category of product is being developed by the client.
 		var/prototypist_id = rand(1,NUM_PROTOTYPISTS)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Increases the baseline payout of prototypist requisitions (before any additional payout relating to individual components) from 800-1400 to 3600-5350. This still comes in below most other requisitions in the category, but by a notably smaller margin.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

While the intent is that prototypist requisitions have part of their value "replaced" with the random additional bonus, the remaining payout felt less like a slightly diminished baseline and more like a bit of spare change you also got along with the items - this should hopefully make prototypist requisitions feel like a bit less of a "dead slot" if you're not particularly excited about the additional item(s) the prototypist has chucked in, and more reliably rewarding to complete.

## Testing

Strictly numerical change without any alterations to functionality.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Increased the baseline payout range of prototypist requisitions (800-1400 > 3600-5350).
```
