### PR TITLE
Add missing tooltip rebuilds to assembly code

### DIFF
--- a/code/obj/item/assembly/misc_assemblies.dm
+++ b/code/obj/item/assembly/misc_assemblies.dm
@@ -112,6 +112,7 @@ Contains:
 		SEND_SIGNAL(src.applier, COMSIG_ITEM_ASSEMBLY_ITEM_ON_TARGET_ADDITION, src, user, new_target)
 	src.UpdateIcon()
 	src.UpdateName()
+	src.tooltip_rebuild = TRUE
 
 /obj/item/assembly/proc/get_trigger_state(var/affected_assembly)
 	if(src.secured)
@@ -529,6 +530,7 @@ Contains:
 	SEND_SIGNAL(src.applier, COMSIG_ITEM_ASSEMBLY_ITEM_SETUP, src, null, FALSE)
 	src.UpdateIcon()
 	src.UpdateName()
+	src.tooltip_rebuild = TRUE
 
 
 ///This proc removes all items attached to the assembly and removes it
@@ -606,6 +608,7 @@ Contains:
 	//Last but not least, we update our icon, w_class and name
 	src.UpdateIcon()
 	src.UpdateName()
+	src.tooltip_rebuild = TRUE
 	//Some Admin logging/messaging
 	logTheThing(LOG_BOMBING, user, "A [src.name] was created at [log_loc(src)]. Created by: [key_name(user)];[src.get_additional_logging_information(user)]")
 	if(src.requires_admin_messaging())
@@ -647,6 +650,7 @@ Contains:
 	SEND_SIGNAL(src, COMSIG_MOVABLE_CONTRABAND_CHANGED, FALSE)
 	src.UpdateIcon()
 	src.UpdateName()
+	src.tooltip_rebuild = TRUE
 	// Since the assembly was done, return TRUE
 	user.put_in_hand_or_drop(src)
 	return TRUE

--- a/code/obj/item/mousetrap.dm
+++ b/code/obj/item/mousetrap.dm
@@ -321,6 +321,7 @@
 		src.frame.master = src
 		// mousetrap roller + wrench -> disassembly
 		src.AddComponent(/datum/component/assembly, TOOL_WRENCHING, PROC_REF(disassemble), FALSE)
+		src.tooltip_rebuild = TRUE
 
 	disposing()
 		UnregisterSignal(src, COMSIG_ITEM_ASSEMBLY_ON_PART_DISPOSAL)


### PR DESCRIPTION
[Internal][Bug]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds `tooltip_rebuild` to the procs of assemblies whenever they are build or modified.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The tooltips of the assemblies were not updating properly, causing issues. This PR fixes #25948

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tried making a singletank bomb. 

<img width="320" height="295" alt="grafik" src="https://github.com/user-attachments/assets/ed535f24-e46c-4c18-afaa-d2a4cf37109b" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
