### PR TITLE
Delete Queue Bugfixes

### DIFF
--- a/code/datums/controllers/process/delete_queue.dm
+++ b/code/datums/controllers/process/delete_queue.dm
@@ -48,11 +48,12 @@ var/global/harddel_count = 0
 
 		//var/t_gccount = gccount
 		//var/t_delcount = delcount
-		for (var/numr in global.delete_queue_2[global.delqueue_pos])
+		for (var/ref as anything in global.delete_queue_2[global.delqueue_pos])
 			scheck()
 
-			var/r = NUM_TO_ADDR(numr)
-			var/datum/D = locate(r)
+			var/datum/D = locate(ref)
+			var/refcount = refcount(D) - 1
+
 			if (!istype(D) || !D.qdeled)
 				// If we can't locate it, it got garbage collected.
 				// If it isn't disposed, it got garbage collected and then a new thing used its ref.
@@ -61,7 +62,7 @@ var/global/harddel_count = 0
 
 			SPAWN(0)
 #ifdef HARD_DELETIONS_DISABLED
-				var/harddel_msg = "Didn't GC (with refcount [refcount(D)]): \ref[D]"
+				var/harddel_msg = "Didn't GC (with refcount [refcount]): [ref]"
 #else
 				var/harddel_msg = "HardDel of"
 #endif

--- a/code/del.dm
+++ b/code/del.dm
@@ -51,8 +51,7 @@ proc/qdel(var/datum/D)
 		//	D.qdeltime = world.time
 
 		// delete_queue.enqueue("\ref[O]")
-		var/refD = "\ref[D]"
-		delete_queue_2[((delqueue_pos + DELQUEUE_WAIT) % DELQUEUE_SIZE) + 1] += ADDR_TO_NUM(refD)
+		delete_queue_2[((delqueue_pos + DELQUEUE_WAIT) % DELQUEUE_SIZE) + 1] += ref(D)
 	else
 		if(islist(D))
 			D:len = 0


### PR DESCRIPTION
## About The PR:
Reversion of 734ca97, which causes the delete queue to miss qdeleted datums whose references are converted to numbers exceeding the maximum integer value.
Also fixes the recorded reference count being two refcounts larger than the true value, caused by the local variable `D` and its image under `SPAWN` not being considered.


## Testing:
<img width="700" height="45" alt="image" src="https://github.com/user-attachments/assets/01b39d59-ecac-4935-b798-f4a37f74c716" />