### PR TITLE
I_WANNA_DO_CRIME build define

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -51,6 +51,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define SHOW_ME_STATUSES // incredibly hacky visible status effects
 //#define ME_AND_MY_40_ALT_ACCOUNTS // Override game mode minimum player requirements for testing revs, nukies etc.
 //#define I_WANNA_BE_THE_JOB "IMCODER" // Spawn as a 'imcoder' job. Gives CE belt, captain ID, etc. Change string to different job ID as needed
+//#define I_WANNA_DO_CRIME ROLE_TRAITOR // Spawn as the matching antagonist role as defined in _std\defines\roles.dm
 //#define NO_ADMIN_SPEECH_MODULES // Loads the admin speech and listen module trees without any modules.
 //#define NO_PREGAME_HTML // Don't spawn the HTML pregame browser lobby screen
 

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -251,6 +251,16 @@ var/global/game_force_started = FALSE
 	//Equip characters
 	equip_characters()
 
+#ifdef I_WANNA_DO_CRIME
+	SPAWN(1 SECOND) //Avoids runtiming on certain special job setups changing equipment through SPAWN()s of their own
+		for (var/datum/mind/mind in src.minds)
+			if(!mind.current.client)
+				continue
+			mind.add_antagonist(I_WANNA_DO_CRIME)
+			if(isnull(mind.current.loc))
+				mind.current.set_loc(pick_landmark(LANDMARK_LATEJOIN))
+#endif
+
 #ifndef IM_REALLY_IN_A_FUCKING_HURRY_HERE
 	Z_LOG_DEBUG("Game Start", "Animating client colors to normal")
 	for (var/client/C in animateclients)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an I_WANNA_DO_CRIME define similar to I_WANNA_BE_THE_JOB that applies the antagonist role the define is.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sometimes you want to test antagonist stuff and don't want to have to change the mode or manually add the antagonist role to yourself.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested spawning as Traitor, Arcfiend, Blob, Nukeop and Mindhack, all worked as expected. There are probably some weird edge cases but those can be fixed as they come up.
<img width="1911" height="838" alt="image" src="https://github.com/user-attachments/assets/b70dbe32-3fad-42aa-b9d2-b7492b34e73b" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
