### PR TITLE
Add door draw layer

### DIFF
--- a/_std/defines/layer.dm
+++ b/_std/defines/layer.dm
@@ -22,9 +22,10 @@
 
 // More specific obj layers
 // OBJ_LAYER - 3
-#define SUB_TAG_LAYER		(OBJ_LAYER - 0.03) //! Graffiti that's been sprayed over sits here
-#define TAG_LAYER			(OBJ_LAYER - 0.02) //! Graffiti layer for gangs, this is the topmost (ie. most recent) tag on a turf
-#define STORAGE_LAYER		(OBJ_LAYER - 0.01) // Keep lockers etc below items
+#define SUB_TAG_LAYER		(OBJ_LAYER - 0.04) //! Graffiti that's been sprayed over sits here
+#define TAG_LAYER			(OBJ_LAYER - 0.03) //! Graffiti layer for gangs, this is the topmost (ie. most recent) tag on a turf
+#define DOOR_LAYER			(OBJ_LAYER - 0.02) // Keep doors below storage objects
+#define STORAGE_LAYER		(OBJ_LAYER - 0.01) // Keep storage objects below items
 #define ABOVE_OBJ_LAYER 	(OBJ_LAYER + 0.01) // For objects that should generally layer above other objects
 
 // Mob clothing and effect layers

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -21,6 +21,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 	var/operating = FALSE
 	var/operation_time = 1 SECOND
 	anchored = ANCHORED
+	layer = DOOR_LAYER
 	var/autoclose = FALSE
 	var/interrupt_autoclose = FALSE
 	var/last_used = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Moves doors' draw layer to a new DOOR_LAYER (2.98) which is under the STORAGE_LAYER (2.99). Bumps the TAG and SUB_TAG layers down by 0.01 to make room.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #8677 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="103" height="160" alt="image" src="https://github.com/user-attachments/assets/634ccf1e-c7d1-4454-9d43-0012fd7b0b12" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
