### PR TITLE
Make broken objectives slightly more sane (not too sane though)

### DIFF
--- a/code/modules/antagonists/eldritch_madness/broken.dm
+++ b/code/modules/antagonists/eldritch_madness/broken.dm
@@ -14,7 +14,8 @@
 /datum/antagonist/broken/assign_objectives()
 	if (!src.shared_objective_text)
 		var/objective_type = pick(concrete_typesof(/datum/objective/madness))
-		var/datum/objective/objective = new objective_type(null, src.owner, src)
+		var/datum/objective/madness/objective = new objective_type(null, src.owner, src)
+		objective.set_up_from_victims(list(src.owner.current))
 		src.shared_objective_text = objective.explanation_text
 	else
 		new /datum/objective/specialist(src.shared_objective_text, src.owner, src)

--- a/code/modules/events/madness.dm
+++ b/code/modules/events/madness.dm
@@ -84,9 +84,21 @@
 		src.num_victims = min(src.num_victims, length(potential_victims))
 		//frick u static
 		/datum/antagonist/broken::shared_objective_text = null
+		var/list/actual_victims = list()
 		for (var/i in 1 to src.num_victims)
-			var/mob/living/carbon/human/victim = pick(potential_victims)
-			victim.mind.add_antagonist(ROLE_BROKEN)
+			actual_victims += pick(potential_victims)
+
+		for (var/mob/living/carbon/human/victim in actual_victims)
+			if (!/datum/antagonist/broken::shared_objective_text)
+				var/objective_type = pick(concrete_typesof(/datum/objective/madness))
+				var/datum/objective/madness/objective = new objective_type(null, victim.mind)
+				objective.set_up_from_victims(actual_victims)
+				/datum/antagonist/broken::shared_objective_text = objective.explanation_text
+			else
+				var/datum/objective/specialist/objective = new(null, victim.mind)
+				objective.explanation_text = /datum/antagonist/broken::shared_objective_text
+			//we're handling objectives manually above so that we can pass the list of victims
+			victim.mind.add_antagonist(ROLE_BROKEN, do_objectives = FALSE)
 			message_admins("[key_name(victim)] surrendered to madness and became a broken antagonist. Source: [source ? "[source]" : "random event"]")
 			logTheThing(LOG_ADMIN, victim, "surrendered to madness and became a broken antagonist. Source: [source ? "[source]" : "random event"]")
 			potential_victims -= victim


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactors broken objective code to allow it to be aware of who is being affected by the event when choosing an objective. The following conditions now apply:
- The captain cannot be broken to destroy the captain, Jones, or Stirstir
- The HoS cannot be broken to destroy Sylvester or Stirstir
- Janitors cannot be broken to kill all janitors
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Thread here: https://forum.ss13.co/showthread.php?tid=25009
tl;dr: there's no conflict if someone with clearance to destroy the thing immediately destroys the thing, HoS and captains can still be broken to blow up genetics etc as god intended.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested both manually adding the antagonist role and running the event.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Neon broken event objectives have been tweaked slightly to ensure there is always conflict.
```
