### PR TITLE
Reinstate barcode click-dragging with AfterAttack trigger

### DIFF
--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -502,6 +502,10 @@ ADMIN_INTERACT_PROCS(/obj/storage, proc/open, proc/close, proc/break_open)
 				user.set_loc(T)
 				return
 
+		if (istype(O,/obj/item/sticker/barcode) && !src.open) //only do it on closed storages, so you can bring barcodes somewhere if you need to
+			O:AfterAttack(src,user,1)
+			return
+
 		if (src.locked)
 			user.show_text("You'll have to unlock [src] first.", "red")
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Mouse-dropping a barcode onto a closed large storage calls its after-attack behavior (attachment and labeling).

Avoids the problems as previously seen in issue #22849 by relying on the barcode's own after-attack behavior instead of reimplementing attachment from scratch (should also mean any future updates to barcode attachment behavior won't take any alteration here).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Useful capability to have, and follows from the help message visible on the sticker parent type (denoting that you can attach directly to storage items by click-dragging; while these kinds of storages aren't items, being able to do the same thing to them seems like a natural continuation). Barcode printer is nice, but this is helpful in general for silicons and humans alike.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Validated ingame that:

* Click-dragging a barcode onto the storage correctly prompts the afterattack.
* The barcode won't apply if you're near the storage but not the barcode, and vice versa.
* The barcode won't apply if you're near the storage and barcode, but are an ephemeral entity (AI eyeghost).

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(*)Barcodes can once again be click-dragged onto large storages (while they're closed).
```
