### PR TITLE
Completely Implements the Glassware Spawner Mapping Helper 

### DIFF
--- a/assets/maps/devtest_prefabs/explosion_test.dmm
+++ b/assets/maps/devtest_prefabs/explosion_test.dmm
@@ -1153,6 +1153,7 @@
 /obj/item/device/radio/intercom/medical{
 	dir = 8
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/space)
 "MJ" = (

--- a/assets/maps/prefabs/space/prefab_customs_shuttle.dmm
+++ b/assets/maps/prefabs/space/prefab_customs_shuttle.dmm
@@ -196,6 +196,7 @@
 	})
 "jS" = (
 /obj/machinery/chem_dispenser/soda,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor,
 /area/prefab/crashed_hop_shuttle)
 "kq" = (
@@ -443,6 +444,7 @@
 /area/prefab/crashed_hop_shuttle)
 "zM" = (
 /obj/machinery/chem_dispenser/alcohol,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor,
 /area/prefab/crashed_hop_shuttle)
 "Al" = (

--- a/assets/maps/prefabs/space/prefab_dreamplaza.dmm
+++ b/assets/maps/prefabs/space/prefab_dreamplaza.dmm
@@ -444,6 +444,7 @@
 /obj/machinery/chem_dispenser/chef{
 	pixel_y = 5
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purple/checker,
 /area/prefab/dreamplaza)
 "pa" = (

--- a/assets/maps/prefabs/space/prefab_safehouse.dmm
+++ b/assets/maps/prefabs/space/prefab_safehouse.dmm
@@ -443,6 +443,7 @@
 "ns" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/machinery/chem_dispenser/alcohol,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/prefab/safehouse)
 "nz" = (
@@ -452,6 +453,7 @@
 "nK" = (
 /obj/machinery/chem_dispenser/soda,
 /obj/decal/tile_edge/stripe/extra_big,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/prefab/safehouse)
 "nQ" = (

--- a/assets/maps/prefabs/space/prefab_silverglass.dmm
+++ b/assets/maps/prefabs/space/prefab_silverglass.dmm
@@ -1245,6 +1245,7 @@
 /obj/drink_rack/cup{
 	pixel_y = 32
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/variableTurf/clear,
 /area/prefab/silverglass/eats)
 "Tf" = (

--- a/assets/maps/prefabs/underwater/nadir/prefab_water_nadirelevator.dmm
+++ b/assets/maps/prefabs/underwater/nadir/prefab_water_nadirelevator.dmm
@@ -1020,11 +1020,13 @@
 /area/skeleton_trader)
 "Jj" = (
 /obj/machinery/chem_dispenser/soda,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black/grime,
 /area/diner/kitchen)
 "Jn" = (
 /obj/machinery/chem_dispenser/alcohol,
 /obj/decal/cleanable/dirt/dirt2,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black/grime,
 /area/diner/kitchen)
 "Jv" = (

--- a/assets/maps/prefabs/underwater/nadir_safe/prefab_water_sketchy.dmm
+++ b/assets/maps/prefabs/underwater/nadir_safe/prefab_water_sketchy.dmm
@@ -313,6 +313,7 @@
 /area/prefab/sea_sketch)
 "br" = (
 /obj/machinery/chem_dispenser/alcohol,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/grime,
 /area/prefab/sea_sketch)
 "bs" = (

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_blindpig.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_blindpig.dmm
@@ -38,6 +38,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/espresso_machine,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/wood,
 /area/prefab/blind_pig)
 "ak" = (
@@ -105,10 +106,12 @@
 /area/prefab/blind_pig)
 "az" = (
 /obj/machinery/chem_dispenser/alcohol,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/wood,
 /area/prefab/blind_pig)
 "aA" = (
 /obj/machinery/chem_dispenser/soda,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/wood,
 /area/prefab/blind_pig)
 "aB" = (

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_greenhouse.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_greenhouse.dmm
@@ -15,6 +15,7 @@
 /area/prefab/helianthus)
 "e" = (
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor,
 /area/prefab/helianthus)
 "f" = (

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_honk.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_honk.dmm
@@ -171,6 +171,7 @@
 /obj/machinery/light/small/floor/warm,
 /obj/machinery/chem_dispenser/soda,
 /obj/decal/cleanable/slime,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_seamonkey.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_seamonkey.dmm
@@ -111,6 +111,7 @@
 "az" = (
 /obj/machinery/chem_dispenser/chemical,
 /obj/decal/cleanable/dirt,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/white,
 /area/prefab/sea_monkey_hideout)
 "aA" = (
@@ -129,9 +130,7 @@
 /area/prefab/sea_monkey_hideout)
 "aC" = (
 /obj/table/auto,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/light/incandescent/cool/very,
-/obj/item/reagent_containers/pill/methamphetamine,
 /turf/simulated/floor/white,
 /area/prefab/sea_monkey_hideout)
 "aD" = (
@@ -1202,6 +1201,17 @@
 /mob/living/carbon/human/npc/monkey/sea/lab,
 /turf/simulated/floor/black/grime,
 /area/prefab/sea_monkey_hideout)
+"RM" = (
+/obj/item/reagent_containers/pill/methamphetamine{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/pill/methamphetamine{
+	pixel_x = -9;
+	pixel_y = -9
+	},
+/turf/simulated/floor/white,
+/area/prefab/sea_monkey_hideout)
 "WJ" = (
 /mob/living/carbon/human/npc/monkey/sea/gang,
 /turf/simulated/floor/plating/random,
@@ -1969,7 +1979,7 @@ ab
 aa
 aa
 aC
-aV
+RM
 bk
 bp
 bC

--- a/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_watertreatment.dmm
+++ b/assets/maps/prefabs/underwater/nadir_unsafe/prefab_water_watertreatment.dmm
@@ -129,6 +129,7 @@
 /area/prefab/water_treatment)
 "aC" = (
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -174,7 +175,6 @@
 /obj/item/clothing/glasses/spectro{
 	pixel_y = 9
 	},
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/purple/side{
 	dir = 9

--- a/assets/maps/random_rooms/3x5/beestro.dmm
+++ b/assets/maps/random_rooms/3x5/beestro.dmm
@@ -81,7 +81,7 @@
 "G" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/espresso_machine,
-/obj/item/reagent_containers/food/drinks/espressocup,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/bar,
 /area/dmm_suite/clear_area)
 "I" = (

--- a/assets/maps/random_rooms/3x5/coffeebar.dmm
+++ b/assets/maps/random_rooms/3x5/coffeebar.dmm
@@ -43,6 +43,7 @@
 /obj/machinery/espresso_machine{
 	pixel_y = 4
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/dmm_suite/clear_area)
 

--- a/assets/maps/random_rooms/3x5/minibar.dmm
+++ b/assets/maps/random_rooms/3x5/minibar.dmm
@@ -20,6 +20,7 @@
 /area/dmm_suite/clear_area)
 "h" = (
 /obj/machinery/chem_dispenser/alcohol,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/bar,
 /area/dmm_suite/clear_area)
 "M" = (

--- a/assets/maps/random_rooms/3x5/snailsoda.dmm
+++ b/assets/maps/random_rooms/3x5/snailsoda.dmm
@@ -227,6 +227,7 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	pixel_y = 10
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/white/checker2,
 /area/dmm_suite/clear_area)
 "V" = (

--- a/assets/maps/random_rooms/5x3/coffebar.dmm
+++ b/assets/maps/random_rooms/5x3/coffebar.dmm
@@ -30,6 +30,7 @@
 /obj/machinery/espresso_machine{
 	pixel_y = 4
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/dmm_suite/clear_area)
 "J" = (

--- a/assets/maps/random_rooms/5x3/donutkitchen.dmm
+++ b/assets/maps/random_rooms/5x3/donutkitchen.dmm
@@ -19,7 +19,7 @@
 /area/dmm_suite/clear_area)
 "j" = (
 /obj/machinery/chem_dispenser/chef,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/dmm_suite/clear_area)
 "v" = (

--- a/assets/maps/random_rooms/5x3/minibar.dmm
+++ b/assets/maps/random_rooms/5x3/minibar.dmm
@@ -17,7 +17,7 @@
 /area/dmm_suite/clear_area)
 "C" = (
 /obj/machinery/chem_dispenser/alcohol,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/bar,
 /area/dmm_suite/clear_area)
 "Q" = (
@@ -25,7 +25,7 @@
 /area/dmm_suite/clear_area)
 "S" = (
 /obj/machinery/chem_dispenser/soda,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/bar,
 /area/dmm_suite/clear_area)
 "Y" = (

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -9753,6 +9753,7 @@
 /area/station/turret_protected/Zeta)
 "dKA" = (
 /obj/machinery/chem_dispenser/chef,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/white/corner{
 	dir = 4
 	},
@@ -10424,10 +10425,7 @@
 /obj/machinery/espresso_machine{
 	pixel_y = 2
 	},
-/obj/item/reagent_containers/food/drinks/espressocup{
-	pixel_y = -1;
-	pixel_x = 10
-	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "eUz" = (
@@ -10615,6 +10613,7 @@
 /area/station/science/lab)
 "fhj" = (
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
@@ -14842,10 +14841,10 @@
 /area/station/security/brig)
 "ltD" = (
 /obj/machinery/chem_dispenser/alcohol/bar,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "ltF" = (
@@ -22709,6 +22708,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -1378,6 +1378,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "apT" = (
@@ -13391,6 +13392,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/autoname_east,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
 "eqq" = (
@@ -17702,7 +17704,7 @@
 /obj/disposalpipe/segment,
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purpleblack{
 	dir = 4
 	},
@@ -18120,7 +18122,7 @@
 /area/station/crew_quarters/cafeteria)
 "hNt" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
 "hNA" = (
@@ -21651,7 +21653,6 @@
 	pixel_x = -2;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/food/drinks/espressocup,
 /obj/item/clothing/head/helmet/space/santahat{
 	pixel_x = 12;
 	pixel_y = 13
@@ -21659,6 +21660,7 @@
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "kiu" = (
@@ -30028,6 +30030,7 @@
 	pixel_x = 10
 	},
 /obj/machinery/chem_dispenser/alcohol/bar,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/caution/west,
 /area/station/crew_quarters/bar)
 "qcy" = (
@@ -40180,6 +40183,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/caution/corner/sw,
 /area/station/crew_quarters/bar)
 "xoG" = (
@@ -41134,11 +41138,11 @@
 "xZx" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/light_switch/north{
 	pixel_x = -10;
 	pixel_y = 28
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -4212,6 +4212,7 @@
 	dir = 1;
 	icon_state = "xtra_bigstripe-edge2"
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "asv" = (
@@ -31258,8 +31259,8 @@
 /area/station/science/chemistry)
 "con" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/decal/tile_edge/stripe/extra_big,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor,
 /area/station/science/chemistry)
 "coo" = (
@@ -32252,10 +32253,10 @@
 /area/station/maintenance/southwest)
 "crw" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor,
 /area/station/science/chemistry)
 "crx" = (
@@ -43777,14 +43778,11 @@
 /obj/drink_rack/cup{
 	pixel_y = 28
 	},
-/obj/item/reagent_containers/food/drinks/espressocup{
-	pixel_y = 2;
-	pixel_x = 8
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6
 	},
 /obj/table/wood/auto/desk,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/bar)
 "iWb" = (
@@ -43978,6 +43976,7 @@
 	dir = 1;
 	pixel_y = 3
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/bar)
 "jeh" = (
@@ -56740,10 +56739,10 @@
 	dir = 4
 	},
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/shuttlebay,
 /area/station/crew_quarters/baroffice)
 "srd" = (
@@ -57986,7 +57985,7 @@
 "tmd" = (
 /obj/machinery/chem_dispenser/chemical,
 /obj/machinery/light,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/pharmacy)
 "tni" = (
@@ -62851,13 +62850,13 @@
 /area/station/security/detectives_office)
 "wDL" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
 /obj/machinery/camera/directional/south{
 	pixel_x = -10
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor,
 /area/station/science/chemistry)
 "wEe" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -8429,13 +8429,13 @@
 /area/station/crew_quarters/cafeteria)
 "aAY" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/light_switch/north,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fpurple2"
@@ -8446,7 +8446,7 @@
 /obj/drink_rack/cup{
 	pixel_y = 32
 	},
-/obj/item/reagent_containers/food/drinks/espressocup,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fpurple2"
@@ -8466,10 +8466,10 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /obj/machinery/partyalarm{
 	pixel_y = 28
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "fpurple2"
@@ -43316,7 +43316,7 @@
 /area/station/science/chemistry)
 "cJb" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purple,
 /area/station/science/chemistry)
 "cJc" = (
@@ -43337,8 +43337,8 @@
 /area/station/science/chemistry)
 "cJf" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/item/storage/wall/random,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purple,
 /area/station/science/chemistry)
 "cJg" = (
@@ -62043,6 +62043,7 @@
 /obj/machinery/camera/directional/west{
 	pixel_y = 10
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
@@ -63481,6 +63482,7 @@
 /area/station/security/checkpoint/podbay)
 "nQy" = (
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/engine{
 	icon_state = "engine_caution_misc"
 	},
@@ -63613,8 +63615,8 @@
 /area/station/hallway/primary/east)
 "nWM" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/firealarm/directional/east,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -64289,8 +64291,8 @@
 "oAR" = (
 /obj/machinery/chem_dispenser/alcohol,
 /obj/item/device/radio/intercom/catering,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /obj/noticeboard/persistent/bar/directional/north,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fpurple2"
@@ -74550,6 +74552,7 @@
 	dir = 4
 	},
 /obj/machinery/chem_dispenser/chef,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "xJW" = (

--- a/maps/density2.dmm
+++ b/maps/density2.dmm
@@ -705,10 +705,10 @@
 /area/station/turret_protected/ai_upload)
 "et" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/camera/directional/north{
 	pixel_x = -10
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "eD" = (
@@ -3182,6 +3182,7 @@
 "uJ" = (
 /obj/machinery/chem_dispenser/soda,
 /obj/decal/cleanable/dirt,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet/red/standard/edge/nw,
 /area/station/bridge)
 "uK" = (
@@ -3234,7 +3235,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher{
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1";
@@ -3749,6 +3749,7 @@
 "yP" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/espresso_machine,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet/red/standard/edge/se,
 /area/station/bridge)
 "yV" = (
@@ -5700,10 +5701,12 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "Nt" = (
 /obj/machinery/chem_dispenser/soda,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "Nu" = (
@@ -5773,7 +5776,7 @@
 /area/station/crew_quarters/cafeteria)
 "NO" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "NS" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -670,6 +670,7 @@
 "afZ" = (
 /obj/machinery/chem_dispenser/chemical,
 /obj/machinery/light/incandescent,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},
@@ -18584,6 +18585,7 @@
 	name = "Margaritaville Margarita Dispenser"
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
@@ -27352,6 +27354,7 @@
 /obj/machinery/chem_dispenser/soda,
 /obj/machinery/light/small/sticky,
 /obj/machinery/light_switch/west,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
@@ -38163,6 +38166,7 @@
 	},
 /obj/decal/cleanable/dirt/dirt2,
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/engine,
 /area/station/crew_quarters/bar)
 "pCY" = (
@@ -41010,6 +41014,7 @@
 /area/station/crew_quarters/fitness)
 "rlR" = (
 /obj/machinery/chem_dispenser/chef,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "rlV" = (
@@ -45269,6 +45274,7 @@
 /obj/drink_rack/cup{
 	pixel_y = -23
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "tKd" = (
@@ -46188,6 +46194,7 @@
 /obj/item/device/radio/intercom/medical{
 	dir = 8
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/white/checker,
 /area/station/medical/medbay/pharmacy)
 "ukm" = (
@@ -46267,6 +46274,7 @@
 	dir = 1
 	},
 /obj/machinery/light/incandescent,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/engine,
 /area/station/crew_quarters/bar)
 "umq" = (
@@ -46707,6 +46715,7 @@
 /obj/item/device/radio/intercom/science{
 	dir = 8
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
@@ -50544,6 +50553,7 @@
 	c_tag = "Chemistry";
 	pixel_y = 10
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -9967,10 +9967,7 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher{
-	pixel_x = -4;
-	pixel_y = 3
-	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor{
 	icon_state = "corner_east"
 	},
@@ -13886,10 +13883,7 @@
 /obj/machinery/camera/directional/north{
 	pixel_x = -10
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher{
-	pixel_x = 7;
-	pixel_y = 3
-	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/caution/corner/sw,
 /area/station/crew_quarters/bar)
 "ejc" = (
@@ -19844,11 +19838,8 @@
 	dir = 1
 	},
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = 6;
-	pixel_y = 1
-	},
 /obj/machinery/firealarm/directional/north,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -22439,6 +22430,7 @@
 /area/station/bridge)
 "gWm" = (
 /obj/machinery/chem_dispenser/chef,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/white/checker2{
 	dir = 1
 	},
@@ -22607,6 +22599,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -36438,6 +36431,7 @@
 /area/station/hallway/primary/west)
 "lsx" = (
 /obj/machinery/chem_dispenser/alcohol,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/bar,
 /area/station/wreckage{
 	name = "Restricted Area"
@@ -43983,6 +43977,7 @@
 	desc = "What? Security has moments of weakness too!";
 	name = "emergency alcohol dispenser"
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/wood/eight,
 /area/station/ai_monitored/armory)
 "nIN" = (
@@ -46878,18 +46873,11 @@
 /area/station/maintenance/inner/se)
 "oDm" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -5;
-	pixel_y = 1
-	},
 /obj/machinery/firealarm/directional/north,
-/obj/item/clothing/glasses/spectro{
-	pixel_x = 4;
-	pixel_y = -2
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor{
 	icon_state = "corner_east"
 	},
@@ -51926,9 +51914,6 @@
 /obj/machinery/espresso_machine{
 	pixel_y = 3
 	},
-/obj/item/reagent_containers/food/drinks/espressocup{
-	pixel_x = 7
-	},
 /obj/drink_rack/cup{
 	pixel_x = 1;
 	pixel_y = 30
@@ -51940,6 +51925,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "qfk" = (
@@ -64222,6 +64208,7 @@
 /obj/machinery/chem_dispenser/chemical,
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/disposalpipe/segment/mail,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -74548,6 +74535,7 @@
 /area/station/maintenance/inner/sw)
 "wWs" = (
 /obj/machinery/chem_dispenser/chef,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/white/checker2{
 	dir = 1
 	},
@@ -74647,6 +74635,7 @@
 	pixel_x = -29;
 	pixel_y = 3
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -78220,6 +78209,7 @@
 /area/station/medical/asylum/main)
 "xVQ" = (
 /obj/machinery/chem_dispenser/alcohol,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/medical/asylum/rec)
 "xVR" = (
@@ -79253,6 +79243,10 @@
 	},
 /obj/machinery/camera/directional/north{
 	pixel_x = -10
+	},
+/obj/item/clothing/glasses/spectro{
+	pixel_x = 12;
+	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)

--- a/maps/events/wrestlemap.dmm
+++ b/maps/events/wrestlemap.dmm
@@ -5784,6 +5784,7 @@
 	icon_state = "bot2";
 	tag = ""
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)
 "cAv" = (
@@ -6564,6 +6565,7 @@
 /area/station/hallway/primary/central)
 "cXv" = (
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -14863,6 +14865,7 @@
 /area/station/hallway/primary/south)
 "gIB" = (
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet/green/standard/edge/west,
 /area/station/crew_quarters/bar)
 "gIE" = (
@@ -16066,7 +16069,6 @@
 "hkT" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/storage/box/beakerbox,
-/obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)
 "hlq" = (
@@ -17400,11 +17402,11 @@
 /area/station/chapel/sanctuary)
 "hPk" = (
 /obj/machinery/chem_dispenser/soda,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /obj/machinery/light/incandescent/warm/very{
 	dir = 4;
 	pixel_x = 10
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet/green/fancy/junction/sw_n,
 /area/station/crew_quarters/jazz)
 "hPw" = (
@@ -22076,7 +22078,6 @@
 	pixel_x = 10
 	},
 /obj/machinery/chem_shaker/large/chemistry,
-/obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)
 "jQL" = (
@@ -24236,10 +24237,10 @@
 	tag = ""
 	},
 /obj/disposalpipe/segment/mail/vertical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/status_display{
 	pixel_y = 30
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/medical/head)
 "kPv" = (
@@ -25430,6 +25431,7 @@
 "lve" = (
 /obj/machinery/chem_dispenser/alcohol,
 /obj/decal/cleanable/cobweb,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/the_cage)
 "lvi" = (
@@ -34037,10 +34039,10 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/bar)
 "poi" = (
@@ -35422,7 +35424,7 @@
 /area/station/security/processing)
 "pXg" = (
 /obj/machinery/chem_dispenser/soda,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet/green/decal,
 /area/station/crew_quarters/bar)
 "pXi" = (
@@ -37944,10 +37946,10 @@
 /area/station/science/lobby)
 "rhG" = (
 /obj/machinery/chem_dispenser/alcohol,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /obj/machinery/firealarm/directional/east{
 	pixel_y = 1
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/jazz)
 "rhT" = (
@@ -43448,7 +43450,6 @@
 /area/station/mining/staff_room)
 "tJz" = (
 /obj/item/storage/box/beakerbox,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/table/reinforced/chemistry/auto,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/chemistry)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -11823,6 +11823,7 @@
 "aZy" = (
 /obj/machinery/chem_dispenser/chemical,
 /obj/item/device/radio/intercom/medical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/blueblack,
 /area/station/medical/medbay/pharmacy)
 "aZz" = (
@@ -14814,6 +14815,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/espresso_machine,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "boy" = (
@@ -15324,7 +15326,7 @@
 /area/station/hydroponics/bay)
 "bqX" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/clothing/glasses/spectro,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "bqZ" = (
@@ -18255,6 +18257,7 @@
 /area/station/science/chemistry)
 "bFh" = (
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},
@@ -27900,6 +27903,7 @@
 /obj/table/reinforced/chemistry/auto{
 	name = "prep counter"
 	},
+/obj/item/clothing/glasses/spectro,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "dfK" = (
@@ -35850,6 +35854,7 @@
 "iys" = (
 /obj/machinery/chem_dispenser/chemical,
 /obj/machinery/light_switch/north,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
 "iyU" = (
@@ -36667,6 +36672,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/crew_quarters/md)
 "iXZ" = (
@@ -46067,6 +46073,7 @@
 /obj/machinery/camera/directional/north{
 	pixel_x = 10
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
 "pzZ" = (
@@ -52743,6 +52750,7 @@
 /area/station/hallway/primary/south)
 "ueg" = (
 /obj/machinery/chem_dispenser/chef,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "uez" = (
@@ -53603,7 +53611,7 @@
 	pixel_x = -10
 	},
 /obj/machinery/chem_dispenser/alcohol/bar,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "uEM" = (

--- a/maps/mushroom.dmm
+++ b/maps/mushroom.dmm
@@ -3474,7 +3474,7 @@
 "auW" = (
 /obj/machinery/chem_dispenser/chemical,
 /obj/item/storage/box/beakerbox,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/baroffice)
 "avh" = (
@@ -7678,6 +7678,7 @@
 	pixel_y = 10
 	},
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
@@ -8906,7 +8907,7 @@
 /area/station/hallway/primary/west)
 "cUl" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/caution/south,
 /area/station/science/chemistry)
 "cUZ" = (
@@ -10239,6 +10240,10 @@
 /obj/machinery/light/small/floor,
 /obj/drink_rack/cup{
 	pixel_x = -27
+	},
+/obj/item/clothing/glasses/spectro{
+	pixel_x = 0;
+	pixel_y = 8
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "carpetSW"
@@ -15224,7 +15229,7 @@
 /area/station/science/hall)
 "hsp" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/caution/north{
 	dir = 8
 	},
@@ -18548,6 +18553,10 @@
 	dir = 4
 	},
 /obj/table/reinforced/bar/auto,
+/obj/item/kitchen/food_box/donut_box{
+	desc = "It appears to be a Martian brand of donuts.";
+	name = "Robust Donuts"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "jPK" = (
@@ -19585,6 +19594,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "kCj" = (
@@ -21981,11 +21991,8 @@
 /area/station/maintenance/southeast)
 "mph" = (
 /obj/table/reinforced/bar/auto,
-/obj/item/kitchen/food_box/donut_box{
-	desc = "It appears to be a Martian brand of donuts.";
-	name = "Robust Donuts"
-	},
 /obj/machinery/espresso_machine,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet{
 	icon_state = "carpetS"
 	},
@@ -28764,6 +28771,7 @@
 /area/station/crew_quarters/kitchen)
 "qJJ" = (
 /obj/machinery/chem_dispenser/chef,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "qKe" = (
@@ -40590,7 +40598,7 @@
 /area/station/chapel/sanctuary)
 "yiB" = (
 /obj/machinery/chem_dispenser/alcohol,
-/obj/item/clothing/glasses/spectro,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "yiJ" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -1406,6 +1406,7 @@
 /area/station/hallway/primary/northwest)
 "aEs" = (
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/engine/caution/south,
 /area/station/medical/head)
 "aEI" = (
@@ -1813,6 +1814,7 @@
 /area/pasiphae/bridge)
 "aRh" = (
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/engine/caution/east,
 /area/station/medical/medbay/pharmacy)
 "aRr" = (
@@ -3936,6 +3938,7 @@
 	})
 "bJE" = (
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/engine/caution/north,
 /area/station/science/chemistry)
 "bJF" = (
@@ -6223,6 +6226,7 @@
 	desc = "What? Security has moments of weakness too!";
 	name = "emergency alcohol dispenser"
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/engine/caution/south,
 /area/station/ai_monitored/armory)
 "cQf" = (
@@ -21923,6 +21927,7 @@
 	name = "Chemistry Lab Shutters";
 	pixel_y = 26
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
@@ -22287,6 +22292,7 @@
 /obj/machinery/phone/wall{
 	pixel_y = 32
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purpleblack{
 	dir = 1
 	},
@@ -29105,7 +29111,7 @@
 "mzV" = (
 /obj/machinery/chem_dispenser/chemical,
 /obj/machinery/firealarm/directional/west,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/engine/caution/west,
 /area/station/crew_quarters/baroffice)
 "mAa" = (
@@ -39384,10 +39390,10 @@
 "ror" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/chem_dispenser/alcohol/bar,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/engine/caution/corner{
 	dir = 4
 	},
@@ -47649,6 +47655,14 @@
 	dir = 8
 	},
 /area/station/security/main)
+"vfb" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/decal/cleanable/dirt/jen,
+/obj/item/raw_material/shard/glass,
+/turf/simulated/floor/grey,
+/area/pasiphae/bridge)
 "vfE" = (
 /obj/stool/chair{
 	dir = 4
@@ -47706,7 +47720,6 @@
 	pixel_y = 5
 	},
 /obj/noticeboard/persistent/bar/directional/north,
-/obj/item/reagent_containers/food/drinks/espressocup,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -47718,6 +47731,7 @@
 	dir = 4;
 	pixel_y = 4
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/engine,
 /area/station/crew_quarters/bar)
 "viB" = (
@@ -47841,6 +47855,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/crew_quarters/catering)
 "vlO" = (
@@ -122645,7 +122660,7 @@ bzS
 gtT
 rcO
 nVY
-vZZ
+vfb
 vSG
 vZZ
 rHX

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -1109,6 +1109,7 @@
 "aNf" = (
 /obj/machinery/chem_dispenser/chemical,
 /obj/machinery/light/incandescent/cool,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
 "aNk" = (
@@ -4253,8 +4254,8 @@
 /area/research_outpost/chamber)
 "dkp" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/light/incandescent/cool,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
@@ -17075,8 +17076,8 @@
 /area/station/science/lab)
 "mgn" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/light/incandescent/cool,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purplewhite{
 	dir = 8
 	},
@@ -19636,6 +19637,7 @@
 "odC" = (
 /obj/machinery/light/incandescent/warm,
 /obj/machinery/chem_dispenser/alcohol/bar,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
 "odE" = (
@@ -23718,6 +23720,7 @@
 /area/tech_outpost)
 "rbY" = (
 /obj/machinery/chem_dispenser/chef,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "rcm" = (
@@ -24449,6 +24452,7 @@
 /area/station/bridge/customs)
 "rDe" = (
 /obj/machinery/chem_dispenser/soda,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/grime,
 /area/diner/kitchen)
 "rDA" = (
@@ -25842,12 +25846,13 @@
 /area/station/turret_protected/Zeta)
 "sEW" = (
 /obj/table/wood/round/auto,
+/obj/drink_rack/cup{
+	pixel_y = 28
+	},
+/obj/mapping_helper/glassware_spawn,
 /obj/machinery/espresso_machine{
 	pixel_y = 8;
 	pixel_x = -8
-	},
-/obj/drink_rack/cup{
-	pixel_y = 28
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
@@ -33642,6 +33647,7 @@
 /obj/machinery/camera/directional/north{
 	pixel_x = -10
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "xWv" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -7533,10 +7533,10 @@
 /area/station/science/chemistry)
 "aHW" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/decal/poster/wallsign/poster_ptoe{
 	pixel_y = -28
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "aIb" = (
@@ -13109,6 +13109,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet/blue/decal/innercross,
 /area/station/crew_quarters/bar)
 "blv" = (
@@ -13219,12 +13220,16 @@
 /area/station/crew_quarters/kitchen)
 "blT" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/clothing/glasses/spectro,
+/obj/item/clothing/glasses/spectro{
+	pixel_x = -6;
+	pixel_y = 12
+	},
 /obj/machinery/power/apc/autoname_south,
 /obj/cable,
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet/blue/fancy/narrow/sw,
 /area/station/crew_quarters/bar)
 "blU" = (
@@ -22143,6 +22148,7 @@
 /area/diner/kitchen)
 "cca" = (
 /obj/machinery/chem_dispenser/alcohol,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/grime,
 /area/diner/kitchen)
 "ccc" = (
@@ -24552,6 +24558,7 @@
 /area/station/science/lobby)
 "cyx" = (
 /obj/machinery/chem_dispenser/chef,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/kitchen)
 "cyT" = (
@@ -26393,13 +26400,13 @@
 /area/station/janitor/office)
 "dVj" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/decal/poster/wallsign/poster_ptoe{
 	pixel_y = 32
 	},
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/purple/checker,
 /area/station/science/chemistry)
 "dVN" = (
@@ -30313,6 +30320,7 @@
 /area/station/security/main)
 "gVI" = (
 /obj/machinery/chem_dispenser/soda,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet/blue/decal/innercross,
 /area/station/crew_quarters/bar)
 "gVN" = (
@@ -32912,6 +32920,7 @@
 /obj/machinery/espresso_machine{
 	pixel_y = 4
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/carpet/blue/fancy/narrow/T_north,
 /area/station/crew_quarters/bar)
 "jll" = (
@@ -45051,6 +45060,7 @@
 "uay" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
 "ubx" = (

--- a/maps/pod_wars.dmm
+++ b/maps/pod_wars.dmm
@@ -231,6 +231,7 @@
 /area/pod_wars/spacejunk/restaurant)
 "aN" = (
 /obj/machinery/chem_dispenser/alcohol,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "aP" = (
@@ -1620,6 +1621,7 @@
 /area/pod_wars/spacejunk/uvb67/crew)
 "fS" = (
 /obj/machinery/chem_dispenser/alcohol/bar,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team2/bar)
 "fT" = (
@@ -3161,6 +3163,7 @@
 /area/pod_wars/team1/equipmentroom)
 "lK" = (
 /obj/machinery/chem_dispenser/medical,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/redwhite{
 	dir = 4
 	},
@@ -4184,8 +4187,8 @@
 /area/pod_wars/spacejunk/reliant)
 "pi" = (
 /obj/machinery/chem_dispenser/alcohol/bar,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /obj/machinery/light/incandescent/netural,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team1/bar)
 "pj" = (
@@ -5895,7 +5898,7 @@
 /area/pod_wars/spacejunk/reliant)
 "vL" = (
 /obj/machinery/chem_dispenser/soda,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
 "vM" = (
@@ -6202,6 +6205,7 @@
 "wK" = (
 /obj/machinery/light/incandescent/netural,
 /obj/machinery/chem_dispenser/medical/fortuna,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
 "wL" = (
@@ -9853,6 +9857,7 @@
 "JB" = (
 /obj/machinery/chem_dispenser/soda,
 /obj/machinery/light/incandescent/netural,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "JC" = (
@@ -9884,6 +9889,7 @@
 /area/pod_wars/team2/medbay)
 "JH" = (
 /obj/machinery/chem_dispenser/medical,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/bluewhite{
 	dir = 8
 	},
@@ -12130,7 +12136,7 @@
 /area/pod_wars/team2/bar)
 "Sf" = (
 /obj/machinery/chem_dispenser/alcohol,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
 "Sg" = (

--- a/maps/setpieces/wetworks.dmm
+++ b/maps/setpieces/wetworks.dmm
@@ -871,6 +871,7 @@
 	pixel_x = 10
 	},
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/shiny{
 	color = "aqua"
 	},

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -571,6 +571,7 @@
 /area/hospital)
 "adW" = (
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/white,
 /area/hospital)
 "adY" = (
@@ -12322,13 +12323,13 @@
 "baZ" = (
 /obj/table/auto,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/syringe,
 /obj/item/chem_grenade/cryo,
 /turf/unsimulated/floor/white,
 /area/upper_arctic/pod1)
 "bba" = (
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/white,
 /area/upper_arctic/pod1)
 "bbe" = (
@@ -21947,6 +21948,7 @@
 /area/solarium)
 "bKc" = (
 /obj/machinery/chem_dispenser/alcohol,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/specialroom/chapel{
 	dir = 1
 	},
@@ -24360,12 +24362,14 @@
 /area/crypt/sigma/mainhall)
 "bSi" = (
 /obj/machinery/chem_dispenser/soda,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/specialroom/chapel{
 	dir = 1
 	},
 /area/crypt/sigma/mainhall)
 "bSj" = (
 /obj/machinery/chem_dispenser/alcohol,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/specialroom/chapel{
 	dir = 4
 	},
@@ -24846,6 +24850,7 @@
 	mouse_opacity = 0
 	},
 /obj/machinery/chem_dispenser/botany,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/wood/three,
 /area/afterlife/heaven/hydroponics)
 "bUm" = (
@@ -32900,6 +32905,7 @@
 /area/owlery/lab)
 "cxt" = (
 /obj/machinery/chem_dispenser/chemical,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/black,
 /area/owlery/lab)
 "cxu" = (
@@ -44699,6 +44705,7 @@
 	icon_state = "tile1"
 	},
 /obj/machinery/espresso_machine,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/carpet{
 	dir = 1;
 	icon_state = "fred1"
@@ -50934,10 +50941,10 @@
 /area/centcom/lounge)
 "dIZ" = (
 /obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/black,
 /area/centcom/lounge)
 "dJa" = (
@@ -51057,12 +51064,12 @@
 /area/centcom/lounge)
 "dJr" = (
 /obj/machinery/chem_dispenser/soda,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/black,
 /area/centcom/lounge)
 "dJs" = (
 /obj/machinery/chem_dispenser/alcohol,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/black,
 /area/centcom/lounge)
 "dJt" = (
@@ -62515,7 +62522,7 @@
 /area/adventure/channel/flingy)
 "kfH" = (
 /obj/machinery/espresso_machine,
-/obj/item/reagent_containers/food/drinks/espressocup,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/outdoors/grass,
 /area/void_diner)
 "kfN" = (
@@ -65240,6 +65247,7 @@
 /area/watchful_eye_sensor)
 "mkm" = (
 /obj/machinery/chem_dispenser/soda,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/outdoors/grass,
 /area/void_diner)
 "mlf" = (
@@ -72071,6 +72079,7 @@
 /turf/unsimulated/floor,
 /area/centcom)
 "rtu" = (
+/obj/mapping_helper/glassware_spawn,
 /obj/machinery/chem_dispenser/soda{
 	pixel_y = 31;
 	density = 0
@@ -74530,6 +74539,7 @@
 "tnk" = (
 /obj/machinery/chem_dispenser/chemical,
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor/plating,
 /area/crater/biodome/research)
 "tnB" = (
@@ -76980,6 +76990,7 @@
 	dir = 8;
 	pixel_x = 4
 	},
+/obj/mapping_helper/glassware_spawn,
 /obj/machinery/chem_dispenser/alcohol/ultra{
 	pixel_y = 31;
 	density = 0

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -4224,7 +4224,7 @@
 /area/radiostation/engineering)
 "asW" = (
 /obj/machinery/espresso_machine,
-/obj/item/reagent_containers/food/drinks/espressocup,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/grime,
 /area/diner/kitchen)
 "atb" = (
@@ -19140,6 +19140,10 @@
 	name = "reinforced plating"
 	},
 /area/diner/motel/chemstorage)
+"kNT" = (
+/obj/item/raw_material/shard/glass,
+/turf/simulated/floor/white/grime,
+/area/derelict_ai_sat)
 "kOK" = (
 /turf/unsimulated/floor,
 /area/timewarp/ship)
@@ -23675,8 +23679,8 @@
 /area/timewarp/ship)
 "vpl" = (
 /obj/machinery/chem_dispenser/alcohol,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /obj/decal/cleanable/dirt,
+/obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/scorched2,
 /area/diner/kitchen)
 "vpt" = (
@@ -64605,7 +64609,7 @@ aRp
 aRo
 aRo
 aSl
-aRo
+kNT
 aTc
 amR
 uBm

--- a/maps/z3_water.dmm
+++ b/maps/z3_water.dmm
@@ -3489,6 +3489,7 @@
 /area/cult_base/leader)
 "qL" = (
 /obj/machinery/chem_dispenser/alcohol,
+/obj/mapping_helper/glassware_spawn,
 /turf/unsimulated/floor,
 /area/cult_base/leader)
 "qR" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[Mapping] [Chemistry] [QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR implements the glassware spawning mapping helper added in PR #25469 across ALL relevant maps. It hasn't been utilized on all chem dispensers since there are some cases where not having glassware start out in a chem dispenser is thematically appropriate.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
See the "Why's this needed?" section of #25469. Aside from that, implementing this helper across all maps ensures a standardized appearance for round start chem dispensers.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Testing to ensure the helper's functionality was done in the prior PR, but I've double-checked it with a couple of the maps changed in this one (Cog1 and Kondaru).
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)QuiteLiterallyAnything
(+)Beakers now appear directly inside most chemical dispensers at round start.
```
