### PR TITLE
Fix THE MONSTER recipe

### DIFF
--- a/code/modules/cooking/cookingrecipes.dm
+++ b/code/modules/cooking/cookingrecipes.dm
@@ -25,6 +25,8 @@ ABSTRACT_TYPE(/datum/recipe/burger)
 	category = "Burgers"
 
 	get_output(var/list/input_list, var/list/output_list)
+		if (length(ingredients) < 2)
+			return ..()
 		//this is dumb and assumes the second thing is always the meat but it usually is so :iiam:
 		var/obj/item/possibly_meat = locate(ingredients[2]) in input_list
 		if (possibly_meat?.reagents?.get_reagent_amount("crime") >= 5)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes an index out of bounds exception during THE MONSTER recipe. Checks that the ingredients list has at least two ingredients before performing the food crime check.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Error caused the recipe to fail and become unusable. 

Fixes #26023

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Spawn "bigburger - x4 to test recipe. 

https://github.com/user-attachments/assets/394a24ec-51cd-431e-88e4-49dab43d8afa

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->