### PR TITLE
Fixes touch-shy trait letting people shove others while lying down

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -745,8 +745,14 @@
 
 	proc/defend_personal_space(mob/owner, mob/target)
 		if(owner != target && can_act(owner) && target.a_intent == INTENT_HELP)
-			owner.disarm(target, is_special = TRUE)
-			playsound(owner, 'sound/impact_sounds/Generic_Swing_1.ogg', 50, TRUE)
+			if(!owner.lying) // Please stop shoving people when you're lying down, that's illegal
+				owner.disarm(target, is_special = TRUE)
+				playsound(owner, 'sound/impact_sounds/Generic_Swing_1.ogg', 50, TRUE)
+			else 
+				if(prob(80))
+					owner.emote(pick("flinch","twitch","twitch_v","shudder"))
+				else
+					owner.emote("scream")
 
 /* Hey dudes, I moved these over from the old bioEffect/Genetics system so they work on clone */
 


### PR DESCRIPTION
[Bug][Possibly Intended][Traits]

## About the PR 
if peoples with touch shy on floor ajd get clicked on withe helping hand, do not doe shoving of hander from floor anymore.
Instead! will do emoting or screaming (sometime) so peoples know they do not like the touching.

## Why's this needed? 
fixes #22885 
it is not alllowed to do shoving from floor! not even bad guy can do this...
may be some peoples want it? ¯\_(ツ)_/¯

## Testing 
give dumny anti_headpat, switch personses and fall down, switch persons again and click with HELP intend. New reactings like expected.
<img width="1457" height="653" alt="newbehavior" src="https://github.com/user-attachments/assets/eff10dd6-2ab7-4216-91b5-a0a1a7d84fff" />


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
Is it needinged? i do not know...

```changelog
(u)NibChocolateeny
(+)Touch-shy individuals no longer have the superpower of shoving people to the ground when touched while lying down. They will panic via emotes instead.
```
