### PR TITLE
Fixes flowers being incapable of getting thrown over tables 

### DIFF
--- a/code/obj/item/clothing/plants.dm
+++ b/code/obj/item/clothing/plants.dm
@@ -4,7 +4,7 @@
 	desc = "A pretty nice flower... you shouldn't see this, though."
 	icon_state = "flower_gard"
 	item_state = "flower_gard"
-	flags = SUPPRESSATTACK
+	flags = TABLEPASS | SUPPRESSATTACK
 	hide_attack = ATTACK_PARTIALLY_HIDDEN
 	var/datum/forensic_id/scent_A = null
 	var/datum/forensic_id/scent_B = null


### PR DESCRIPTION
[Bug][Hydroponics]

## About the PR 
make it so flowre can be toss over table

## Why's this needed? 
Fixes  #24614 , also fix all other flower not throwimg over table

## Testing
I do flower throwing. poke fingor. >:/
thowing works. 👍
<img width="1214" height="704" alt="tablepass_morelike_tableass_amiritefellas" src="https://github.com/user-attachments/assets/a5bb5a9a-885a-416a-bb91-cc675f31bd17" />

BUT...i chekc other thingy with "SUPPRESSATTACK" and it can not be thorw over table (/obj/item/triage_tagger)...very weird...

## Changelog 
not needing changelog, yes?

## question...
To develeoper: why does the "SUPPRESSATTACK" flag makeit so item do not pass over tables? I do not htink it is that good...for exemple, tiriage tag cannot throwover table.

there can be fix were, unless there is need for spesific item to not change, all "SUPPRESSATTACK" get "TABLEPASS" too. Or maybe can fix SUPPRESSATTACK...
