### PR TITLE
Fixes miscounted shot callouts for pod weapons that use ammo

### DIFF
--- a/code/modules/transport/pods/MainWeapon.dm
+++ b/code/modules/transport/pods/MainWeapon.dm
@@ -108,7 +108,11 @@
 			boutput(user, "[ship.ship_message("You need [ship.AmmoPerShot()] to fire the weapon. You currently have [remaining_ammunition] loaded.")]")
 			return
 		else
-			boutput(user, "[ship.ship_message("[remaining_ammunition] shots remaining.")]")
+			if(remaining_ammunition <= ship.AmmoPerShot())  //Janky because this gets called before ammo is decremented by shooting.
+				boutput(user, "[ship.ship_message("<b>All ammunition expended.</b>")]")
+			else
+				boutput(user, "[ship.ship_message("[remaining_ammunition - ship.AmmoPerShot()] shots remaining.")]")
+
 
 	var/rdir = ship.dir
 	if (shot_dir_override > 1)


### PR DESCRIPTION
[Vehicles][QoL][Bug]

## About the PR
for gun on pod that usea bullet (can run out), make it so shooting makes pod say the righet number of shot that are left (it was saying the numbere of shot left BEFORE doing shooting, so it make sound like can shoot 1 moer time than posssible)

## Why's this needed?
fixes #25860 , maybe? I am not so sure...
but it is better in any case

## Testing 
did testing on pep- gun and gerenade launcher gun. Both say number of ammos right now
<img width="2148" height="1083" alt="guntesting" src="https://github.com/user-attachments/assets/341ce406-20f1-44ec-bcb0-c5505d40d96a" />


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
ueeh, not needing it? it is for bug fix...