### PR TITLE
Allow VR ghosts to use the lawbringer

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1430,7 +1430,7 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 				"energy_high" = 5)
 	start_listen_effects = list(LISTEN_EFFECT_LAWBRINGER)
 	start_listen_modifiers = null
-	start_listen_inputs = list(LISTEN_INPUT_OUTLOUD_RANGE_0, LISTEN_INPUT_EQUIPPED)
+	start_listen_inputs = list(LISTEN_INPUT_OUTLOUD_RANGE_0, LISTEN_INPUT_EQUIPPED, LISTEN_INPUT_DEADCHAT)
 	start_listen_languages = list(LANGUAGE_ENGLISH)
 
 /obj/item/gun/energy/lawbringer
@@ -1477,15 +1477,6 @@ TYPEINFO(/obj/item/gun/energy/lawbringer)
 	get_desc(dist, mob/user)
 		if (user.mind.is_antagonist())
 			. += SPAN_ALERT("<b>It doesn't seem to like you...</b>")
-
-	pickup(mob/user)
-		. = ..()
-		if(isVRghost(user))
-			src.ensure_listen_tree().AddListenInput(LISTEN_INPUT_DEADCHAT)
-
-	dropped(mob/user)
-		. = ..()
-		src.ensure_listen_tree().RemoveListenInput(LISTEN_INPUT_DEADCHAT)
 
 	attack_hand(mob/user)
 		if (!owner_prints)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If a vr ghost is currently holding a lawbringer, allow it to hear deadchat. It will still ignore anyone that isn't holding it.

Its possible that allowing lawbringers to always hear deadchat would work but for sanity they only need it in this scenario.

Fixes #26049
Fixes #26050
Fixes #26059

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lets the lawbringers in the murderbox get used

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Could use lawbringer normally as a human, could use as VR ghost, could not use as observer.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
