### PR TITLE
Buff crystal plant yield and growth speed, prevents produce from scaling

### DIFF
--- a/code/modules/hydroponics/plants_alien.dm
+++ b/code/modules/hydroponics/plants_alien.dm
@@ -400,16 +400,17 @@ ABSTRACT_TYPE(/datum/plant/artifact)
 			user.show_text("You were interrupted!", "red")
 			return
 
-
-
 /datum/plant/crystal
 	name = "Crystal"
 	plant_icon = 'icons/obj/hydroponics/plants_alien.dmi'
 	sprite = "Crystal"
 	starthealth = 50
-	growtime = 300
-	harvtime = 600
+	growtime = 250
+	harvtime = 450
+	cropsize = 4
 	harvestable = 1
 	endurance = 100
 	vending = 0
+	stop_size_scaling = TRUE // Let's not have huge plasmaglass shards, that looks wacky
 	crop = /obj/item/raw_material/shard/plasmacrystal
+


### PR DESCRIPTION
[Hydroponics][Balance][QoL]

## About the PR
4 change to crystal platn:
1. decrease growth time (300 -> 250); a bit more long than rock plant (220)
2. decrease harvest time (600 -> 450); a bit less long than rock plant (500)
3. increase cropsize (0 -> 4)
4. adds "stop_size_scaling = TRUE"

## Why's this needed? 
after the hvasting rewrok (#24128), the yield of crystal plants was very very bad! Would be waiting for 10 minute and may not get any crystals at all, maybe 1. this is since original cropsize was 0. with old harvesting/yield caclulations it is ok, but after changes it is very not good.

i do not think it was intensional change by @Egregorious to do crystal nerfing, so I improve crystal so it is like before. i also make a bit stronger (faster growing), siance it can be good tool for botanists that I do not see very much using of now. 

also change so crystal from plant regular sizing, because big shard is weird!

## Testing 
plant 5 crystal from the shard (on top) and 5 crystal form the seed (bottom). Bottom is iffused with 40u ammonia per seed, top has no buffing. both using potash + saltpetre + compost water mix (easy, standart nutrient mix). Wait 10 minute to get result:
TOP PLANTS: 32 shards (6.4 per plant)
BOTTOM PLANTS: 35 shards (7 per plant)
<img width="1015" height="865" alt="shardcounts" src="https://github.com/user-attachments/assets/daf84c22-5b5e-4c7b-850c-df56182ac7be" />

crystal not scaling visqually, which is intent

## Changelog
```changelog
(u)NibChocolateeny
(+)Recent studies from NT's botanists reveal that plasmaglass-producing organisms are faster-growing and have higher yields than was previously assumed.
```
