### PR TITLE
Adds A Comms Console To The Clarion's Armoury

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -21509,7 +21509,6 @@
 /area/station/hallway/primary/southeast)
 "kcn" = (
 /obj/random_item_spawner/armory_phasers,
-/obj/machinery/power/apc/autoname_east,
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = 10

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -10047,6 +10047,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "bSk" = (
@@ -11585,11 +11588,11 @@
 /turf/space,
 /area/space)
 "cUY" = (
-/obj/machinery/light{
+/obj/storage/secure/crate/weapon/armory/pod_weapons,
+/obj/machinery/light/emergency{
 	dir = 4;
 	pixel_x = 10
 	},
-/obj/storage/secure/crate/weapon/armory/pod_weapons,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -15195,11 +15198,16 @@
 /turf/simulated/floor/orangeblack,
 /area/station/hangar/main)
 "fEx" = (
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/vending/security_ammo,
+/obj/machinery/computer3/generic/communications{
+	dir = 8
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/recharger/wall{
+	pixel_y = 28
+	},
 /turf/simulated/floor/redblack{
 	dir = 5
 	},
@@ -16285,13 +16293,13 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "gpb" = (
-/obj/storage/secure/crate/gear/armory/equipment,
-/obj/machinery/recharger/wall{
-	dir = 8;
-	pixel_x = -19
-	},
 /obj/machinery/status_display{
 	pixel_y = 30
+	},
+/obj/machinery/vending/security_ammo,
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/redblack{
 	dir = 9
@@ -18360,7 +18368,7 @@
 /turf/simulated/floor/plating,
 /area/station/engine/gas)
 "hTx" = (
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -19317,8 +19325,17 @@
 /obj/machinery/camera/directional/west{
 	pixel_y = 10
 	},
-/obj/storage/secure/crate/weapon/armory/tranquilizer,
 /obj/machinery/light_switch/west,
+/obj/table/reinforced/auto,
+/obj/item/kitchen/food_box/donut_box{
+	pixel_x = -2;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/food/snacks/donut/custom/robust{
+	pixel_x = -1;
+	pixel_y = 2;
+	rand_pos = 0
+	},
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
@@ -21491,11 +21508,12 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "kcn" = (
-/obj/machinery/light/emergency{
+/obj/random_item_spawner/armory_phasers,
+/obj/machinery/power/apc/autoname_east,
+/obj/machinery/light{
 	dir = 4;
 	pixel_x = 10
 	},
-/obj/random_item_spawner/armory_phasers,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -22021,15 +22039,9 @@
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
-/obj/table/reinforced/auto,
-/obj/item/kitchen/food_box/donut_box{
-	pixel_x = -2;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/food/snacks/donut/custom/robust{
-	pixel_x = -1;
-	pixel_y = 2;
-	rand_pos = 0
+/obj/stool/chair/office/red{
+	dir = 4;
+	tag = "icon-office_chair_red (EAST)"
 	},
 /turf/simulated/floor/redblack/corner{
 	dir = 8
@@ -26750,6 +26762,16 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
+"nIv" = (
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 10
+	},
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/station/ai_monitored/armory)
 "nKb" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/security_horizontal,
 /obj/forcefield/energyshield/perma/doorlink{
@@ -31928,6 +31950,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
+"rDn" = (
+/obj/random_item_spawner/armory_armor_supplies,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/redblack{
+	dir = 8
+	},
+/area/station/ai_monitored/armory)
 "rDo" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -36514,10 +36546,6 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "uDF" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -10
-	},
 /obj/storage/secure/crate/gear/armory/grenades,
 /turf/simulated/floor/redblack{
 	dir = 8
@@ -39891,7 +39919,7 @@
 /obj/machinery/turretid/armory_perimeter{
 	pixel_x = -24
 	},
-/obj/random_item_spawner/armory_armor_supplies,
+/obj/storage/secure/crate/gear/armory/equipment,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
@@ -83970,7 +83998,7 @@ csQ
 csQ
 csQ
 uPa
-bIO
+uPa
 bIO
 bFo
 bIO
@@ -84269,10 +84297,10 @@ iyl
 uDF
 qLR
 xdq
+rDn
 txc
 oxR
 uPa
-bIO
 bIO
 bFo
 bIO
@@ -84571,10 +84599,10 @@ biM
 biM
 biM
 biM
+biM
 frn
 ozI
 uPa
-bIO
 bIO
 bFo
 bIO
@@ -84873,10 +84901,10 @@ glL
 glL
 glL
 glL
+glL
 pzC
 hjZ
 uPa
-bIO
 bIO
 bFo
 bIO
@@ -85175,10 +85203,10 @@ kcn
 jOO
 cUY
 hTx
+nIv
 rTC
 hjZ
 uPa
-bIO
 bIO
 bFo
 bIO
@@ -85478,9 +85506,9 @@ vpj
 sPv
 sPv
 sPv
+sPv
 htj
 uPa
-bIO
 bIO
 bFo
 bIO
@@ -85782,7 +85810,7 @@ uPa
 uPa
 uPa
 uPa
-bXM
+uPa
 bXM
 mUF
 bXM


### PR DESCRIPTION
## About The PR:
Expands the Clarion's Armoury by a tile westwards and adds a communications console, while reshuffling the contents slightly to fit it in neatly.


## Why Is This Needed?
See #26086.


## Testing:
<img width="468" height="658" alt="image" src="https://github.com/user-attachments/assets/225c93ad-780d-4665-a2b2-357eab2ac7b4" />