### PR TITLE
Adds Laughtracks one and three to the Noisemaker/sound synthesizer

### DIFF
--- a/code/obj/item/noisemaker.dm
+++ b/code/obj/item/noisemaker.dm
@@ -30,6 +30,11 @@
 			if ("bang") playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg', 40, 1)
 			if ("buzz") playsound(src.loc, 'sound/machines/warning-buzzer.ogg', 50, 1)
 			if ("gunshot") playsound(src.loc, 'sound/weapons/Gunshot.ogg', 50, 1)
+			if ("laughter")
+				var/which = rand(1,2)
+				switch(which)
+					if(1) playsound(src.loc, 'sound/misc/laughter/laughtrack1.ogg', 50, 0)
+					if(2) playsound(src.loc, 'sound/misc/laughter/laughtrack3.ogg', 50, 0)
 			if ("siren") playsound(src.loc, 'sound/machines/siren_police.ogg', 50, 1)
 			if ("coo") playsound(src.loc, 'sound/voice/babynoise.ogg', 50, 1)
 			if ("rimshot") playsound(src.loc, 'sound/misc/rimshot.ogg', 50, 1)
@@ -40,7 +45,7 @@
 			else playsound(src.loc, 'sound/machines/buzz-two.ogg', 50, 1)
 
 	attack(mob/target, mob/user, def_zone, is_special = FALSE, params = null)
-		var/newmode = tgui_input_list(user, "Select sound to play", "Make some noise", list("bang", "burp", "buzz", "cat", "coo", "fart", "gunshot", "harmonica", "honk", "rimshot", "siren", "squeak", "trombone", "vuvuzela"), src.mode)
+		var/newmode = tgui_input_list(user, "Select sound to play", "Make some noise", list("bang", "burp", "buzz", "cat", "coo", "fart", "gunshot", "harmonica", "honk", "laughter", "rimshot", "siren", "squeak", "trombone", "vuvuzela"), src.mode)
 
 		if (newmode && rand(1,150) == 1)
 			boutput(user, SPAN_ALERT("BZZZ SOUND SYNTHESISER ERROR"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR Adds laughtracks to the Noisemaker item

## Why's this needed? I think it would be swell to have more laughter

## Testing  I tested this by using the noisemaker both in a borg and the item in person and neither returned an error. 

## Changelog  Released. Edit: Added Screenshot

<img width="1157" height="725" alt="Screenshot 2026-03-10 104648" src="https://github.com/user-attachments/assets/89cf4d4d-4959-4f94-ad4b-42a18869a678" />
