### PR TITLE
Adds baton emag act

### DIFF
--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -31,6 +31,7 @@ TYPEINFO(/obj/item/baton)
 	var/item_off = "baton-D"
 	var/flick_baton_active = "baton_active"
 	var/wait_cycle = 0 // Update sprite periodically if we're using a self-charging cell.
+	var/emagged = FALSE
 
 	var/cell_type = /obj/item/ammo/power_cell/med_power // Type of cell to spawn by default.
 	var/from_frame_cell_type = /obj/item/ammo/power_cell //type of cell to spawn when mechscanned
@@ -335,6 +336,32 @@ TYPEINFO(/obj/item/baton)
 			src.UpdateIcon()
 			user.update_inhands()
 		..()
+
+	emag_act(mob/user, obj/item/card/emag/E)
+		if (!src.emagged)
+			boutput(user, SPAN_ALERT("You jam [E] into [src]'s charging port."))
+			src.emagged = TRUE
+			src.is_active = FALSE
+			src.process_charges(-INFINITY)
+			playsound(src, "sparks", 75, 1, -1)
+			if (src.name == "extendable stun baton")
+				src.name = pick("extendable batong","extensible stong baton","extensive stun batong")
+			else if (src.name == "stun cane")
+				src.name = "long batong"
+			else
+				src.name = pick("batong","stong baton","stung baton","stun batong")
+				src.desc = "For some reason you can't figure out how to recharge this thing."
+				var/datum/component/cell_holder/CH = GetComponent(/datum/component/cell_holder)
+				if (CH) // Can never be charged again
+					CH.can_be_recharged = FALSE
+					CH.swappable_cell = FALSE
+					return
+			src.UpdateIcon()
+			user.update_inhands()
+			return TRUE
+		return FALSE
+
+
 
 /////////////////////////////////////////////// Subtypes //////////////////////////////////////////////////////
 

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -341,23 +341,26 @@ TYPEINFO(/obj/item/baton)
 		if (!src.emagged)
 			boutput(user, SPAN_ALERT("You jam [E] into [src]'s charging port."))
 			src.emagged = TRUE
-			src.is_active = FALSE
-			src.process_charges(-INFINITY)
 			playsound(src, "sparks", 75, 1, -1)
+			src.desc = "For some reason you can't figure out how to recharge this thing."
+			var/datum/component/cell_holder/CH = GetComponent(/datum/component/cell_holder)
 			if (src.name == "extendable stun baton")
 				src.name = pick("extendable batong","extensible stong baton","extensive stun batong")
+				if (CH?.cell)
+					var/datum/component/power_cell/PCC = CH.cell.GetComponent(/datum/component/power_cell)
+					if (PCC)
+						PCC.recharge_rate = 0
 			else if (src.name == "stun cane")
 				src.name = "long batong"
+				if (CH?.cell)
+					var/datum/component/power_cell/PCC = CH.cell.GetComponent(/datum/component/power_cell)
+					if (PCC)
+						PCC.recharge_rate = 0
 			else
 				src.name = pick("batong","stong baton","stung baton","stun batong")
-				src.desc = "For some reason you can't figure out how to recharge this thing."
-				var/datum/component/cell_holder/CH = GetComponent(/datum/component/cell_holder)
-				if (CH) // Can never be charged again
+				if (CH)
 					CH.can_be_recharged = FALSE
 					CH.swappable_cell = FALSE
-					return
-			src.UpdateIcon()
-			user.update_inhands()
 			return TRUE
 		return FALSE
 

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -202,6 +202,13 @@ TYPEINFO(/obj/item/baton)
 				FLICK(flick_baton_active, src)
 				JOB_XP(victim, "Clown", 3)
 
+			if ("stun_backfire") //emag effect
+				user.visible_message(SPAN_ALERT("<B>[user] tries to stun [victim] with the [src.name] but somehow stuns [himself_or_herself(user)] instead!</B>"))
+				logTheThing(LOG_COMBAT, user, "tries to stun [constructTarget(victim,"combat")] with the emagged [src.name] but stuns themselves at [log_loc(user)].")
+				playsound(src, 'sound/impact_sounds/Energy_Hit_3.ogg', 50, TRUE, -1)
+				FLICK(flick_baton_active, src)
+				JOB_XP(user, "Head of Security", 3)
+
 			else
 				logTheThing(LOG_DEBUG, user, "<b>Convair880</b>: stun baton ([src.type]) do_stun() was called with an invalid argument ([type]), aborting. Last touched by: [replace_if_false(src.get_last_ckey(), "None")]")
 				return
@@ -267,6 +274,27 @@ TYPEINFO(/obj/item/baton)
 		if (src.can_stun() == 1 && user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50))
 			src.do_stun(user, target, "failed", 1)
 			JOB_XP(user, "Clown", 1)
+			return
+
+		if (src.emagged)
+			switch (user.a_intent)
+				if ("harm")
+					// Looks flipped/dangerous but actually works normally
+					if (!src.is_active || (src.is_active && src.can_stun() == 0))
+						src.do_stun(user, target, "failed_stun", 1)
+					else
+						if (user.mind && target.mind && (user.mind.get_master(ROLE_VAMPTHRALL) == target.mind))
+							boutput(user, SPAN_ALERT("You cannot harm your master!"))
+							return
+						if (target.do_dodge(user, src) || target.parry_or_dodge(user, src))
+							return
+						src.do_stun(user, target, "stun", 2)
+				else
+					// Looks normal/safe but stuns the user
+					if (!src.is_active || (src.is_active && src.can_stun() == 0))
+						src.do_stun(user, target, "failed_stun", 1)
+					else
+						src.do_stun(user, target, "stun_backfire", 1)
 			return
 
 		switch (user.a_intent)
@@ -342,27 +370,15 @@ TYPEINFO(/obj/item/baton)
 			boutput(user, SPAN_ALERT("You jam [E] into [src]'s charging port."))
 			src.emagged = TRUE
 			playsound(src, "sparks", 75, 1, -1)
-			src.desc = "For some reason you can't figure out how to recharge this thing."
-			var/datum/component/cell_holder/CH = GetComponent(/datum/component/cell_holder)
 			if (src.name == "extendable stun baton")
 				src.name = pick("extendable batong","extensible stong baton","extensive stun batong")
-				if (CH?.cell)
-					var/datum/component/power_cell/PCC = CH.cell.GetComponent(/datum/component/power_cell)
-					if (PCC)
-						PCC.recharge_rate = 0
 			else if (src.name == "stun cane")
 				src.name = "long batong"
-				if (CH?.cell)
-					var/datum/component/power_cell/PCC = CH.cell.GetComponent(/datum/component/power_cell)
-					if (PCC)
-						PCC.recharge_rate = 0
 			else
 				src.name = pick("batong","stong baton","stung baton","stun batong")
-				if (CH)
-					CH.can_be_recharged = FALSE
-					CH.swappable_cell = FALSE
 			return TRUE
 		return FALSE
+
 
 
 

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -367,7 +367,7 @@ TYPEINFO(/obj/item/baton)
 
 	emag_act(mob/user, obj/item/card/emag/E)
 		if (!src.emagged)
-			boutput(user, SPAN_ALERT("You jam [E] into [src]'s charging port."))
+			boutput(user, SPAN_ALERT("You short out the circuitry in [src]'s handle."))
 			src.emagged = TRUE
 			playsound(src, "sparks", 75, 1, -1)
 			if (src.name == "extendable stun baton")


### PR DESCRIPTION
[FEATURE]

## About the PR 
Adds an emag act for the stun baton, NTSC extendable baton and the stun cane. Emagging a baton renames it to "batong" or some variant of that. It also swaps the harm effect with the help/disarm/grab effect. I.e., attempting to stun someone regularly will stun the user instead, and trying to stun someone on harm intent will work sucessfully. Inhand sprites remain the same. 


## Why's this needed? 
Where I charge batong? Also it's good to give emags more interaction with security equipment. In this case, a traitor may steal an officers baton, emag it, and give it back to them and gloat etc. 

## Testing 
Tested with baton, NTSC baton and stun cane and all work as intended. Also as a note, it took me a while to figure out how to get this working with the extendable baton/stun cane so if there is a better implementation please let me know. 

## Changelog 


```changelog
(u)bamlord
(*)Added baton emag interaction
```
