### PR TITLE
Add poker chip cases and stacks of poker chips

### DIFF
--- a/code/WorkInProgress/HaineWhatever.dm
+++ b/code/WorkInProgress/HaineWhatever.dm
@@ -430,6 +430,9 @@ var/list/special_parrot_species = list("ikea" = /datum/species_info/parrot/kea/i
 	New()
 		..()
 		src.UpdateStackAppearance()
+		if (!src.inventory_counter)
+			src.create_inventory_counter()
+		src.inventory_counter.update_number(src.amount)
 
 	UpdateName()
 		src.name = "[src.amount > 1 ? "[src.amount] " : null][name_prefix(null, 1)][src.value]-credit [src.real_name][s_es(src.amount)][name_suffix(null, 1)]"
@@ -463,15 +466,21 @@ var/list/special_parrot_species = list("ikea" = /datum/species_info/parrot/kea/i
 			..(I, user)
 
 	attack_hand(mob/user)
-		if ((user.l_hand == src || user.r_hand == src) && user.equipped() != src)
-			var/amt = src.amount == 2 ? 1 : round(input("How many [src.real_name]s do you want to take from the stack?") as null|num)
-			if (amt && src.loc == user && !user.equipped())
-				if (amt > src.amount || amt < 1)
-					boutput(user, SPAN_ALERT("You wish!"))
-					return
-				src.change_stack_amount(0 - amt)
-				var/obj/item/dice/coin/poker_chip/P = new src.type(user.loc)
-				P.Attackhand(user)
+		if((user.r_hand == src || user.l_hand == src) && src.amount > 1)
+			var/splitnum = round(input("How many [src.real_name]s do you want to take from the stack?","Stack of [src.amount]") as null|num)
+			if(!global.in_interact_range(src, user) || !isnum_safe(splitnum))
+				return
+			splitnum = round(clamp(splitnum, 0, src.amount))
+			if(amount == 0)
+				return
+
+			var/obj/item/dice/coin/poker_chip/new_chip = src.split_stack(splitnum)
+			if (!istype(new_chip))
+				boutput(user, SPAN_ALERT("Invalid entry, try again."))
+				return
+			user.put_in_hand_or_drop(new_chip)
+			new_chip.add_fingerprint(user)
+			boutput(user, SPAN_NOTICE("You take [splitnum] chips from the stack, leaving [src.amount] chips behind."))
 		else
 			..(user)
 
@@ -479,35 +488,167 @@ var/list/special_parrot_species = list("ikea" = /datum/species_info/parrot/kea/i
 	color = "#DC0E18" // red
 	value = 5
 
+	stack
+		amount = 20
+
+		house
+			amount = 1000
+			max_stack = 9999
+
 /obj/item/dice/coin/poker_chip/v10
 	color = "#30BA67" // green
 	value = 10
 
+	stack
+		amount = 20
+
+		house
+			amount = 1000
+			max_stack = 9999
+
 /obj/item/dice/coin/poker_chip/v25
 	color = "#3153CE" // blue
 	value = 25
+
+	stack
+		amount = 20
+
+		house
+			amount = 1000
+			max_stack = 9999
 
 /obj/item/dice/coin/poker_chip/v50
 	color = "#FFFFFF" // white
 	pip_color = "#3153CE" // blue
 	value = 50
 
+	stack
+		amount = 20
+
+		house
+			amount = 1000
+			max_stack = 9999
+
 /obj/item/dice/coin/poker_chip/v100
 	color = "#FF7BD2" // pink
 	value = 100
+
+	stack
+		amount = 20
+
+		house
+			amount = 1000
+			max_stack = 9999
 
 /obj/item/dice/coin/poker_chip/v250
 	color = "#E78B2E" // orange
 	value = 250
 
+	stack
+		amount = 20
+
+		house
+			amount = 1000
+			max_stack = 9999
+
 /obj/item/dice/coin/poker_chip/v500
 	color = "#BE3ED6" // purple
 	value = 500
+
+	stack
+		amount = 20
+
+		house
+			amount = 1000
+			max_stack = 9999
 
 /obj/item/dice/coin/poker_chip/v1000
 	color = "#4BE1DD" // aqua
 	value = 1000
 
+	stack
+		amount = 20
+
+		house
+			amount = 1000
+			max_stack = 9999
+
+/obj/item/storage/briefcase/poker_chips
+	name = "Variety Poker Chip Case"
+	desc = "A briefcase containing a variety of poker-style betting chips."
+	can_hold = list(/obj/item/dice/coin/poker_chip)
+	slots = 8
+	w_class = W_CLASS_BULKY
+	spawn_contents = list(
+		/obj/item/dice/coin/poker_chip/v5/stack, // 5 * 20 = 100
+		/obj/item/dice/coin/poker_chip/v10/stack, // 10 * 20 = 200 etc.
+		/obj/item/dice/coin/poker_chip/v25/stack, // 500
+		/obj/item/dice/coin/poker_chip/v50/stack, // 1000
+		/obj/item/dice/coin/poker_chip/v100/stack, // 2000
+		/obj/item/dice/coin/poker_chip/v250/stack, // 5000
+		/obj/item/dice/coin/poker_chip/v500/stack, // 10 000
+		/obj/item/dice/coin/poker_chip/v1000/stack, // 20 000
+	)
+
+/obj/item/storage/briefcase/poker_chips/low_stakes
+	name = "low-stakes poker chip case"
+	slots = 7
+	spawn_contents = list(
+		/obj/item/dice/coin/poker_chip/v5/stack, // 100
+		/obj/item/dice/coin/poker_chip/v5/stack, // 100
+		/obj/item/dice/coin/poker_chip/v10/stack, // 200
+		/obj/item/dice/coin/poker_chip/v10/stack, // 200
+		/obj/item/dice/coin/poker_chip/v25/stack, // 500
+		/obj/item/dice/coin/poker_chip/v25/stack, // 500
+		/obj/item/dice/coin/poker_chip/v50/stack, // 1000
+	) // 2 600 credits, update vending machine costs if changed
+
+/obj/item/storage/briefcase/poker_chips/medium_stakes
+	name = "medium-stakes poker chip case"
+	icon_state = "briefcase_black"
+	item_state = "sec-case"
+	slots = 7
+	spawn_contents = list(
+		/obj/item/dice/coin/poker_chip/v25/stack, // 500
+		/obj/item/dice/coin/poker_chip/v25/stack, // 500
+		/obj/item/dice/coin/poker_chip/v50/stack, // 1000
+		/obj/item/dice/coin/poker_chip/v50/stack, // 1000
+		/obj/item/dice/coin/poker_chip/v100/stack, // 2000
+		/obj/item/dice/coin/poker_chip/v100/stack, // 2000
+		/obj/item/dice/coin/poker_chip/v250/stack, // 5000
+	) // 12 000 credits, update vending machine costs if changed
+
+/obj/item/storage/secure/sbriefcase/high_stakes
+	name = "high-stakes poker chip case"
+	desc = "A briefcase set of high-value poker-style betting chips, with included digital locking system."
+	check_wclass = STORAGE_CHECK_W_CLASS_IGNORE
+	can_hold = list(/obj/item/dice/coin/poker_chip)
+	spawn_contents = list(
+		/obj/item/dice/coin/poker_chip/v100/stack, // 2000
+		/obj/item/dice/coin/poker_chip/v100/stack, // 2000
+		/obj/item/dice/coin/poker_chip/v250/stack, // 5000
+		/obj/item/dice/coin/poker_chip/v250/stack, // 5000
+		/obj/item/dice/coin/poker_chip/v500/stack, // 10 000
+		/obj/item/dice/coin/poker_chip/v500/stack, // 10 000
+		/obj/item/dice/coin/poker_chip/v1000/stack, // 20 000
+	) // 54 000 credits, update vending machine costs if changed
+
+// admin spawn
+/obj/item/storage/briefcase/poker_chips/the_house
+	name = "The House's Poker Chip Case"
+	icon_state = "briefcase_rd"
+	item_state = "rd-case"
+	slots = 8
+	spawn_contents = list(
+		/obj/item/dice/coin/poker_chip/v5/stack/house,
+		/obj/item/dice/coin/poker_chip/v10/stack/house,
+		/obj/item/dice/coin/poker_chip/v25/stack/house,
+		/obj/item/dice/coin/poker_chip/v50/stack/house,
+		/obj/item/dice/coin/poker_chip/v100/stack/house,
+		/obj/item/dice/coin/poker_chip/v250/stack/house,
+		/obj/item/dice/coin/poker_chip/v500/stack/house,
+		/obj/item/dice/coin/poker_chip/v1000/stack/house,
+	)
 /*
                     +---------------+
                     ¦m  S N A K E   ¦

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2975,11 +2975,14 @@ TYPEINFO(/obj/machinery/vending/chem)
 		product_list += new/datum/data/vending_product(/obj/item/clow_key, 5, cost=PAY_TRADESMAN/2)      //      (please laugh)
 		product_list += new/datum/data/vending_product(/obj/item/card_box/solo, 5, cost=PAY_UNTRAINED/4)
 		product_list += new/datum/data/vending_product(/obj/item/paper/book/from_file/solo_rules, 5, cost=PAY_UNTRAINED/5)
+		product_list += new/datum/data/vending_product(/obj/item/storage/briefcase/poker_chips/low_stakes, 8, cost=2600)  // cost equals the sum of chip value
+		product_list += new/datum/data/vending_product(/obj/item/storage/briefcase/poker_chips/medium_stakes, 4, cost=12000)  // cost equals the sum of chip value
 		product_list += new/datum/data/vending_product(/obj/item/currency/fakecash/fivehundred, 10, cost=PAY_UNTRAINED/4)
 		product_list += new/datum/data/vending_product(/obj/item/currency/fakecash/thousand, 10, cost=PAY_UNTRAINED/2)
 		product_list += new/datum/data/vending_product(/obj/item/currency/fakecash/hundredthousand, 1, cost=PAY_DOCTORATE)
 		product_list += new/datum/data/vending_product(/obj/item/dice/weighted, rand(1,3), cost=PAY_TRADESMAN/2, hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/dice/d1, rand(0,1), cost=PAY_TRADESMAN/3, hidden=1)
+		product_list += new/datum/data/vending_product(/obj/item/storage/secure/sbriefcase/high_stakes, 4, cost=54000, hidden=1) // cost equals the sum of chip value
 
 /obj/machinery/vending/clothing
 	name = "FancyPantsCo Sew-O-Matic"

--- a/code/obj/item/storage/secure_safe.dm
+++ b/code/obj/item/storage/secure_safe.dm
@@ -286,6 +286,8 @@ TYPEINFO(/obj/item/storage/secure/sbriefcase)
 	check_wclass = STORAGE_CHECK_W_CLASS_INCLUDE
 	can_hold = list(/obj/item/stamped_bullion)
 
+	HELP_MESSAGE_OVERRIDE("Set or enter a code by <b>using in-hand</b>.<br>View contents by <b>click-dragging</b> from the briefcase to your character.")
+
 TYPEINFO(/obj/item/storage/secure/ssafe)
 	mats = 8
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds pre-made stacks of 20 chips of each type,
Fixes some stacking oddities by converting existing code to use more standard procs.
Adds two new briefcases to the gaming vending machine:"low-stakes poker chip case" and "medium-stakes poker chip case"
Adds admin-only birefacase with extremely large chip stacks for dealer gimmicks.
Add help message for unlocking and accessing secure briefcases

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
spawned the cases local and verified they all worked.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)The gaming vending machines stock some pre-made poker chip sets, all at one to one credit value.
```
