### PR TITLE
Fix infinite fertilisers in the plant tray

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -165,6 +165,8 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 
 		handle_reactions()
 
+	/// Removes a certain amount of reagents, prorated by their current volume. Returns the amount removed.
+	/// This simulates pouring fluids, and thus will often not completely remove any one reagent until the total volume approaches 0.
 	proc/remove_any(var/amount=1)
 		if(amount > total_volume) amount = total_volume
 		if(amount <= 0) return
@@ -224,6 +226,26 @@ proc/chem_helmet_check(mob/living/carbon/human/H, var/what_liquid="hot")
 		src.update_total()
 
 		return amount
+
+	/// Similar to remove_any, but a portion of the reagent is removed non-proportional to its volume.
+	/// This is useful when reagents are binary and simulating fluid mechanics fully is undesirable.
+	/// This is not intended for transferring reagents, there is no support for remembering the removed reagent amounts.
+	proc/consume_any(var/amount=1, var/consumption_ratio = 0.5, var/exception = null)
+		var/total_consumption_amount = amount * consumption_ratio
+		var/remove_amount = amount - total_consumption_amount
+		if (remove_amount > 0)
+			// little bit inefficient to call this rather than implement it in the loop below, but cleaner and probably not a performance issue
+			src.remove_any_except(remove_amount, exception)
+		if (total_consumption_amount <= 0)
+			return amount
+		var/consumption_per_reagent = total_consumption_amount / length(reagent_list)
+		for(var/reagent_id in reagent_list)
+			if (reagent_id == exception)
+				continue
+			var/datum/reagent/current_reagent = reagent_list[reagent_id]
+			if(current_reagent)
+				src.remove_reagent(reagent_id, consumption_per_reagent)
+
 
 	proc/get_master_reagent_name()
 		var/largest_name = null

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -901,7 +901,7 @@ TYPEINFO(/obj/machinery/plantpot)
 		DNA.endurance += HYPstat_rounding(src.current_tick.endurance_bonus * src.current_tick.tick_multiplier)
 	// Now we modify chems in the tray
 	if (src.reagents)
-		src.reagents?.remove_any_except(src.current_tick.water_consumption * src.current_tick.tick_multiplier * src.drink_mult, "nectar")
+		src.reagents?.consume_any(src.current_tick.water_consumption * src.current_tick.tick_multiplier * src.drink_mult, 0.1, "nectar")
 		// This is where drink_rate does its thing. It will remove a bit of all reagents to meet
 		// it's quota, except nectar because that's supposed to stay in the plant pot.
 		// We give off nectar and should check our nectar levels


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds `consume_any()` to chemistry holders, which functions similarly to `remove_any()`, but a portion of the amount removed is removed flatly instead of as a ratio of the total volume. 

Plant trays now use `consume_any()` instead of `remove_any()` to tick down fertiliser contents. 10% of the removed reagents are removed flatly, and 90% as a ratio. This means that fertilisers in the plant tray will be fully consumed at low values instead of infinitely trend towards 0. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I believe `remove_any()` is a bit buggy due to how Byond maths works, but even if it functioned perfectly I do think the purpose of it is to simulate fluid mechanics such as pouring, and thus it mechanically wants to trend towards zero and maintain ratios to the extent of parts per million/billion etc. 

Plant trays function differently, they want to simulate something actively extracting certain reagents or nutrients from liquid, and thus I think it warrants a different method altogether anyway. 

This does change the balance of tray fertilising a great deal and therefore it probably creates the need for some kind of numbers rebalance but since that would need testing for feel, it's not included in this PR. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/7b86f753-fae9-48f9-9e21-737a594cbfa5

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Egregorious
(*)Fertilizer in plant trays are no longer infinite.
```
