### PR TITLE
Adds a new "Gene Inhibitor" gene to Pear plants

### DIFF
--- a/code/modules/hydroponics/gene_strains.dm
+++ b/code/modules/hydroponics/gene_strains.dm
@@ -58,7 +58,7 @@ ABSTRACT_TYPE(/datum/plant_gene_strain)
 		if (.)
 			//we remove this commut and add splice disabler
 			HYPremoveCommut(gene_pool, /datum/plant_gene_strain/temporary_splice_stabilizer)
-			HYPaddCommut(gene_pool, /datum/plant_gene_strain/splicing/disabled)
+			HYPaddCommut(gene_pool, /datum/plant_gene_strain/splicing/disabled, TRUE) // Important to make this unaffected by commutblocker.
 
 /datum/plant_gene_strain/overpowering_genome
 	name = "Overpowering Genome"
@@ -319,7 +319,11 @@ ABSTRACT_TYPE(/datum/plant_gene_strain)
 
 /datum/plant_gene_strain/stabilizer
 	name = "Stabilizer"
-	desc = "A strengthened genetic structure prevents mutations from occurring."
+	desc = "A strengthened genetic structure prevents any mutations from occurring."
+
+/datum/plant_gene_strain/commutblocker
+	name = "Gene Inhibitor"
+	desc = "A modified DNA repair response will prevent this plant from gaining unusual genetic traits. Other mutations can still occur."
 
 /datum/plant_gene_strain/accelerator
 	name = "Accelerator"

--- a/code/modules/hydroponics/hydroponics_misc_procs.dm
+++ b/code/modules/hydroponics/hydroponics_misc_procs.dm
@@ -367,7 +367,7 @@ proc/HYPCheckCommut(var/datum/plantgenes/DNA,var/searchtype)
 proc/HYPnewcommutcheck(var/datum/plant/P,var/datum/plantgenes/DNA, var/frequencymult = 1)
 	// This is the proc for checking if a new random gene strain will appear in the plant.
 	if(!P || !DNA) return
-	if(HYPCheckCommut(DNA,/datum/plant_gene_strain/stabilizer))
+	if(HYPCheckCommut(DNA,/datum/plant_gene_strain/stabilizer) || HYPCheckCommut(DNA,/datum/plant_gene_strain/commutblocker))
 		return
 	if(length(P.commuts) > 0)
 		var/datum/plant_gene_strain/MUT = null
@@ -388,7 +388,7 @@ proc/HYPnewcommutcheck(var/datum/plant/P,var/datum/plantgenes/DNA, var/frequency
 			//now, if the gene strain needs to do anything, we do it now
 			MUT.on_addition(DNA)
 
-proc/HYPaddCommut(var/datum/plantgenes/DNA, var/commut)
+proc/HYPaddCommut(var/datum/plantgenes/DNA, var/commut, var/always_add = FALSE) //always_add overrides the effects of commutblocker
 	// And this one is for forcibly adding specific strains.
 	if(!DNA || !commut) return
 	if(!ispath(commut)) return
@@ -399,13 +399,13 @@ proc/HYPaddCommut(var/datum/plantgenes/DNA, var/commut)
 	var/datum/plant_gene_strain/added_commut = HY_get_strain_from_path(commut)
 	// create a new list here (i.e. do not use +=) so as to not affect related seeds/plants
 	if(added_commut)
-		if(DNA.commuts)
-			DNA.commuts = DNA.commuts + added_commut
-		else
-			DNA.commuts = list(added_commut)
-		//now, if the gene strain needs to do anything, we do it now
-		added_commut.on_addition(DNA)
-
+		if (always_add || !HYPCheckCommut(DNA,/datum/plant_gene_strain/commutblocker))
+			if(DNA.commuts)
+				DNA.commuts = DNA.commuts + added_commut
+			else
+				DNA.commuts = list(added_commut)
+			//now, if the gene strain needs to do anything, we do it now
+			added_commut.on_addition(DNA)
 
 proc/HYPremoveCommut(var/datum/plantgenes/DNA, var/commut)
 	// And this one is for forcibly removing specific strains.
@@ -417,8 +417,6 @@ proc/HYPremoveCommut(var/datum/plantgenes/DNA, var/commut)
 	if(removed_commut)
 		DNA.commuts = DNA.commuts - removed_commut
 		removed_commut.on_removal(DNA)
-
-
 
 proc/HYPmutateDNA(var/datum/plantgenes/DNA,var/severity = 1)
 	// This proc jumbles up the variables in a plant's genes. It's fundamental to breeding.

--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -573,7 +573,7 @@ ABSTRACT_TYPE(/datum/plantmutation)
 	special_proc_override = TRUE
 
 	HYPon_mutation_general(var/datum/plant/parent_plant, var/datum/plantgenes/passed_genes)
-		HYPaddCommut(passed_genes, /datum/plant_gene_strain/inert)
+		HYPaddCommut(passed_genes, /datum/plant_gene_strain/inert) // Allowing this to be blocked by commutblocker, because it'd be funny/practical.
 		return
 
 	HYPspecial_proc_M(var/obj/machinery/plantpot/POT)

--- a/code/modules/hydroponics/plants_fruit.dm
+++ b/code/modules/hydroponics/plants_fruit.dm
@@ -276,7 +276,7 @@ ABSTRACT_TYPE(/datum/plant/fruit)
 	endurance = 5
 	genome = 19
 	nectarlevel = 10
-	commuts = list(/datum/plant_gene_strain/quality)
+	commuts = list(/datum/plant_gene_strain/quality, /datum/plant_gene_strain/commutblocker)
 
 
 /*

--- a/code/modules/hydroponics/plants_weed.dm
+++ b/code/modules/hydroponics/plants_weed.dm
@@ -74,7 +74,7 @@ ABSTRACT_TYPE(/datum/plant/weed)
 			boutput(user, SPAN_ALERT("The lasher flails at you violently! You might need to weaken it first..."))
 			return 1
 		else
-			HYPaddCommut(POT.plantgenes, /datum/plant_gene_strain/reagent_adder/lasher)
+			HYPaddCommut(POT.plantgenes, /datum/plant_gene_strain/reagent_adder/lasher, TRUE) //You will always get Enzymatic. ALWAYS.
 			return 0
 
 

--- a/code/obj/item/seeds.dm
+++ b/code/obj/item/seeds.dm
@@ -113,7 +113,7 @@ ADMIN_INTERACT_PROCS(/obj/item/seed, proc/admin_set_mutation)
 			// We call this only if the seed has not a parent. In this case, HYPpassplantgenes adds the commuts in question
 			if (!has_parent && length(src.planttype.innate_commuts) > 0)
 				for (var/commut_to_add in src.planttype.innate_commuts)
-					HYPaddCommut(src.plantgenes, commut_to_add)
+					HYPaddCommut(src.plantgenes, commut_to_add, TRUE)
 		else
 			src.name = "[src.name] seed"
 		if (src.charges > 1) src.name += " packet"

--- a/strings/books/hydroponicsguide.txt
+++ b/strings/books/hydroponicsguide.txt
@@ -169,6 +169,7 @@ globules of this sludge can be harvested from the plant however - with proper pr
 <p><b>Damage Resistance</b>: Harmful things like toxins and physical trauma from chainsaws are less damaging to plants with this gene strain.</p>
 <p><b>Vulnerability</b>: Plants with this strain are more easily damaged by toxins or physical trauma.</p>
 <p><b>Stabilizer</b>: This strain prevents plants from randomly mutating or from mutating via reagent exposure.</p>
+<p><b>Gene Inhibitor</b>: This strain prevents plants from gaining unusual genes when mutating or through seed infusions.</p>
 <p><b>Mutagenic</b>: Plants with the Mutagenic strain are more likely to randomly mutate.</p>
 <p><b>Anti-Mutagenic</b>: Plants with this strain are less likely to randomly mutate.</p>
 <p><b>Advanced Photosynthesis</b>: Providing additional light to plants with this strain triggers quicker maturation.</p>


### PR DESCRIPTION
[Hydroponics][Feature]

## About the PR 
Adds a new gene/trait/common mutation, "Gene Inhibitor," a.k.a "commutblocker," which prevents plants from gaining traits from most sources.
Importantly, this DOESN'T prevent plants from mutating, unlike its closest existing counterpart, Stabilizer. 
For example: if Cannabis has been spliced to have "Gene Inhibitor" in it, it will be able to mutate into various different cannabis types as usual (e.g. rainbow weed, white weed, etc.)
However, it won't be able to gain the two traits it could usually randomly mutate, Drought Resistance and Stunted Yield. 

Currently, it can only be obtained from a random mutation in pear plants. In the future it may be added to another plant line.

## Why's this needed? 
I've wanted to add this for a long time! It's very useful for big plant splices that can have lots of possible genes (most of which you don't want) without preventing your plant from mutating into different variants.
An example is if you want to make a delicious peanut butter sandwich plant with produce full of fruit juices and don't want it to get the Toxic gene by accident (because you used onion to help splice all of your fruits together).
It also has the unique benefit of preventing seeds from getting genes via specific infusions, like Mutadone or Unstable Mutagen, which stabilizer does not prevent.
Hopefully, this makes it different enough from Stabilizer to be worth adding.

## Balance Considerations
Gene inhibitor does not affect the addition of the following genes:
- Splice Disabler in Maneater plants (after being spliced, this is important to maneater balancing).
- Enzymatic in Blooming Lasher plants upon being harvested (you probably want it).

Gene inhibitor **does** affect the following sources of genes:
- Randomly mutated genes.
- Genes produced from seed infusions (e.g. Accelerator from Ammonia infusions).
- The "inert" gene granted upon mutating Houttyunia Cordata into Wholetuna Cordata.
- Any other source of genes/traits/common mutations outside of addition via splicing.

## Testing 
1. Verify that Pears can randomly mutate commutblocker (PASS)
2. Verify that Enzymatic still applies upon a successful Blooming Lasher harvest with commutblocker (PASS)
3. Verify that the addition of inert is overridden by commutblocker in Wholetuna Cordata (PASS)
4. Verify that plants do not gain commuts via infusions (use Glowing Slurry and Unstable for this) (PASS)
5. Verify that Temporary Splicability properly turns into Splice Disabler in maneaters when spliced with commutblocker (PASS)
6. Verify that generic mutations (try in-tray mutations using Glowing Slurry) cannot add new commuts on plants with commutblocker (PASS)
7. Verify that the Hydroponics guide has been properly updated with information on “Gene Inhibitor” (PASS)
8. Verify that random mutations and infusions can still grant commuts for plants without commutblocker (PASS)
<img width="3374" height="2309" alt="testingspread" src="https://github.com/user-attachments/assets/b5ead6f4-ad20-44f4-a63a-f289d8c2c6ff" />


**TESTING DISCLAIMERS:** 
Avocado was given "commutblocker" as an innate commut for testing. This was removed at testing completion.
A new plant with a low genome (5) named "Fravocado" was created for testing the Blooming Lasher interaction. This was removed at testing completion.

Thanks to my roommate for helping spell-check the PR description! [Don't count on it.]

## Changelog 

```changelog
(u)NibChocolateeny
(+)Adds a new plant gene, "Gene Inhibitor," which prevents your plants from getting genes. Funny, that.
(+)Adds "Gene Inhibitor" as a possible gene in Pear plants.
```