### PR TITLE
Moves term_clear to termOS

### DIFF
--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -435,9 +435,6 @@
 				return src.traverse_history(params["ckey"],  1)
 		if("text")
 			if(src.active_program && params["value"]) // haha it fucking works WOOOOOO
-				if(params["value"] == "term_clear")
-					src.temp = "Cleared\n"
-					return
 				src.active_program.input_text(params["value"])
 				src.add_history(params["ckey"], params["value"])
 				playsound(src.loc, "keyboard", 50, 1, -15)

--- a/code/modules/networks/computer3/terminal.dm
+++ b/code/modules/networks/computer3/terminal.dm
@@ -54,6 +54,10 @@ file_save - Save file to local disk."}
 			return
 
 		switch(command)
+			if("term_clear")
+				src.master.temp = null
+				src.master.temp_add = "Cleared\n"
+
 			if("term_status")
 				if(src.netcard)
 					var/statdat = netcard.return_status_text()
@@ -290,7 +294,7 @@ file_save - Save file to local disk."}
 				if (!src.temp_file)
 					src.print_text("Alert: No file to save.")
 					return
-				
+
 				if (src.temp_file.dont_copy)
 					src.print_text("Error: File is copy-protected.")
 					return


### PR DESCRIPTION
[[A-Station-Systems]](https://github.com/goonstation/goonstation/issues?q=state%3Aopen%20label%3AA-Station-Systems)

## About the PR
Moves the `term_clear` command to TermOS
Removes `term_clear` from Computer3

## Why's this needed?
You could use term_clear on ThinkDOS for whatever reason and it seemed silly, especially because ThinkDOS has it's own clear commands.
Cleans up the code as well since `term_clear` was only command baked into computer3 itself.

## Testing
<img width="465" height="396" alt="image" src="https://github.com/user-attachments/assets/93885fd6-2214-40dc-ab7e-c7882eaac594" />
<img width="440" height="396" alt="image" src="https://github.com/user-attachments/assets/4f72854f-d691-4cca-a7df-28a2e8ee8b20" />
<img width="420" height="392" alt="image" src="https://github.com/user-attachments/assets/54b008d6-1cdc-47a4-875e-925256ceb1d9" />
<img width="420" height="369" alt="image" src="https://github.com/user-attachments/assets/301ad142-8118-4f27-aec8-b8d3b768679b" />
