### PR TITLE
Adds a beaker lid to the pharmacist's starting backpack

### DIFF
--- a/code/datums/jobs/jobs_medical.dm
+++ b/code/datums/jobs/jobs_medical.dm
@@ -105,5 +105,5 @@ ABSTRACT_TYPE(/datum/job/medical)
 	slot_suit = list(/obj/item/clothing/suit/labcoat/pharmacist)
 	slot_ears = list(/obj/item/device/radio/headset/pharmacist)
 	slot_eyes = list(/obj/item/clothing/glasses/spectro)
-	items_in_backpack = list(/obj/item/storage/box/beakerbox, /obj/item/reagent_containers/injector_filler)
+	items_in_backpack = list(/obj/item/storage/box/beakerbox, /obj/item/beaker_lid, /obj/item/reagent_containers/injector_filler)
 	wiki_link = "https://wiki.ss13.co/Pharmacist"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a beaker lid to the pharmacist's starting backpack

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A lot of medical reagent recipes benefit significantly from being able to close a container, even simple ones like styptic powder and charcoal. With pharmacist now being a separate medical job with more focus on chemistry, it seems kind to provide them with a lid for such purposes. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="1447" height="1079" alt="image" src="https://github.com/user-attachments/assets/58baf2d4-bc83-4892-912e-946d157ce1ec" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Spyritdragon
(+)Pharmacists now get a beaker lid in their starting backpack. 
```
