### PR TITLE
Reimplement adminprints keyname

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1027,7 +1027,7 @@ var/list/fun_images = list()
 
 	ADMIN_ONLY
 	SHOW_VERB_DESC
-	boutput(src, O.get_adminprints())
+	boutput(src, replacetext(replacetext(O.get_adminprints(), "%admin_ref%", "\ref[src.holder]"), "%client_ref%", "\ref[src]"))
 
 /client/proc/respawn_cinematic()
 	set name = "Respawn Cinematic"

--- a/code/modules/forensics/forensic_data.dm
+++ b/code/modules/forensics/forensic_data.dm
@@ -81,8 +81,8 @@
 		var/mins_start = src.get_minutes_since(TIME, TRUE)
 		var/mins_end = src.get_minutes_since(TIME)
 		if(mins_start == mins_end)
-			return src.clientKey.id + SPAN_SUBTLE(" ([mins_end] mins ago)")
-		return src.clientKey.id + SPAN_SUBTLE(" ([mins_end] to [mins_start] mins ago)")
+			return key_name(src.clientKey.id) + SPAN_SUBTLE(" ([mins_end] mins ago)")
+		return key_name(src.clientKey.id) + SPAN_SUBTLE(" ([mins_end] to [mins_start] mins ago)")
 
 	get_copy()
 		var/datum/forensic_data/adminprint/data_copy = new(src.clientKey)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Viewing adminprints once again uses key_name(target) to display current character name and player options button.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Admin QoL instead of manually having to run player-options-key (pok) for a ckey.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Clicking the player options button or ckey correctly opens player options or adminpm
<img width="345" height="81" alt="image" src="https://github.com/user-attachments/assets/4997adcb-9d22-49a0-b361-12eb0e20418d" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->


