### PR TITLE
adds two wizard headsets to magivend

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2624,12 +2624,13 @@ TYPEINFO(/obj/machinery/vending/monkey)
 		product_list += new/datum/data/vending_product(/obj/item/clothing/head/wizard/green, 2)
 		product_list += new/datum/data/vending_product(/obj/item/clothing/suit/wizrobe/green, 2)
 		product_list += new/datum/data/vending_product(/obj/item/clothing/head/wizard/witch, 2)
-		product_list += new/datum/data/vending_product(/obj/item/clothing/head/wizard/necro, 2, hidden=1)
-		product_list += new/datum/data/vending_product(/obj/item/clothing/suit/wizrobe/necro, 2, hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/clothing/shoes/sandal/magic/wizard, 8)
 		product_list += new/datum/data/vending_product(/obj/item/staff, 4)
+		product_list += new/datum/data/vending_product(/obj/item/device/radio/headset/wizard, 4)
+
 		product_list += new/datum/data/vending_product(/obj/item/staff/crystal, 4, hidden=1)
-		product_list += new/datum/data/vending_product(/obj/item/device/radio/headset/wizard, 2)
+		product_list += new/datum/data/vending_product(/obj/item/clothing/head/wizard/necro, 2, hidden=1)
+		product_list += new/datum/data/vending_product(/obj/item/clothing/suit/wizrobe/necro, 2, hidden=1)
 
 /obj/machinery/vending/standard
 	desc = "A vending machine full of various useful tools and devices that definitely cannot be used to make bombs"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds two wizard headsets to magivend

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wizards cannot talk over/hear the radio without an EMP proof headset. Wizards who are resurrected through soul guard or who lose theirs to the clown can now get a new one from the wizards den. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested on local, works as intended. 

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bamlord
(+)Wizards can now collect a new headset from the magivend after losing theirs to the clown/dying
```
