### PR TITLE
Harmonic Siphon: scaling power consumption + overload adjustment

### DIFF
--- a/code/modules/siphon/siphon_controls.dm
+++ b/code/modules/siphon/siphon_controls.dm
@@ -430,7 +430,7 @@
 	have a linear effect on extraction rate, their effect<br>
 	on power consumption is not linear; additional<br>
 	consumption from intensity is equal to 800 watts times<br>
-	the draw factor (intensity to the power of 1.6,
+	the draw factor (intensity to the power of 1.55,
 	minus intensity times two). Lower levels of intensity<br>
 	offer significantly better electrical efficiency.<br>
 	<br>

--- a/code/modules/siphon/siphon_machinery.dm
+++ b/code/modules/siphon/siphon_machinery.dm
@@ -645,7 +645,7 @@ ABSTRACT_TYPE(/obj/machinery/siphon)
 		return devdat
 
 	proc/get_drawmod()
-		return max(1,src.resofactor ** 1.6 - (2 * src.resofactor))
+		return max(1,src.resofactor ** 1.55 - (2 * src.resofactor))
 
 	proc/clear_siphon_console()
 		var/datum/signal/reply = new


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[FEAT][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adjusts the harmonic siphon to require additional power, and have additional consequences when that power demand is not met.

- Instead of linearly scaling electrical draw based on intensity (800 watts times intensity), the effective multiplier to electrical draw is now intensity raised to the power of 1.55, minus the intensity times two (more details below).
- To make this legible to players, estimated active draw is now included in the siphon systems control's readout of the harmonic siphon, and the formula has been added to the calibration database's glossary section.
- Interruption to power while extraction is underway now has a chance to cause resonator failure under some circumstances. Failure chance is based on the **sum of both shear and field dilation** and is rolled individually per resonator, with a 1% chance of failure per 8 shear or 1.6% field dilation; it will never occur below 8% chance (similar to being off extraction target at low levels of shear). This does _not_ make field dilation increase the odds of off-target resonator failure.

The new power draw formula is designed to have a quite mild impact to setups using the set of resonators available at round start, while making high intensity levels a significant imposition on your electrical inputs (and preferably local cell). Here are some before-and-after cases to demonstrate the difference.

- **10 intensity** (used by several reference configurations): Effective multiplier of ~15.5, draw addition from intensity increased from 8 kW to ~12.4 kW.
- **16 intensity** (maximum intensity possible with roundstart Type-AX resonators): Effective multiplier of ~41.5, draw addition from intensity increased from 12.8 kW to ~33.2 kW.
- **50 intensity** (typical figure with several custom resonators trying to hit an advanced target): Effective multiplier of ~330, draw addition from intensity increased from 40 kW to ~264 kW.
- **180 intensity** (high-power setup producing large volumes of advanced-target materials): Effective multiplier of ~2,770, draw addition from intensity increased from 144 kW to ~2.21 MW.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Now that Nadir has a real engine (nuclear), increasing the electrical demand of high-power setups increases the overall mechanical depth of advanced extraction. This isn't intended primarily as a nerf, though it does function as one in practice; that being said, basic 4-resonator use remains able to comfortably operate off of catalytic generators or the local generator that can be retrieved from Engineering.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Validated ingame that estimated draw is displaying at intended value (and actual draw is appropriate), and outages will cause failures under intended circumstances.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(*)Nadir's Harmonic Siphon now consumes dramatically more power at high intensity, and may experience mechanical failures if power is interrupted mid-operation.
```
