### PR TITLE
Kleptomaniac trait rework

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -18978,6 +18978,9 @@
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bIw" = (
@@ -18992,6 +18995,9 @@
 "bIy" = (
 /obj/table/reinforced/auto,
 /obj/item/pen,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/courtroom)
 "bIz" = (
@@ -19008,11 +19014,11 @@
 /obj/item/device/radio/intercom{
 	pixel_x = 1
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/disposalpipe/segment/brig{
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/bar/edge{
 	dir = 10
@@ -29942,6 +29948,12 @@
 /obj/decal/tile_edge/floorguide/hop,
 /turf/simulated/floor/red/corner,
 /area/station/hallway/primary/south)
+"ewG" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
 "ewL" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
@@ -30936,6 +30948,14 @@
 	},
 /turf/space,
 /area/station/turret_protected/armory_outside)
+"fhM" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/stairs/wood{
+	dir = 9
+	},
+/area/station/crew_quarters/courtroom)
 "fhZ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -31805,6 +31825,16 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/white/grime,
 /area/station/hangar/science)
+"fMY" = (
+/obj/disposalpipe/segment/brig{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
 "fNA" = (
 /obj/item/storage/wall/random{
 	dir = 8;
@@ -33783,6 +33813,15 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"gYX" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/courtroom)
 "gYY" = (
 /turf/simulated/floor/red,
 /area/station/ai_monitored/armory)
@@ -35837,9 +35876,6 @@
 "izO" = (
 /obj/table/reinforced/bar/auto{
 	name = "wooden table"
-	},
-/obj/cable{
-	icon_state = "0-2"
 	},
 /obj/machinery/shredder{
 	pixel_y = 11
@@ -38986,6 +39022,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
+"kEF" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/courtroom)
 "kER" = (
 /obj/lattice{
 	dir = 6;
@@ -40699,6 +40744,9 @@
 "lIw" = (
 /obj/stool/chair{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
 /area/station/crew_quarters/courtroom)
@@ -42646,6 +42694,9 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
 "nbp" = (
@@ -55471,6 +55522,15 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/west)
+"vVP" = (
+/obj/stool/chair{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/courtroom)
 "vWN" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/purple/side{
@@ -115759,9 +115819,9 @@ bDA
 pdL
 bFO
 bGV
-bMt
-bMt
-bMt
+vVP
+gYX
+kEF
 bMt
 cnX
 tiv
@@ -116061,7 +116121,7 @@ bDA
 bEv
 bFO
 eCH
-bMu
+fhM
 bMu
 bMu
 bMu
@@ -116665,7 +116725,7 @@ ugo
 ewx
 kpk
 hKu
-pAz
+ewG
 pAz
 spB
 pot
@@ -117571,7 +117631,7 @@ bDA
 bEv
 bFO
 rpN
-bIz
+fMY
 bJV
 pAz
 pAz


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The kleptomaniac trait now makes you occasionally grab something and stuff it into your pockets, bag, or belt. It won't do this if you don't have space for the item.
Also adds an even smaller chance to try to pickpocket something from someone standing next to you.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Kleptomaniac is a cool trait idea that almost nobody uses because it's extremely annoying. Most of the time you just pick up random junk objects and then have to drop them again, or go to click on a fabricator and accidentally hit it with the pen you grabbed 1 tick before.
This changes it so you're actually stealing things and not just picking them up to drop again.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested with highly increased odds, standing next to a variety of items including paper bins and other things with weird click interactions.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)The kleptomaniac trait now makes you grab things and stuff them in your bag and pockets, stopping when you have no more space. It also now makes you rarely try to pickpocket the person standing next to you.
```
