### PR TITLE
PDA-Text Chat Notification

### DIFF
--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -1062,6 +1062,7 @@
 				return 1
 
 			message = copytext(message, 1, 257)
+			usr.visible_message(SPAN_NOTICE("[usr] types on their PDA."), "you type on your PDA","you hear typing.")
 
 			phrase_log.log_phrase("pda", message)
 

--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -1062,8 +1062,7 @@
 				return 1
 
 			message = copytext(message, 1, 257)
-			usr.visible_message(SPAN_NOTICE("[usr] types on their PDA."), "you type on your PDA.","you hear typing.")
-
+			usr.audible_message(SPAN_NOTICE("You hear a faint typing noise."),SPAN_NOTICE("You type on your PDA."))
 			phrase_log.log_phrase("pda", message)
 
 			if (findtext(message, "bitcoin") != 0 || findtext(message, "drug") != 0 || findtext(message, "pharm") != 0 || findtext(message, "lottery") != 0 || findtext(message, "scient") != 0 || findtext(message, "luxury") != 0 || findtext(message, "vid") != 0 || findtext(message, "quality") != 0)

--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -1062,7 +1062,7 @@
 				return 1
 
 			message = copytext(message, 1, 257)
-			usr.visible_message(SPAN_NOTICE("[usr] types on their PDA."), "you type on your PDA","you hear typing.")
+			usr.visible_message(SPAN_NOTICE("[usr] types on their PDA."), "you type on your PDA.","you hear typing.")
 
 			phrase_log.log_phrase("pda", message)
 


### PR DESCRIPTION
## About the PR 
Makes it so when you send someone a text over the PDA, a message/notification is given in the chat of the other players around you.

## Why's this needed? 
The main goal is to limit secret communication. If you press a crisis alert everyone will know, however if you just send a message to the same line, no one will. This PR aims to change that.

## Testing 
Spawned in two accounts, sent a PDA message, text appeared as expected. Testing did not show interferance with Crisis alert/ACK.

```changelog
(u)LDee
(*)Added a chat message to show when a PDA message was sent from the user.
