### PR TITLE
Neon Clone Lab Fix

### DIFF
--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -23888,7 +23888,7 @@
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
 "reZ" = (
-/obj/storage/secure/closet/medical,
+/obj/storage/secure/closet/medical/cloning,
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
 	icon_state = "0-8"


### PR DESCRIPTION
## About The PR:
Replaces the medical locker (`/obj/storage/secure/closet/medical`) in Neon's Clone Lab with a cloning storage locker (`/obj/storage/secure/closet/medical/cloning`). The only difference between the two types is that the cloning storage locker does not start bolted to the floor.


## Why Is This Needed?
See #26086.


## Testing:
Neon does indeed now have a cloning storage locker, and it is able to be dragged freely.