### PR TITLE
Allow lifeforms to breathe disposal holder air

### DIFF
--- a/code/modules/disposals/disposal.dm
+++ b/code/modules/disposals/disposal.dm
@@ -15,10 +15,15 @@
 
 /obj/disposalholder
 	invisibility = INVIS_ALWAYS
-	var/datum/gas_mixture/gas = null	// gas used to flush, will appear at exit point
-	var/active = 0	// true if the holder is moving, otherwise inactive
+	///Gas used to flush the holder; will appear at exit point if vent_on_exit is TRUE
+	var/datum/gas_mixture/gas
+	///Whether to emit gas at the exit point (disabled for mail chutes)
+	var/vent_on_exit = TRUE
+	///True if the holder is moving, otherwise inactive
+	var/active = 0
 	dir = 0
-	var/count = 1000	//! can travel 1000 steps before going inactive (in case of loops)
+	///Budget of steps the disposalholder is allowed to travel before going inactive (in case of loops)
+	var/count = 1000
 
 	var/slowed = 0 // when you move, slows you down
 
@@ -157,6 +162,11 @@
 		damage_pipe(5)
 		slowed++
 
+	handle_internal_lifeform(mob/lifeform_inside_me, breath_request, mult)
+		if (src.gas && breath_request > 0)
+			return src.gas
+		..()
+
 	proc/damage_pipe(var/amount = 3)
 		var/obj/disposalpipe/P = src.loc
 		if(istype(P))
@@ -166,8 +176,9 @@
 
 	// called to vent all gas in holder to a location
 	proc/vent_gas(var/atom/location)
-		location?.assume_air(gas)  // vent all gas to turf
-		gas = null
+		if(src.gas && src.vent_on_exit)
+			location?.assume_air(gas)  // vent all gas to turf
+		src.gas = null
 		return
 
 // Disposal pipes

--- a/code/modules/disposals/mail_chute.dm
+++ b/code/modules/disposals/mail_chute.dm
@@ -94,17 +94,18 @@
 		if (istype(src, /obj/machinery/disposal/mail)) FLICK("[src.icon_state]-flush", src)
 		else FLICK("disposal-flush", src)
 
-		ZERO_GASES(air_contents)
-
-		sleep(1 SECOND)
-		playsound(src, 'sound/machines/disposalflush.ogg', 50, FALSE, 0)
-		sleep(0.5 SECONDS) // wait for animation to finish
-
 		var/obj/disposalholder/H = new /obj/disposalholder	// virtual holder object which actually
 																// travels through the pipes.
 
 		H.init(src)	// copy the contents of disposer to holder
 		H.mail_tag = src.destination_tag
+		H.vent_on_exit = FALSE
+
+		ZERO_GASES(air_contents)
+
+		sleep(1 SECOND)
+		playsound(src, 'sound/machines/disposalflush.ogg', 50, FALSE, 0)
+		sleep(0.5 SECONDS) // wait for animation to finish
 
 		H.start(src) // start the holder processing movement
 		flushing = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[ATMOS][LOGISTICS][REWORK]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Exposes the gas used to flush a disposalholder for breathing by lifeforms inside that disposalholder.

As an associated change, mail chutes no longer delete their flushing atmosphere entirely; instead, the disposalholder has a new vent_on_exit variable that can be set to FALSE to achieve the same effect of not venting the gasses at the exit while preserving the gathered atmosphere for anything traveling in the disposalholder.

Also adjusted comments on /obj/disposalholder in the immediate vicinity of the newly added vent_on_exit variable.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Gives more functionality to an already-present system. Particularly useful for transferring people through space pipes (ie Fleet2).

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Did a big loop in a disposal pipe routed through space and could breathe in the process.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)While in the disposal system, you can breathe the atmosphere that was used by disposal units to flush you along.
```