### PR TITLE
Tables prevent hiding items under floors on their tiles

### DIFF
--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -2387,10 +2387,10 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 
 /turf/simulated/floor/restore_tile(do_hide = TRUE)
 	..()
-	if (!do_hide)
+	if (!do_hide || (locate(/obj/table) in src))
 		return
 	for (var/obj/item/item in src.contents)
-		if (item.w_class <= W_CLASS_TINY && !item.anchored && !(locate(/obj/table) in item.loc)) //I wonder if this will cause problems
+		if (item.w_class <= W_CLASS_TINY && !item.anchored) //I wonder if this will cause problems
 			src.hide_inside(item)
 
 ///CRIME


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Items on the same tile as tables won't be hidden when floor tiles are replaced under them. 

Also, if any reviewers are wondering why I didn't just put the table locating check next to the do_hide check: I tried, but it kept detecting tables which didn't actually exist.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Items on top of tables getting hidden when you replace the floor tiles under the table doesn't make sense and is mildly annoying when you're replacing already-missing floor tiles.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Pried up and replaced a floor tile under a table with a pen on it, pen didn't get hidden. Dropped pen onto the floor and replaced the floor tile, pen did get hidden.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)nova2053
(+)Replacing floor tiles under tables will no longer hide items under the floor tiles.
```
