### PR TITLE
Fixes `mv` Not Telling The User If A Path Does Not Exist

### DIFF
--- a/code/modules/networks/computer3/mainframe2/programs/utilities/mv.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/mv.dm
@@ -24,14 +24,18 @@
 
 	var/copy_name = null
 	var/dest_check = src.signal_program(1, list("command" = DWAINE_COMMAND_FGET, "path" = initlist[2]))
-	if (dest_check != ESIG_NOFILE)
-		if (istype(dest_check, /datum/computer/folder) && !src.get_computer_datum(target.name, dest_check))
-			copy_name = target.name
+	if (dest_check == ESIG_NOFILE)
+		src.message_user("Error: Destination path does not exist.")
+		mainframe_prog_exit
+		return
 
-		else
-			src.message_user("Error: Invalid destination path (Path already taken?).")
-			mainframe_prog_exit
-			return
+	else if (istype(dest_check, /datum/computer/folder) && !src.get_computer_datum(target.name, dest_check))
+		copy_name = target.name
+
+	else
+		src.message_user("Error: Invalid destination path (Path already taken?).")
+		mainframe_prog_exit
+		return
 
 	var/list/destination_path = splittext(initlist[2], "/")
 	if (!copy_name)

--- a/code/modules/networks/computer3/mainframe2/programs/utilities/mv.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/mv.dm
@@ -29,7 +29,7 @@
 		mainframe_prog_exit
 		return
 
-	else if (istype(dest_check, /datum/computer/folder) && !src.get_computer_datum(target.name, dest_check))
+	if (istype(dest_check, /datum/computer/folder) && !src.get_computer_datum(target.name, dest_check))
 		copy_name = target.name
 
 	else


### PR DESCRIPTION
## About The PR:
`mv` will now inform the user if the directory they are attempting to move a file to does not exist.
This is consistent with how `mv` works on Unix.


## Testing:
<img width="303" height="96" alt="image" src="https://github.com/user-attachments/assets/7d707ac0-8560-48e7-b01e-3792181fef44" />