### PR TITLE
Comp3s check for motherboard instead of periph. Fixes #26202

### DIFF
--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -291,7 +291,10 @@
 		src.AddOverlays(screen_image, "screen_image")
 
 	SPAWN(0.4 SECONDS)
-		if(!length(src.peripherals)) // make sure this is the first time we're initializing this computer
+		if(!src.mainboard) // make sure this is the first time we're initializing this computer
+			mainboard = new /obj/item/motherboard()
+			if(mainboard.created_name)src.name = mainboard.created_name
+
 			if(ispath(src.setup_starting_peripheral1))
 				new src.setup_starting_peripheral1(src) //Peripherals add themselves automatically if spawned inside a computer3
 
@@ -331,11 +334,6 @@
 					src.active_program = os
 
 				src.hd.root.add_file(os)
-
-			if(!src.mainboard)
-				mainboard = new /obj/item/motherboard()
-			if(mainboard.created_name)src.name = mainboard.created_name
-
 
 		src.post_system()
 


### PR DESCRIPTION
## About the PR
Computer3 now checks to see if it has a motherboard instead of checking to see if it has peripherals before self-initialising.

## Why's this needed?
Old bug that was recently uncovered with my PR. Basically computers can self-initialise for round start purposes if they have no peripherals. This is a flawed method because it's possible to complete a computer without peripherals, and thus you can trigger a pre-built computer to reinitialise itself.
I check for motherboard existence now instead because completing a computer always requires a motherboard.

## Testing
<img width="667" height="446" alt="image" src="https://github.com/user-attachments/assets/868e73ca-3d1d-4518-af07-9f34dd28289b" />

_Computer with all peripherals_


<img width="633" height="380" alt="image" src="https://github.com/user-attachments/assets/29ae069e-8b07-40fb-98b7-526a33b0e8cc" />

_Removed computer peripherals_


<img width="597" height="419" alt="image" src="https://github.com/user-attachments/assets/3ee59fd1-3157-4bad-90bb-2db94ca90b12" />

_Rebuilt pc, no ID scanner, so it didn't reinitialise, unlike on the master branch where there would be a new ID scanner._