### PR TITLE
Remove req_access_txt from z2

### DIFF
--- a/_std/defines/access.dm
+++ b/_std/defines/access.dm
@@ -126,3 +126,6 @@
 
 //Lunar door access, given to the tour guide to open the door
 #define access_lunar_breakdoor 90
+
+//Access to the captain's quarters on the russian ainley ship. Only given to the relavant guardbuddy.
+#define access_ainley_buddy 91

--- a/code/modules/mapping/helpers/access_spawn.dm
+++ b/code/modules/mapping/helpers/access_spawn.dm
@@ -347,6 +347,11 @@
 	req_access = list(access_lunar_breakdoor)
 	color = ENGINEERING
 
+/obj/mapping_helper/access/ainley_buddy
+	name = "ainley buddy access spawn"
+	req_access = list(access_ainley_buddy)
+	color = COMMAND
+
 #undef MEDICAL
 #undef SECURITY
 #undef MORGUE_BLACK

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1532,6 +1532,9 @@ TYPEINFO(/obj/machinery/vending/medical)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38, rand(1, 2), hidden=1) // Obtaining a backpack full of lethal ammo required no effort whatsoever, hence why nobody ordered AP speedloaders from the Syndicate (Convair880).
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/snacks/donut, rand(2, 4), hidden=1) // emergency snack
 
+/obj/machinery/vending/security/owlery
+	req_access = list(access_owlerysec)
+
 /obj/machinery/vending/security_ammo //shitsec time yes
 	name = "AmmoTech"
 	desc = "A restricted vendor stocked with various riot-suppressive ammunitions."

--- a/code/obj/storage/secure_crates.dm
+++ b/code/obj/storage/secure_crates.dm
@@ -48,6 +48,9 @@
 		icon_closed = "sec_contraband"
 		icon_state = "sec_contraband"
 
+		owlery
+			req_access = list(access_owlerysec)
+
 	armory
 		name = "secure weapons crate"
 		req_access = list(access_armory)

--- a/code/z_adventurezones/hospital.dm
+++ b/code/z_adventurezones/hospital.dm
@@ -457,7 +457,7 @@ TYPEINFO(/obj/machinery/bot/guardbot/soviet)
 #endif
 		SPAWN(1 SECOND)
 			if (src.botcard)
-				src.botcard.access += FREQ_AINLEY_BUDDY
+				src.botcard.access += access_ainley_buddy
 
 	turn_on()
 		if(!src.cell || src.cell.charge <= 0)

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -349,8 +349,7 @@
 /area/hospital)
 "adl" = (
 /obj/machinery/door/airlock/pyro/medical{
-	name = "Hydrotherapy Room";
-	req_access_txt = ""
+	name = "Hydrotherapy Room"
 	},
 /turf/unsimulated/floor/blue,
 /area/hospital)
@@ -1106,8 +1105,7 @@
 "agc" = (
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
-	name = "Patient Room";
-	req_access_txt = ""
+	name = "Patient Room"
 	},
 /turf/unsimulated/floor/white,
 /area/hospital)
@@ -2280,8 +2278,7 @@
 "amb" = (
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
-	name = "Patient Room";
-	req_access_txt = ""
+	name = "Patient Room"
 	},
 /turf/unsimulated/floor/white/grime,
 /area/hospital)
@@ -2792,9 +2789,9 @@
 /area/hospital/samostrel)
 "anP" = (
 /obj/machinery/door/airlock/pyro/command{
-	name = "captain's quarters";
-	req_access_txt = "1917"
+	name = "captain's quarters"
 	},
+/obj/mapping_helper/access/ainley_buddy,
 /turf/unsimulated/floor/carpet/office,
 /area/hospital/samostrel)
 "anS" = (
@@ -2894,9 +2891,9 @@
 "aor" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
-	name = "Security Booth";
-	req_access_txt = "1"
+	name = "Security Booth"
 	},
+/obj/mapping_helper/access/security,
 /turf/unsimulated/floor/red/side{
 	dir = 4
 	},
@@ -3763,8 +3760,7 @@
 "asj" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
-	name = "Compartment Access";
-	req_access_txt = ""
+	name = "Compartment Access"
 	},
 /turf/unsimulated/floor/caution/east,
 /area/hospital/samostrel)
@@ -4386,8 +4382,7 @@
 /obj/machinery/door/airlock/pyro/engineering{
 	desc = "Oh sure it looks the same, but all the connections and mounting points are different.  Also all the screw heads are those awful triangular ones.";
 	dir = 4;
-	name = "Reactor Control";
-	req_access_txt = ""
+	name = "Reactor Control"
 	},
 /turf/unsimulated/floor{
 	icon = 'icons/turf/shuttle.dmi';
@@ -5162,8 +5157,7 @@
 /area/owlery/owllock)
 "azn" = (
 /obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	req_access_txt = ""
+	dir = 4
 	},
 /turf/unsimulated/floor,
 /area/hospital)
@@ -22395,8 +22389,7 @@
 "bLA" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
-	name = "Toilet Cubicle";
-	req_access_txt = "0"
+	name = "Toilet Cubicle"
 	},
 /turf/unsimulated/floor/white/corner,
 /area/crunch)
@@ -25113,9 +25106,9 @@
 /area/crypt/sigma/mainhall)
 "bVm" = (
 /obj/machinery/door/airlock/pyro{
-	name = "Kitchen";
-	req_access_txt = "28"
+	name = "Kitchen"
 	},
+/obj/mapping_helper/access/kitchen,
 /turf/unsimulated/floor/white/grime,
 /area/crypt/sigma/mainhall)
 "bVn" = (
@@ -25456,9 +25449,9 @@
 "bWK" = (
 /obj/creepy_sound_trigger,
 /obj/machinery/door/airlock/pyro{
-	name = "Kitchen";
-	req_access_txt = "28"
+	name = "Kitchen"
 	},
+/obj/mapping_helper/access/kitchen,
 /turf/unsimulated/floor/white/grime,
 /area/crypt/sigma/kitchen)
 "bWM" = (
@@ -26624,8 +26617,7 @@
 "caH" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
-	name = "Lab Maintenance Access";
-	req_access_txt = ""
+	name = "Lab Maintenance Access"
 	},
 /obj/trigger/critter,
 /turf/unsimulated/floor/white,
@@ -27525,8 +27517,7 @@
 	icon_state = "fdoor0"
 	},
 /obj/machinery/door/airlock/pyro/medical{
-	name = "Receiver Control";
-	req_access_txt = ""
+	name = "Receiver Control"
 	},
 /turf/unsimulated/floor,
 /area/meat_derelict/entry)
@@ -31154,8 +31145,7 @@
 /area/crunch/wtc)
 "crD" = (
 /obj/machinery/door/airlock/pyro/classic{
-	dir = 4;
-	req_access_txt = "12"
+	dir = 4
 	},
 /turf/unsimulated/floor/grey,
 /area/crunch/wtc)
@@ -31174,8 +31164,7 @@
 /area/crunch/wtc)
 "crH" = (
 /obj/machinery/door/airlock/pyro/classic{
-	dir = 4;
-	req_access_txt = "12"
+	dir = 4
 	},
 /turf/unsimulated/floor/neutral,
 /area/crunch/wtc)
@@ -33057,8 +33046,7 @@
 "cxU" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/window{
-	icon_state = "right";
-	req_access_txt = "0"
+	icon_state = "right"
 	},
 /obj/random_item_spawner/desk_stuff,
 /turf/unsimulated/floor/bluewhite{
@@ -33162,8 +33150,7 @@
 "cyn" = (
 /obj/machinery/door/airlock/pyro/classic{
 	dir = 4;
-	name = "Kitchen";
-	req_access_txt = "12"
+	name = "Kitchen"
 	},
 /turf/unsimulated/floor/wood/two,
 /area/owlery/staffhall)
@@ -33343,8 +33330,7 @@
 /area/owlery/staffhall)
 "cyR" = (
 /obj/machinery/door/airlock/gannets/alt{
-	dir = 8;
-	req_access_txt = "12"
+	dir = 8
 	},
 /turf/unsimulated/floor/white,
 /area/owlery/staffhall)
@@ -33742,8 +33728,7 @@
 /area/owlery/staffhall)
 "cAc" = (
 /obj/machinery/door/airlock/pyro/glass{
-	name = "Owl Ward";
-	req_access_txt = "12"
+	name = "Owl Ward"
 	},
 /turf/unsimulated/floor/black,
 /area/owlery/gangzone)
@@ -34872,9 +34857,7 @@
 	},
 /area/owlery/Owlopen)
 "cDv" = (
-/obj/machinery/vending/security{
-	req_access_txt = "71"
-	},
+/obj/machinery/vending/security/owlery,
 /turf/unsimulated/floor/redblack/corner,
 /area/owlery/Owlopen)
 "cDw" = (
@@ -35027,8 +35010,7 @@
 	},
 /obj/machinery/door/window{
 	dir = 8;
-	icon_state = "right";
-	req_access_txt = "0"
+	icon_state = "right"
 	},
 /turf/unsimulated/floor/redblack{
 	dir = 8
@@ -35087,8 +35069,7 @@
 	name = "exhibit window"
 	},
 /obj/machinery/door/window{
-	dir = 4;
-	req_access_txt = "0"
+	dir = 4
 	},
 /turf/unsimulated/floor/redblack{
 	dir = 4
@@ -35387,12 +35368,10 @@
 /obj/item/gun/flamethrower/assembled/loaded,
 /obj/item/clothing/suit/hazard/fire/armored,
 /obj/item/clothing/head/helmet/welding,
-/obj/storage/secure/crate/weapon/confiscated_items{
-	req_access_txt = "71"
-	},
 /obj/machinery/light/emergency{
 	dir = 4
 	},
+/obj/storage/secure/crate/weapon/confiscated_items/owlery,
 /turf/unsimulated/floor/redblack/corner{
 	dir = 1
 	},
@@ -36961,8 +36940,7 @@
 /area/owlery/owleryhall)
 "cJN" = (
 /obj/machinery/door/window{
-	dir = 4;
-	req_access_txt = "12"
+	dir = 4
 	},
 /turf/unsimulated/floor/wood/two,
 /area/owlery/owleryhall)
@@ -40337,8 +40315,7 @@
 "cTq" = (
 /obj/machinery/door/window{
 	dir = 8;
-	icon_state = "right";
-	req_access_txt = "0"
+	icon_state = "right"
 	},
 /turf/unsimulated/floor/yellowblack{
 	dir = 4
@@ -47284,9 +47261,9 @@
 	},
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
-	name = "Morgue";
-	req_access_txt = "5"
+	name = "Morgue"
 	},
+/obj/mapping_helper/access/medical,
 /turf/unsimulated/floor/black,
 /area/crypt/sigma/lab)
 "dvl" = (
@@ -49449,10 +49426,10 @@
 /area/shuttle/merchant_shuttle/right_centcom/destiny)
 "dEe" = (
 /obj/machinery/door/airlock/pyro/medical{
-	name = "Morgue";
-	req_access_txt = "5"
+	name = "Morgue"
 	},
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/access/medical,
 /turf/unsimulated/floor/plating,
 /area/crypt/sigma/lab)
 "dEm" = (
@@ -49851,9 +49828,9 @@
 /obj/creepy_sound_trigger,
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
-	name = "Morgue";
-	req_access_txt = "5"
+	name = "Morgue"
 	},
+/obj/mapping_helper/access/medical,
 /turf/unsimulated/floor/white/grime,
 /area/crypt/sigma/lab)
 "dFE" = (
@@ -55946,10 +55923,10 @@
 /area/retentioncenter)
 "feE" = (
 /obj/machinery/door/airlock/pyro/command{
-	name = "Research Director's Office";
-	req_access_txt = "19"
+	name = "Research Director's Office"
 	},
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/access/heads,
 /turf/unsimulated/floor/plating,
 /area/crypt/sigma/rd)
 "ffj" = (
@@ -57482,10 +57459,10 @@
 	aiControlDisabled = 1;
 	dir = 4;
 	locked = 1;
-	name = "Lower Level Access";
-	req_access_txt = "33"
+	name = "Lower Level Access"
 	},
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/access/chemistry,
 /turf/unsimulated/floor/plating,
 /area/crypt/sigma/mainhall)
 "gpj" = (
@@ -62650,8 +62627,7 @@
 /obj/machinery/door/airlock/pyro/engineering{
 	desc = "Oh sure it looks the same, but all the connections and mounting points are different.  Also all the screw heads are those awful triangular ones.";
 	dir = 4;
-	name = "Reactor Control";
-	req_access_txt = ""
+	name = "Reactor Control"
 	},
 /turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
@@ -64132,10 +64108,10 @@
 	aiControlDisabled = 1;
 	dir = 4;
 	locked = 1;
-	name = "Upper Level Access";
-	req_access_txt = "33"
+	name = "Upper Level Access"
 	},
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/access/chemistry,
 /turf/unsimulated/floor/plating,
 /area/crater/biodome/crew)
 "loh" = (
@@ -66755,9 +66731,7 @@
 	},
 /area/centcom)
 "nvY" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	req_access_txt = ""
-	},
+/obj/machinery/door/airlock/pyro/maintenance,
 /turf/unsimulated/floor/plating,
 /area/hospital)
 "nwd" = (
@@ -70641,8 +70615,7 @@
 /area/watchful_eye_sensor)
 "qlV" = (
 /obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	req_access_txt = ""
+	dir = 4
 	},
 /turf/unsimulated/floor/plating,
 /area/hospital/underground)
@@ -70867,7 +70840,6 @@
 	dir = 4;
 	locked = 1;
 	name = "Hazardous Materials Storage";
-	req_access_txt = "";
 	secondsElectrified = -1
 	},
 /obj/trigger/critter,
@@ -71030,8 +71002,7 @@
 /area/centcom/gallery)
 "qAU" = (
 /obj/machinery/door/airlock/pyro/security{
-	name = "Lab Security";
-	req_access_txt = ""
+	name = "Lab Security"
 	},
 /obj/decal/stripe_delivery,
 /turf/unsimulated/floor/plating,
@@ -73584,8 +73555,7 @@
 /area/shuttle/merchant_shuttle/left_centcom/cogmap)
 "srF" = (
 /obj/machinery/door/airlock/pyro/maintenance{
-	name = "Maintenance Office";
-	req_access_txt = ""
+	name = "Maintenance Office"
 	},
 /turf/unsimulated/floor/plating,
 /area/hospital/underground)
@@ -74693,8 +74663,7 @@
 /area/upper_arctic/mining)
 "tsB" = (
 /obj/machinery/door/airlock/pyro/maintenance{
-	name = "Compartment Access";
-	req_access_txt = ""
+	name = "Compartment Access"
 	},
 /turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
@@ -74959,8 +74928,7 @@
 "tIZ" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/window{
-	dir = 4;
-	req_access_txt = "0"
+	dir = 4
 	},
 /obj/machinery/recharger,
 /obj/mapping_helper/access/owlsecurity,
@@ -74980,8 +74948,7 @@
 /area/void_diner)
 "tKZ" = (
 /obj/machinery/door/airlock/pyro/maintenance{
-	name = "Atmospheric Processing";
-	req_access_txt = ""
+	name = "Atmospheric Processing"
 	},
 /turf/unsimulated/floor/plating,
 /area/hospital)
@@ -76075,9 +76042,7 @@
 	},
 /area/titlescreen)
 "uEt" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	req_access_txt = ""
-	},
+/obj/machinery/door/airlock/pyro/maintenance,
 /turf/unsimulated/floor/plating,
 /area/meat_derelict/main)
 "uEu" = (
@@ -76488,8 +76453,7 @@
 "uVk" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4;
-	name = "Compartment Access";
-	req_access_txt = ""
+	name = "Compartment Access"
 	},
 /turf/unsimulated/floor/plating,
 /area/hospital/samostrel)
@@ -78464,9 +78428,7 @@
 	},
 /area/meat_derelict/soviet)
 "wmE" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	req_access_txt = ""
-	},
+/obj/machinery/door/airlock/pyro/maintenance,
 /turf/unsimulated/floor/plating,
 /area/hospital/underground)
 "wmU" = (
@@ -78671,8 +78633,7 @@
 "wvp" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/window{
-	icon_state = "right";
-	req_access_txt = "0"
+	icon_state = "right"
 	},
 /obj/item/folder,
 /obj/item/card/id/owlgold{
@@ -79386,10 +79347,10 @@
 	locked = 1;
 	name = "Armory";
 	opacity = 0;
-	operating = -1;
-	req_access_txt = "37"
+	operating = -1
 	},
 /obj/decal/stripe_caution,
+/obj/mapping_helper/access/armory,
 /turf/unsimulated/floor/plating,
 /area/hospital)
 "wUb" = (
@@ -81203,12 +81164,10 @@
 	layer = 2
 	},
 /obj/machinery/door/window{
-	icon_state = "right";
-	req_access_txt = "0"
+	icon_state = "right"
 	},
 /obj/machinery/door/window{
-	dir = 8;
-	req_access_txt = "0"
+	dir = 8
 	},
 /obj/mapping_helper/access/owlcommand,
 /turf/unsimulated/floor/white,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes all req_access_txt varedits from Z2. Non-mapping helper or functionality changes listed below:
- The Ainley buddy access found on the Ainley ship guardbuddy and the Ainley ship captains office has been defined as access 91. It was previously 1917 as presumably a lore tidbit, the frequency for this guardbuddy has been left as that number.
- The owlery has received its own types for its sectech and confiscated items crate with the appropriate owlerysec access.
- The Ainley armory airlock (sealed open by default) has been updated to armory access rather than HoS office access.
- Several airlocks appear to have erroneously copied maintenance access to places that didn't really make sense (for example: the owlery kitchen). These airlocks have had their access requirements removed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This variable is outdated, janky, and often leads to accidental copyings.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Not done yet
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
