### PR TITLE
The Gasps Of Fibre Wire Victims Now Respect LoS

### DIFF
--- a/code/WorkInProgress/SpyGuyStuff.dm
+++ b/code/WorkInProgress/SpyGuyStuff.dm
@@ -861,9 +861,12 @@ proc/Create_Tommyname()
 	// Are we ready to do something mean here?
 	var/wire_readied = 0
 
-	HELP_MESSAGE_OVERRIDE({"Use the garrot wire in hand to hold it with two hands, then place yourself behind your target.
-							Click them with the wire to attempt to grab them.
-							While a target is being strangled, use the wire in hand to inflict more damage and bleed in addition to the suffocation."})
+	HELP_MESSAGE_OVERRIDE({"\
+		The fibre wire may be used in-hand to stretch it between two hands. A readied fibre wire may be \
+		used to garrote a target from behind; this will immediately place them into a deadly chokehold \
+		and will prevent their gasps and screams from being heard through walls.
+	"})
+
 
 	New()
 		..()
@@ -985,6 +988,7 @@ proc/Create_Tommyname()
 /obj/item/grab/garrote_grab
 	// No breaking out under own power
 	irresistible = 1
+	muffle_affecting = TRUE
 
 	check()
 		if(!assailant || !affecting)

--- a/code/WorkInProgress/WiresStuff.dm
+++ b/code/WorkInProgress/WiresStuff.dm
@@ -140,10 +140,13 @@ var/global/deathConfettiActive = 1
 var/global/deathConfettiActive = 0
 #endif
 
-/mob/proc/deathConfetti()
+/mob/proc/deathConfetti(muffled = FALSE)
 	particleMaster.SpawnSystem(new /datum/particleSystem/confetti(src.loc))
 	SPAWN(1 SECOND)
-		playsound(src.loc, 'sound/voice/yayyy.ogg', 50, 1)
+		if (muffled)
+			playsound(src.loc, 'sound/voice/yayyy.ogg', 25, 1, flags = SOUND_DO_LOS)
+		else
+			playsound(src.loc, 'sound/voice/yayyy.ogg', 50, 1)
 
 /client/proc/toggle_death_confetti()
 	set popup_menu = 0

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1798,3 +1798,10 @@ TYPEINFO(/mob/living)
 
 /mob/living/HealBleeding(amt)
 	src.bleeding = max(src.bleeding - amt, 0)
+
+/mob/living/proc/muffled_by_grab()
+	for (var/obj/item/grab/G as anything in src.grabbed_by)
+		if ((G.state >= GRAB_CHOKE) && G.muffle_affecting)
+			return TRUE
+
+	return FALSE

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -60,7 +60,7 @@
 			// most commonly used emotes first for minor performance improvements
 			if ("scream")
 				if (src.emote_check(voluntary, 5 SECONDS))
-					if(src.bioHolder?.HasEffect("mute"))
+					if(src.bioHolder?.HasEffect("mute") || src.muffled_by_grab())
 						var/pre_message = "[pick("vibrates for a moment, then stops", "opens [his_or_her(src)] mouth, but no sound comes out",
 						"tries to scream, but can't", "emits an audible silence", "huffs and puffs with all [his_or_her(src)] might, but can't seem to make a sound",
 						"opens [his_or_her(src)] mouth to produce a resounding lack of noise","flails desperately","")]..."
@@ -891,14 +891,20 @@
 
 				if (src.emote_check(voluntary,20))
 					if (act == "gasp")
+						var/sound_volume_mult = 1
+						var/sound_flags = 0
+						if (src.muffled_by_grab())
+							sound_volume_mult = 0.5
+							sound_flags = SOUND_DO_LOS
+
 						if (src.find_ailment_by_type(/datum/ailment/malady/flatline))
 							var/dying_gasp_sfx = "sound/voice/gasps/[src.gender == MALE ? MALE : FEMALE]_gasp_[pick(1,3)].ogg"
-							playsound(src, dying_gasp_sfx, 40, FALSE, 0, src.get_age_pitch())
+							playsound(src, dying_gasp_sfx, 40 * sound_volume_mult, FALSE, 0, src.get_age_pitch(), flags = sound_flags)
 						else if (src.health <= 0)
 							var/dying_gasp_sfx = "sound/voice/gasps/[src.gender == MALE ? MALE : FEMALE]_gasp_[pick(4,5)].ogg"
-							playsound(src, dying_gasp_sfx, 40, FALSE, 0, src.get_age_pitch())
+							playsound(src, dying_gasp_sfx, 40 * sound_volume_mult, FALSE, 0, src.get_age_pitch(), flags = sound_flags)
 						else
-							playsound(src, src.sound_gasp, 15, 0, 0, src.get_age_pitch())
+							playsound(src, src.sound_gasp, 15 * sound_volume_mult, 0, 0, src.get_age_pitch(), flags = sound_flags)
 
 			if ("laugh","chuckle","giggle","chortle","guffaw","cackle")
 				if (!muzzled)
@@ -1617,12 +1623,17 @@
 							SEND_SIGNAL(src, COMSIG_MOB_FAKE_DEATH)
 							#endif
 
+						var/muffled = src.muffled_by_grab()
+
 						// Active if XMAS or manually toggled.
-						if (deathConfettiActive)
-							src.deathConfetti()
+						if (global.deathConfettiActive)
+							src.deathConfetti(muffled)
 
 						message = SPAN_REGULAR("<b>[src]</b> seizes up and falls limp, [his_or_her(src)] eyes dead and lifeless...")
-						playsound(src, "sound/voice/death_[pick(1,2)].ogg", 40, 0, 0, src.get_age_pitch())
+						if (muffled)
+							playsound(src, "sound/voice/death_[pick(1,2)].ogg", 20, 0, 0, src.get_age_pitch(), flags = SOUND_DO_LOS)
+						else
+							playsound(src, "sound/voice/death_[pick(1,2)].ogg", 40, 0, 0, src.get_age_pitch())
 					m_type = 1
 
 			if ("johnny")

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -14,6 +14,7 @@
 	var/prob_mod = 1
 	var/assailant_stam_drain = 30
 	var/affecting_stam_drain = 20
+	var/muffle_affecting = FALSE
 	var/resist_count = 0
 	var/item_grab_overlay_state = "grab_small"
 	var/transfering_chemicals = FALSE


### PR DESCRIPTION
## About The PR:
Fibre wires will now half the sound of victims' gasps and deathgaps and force them to respect line-of-sight. Fibre wire victims are also no longer capable of screaming, instead they emit the same `"tries to scream, but can't"` emotes that the mute effect causes.


## Why Is This Needed?
The fibre wire currently takes upwards of a minute thirty to kill someone, which is more than enough time for a passerby to hear the gasps of the victim and interrupt your assassination.
Also, stealth is fun.


## Testing:
https://github.com/user-attachments/assets/ba8ee634-6268-451d-ad06-10b666bda3ce


## Changelog:
```changelog
(u)Mr. Moriarty
(*)The gasps and deathgasps of fibre wire victims are quieter and are no longer able to be heard through walls. Fibre wire victims are also no longer capable of screaming.
```