### PR TITLE
Improve automatic phone department assignment

### DIFF
--- a/code/obj/machinery/phone/phone.dm
+++ b/code/obj/machinery/phone/phone.dm
@@ -41,27 +41,29 @@ TYPEINFO(/obj/machinery/phone)
 	var/area/location = get_area(src)
 
 	// Give the phone an appropriate departmental color. Jesus christ thats fancy.
-	if (isnull(src.stripe_color)) // maps can override it now
-		if (istype(location,/area/station/security))
-			src.stripe_color = "#ff0000"
-			src.phone_category = "security"
-		else if (istype(location,/area/station/bridge))
-			src.stripe_color = "#00ff00"
-			src.phone_category = "bridge"
-		else if (istype(location, /area/station/engine) || istype(location, /area/station/quartermaster) || istype(location, /area/station/mining))
-			src.stripe_color = "#ffff00"
-			src.phone_category = "engineering"
-		else if (istype(location, /area/station/science))
-			src.stripe_color = "#8409ff"
-			src.phone_category = "research"
-		else if (istype(location, /area/station/medical))
-			src.stripe_color = "#3838ff"
-			src.phone_category = "medical"
-		else
-			src.stripe_color = "#b65f08"
-			src.phone_category = "uncategorized"
-	else
-		src.phone_category = "uncategorized"
+	var/area_color = "#b65f08"
+	var/area_category = "uncategorized"
+	switch(location.station_map_colour)
+		if (MAPC_SECURITY, MAPC_ARMOURY, MAPC_BRIG)
+			area_color = "#ff0000"
+			area_category = "security"
+		if (MAPC_COMMAND)
+			area_color = "#00ff00"
+			area_category = "bridge"
+		if (MAPC_ENGINEERING, MAPC_MECHLAB, MAPC_QUARTERMASTER, MAPC_MINING)
+			area_color = "#ffff00"
+			area_category = "engineering"
+		if (MAPC_RESEARCH, MAPC_CHEMISTRY, MAPC_TELESCI, MAPC_ARTLAB)
+			area_color = "#8409ff"
+			area_category = "research"
+		if (MAPC_MEDICAL, MAPC_MEDLOBBY, MAPC_ROBOTICS, MAPC_MORGUE, MAPC_MEDRESEARCH, MAPC_PATHOLOGY)
+			area_color = "#3838ff"
+			area_category = "medical"
+	//Allow maps to override either
+	if(isnull(src.stripe_color))
+		src.stripe_color = area_color
+	if(isnull(src.phone_category))
+		src.phone_category = area_category
 
 	src.UpdateOverlays(image('icons/obj/machines/phones.dmi',"[src.dialicon]"), "dial")
 	var/image/stripe_image = image('icons/obj/machines/phones.dmi',"[src.icon_state]-stripe")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Instead of strict istype checks, phones now check the area's map colour for automatically determining where to sort the phone. This mainly affects command quarters, hangars, and other weirdly pathed areas.
Mappers can now independently override the category and color of a phone, instead of changing the colour automatically clearing the category (not checked what happens if a category isn't in the expected list, so just don't map those)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Command office phones are often uncategorised thanks to them not being /bridge areas but /crew_quarters areas. Area colour more accurately defines how these areas are used than the strict type.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Nadir's phone network:
<img width="263" height="958" alt="image" src="https://github.com/user-attachments/assets/b63a7ab2-e5cc-4a78-bfef-2aac2958584e" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Phones should now be categorised a little bit more consistently
```
