### PR TITLE
Changes Oshan to a 25 pop minimum

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -35,7 +35,7 @@ var/global/list/mapNames = list(
 
 	"Crash" = 				list("id" = "CRASH",		"settings" = "crash",			"playerPickable" = FALSE),
 	"Atlas" =				list("id" = "ATLAS",		"settings" = "atlas",			"playerPickable" = FALSE,	"MaxPlayersAllowed" = 30),
-	"Mushroom" =			list("id" = "MUSHROOM",		"settings" = "mushroom",		"playerPickable" = FALSE),
+	"Mushroom <i>2<i>" =	list("id" = "MUSHROOM",		"settings" = "mushroom",		"playerPickable" = FALSE),
 	"Density2" = 			list("id" = "DENSITY2",		"settings" = "density2",		"playerPickable" = FALSE,	"MaxPlayersAllowed" = 20),
 	"blank" =				list("id" = "BLANK",		"settings" = "", 				"playerPickable" = FALSE),
 	"blank_underwater" =	list("id" = "BLANK_UNDERWATER", "settings" = "", 			"playerPickable" = FALSE),

--- a/maps/mushroom.dmm
+++ b/maps/mushroom.dmm
@@ -69,9 +69,10 @@
 	},
 /area/shuttle/arrival/station)
 "aau" = (
-/obj/machinery/drainage,
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
+/turf/simulated/floor/redwhite{
+	dir = 4
+	},
+/area/station/medical/medbay/surgery)
 "aay" = (
 /obj/cryotron{
 	layer = 3.9
@@ -623,28 +624,14 @@
 /obj/machinery/vehicle/miniputt/armed,
 /turf/simulated/floor/engine,
 /area/station/hangar/main)
-"adW" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
 "adX" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/entry)
 "adY" = (
-/obj/machinery/chem_master,
-/obj/machinery/camera/directional/north{
-	c_tag = "Chemistry Department";
-	pixel_x = -10
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/caution/corner/sw,
+/turf/simulated/floor/white,
 /area/station/science/chemistry)
 "aea" = (
 /obj/machinery/door/airlock/pyro/external,
@@ -1041,12 +1028,18 @@
 /turf/simulated/floor,
 /area/station/hangar/main)
 "agH" = (
+/mob/living/critter/small_animal/dog/george,
 /obj/cable{
-	dir = null
+	icon_state = "2-10"
 	},
-/obj/machinery/power/apc/autoname_south,
-/turf/simulated/floor/purple/side,
-/area/station/hallway/primary/south)
+/obj/cable{
+	icon_state = "8-10"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "agO" = (
 /obj/machinery/light/incandescent{
 	dir = 1
@@ -1258,9 +1251,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aiw" = (
-/obj/machinery/hair_dye_dispenser,
-/turf/simulated/floor,
-/area/station/maintenance/east)
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/blueblack{
+	dir = 1
+	},
+/area/station/medical/medbay/pharmacy)
 "aix" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -1521,6 +1518,17 @@
 /obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"ajF" = (
+/obj/decal/tile_edge/stripe/big,
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 6;
+	icon_state = "bigstripe-corner2"
+	},
+/turf/simulated/floor/specialroom/medbay,
+/area/station/hangar/medical)
 "ajG" = (
 /obj/machinery/emitter{
 	dir = 8
@@ -1757,6 +1765,10 @@
 "alA" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/solar/west)
+"alB" = (
+/obj/stool/chair/purple,
+/turf/simulated/floor/white,
+/area/station/science/chemistry)
 "alD" = (
 /obj/storage/secure/closet/engineering/mining,
 /turf/simulated/floor/yellow/side{
@@ -1977,13 +1989,14 @@
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "amQ" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Genetics Research Morgue";
-	pixel_y = 10
+/obj/table/auto/desk,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
 	},
-/obj/blind_switch/area/east,
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/medical,
+/turf/simulated/floor/greenwhite,
+/area/station/medical/medbay)
 "amR" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/communications_dish{
@@ -2168,6 +2181,12 @@
 	},
 /turf/space,
 /area/space)
+"anB" = (
+/obj/cable{
+	icon_state = "4-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "anE" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
@@ -2530,13 +2549,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "apr" = (
-/obj/stool/chair/pew/left{
-	dir = 4
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
 	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 6
+/obj/mapping_helper/airlock/cycler{
+	enter_id = "inner";
+	cycle_id = "secsps";
+	name = "Security Space"
 	},
-/area/station/chapel/sanctuary)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "apw" = (
 /obj/machinery/recharge_station,
 /obj/cable{
@@ -3435,14 +3457,13 @@
 /turf/simulated/floor/airless/solar,
 /area/space)
 "aug" = (
-/obj/machinery/meter{
-	pixel_y = -9;
-	pixel_x = 10
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/overfloor{
+/turf/simulated/floor/blackwhite{
 	dir = 1
 	},
-/turf/simulated/floor/white,
 /area/station/medical/medbay)
 "auq" = (
 /obj/cable{
@@ -3474,6 +3495,11 @@
 	},
 /turf/simulated/floor,
 /area/station/janitor/office)
+"avm" = (
+/obj/disposalpipe/trunk/mail/south,
+/obj/machinery/vending/player/chemicals,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "avz" = (
 /obj/item/device/radio/intercom,
 /obj/machinery/portable_reclaimer,
@@ -3519,6 +3545,18 @@
 	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
+"axw" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "axI" = (
 /obj/decal/poster/wallsign/escape_left,
 /turf/simulated/wall/auto/supernorn,
@@ -3715,12 +3753,18 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gravity)
 "aDh" = (
-/obj/cable{
-	icon_state = "0-4"
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/medbay/cloner)
 "aDi" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -3840,6 +3884,16 @@
 	dir = 4
 	},
 /area/station/hallway/primary/south)
+"aIx" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2{
+	dir = 8
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "aIH" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/orangeblack/side{
@@ -3892,21 +3946,10 @@
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "aJC" = (
-/obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "5-8"
+/obj/table/wood/auto,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "2-4";
-	pixel_y = 0
-	},
-/obj/cable{
-	icon_state = "1-10"
-	},
-/obj/cable{
-	icon_state = "4-6"
-	},
-/turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "aJF" = (
 /obj/cable{
@@ -3995,6 +4038,13 @@
 	dir = 9
 	},
 /area/station/chapel/sanctuary)
+"aLz" = (
+/obj/machinery/light/small/floor,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "aMf" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -4058,15 +4108,15 @@
 	},
 /area/station/chapel/sanctuary)
 "aNk" = (
-/obj/machinery/vending/cigarette,
+/obj/machinery/computer/chem_requester/science,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue,
 /area/station/hallway/primary/central)
 "aNn" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpetN"
+/obj/table/wood/auto,
+/obj/candle_light,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
 	},
 /area/station/chapel/sanctuary)
 "aNp" = (
@@ -4234,11 +4284,11 @@
 /turf/simulated/floor/orangeblack,
 /area/station/teleporter)
 "aRU" = (
-/obj/cable{
-	icon_state = "2-6"
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
 	},
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "aSu" = (
 /obj/cable{
 	icon_state = "4-5"
@@ -4295,14 +4345,12 @@
 /turf/simulated/floor/plating,
 /area/station/security/beepsky)
 "aTd" = (
-/obj/item/device/light/flashlight,
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
-"aTg" = (
-/obj/cable{
-	icon_state = "1-9"
+/obj/machinery/light/incandescent{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 10
+	},
 /area/station/chapel/sanctuary)
 "aTu" = (
 /obj/disposalpipe/segment/mail,
@@ -4446,9 +4494,12 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aYL" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "aZf" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -4475,18 +4526,16 @@
 /area/station/hallway/primary/central)
 "aZE" = (
 /obj/cable{
-	icon_state = "1-10"
+	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aZH" = (
-/obj/item/rods{
-	amount = 10
+/obj/cable{
+	icon_state = "1-8"
 	},
-/obj/item/wrench,
-/turf/simulated/floor,
-/area/station/maintenance/east)
+/turf/simulated/floor/black,
+/area/station/medical/medbay/pharmacy)
 "aZK" = (
 /obj/mesh/catwalk,
 /obj/landmark/magnet_shield,
@@ -4529,9 +4578,18 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/emergency)
 "bap" = (
-/obj/disposalpipe/segment/morgue,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/machinery/door/airlock/pyro/glass/med,
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/pharmacy,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay/pharmacy)
 "baU" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -4548,6 +4606,14 @@
 /obj/machinery/ore_cloud_storage_container,
 /turf/simulated/floor/grime,
 /area/station/mining/magnet)
+"bbt" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluewhite{
+	dir = 9
+	},
+/area/station/medical/head)
 "bbz" = (
 /obj/securearea{
 	desc = "";
@@ -4568,15 +4634,34 @@
 	},
 /area/station/science/lobby)
 "bbU" = (
-/obj/reagent_dispensers/watertank,
-/turf/simulated/floor,
-/area/station/maintenance/east)
+/obj/machinery/coffeemaker/medbay,
+/obj/table/glass/auto,
+/obj/item/reagent_containers/food/drinks/creamer{
+	pixel_x = 12
+	},
+/obj/drink_rack/mug{
+	pixel_y = 28
+	},
+/obj/machinery/light/incandescent{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "bco" = (
 /turf/simulated/floor/carpet/green/standard/edge/north,
 /area/station/engine/engineering/private)
 "bcB" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"bdR" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "6-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -4591,38 +4676,39 @@
 /obj/cable{
 	icon_state = "4-9"
 	},
-/obj/disposalpipe/segment/morgue{
+/obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "bee" = (
 /obj/cable{
 	icon_state = "6-8"
 	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"beh" = (
-/obj/cable{
-	icon_state = "1-6"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"bej" = (
-/obj/cable{
-	icon_state = "2-5"
+/obj/machinery/light/incandescent{
+	dir = 1
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"beh" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/window_blinds/cog2/right{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/pharmacy)
+"bej" = (
+/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "ben" = (
@@ -4637,19 +4723,50 @@
 	},
 /area/station/crew_quarters/supplylobby)
 "bet" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/table/auto,
+/obj/item/storage/box/evidence{
+	pixel_x = -9;
+	pixel_y = 15
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/robotics)
+/obj/item/storage/box/evidence{
+	pixel_x = -6;
+	pixel_y = 15
+	},
+/obj/item/storage/box/evidence{
+	pixel_x = -3;
+	pixel_y = 15
+	},
+/obj/item/storage/box/evidence{
+	pixel_y = 15
+	},
+/obj/item/storage/box/evidence{
+	pixel_x = 3;
+	pixel_y = 15
+	},
+/obj/item/body_bag{
+	pixel_x = -11;
+	pixel_y = 5
+	},
+/obj/item/body_bag{
+	pixel_x = -10;
+	pixel_y = 3
+	},
+/obj/item/body_bag{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/obj/table/auto,
+/obj/item/reagent_containers/glass/bottle/formaldehyde,
+/obj/item/reagent_containers/syringe,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "beu" = (
-/obj/storage/closet/emergency,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
+/obj/machinery/light{
+	dir = 8;
+	tag = ""
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/engine,
+/area/station/hangar/medical)
 "beB" = (
 /obj/mesh/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -4731,16 +4848,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/hangar/engine)
-"bfc" = (
-/turf/simulated/floor/yellow/corner,
-/area/station/hallway/primary/central)
 "bfd" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/central)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "bfe" = (
 /obj/cable{
 	icon_state = "4-9"
@@ -4748,37 +4862,29 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"bff" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "4-9"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "bfg" = (
 /obj/cable{
 	icon_state = "6-8"
 	},
-/obj/disposalpipe/segment/morgue,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"bfh" = (
 /obj/cable{
-	icon_state = "1-10"
+	icon_state = "5-8"
 	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"bfh" = (
+/obj/machinery/atmospherics/pipe/simple/overfloor{
+	dir = 5
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "bfi" = (
 /obj/decal/poster/wallsign/poster_borg,
 /turf/simulated/wall/auto/supernorn,
@@ -4852,22 +4958,16 @@
 /obj/item/device/t_scanner,
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
-"bfY" = (
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/hallway/primary/central)
-"bfZ" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/yellow,
-/area/station/hallway/primary/central)
 "bgc" = (
 /obj/cable{
 	icon_state = "2-9"
 	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/disposalpipe/switch_junction/left/north{
+	mail_tag = "robotics";
+	name = "robotics mail junction"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "bgd" = (
 /obj/item/clothing/head/apprentice,
 /turf/simulated/floor/plating/airless,
@@ -4876,47 +4976,50 @@
 /obj/cable{
 	icon_state = "2-5"
 	},
-/obj/disposalpipe/segment/morgue,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/blueblack,
+/area/station/medical/medbay/pharmacy)
 "bgh" = (
 /turf/simulated/floor/blueblack/corner{
 	dir = 1
 	},
 /area/station/medical/robotics)
 "bgj" = (
-/obj/cable{
-	icon_state = "4-10"
+/obj/table/auto,
+/obj/item/clothing/glasses/visor,
+/obj/item/device/radio/headset/deaf,
+/obj/item/robodefibrillator,
+/obj/item/remote/porter/port_a_nanomed,
+/obj/item/device/analyzer/healthanalyzer/upgraded,
+/obj/item/clothing/glasses/healthgoggles,
+/obj/item/item_box/postit,
+/obj/item/reagent_containers/hypospray,
+/obj/machinery/firealarm/directional/east,
+/turf/simulated/floor/bluewhite{
+	dir = 6
 	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/blueblack/corner,
-/area/station/medical/robotics)
+/area/station/medical/head)
 "bgk" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/disposalpipe/segment/morgue{
+	dir = 1;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
 	},
-/turf/simulated/floor/blueblack/corner{
-	dir = 1
-	},
-/area/station/medical/robotics)
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "bgn" = (
+/mob/living/critter/small_animal/opossum/morty,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/blueblack/corner,
-/area/station/medical/robotics)
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "bgo" = (
-/obj/machinery/light_switch{
-	name = "N light switch";
-	pixel_y = 24
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/blueblack/corner{
-	dir = 1
-	},
-/area/station/medical/robotics)
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "bgC" = (
 /obj/cable/yellow{
 	icon_state = "0-8"
@@ -5048,33 +5151,25 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bhl" = (
-/turf/simulated/floor/yellow/corner{
-	dir = 4
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
 	},
+/turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "bhn" = (
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/hallway/primary/central)
-"bhp" = (
-/obj/machinery/light/emergency{
-	dir = 1
-	},
-/turf/simulated/floor/yellow/corner{
-	dir = 1
-	},
-/area/station/hallway/primary/central)
-"bhr" = (
-/obj/landmark/start{
-	name = "predator"
+/obj/overlay{
+	anchored = 1;
+	icon = 'icons/misc/beach2.dmi';
+	icon_state = "palm2";
+	layer = 10;
+	name = "palm tree"
 	},
 /obj/cable{
-	icon_state = "1-6"
+	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/morgue,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "bhu" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment/mail,
@@ -5089,10 +5184,13 @@
 /turf/simulated/floor,
 /area/station/hangar/qm)
 "bhy" = (
-/obj/landmark/start/job/roboticist,
-/obj/disposalpipe/segment,
-/turf/simulated/floor/blueblack/corner,
-/area/station/medical/robotics)
+/obj/machinery/light/small/floor,
+/obj/disposalpipe/switch_junction/left/south,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "bhE" = (
 /obj/machinery/computer/robot_module_rewriter,
 /turf/simulated/floor/blueblack/corner{
@@ -5100,15 +5198,27 @@
 	},
 /area/station/medical/robotics)
 "bhQ" = (
-/obj/overlay{
-	anchored = 1;
-	icon = 'icons/misc/beach2.dmi';
-	icon_state = "palm2";
-	layer = 10;
-	name = "palm tree"
+/obj/surgery_tray,
+/obj/item/circular_saw{
+	pixel_x = 3;
+	pixel_y = 12
 	},
-/turf/simulated/floor/grass,
-/area/station/medical/dome)
+/obj/item/suture,
+/obj/item/scalpel,
+/obj/item/hemostat,
+/obj/item/staple_gun{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/scissors/surgical_scissors{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "bhR" = (
 /obj/landmark/magnet_shield,
 /obj/securearea{
@@ -5234,16 +5344,15 @@
 	icon_state = "2-4";
 	pixel_y = 0
 	},
-/obj/disposalpipe/segment/morgue,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "biz" = (
 /obj/cable{
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "biP" = (
 /obj/table/auto,
 /obj/item/paper/book/from_file/matsci_guide{
@@ -5335,32 +5444,49 @@
 /obj/cable{
 	icon_state = "1-6"
 	},
-/obj/disposalpipe/segment/morgue,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/item/device/radio/intercom/medical{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "bjr" = (
 /obj/cable{
 	icon_state = "1-9"
 	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "bjs" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/machinery/atmospherics/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "bju" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/table/auto,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -1;
+	pixel_y = 5
 	},
-/turf/simulated/floor/blueblack/corner{
-	dir = 1
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -3;
+	pixel_y = 2
 	},
-/area/station/medical/robotics)
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -5
+	},
+/obj/item/paper/cryo{
+	pixel_x = 5
+	},
+/obj/item/wrench,
+/obj/item/robodefibrillator,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/light/small/floor,
+/obj/machinery/camera/directional/north{
+	c_tag = "Robotics Laboratory";
+	pixel_x = -10
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "bjv" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -5417,14 +5543,12 @@
 /turf/simulated/floor,
 /area/station/engine/inner)
 "bkL" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "8-9"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/mob/living/carbon/human/npc/monkey,
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "bkO" = (
 /obj/lattice{
 	icon_state = "lattice-dir-b"
@@ -5438,6 +5562,10 @@
 	},
 /turf/space,
 /area/space)
+"blf" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "blm" = (
 /obj/lattice{
 	dir = 8;
@@ -5499,12 +5627,17 @@
 	},
 /area/station/hallway/primary/central)
 "bnh" = (
+/obj/machinery/bot/secbot{
+	name = "Doctor Batonsly"
+	},
 /obj/cable{
 	icon_state = "9-10"
 	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/bluewhite{
+	dir = 6
+	},
+/area/station/medical/medbay/lobby)
 "bnm" = (
 /obj/random_item_spawner/desk_stuff,
 /obj/table/glass/auto,
@@ -5535,20 +5668,28 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/bathroom)
 "bnH" = (
-/obj/disposalpipe/segment/mail{
+/obj/machinery/atmospherics/pipe/simple/overfloor{
+	dir = 8
+	},
+/obj/landmark/start/job/medical_doctor,
+/obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/blueblack/corner{
-	dir = 1
-	},
-/area/station/medical/robotics)
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "bnI" = (
-/obj/disposalpipe/segment/mail{
+/obj/machinery/atmospherics/pipe/simple/overfloor{
+	dir = 9
+	},
+/obj/machinery/light/emergency{
 	dir = 4
 	},
-/turf/simulated/floor/blueblack/corner,
-/area/station/medical/robotics)
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "bnL" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/elect)
@@ -5736,42 +5877,35 @@
 /obj/cable{
 	icon_state = "2-5"
 	},
-/obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/shrub{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant";
+	level = 1.9
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "boM" = (
-/obj/cable{
-	icon_state = "2-6"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"boN" = (
-/obj/item/extinguisher,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
+/turf/simulated/floor/bluewhite/corner{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/medical/medbay/lobby)
+"boN" = (
+/obj/landmark/gps_waypoint,
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon12,
+/obj/item/device/radio/beacon,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "boO" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering)
 "boS" = (
-/obj/cable{
-	icon_state = "2-5"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 8;
+/obj/disposalpipe/segment/mail{
+	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "boU" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -5905,17 +6039,11 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "bpR" = (
 /obj/cable{
 	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"bpS" = (
-/obj/cable{
-	icon_state = "6-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -5929,25 +6057,24 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/lobby)
 "bpW" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor/blackwhite{
-	dir = 1
-	},
-/area/station/medical/medbay/lobby)
+/obj/machinery/vending/port_a_nanomed,
+/obj/machinery/drainage,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "bpX" = (
-/turf/simulated/floor/blackwhite{
-	dir = 1
-	},
-/area/station/medical/medbay/lobby)
+/obj/landmark/pest,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "bqd" = (
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "bql" = (
-/obj/machinery/genetics_scanner,
-/turf/simulated/floor/greenwhite{
-	dir = 5
+/obj/machinery/computer/operating/small,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/area/station/medical/research)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "bqn" = (
 /obj/storage/secure/closet/engineering/electrical,
 /turf/simulated/floor/black,
@@ -5996,10 +6123,15 @@
 /area/station/storage/warehouse)
 "bqx" = (
 /obj/cable{
-	icon_state = "2-5"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/blueblack{
+	dir = 10
+	},
+/area/station/medical/medbay/pharmacy)
 "bqz" = (
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -6020,17 +6152,35 @@
 /turf/space,
 /area/space)
 "bqJ" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/cloner)
 "bqL" = (
 /obj/surgery_tray/kitchen_island,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bqM" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/obj/machinery/clone_scanner,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/camera/directional/east{
+	c_tag = "Habitation Ring East";
+	pixel_y = 10
+	},
+/obj/machinery/light/incandescent{
+	dir = 4
+	},
+/obj/machinery/power/apc/autoname_east,
+/turf/simulated/floor/greenwhite{
+	dir = 4
+	},
+/area/station/medical/medbay/cloner)
 "bqO" = (
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
@@ -6039,20 +6189,20 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "bqU" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/segment{
+	dir = 4;
+	level = -1
 	},
-/turf/simulated/floor/greenwhite/corner,
-/area/station/medical/medbay/cloner)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "bqV" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/stool/chair/blue{
-	dir = 1
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay)
 "bqW" = (
 /turf/space,
 /area/mining/magnet)
@@ -6201,21 +6351,22 @@
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "bsb" = (
-/obj/cable{
-	icon_state = "1-9"
+/obj/disposalpipe/switch_junction/left/north{
+	name = "medbay mail junction";
+	mail_tag = "medbay"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"bsd" = (
-/obj/disposalpipe/junction/right/south,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/greenwhite,
+/area/station/medical/medbay)
 "bse" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/pyro/glass/med,
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/medical,
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/medbay/cloner)
 "bsh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -6223,34 +6374,14 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bsk" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/door/airlock/pyro/glass/med,
+/obj/mapping_helper/access/medical,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/lobby)
 "bsl" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/green,
-/area/station/medical/medbay/cloner)
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "bso" = (
 /obj/landmark/halloween,
 /obj/cable{
@@ -6259,10 +6390,18 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bst" = (
-/turf/simulated/floor/bluewhite{
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	dir = null
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/window_blinds/cog2/left{
 	dir = 4
 	},
-/area/station/medical/research)
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/pharmacy)
 "bsu" = (
 /obj/submachine/cargopad/qm,
 /turf/simulated/floor,
@@ -6332,45 +6471,42 @@
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "bsY" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
-"bta" = (
-/obj/disposalpipe/switch_junction/left/east{
-	mail_tag = "medbay";
-	name = "Mail Junction - Medical Bay"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
-"btd" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/cable{
+	icon_state = "6-8"
 	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
+"bta" = (
+/obj/storage/secure/closet/medical/medicine,
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay)
+"btd" = (
+/obj/storage/secure/closet/medical/medkit,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "bte" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/storage/secure/closet/medical{
-	name = "locker"
+/obj/window_blinds/cog2{
+	dir = 4
 	},
-/turf/simulated/floor/greenwhite/corner{
-	dir = 1
-	},
-/area/station/medical/medbay/cloner)
+/turf/simulated/floor/plating,
+/area/station/medical/head)
 "btg" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/overlay{
+	icon = 'icons/misc/beach2.dmi';
+	icon_state = "palm2";
+	layer = 10;
+	name = "palm tree"
 	},
-/turf/simulated/floor/purplewhite/corner,
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "btm" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/electrical,
@@ -6391,11 +6527,16 @@
 	},
 /area/station/hydroponics/bay)
 "bts" = (
-/obj/monkeyplant,
-/turf/simulated/floor/greenwhite{
-	dir = 6
+/obj/machinery/computer/operating/small,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4;
+	icon_state = "xtra_bigstripe-edge2"
 	},
-/area/station/medical/research)
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/red/redblackchecker,
+/area/station/medical/robotics)
 "btt" = (
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -6461,39 +6602,45 @@
 /obj/machinery/light/emergency{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
-"btI" = (
-/obj/cable{
-	icon_state = "1-10"
+/obj/machinery/camera/directional/east{
+	c_tag = "Habitation Ring East";
+	pixel_y = 10
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"btJ" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
-"btK" = (
-/obj/disposalpipe/segment/mail{
+/turf/simulated/floor/blue/side{
 	dir = 4
 	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/white,
+/area/station/hallway/primary/central)
+"btI" = (
+/turf/simulated/floor/greenwhite,
 /area/station/medical/medbay/lobby)
-"btL" = (
-/obj/disposalpipe/switch_junction/right/north{
-	mail_tag = "robotics";
-	name = "Mail Junction - Robotics"
+"btJ" = (
+/obj/stool/chair/blue{
+	dir = 4
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/greenwhite{
+	dir = 1
+	},
+/area/station/medical/medbay/cloner)
+"btK" = (
+/obj/machinery/computer/cloning{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/greenwhite{
+	dir = 5
+	},
+/area/station/medical/medbay/cloner)
 "btN" = (
-/obj/machinery/disposal/mail/autoname/medbay,
-/obj/disposalpipe/trunk/mail/north,
-/turf/simulated/floor/white,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/greenwhite,
 /area/station/medical/medbay/lobby)
 "bul" = (
 /obj/disposalpipe/segment/mail,
@@ -6656,10 +6803,13 @@
 /turf/simulated/floor/engine,
 /area/station/hallway/secondary/exit)
 "bzx" = (
-/turf/simulated/floor/bluewhite{
+/obj/machinery/light{
 	dir = 1
 	},
-/area/station/medical/research)
+/turf/simulated/floor/greenwhite{
+	dir = 1
+	},
+/area/station/medical/medbay/cloner)
 "bzW" = (
 /obj/disposalpipe/segment/ejection,
 /turf/simulated/wall/auto/supernorn,
@@ -6733,17 +6883,15 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "bBS" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbay)
+/obj/iv_stand,
+/obj/item/reagent_containers/iv_drip/saline,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "bCa" = (
-/obj/item/device/radio/intercom/medical{
-	dir = 1
-	},
-/turf/simulated/floor/greenwhite,
-/area/station/medical/research)
+/obj/machinery/optable,
+/obj/machinery/drainage,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "bCc" = (
 /obj/machinery/door/airlock/pyro/glass/security{
 	dir = 4
@@ -6764,13 +6912,9 @@
 	},
 /area/station/security/brig)
 "bCp" = (
-/obj/machinery/space_heater,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/mapping_helper/wingrille_spawn/auto,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "bCZ" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -6789,20 +6933,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"bDy" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 10
-	},
-/obj/item/cloneModule/genepowermodule,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = 9;
-	pixel_y = -3
-	},
-/turf/simulated/floor/greenwhite{
-	dir = 4
-	},
-/area/station/medical/research)
 "bEf" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -6880,12 +7010,12 @@
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "bGK" = (
-/obj/machinery/power/apc/autoname_east,
+/obj/disposalpipe/segment/mail,
 /obj/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
+/turf/simulated/floor/greenwhite,
+/area/station/medical/medbay/cloner)
 "bHL" = (
 /obj/stool/chair/boxingrope_corner{
 	dir = 9
@@ -6893,12 +7023,14 @@
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "bIc" = (
-/obj/cable{
-	icon_state = "2-9"
+/obj/machinery/disposal/mail/autoname/medbay,
+/obj/disposalpipe/trunk/mail/north{
+	dir = 2
 	},
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/blackwhite/corner{
+	dir = 1
+	},
+/area/station/medical/medbay)
 "bIs" = (
 /turf/simulated/floor/blue/corner{
 	dir = 8
@@ -6969,7 +7101,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bKs" = (
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon12,
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon11,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bKv" = (
@@ -7050,17 +7182,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
-"bMy" = (
-/obj/machinery/genetics_scanner,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -12;
-	tag = ""
-	},
-/turf/simulated/floor/greenwhite{
-	dir = 8
-	},
-/area/station/medical/research)
 "bMY" = (
 /obj/stool/chair,
 /turf/simulated/floor/black,
@@ -7117,11 +7238,10 @@
 /turf/simulated/floor,
 /area/station/science/artifact)
 "bPT" = (
-/obj/cable{
-	icon_state = "5-6"
-	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/medical/research)
 "bPX" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Robotics Laboratory";
@@ -7203,9 +7323,10 @@
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/west)
 "bSt" = (
-/obj/landmark/kudzu,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/medical/research)
 "bSJ" = (
 /obj/machinery/computer3/generic/med_data,
 /obj/machinery/power/data_terminal,
@@ -7229,13 +7350,21 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bST" = (
-/obj/table/reinforced/chemistry/auto,
-/obj/machinery/glass_recycler{
-	glass_amt = 5;
-	pixel_y = 4
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/medical{
+	name = "Robotics";
+	req_access = null;
+	dir = 4
 	},
-/turf/simulated/floor/blueblack,
-/area/station/medical/medbay/pharmacy)
+/obj/mapping_helper/access/robotics,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "bSX" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -7259,13 +7388,17 @@
 	},
 /area/station/bridge)
 "bTJ" = (
-/obj/disposalpipe/segment/mail,
-/obj/decal/stripe_caution,
-/obj/machinery/light/incandescent{
-	dir = 4
+/obj/machinery/door/airlock/pyro/glass/med,
+/obj/mapping_helper/access/pharmacy,
+/obj/mapping_helper/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay/pharmacy)
 "bUg" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -7310,11 +7443,11 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bVf" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/black,
-/area/station/chapel/sanctuary)
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "bVj" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/chemistry)
@@ -7345,13 +7478,17 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "bVF" = (
-/obj/mapping_helper/access/morgue,
-/obj/mapping_helper/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/disposal/morgue{
+	desc = "A pneumatic chute used to transport corpses.";
+	name = "mortician's chute"
 	},
-/obj/machinery/door/airlock/pyro/medical{
-	name = "Morgue"
+/obj/disposalpipe/trunk/morgue{
+	dir = 2;
+	name = "crematorium pipe"
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
@@ -7390,19 +7527,13 @@
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "bWx" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -12;
-	tag = ""
-	},
-/turf/simulated/floor/greenwhite{
-	dir = 8
-	},
-/area/station/medical/research)
+/obj/machinery/clonegrinder,
+/obj/machinery/light/incandescent,
+/obj/cable,
+/obj/machinery/power/apc/autoname_south,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/greenwhite,
+/area/station/medical/medbay/cloner)
 "bWN" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
@@ -7473,13 +7604,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
-"cal" = (
-/obj/machinery/computer3/generic/med_data,
-/obj/machinery/firealarm/directional/north,
-/turf/simulated/floor/bluewhite{
-	dir = 1
-	},
-/area/station/medical/medbay)
 "can" = (
 /obj/machinery/networked/secdetector{
 	area_access = 99;
@@ -7578,13 +7702,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
-"cdz" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/dome)
 "cdK" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/machinery/light/incandescent/warm/very{
@@ -7602,44 +7719,13 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/courtroom)
 "cem" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/surgery_tray,
-/obj/item/scalpel{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/scissors/surgical_scissors{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/hemostat{
-	pixel_x = 3;
-	pixel_y = -5
-	},
-/obj/item/suture{
-	pixel_y = 5
-	},
-/obj/item/staple_gun{
-	pixel_x = 4;
-	pixel_y = 9
-	},
-/obj/item/circular_saw{
-	pixel_y = 11
-	},
-/obj/machinery/light/incandescent{
+/obj/stool/chair/comfy/wheelchair{
 	dir = 8
 	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/turf/simulated/floor/greenwhite{
+	dir = 4
 	},
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/medical/medbay/surgery)
+/area/station/medical/medbay)
 "ceZ" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -7652,16 +7738,6 @@
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
-"cfe" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Medbay East";
-	pixel_y = 10
-	},
-/obj/machinery/chem_dispenser/chemical,
-/turf/simulated/floor/blueblack{
-	dir = 4
-	},
-/area/station/medical/medbay/pharmacy)
 "cfk" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -7682,9 +7758,14 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/bathroom)
 "chb" = (
-/obj/machinery/vending/medical_public,
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/obj/storage/secure/closet/medical/chemical,
+/obj/machinery/light/incandescent{
+	dir = 1
+	},
+/turf/simulated/floor/blueblack{
+	dir = 1
+	},
+/area/station/medical/medbay/pharmacy)
 "che" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Arrival Hallway";
@@ -7838,10 +7919,13 @@
 /area/station/engine/gravity)
 "clo" = (
 /obj/cable{
-	icon_state = "2-9"
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/monkeyplant,
+/turf/simulated/floor/greenwhite{
+	dir = 1
+	},
+/area/station/medical/research)
 "clB" = (
 /obj/stool/chair/comfy/green{
 	dir = 1
@@ -7911,25 +7995,31 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "cnf" = (
-/obj/cable{
-	icon_state = "4-10"
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/storage/crate/robotics_supplies,
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "cof" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /turf/simulated/floor,
 /area/station/science/lab)
 "coi" = (
-/obj/machinery/firealarm/directional/east,
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/machinery/door_control{
+	id = "medbay_entrance";
+	name = "Medbay Door Control";
+	pixel_x = -32;
+	pixel_y = 20
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/obj/stool/chair/office/blue{
+	dir = 8
+	},
+/obj/landmark/start/job/medical_doctor,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "coD" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -8031,12 +8121,13 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "crB" = (
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/mapping_helper/access/medical_director,
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/command/alt{
+	id = "quarters_mdir"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/blue,
+/area/station/medical/head)
 "crI" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -8049,27 +8140,20 @@
 /turf/simulated/floor/auto/dirt,
 /area/station/ranch)
 "csa" = (
-/obj/machinery/manufacturer/robotics,
-/obj/decal/tile_edge/stripe/extra_big{
+/obj/mapping_helper/access/medlab,
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/maintenance,
+/turf/simulated/floor/blue/checker,
+/area/station/medical/research)
+"csk" = (
+/obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/darkblue,
-/area/station/medical/robotics)
-"csk" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 12;
-	tag = ""
-	},
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "csl" = (
 /obj/cable{
 	icon_state = "8-10"
@@ -8086,13 +8170,13 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "cst" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/landmark/start/job/roboticist,
-/turf/simulated/floor/blueblack/corner,
+/turf/simulated/floor/blueblack/corner{
+	dir = 1
+	},
 /area/station/medical/robotics)
 "csM" = (
 /obj/cable{
@@ -8197,6 +8281,10 @@
 "cuK" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/catering)
+"cvn" = (
+/obj/landmark/random_room/size3x3,
+/turf/simulated/floor/plating,
+/area/space)
 "cvt" = (
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/black,
@@ -8213,17 +8301,6 @@
 /obj/machinery/light/runway_light/delay3,
 /turf/space,
 /area/space)
-"cvK" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Robotics Laboratory";
-	pixel_x = -10
-	},
-/obj/storage/crate/robotics_supplies,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/turf/simulated/floor/blueblack/corner{
-	dir = 1
-	},
-/area/station/medical/robotics)
 "cwj" = (
 /obj/mapping_helper/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -8238,7 +8315,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/disposalpipe/segment/morgue,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "cwr" = (
@@ -8302,9 +8379,20 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "cxt" = (
-/mob/living/carbon/human/npc/monkey,
-/turf/simulated/floor/grass,
-/area/station/medical/dome)
+/obj/disposalpipe/trunk/mail{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	dir = null
+	},
+/obj/machinery/disposal/chemlink,
+/turf/simulated/floor/blueblack{
+	dir = 9
+	},
+/area/station/medical/medbay/pharmacy)
 "cxz" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
@@ -8336,16 +8424,9 @@
 /turf/simulated/floor/engine,
 /area/station/engine/singcore)
 "cyE" = (
-/obj/table/auto/desk,
-/obj/machinery/cashreg,
-/obj/item/kitchen/food_box/lollipop,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
-	},
-/obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/medical,
-/turf/simulated/floor/blue,
-/area/station/medical/medbay)
+/obj/machinery/vending/jobclothing/medical,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "cyH" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/card_box/plain,
@@ -8384,6 +8465,14 @@
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/industrial,
 /area/station/storage/warehouse)
+"czA" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluewhite{
+	dir = 6
+	},
+/area/station/medical/head)
 "czC" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay)
@@ -8477,6 +8566,12 @@
 	dir = 8
 	},
 /area/station/engine/engineering/private)
+"cDb" = (
+/obj/disposalpipe/switch_junction/left/south,
+/turf/simulated/floor/blueblack{
+	dir = 1
+	},
+/area/station/medical/medbay/pharmacy)
 "cDp" = (
 /obj/securearea{
 	desc = "A warning sign telling of the dangers of gravitational singularities.  Apparently they are dangerous.";
@@ -8558,35 +8653,17 @@
 /obj/item/clothing/shoes/brown,
 /turf/simulated/floor/bluegreen,
 /area/station/crew_quarters/lounge)
-"cGn" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
 "cGx" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/door/airlock/pyro/glass/sci,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/purple,
-/area/station/science/lobby)
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "cGX" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/stool/bench/blue/auto,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "cHc" = (
 /obj/machinery/chemicompiler_stationary,
 /turf/simulated/floor/white,
@@ -8607,16 +8684,10 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "cHm" = (
-/obj/storage/closet/wardrobe/grey,
-/obj/item/device/radio/intercom{
+/obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8;
-	tag = "icon-bulb1 (WEST)"
-	},
-/obj/landmark/bill_spawn,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "cHM" = (
 /turf/simulated/floor{
@@ -8662,11 +8733,12 @@
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "cLh" = (
-/obj/machinery/vending/medical,
-/turf/simulated/floor/bluewhite{
-	dir = 1
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/area/station/medical/medbay)
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "cLU" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
@@ -8674,6 +8746,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
+"cMc" = (
+/obj/machinery/atmospherics/unary/cryo_cell,
+/obj/machinery/light/incandescent{
+	dir = 1
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "cMd" = (
 /obj/chicken_nesting_box,
 /turf/simulated/floor/grass/leafy,
@@ -8733,18 +8812,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"cMV" = (
-/obj/item/storage/firstaid/regular{
-	pixel_y = -7
-	},
-/obj/table/auto,
-/obj/machinery/cashreg{
-	pixel_y = 5
-	},
-/turf/simulated/floor/greenwhite{
-	dir = 4
-	},
-/area/station/medical/research)
 "cNb" = (
 /turf/simulated/floor{
 	icon_state = "L2";
@@ -8834,13 +8901,9 @@
 	},
 /area/station/solar/aisat)
 "cPT" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/greenwhite{
-	dir = 1
-	},
-/area/station/medical/research)
+/obj/machinery/computer3/generic/med_data,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "cPY" = (
 /turf/simulated/floor/red/corner,
 /area/station/hallway/primary/south)
@@ -8889,14 +8952,17 @@
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/west)
 "cUl" = (
-/obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/caution/south,
+/obj/machinery/chem_heater/chemistry,
+/turf/simulated/floor{
+	icon_state = "corner_east";
+	tag = "icon-corner_east"
+	},
 /area/station/science/chemistry)
 "cUZ" = (
-/obj/machinery/bot/medbot/head_surgeon,
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/crew_quarters/md)
+/turf/simulated/floor/greenwhite{
+	dir = 4
+	},
+/area/station/medical/research)
 "cVb" = (
 /obj/cable{
 	icon_state = "1-6"
@@ -8976,11 +9042,13 @@
 /turf/simulated/floor/purple/side,
 /area/station/science/lab)
 "cYc" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor/greenwhite/corner{
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	id = "capoffice";
 	dir = 4
 	},
-/area/station/medical/medbay/cloner)
+/turf/simulated/floor/plating,
+/area/station/medical/head)
 "cYN" = (
 /obj/storage/closet/welding_supply,
 /turf/simulated/floor/red,
@@ -9013,12 +9081,43 @@
 	},
 /area/station/hallway/primary/south)
 "dbJ" = (
-/obj/machinery/chem_heater/chemistry,
-/turf/simulated/floor{
-	icon_state = "corner_east";
-	tag = "icon-corner_east"
+/obj/table/auto,
+/obj/item/reagent_containers/glass/beaker/large/antitox{
+	pixel_x = -10;
+	pixel_y = 15
 	},
-/area/station/science/chemistry)
+/obj/item/reagent_containers/glass/beaker/large/epinephrine{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/glass/beaker/large/burn{
+	pixel_x = -4;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/glass/beaker/large/brute{
+	pixel_x = -1;
+	pixel_y = 12
+	},
+/obj/item/clothing/glasses/healthgoggles{
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid/oxygen{
+	pixel_x = -11;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/turf/simulated/floor/redwhite{
+	dir = 4
+	},
+/area/station/medical/medbay/surgery)
 "dbN" = (
 /obj/disposalpipe/trunk/morgue{
 	dir = 4
@@ -9075,6 +9174,13 @@
 	dir = 4
 	},
 /area/station/security/processing)
+"dei" = (
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/grime,
+/area/station/medical/robotics)
 "des" = (
 /obj/mesh/catwalk{
 	dir = 10;
@@ -9141,20 +9247,30 @@
 	},
 /area/station/chapel/sanctuary)
 "dgF" = (
-/obj/cable{
-	icon_state = "0-8"
+/obj/storage/secure/closet/medical{
+	name = "Spare Handicap Equipment"
 	},
-/obj/machinery/power/apc/autoname_east,
-/obj/machinery/chem_master{
-	dir = 8
+/obj/item/clothing/glasses/visor{
+	pixel_x = 1;
+	pixel_y = 6
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/item/clothing/glasses/visor{
+	pixel_x = 1;
+	pixel_y = 11
 	},
-/turf/simulated/floor/blueblack{
-	dir = 5
+/obj/item/device/radio/headset/deaf{
+	pixel_x = 9;
+	pixel_y = -7
 	},
-/area/station/medical/medbay/pharmacy)
+/obj/item/device/radio/headset/deaf{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/bluewhite{
+	dir = 6
+	},
+/area/station/medical/head)
 "dgM" = (
 /obj/cable/reinforced{
 	icon_state = "1-4-thick"
@@ -9167,11 +9283,6 @@
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
-"dhy" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/medical/medbay)
 "dhW" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -9184,17 +9295,14 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "dhZ" = (
-/obj/cable{
-	icon_state = "1-9"
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/cable{
-	icon_state = "4-10"
+/turf/simulated/floor/blueblack/corner{
+	dir = 1
 	},
-/obj/cable{
-	icon_state = "4-6"
-	},
-/turf/simulated/floor/plating/damaged1,
-/area/station/chapel/sanctuary)
+/area/station/medical/robotics)
 "dii" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -9211,9 +9319,8 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/mapping_helper/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/south)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "diI" = (
 /obj/mesh/catwalk{
 	dir = 4
@@ -9291,8 +9398,13 @@
 /turf/simulated/floor/blueblack,
 /area/station/crew_quarters/captain)
 "dln" = (
-/turf/simulated/floor/bluewhite,
-/area/station/medical/research)
+/obj/cable{
+	icon_state = "2-4";
+	pixel_y = 0
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "dlq" = (
 /obj/machinery/disposal/mail/autoname/security,
 /obj/disposalpipe/trunk/mail/north,
@@ -9402,13 +9514,12 @@
 	},
 /area/station/hydroponics/bay)
 "doY" = (
-/obj/decal/cleanable/paper,
-/obj/machinery/light/small{
-	dir = 1;
-	status = 2
+/obj/machinery/light/small/sticky/frostedred{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
+/obj/machinery/vending/standard,
+/turf/simulated/floor/grime,
+/area/station/medical/robotics)
 "dpz" = (
 /obj/table/reinforced/industrial/auto{
 	icon_state = "3"
@@ -9446,9 +9557,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "dpC" = (
-/obj/decal/cleanable/machine_debris,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
+/area/station/medical/robotics)
 "dpD" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
@@ -9504,15 +9618,13 @@
 	},
 /area/station/hydroponics/bay)
 "dqJ" = (
-/obj/machinery/light_switch{
-	name = "S light switch";
-	pixel_y = -24
+/obj/blind_switch/area/east,
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/unary/cold_sink/freezer/cryo{
-	dir = 1
-	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbay)
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "dri" = (
 /obj/machinery/light/incandescent{
 	dir = 4
@@ -9618,10 +9730,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "dtv" = (
-/turf/simulated/floor/purple/side{
-	dir = 8
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/hallway/primary/south)
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "dtM" = (
 /obj/cable{
 	icon_state = "4-9"
@@ -9711,18 +9827,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "dxC" = (
-/obj/machinery/sleeper/port_a_medbay{
-	dir = 8
+/obj/storage/closet/welding_supply,
+/obj/machinery/light/small/frostedred{
+	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 12;
-	tag = ""
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 4
-	},
-/area/station/medical/medbay)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "dxZ" = (
 /obj/machinery/camera/directional/east{
 	pixel_y = -10
@@ -9736,6 +9846,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"dyu" = (
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/blackwhite{
+	dir = 4
+	},
+/area/station/medical/medbay/lobby)
 "dyH" = (
 /obj/cable/blue{
 	icon_state = "1-2"
@@ -9758,14 +9877,12 @@
 /turf/space,
 /area/space)
 "dAF" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	icon_state = "2-4";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/bluewhite{
-	dir = 1
-	},
-/area/station/medical/medbay)
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/surgery)
 "dAS" = (
 /obj/mesh/catwalk{
 	dir = 4
@@ -9938,15 +10055,6 @@
 /obj/item/clothing/head/helmet/space/captain,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/captain)
-"dFv" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbay)
 "dFD" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
@@ -10098,11 +10206,18 @@
 /turf/simulated/floor/plating,
 /area/station/turret_protected/armory_outside)
 "dMz" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
 /obj/machinery/camera/directional/north{
+	c_tag = "Robotics Laboratory";
 	pixel_x = -10
 	},
-/turf/simulated/floor/plating/airless,
-/area/space)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "dMU" = (
 /obj/machinery/disposal/small/west,
 /obj/disposalpipe/trunk{
@@ -10216,6 +10331,10 @@
 /obj/machinery/light/emergency{
 	dir = 1
 	},
+/obj/disposalpipe/segment/morgue{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -10252,11 +10371,15 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "dRJ" = (
-/obj/machinery/bot/secbot{
-	name = "Doctor Batonsly"
+/obj/table/reinforced/chemistry/auto,
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/pharmacy,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/cable{
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/specialroom/medbay,
+/area/station/medical/medbay/pharmacy)
 "dRO" = (
 /obj/machinery/the_singularitygen,
 /obj/cable,
@@ -10297,6 +10420,10 @@
 /obj/item/storage/box/beakerbox,
 /obj/machinery/light/incandescent,
 /obj/machinery/chem_shaker/large,
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/medbay/pharmacy)
 "dTT" = (
@@ -10368,11 +10495,17 @@
 	dir = 9
 	},
 /area/station/crew_quarters/supplylobby)
-"dVr" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk,
+"dVo" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
+"dVr" = (
+/obj/machinery/traymachine/morgue,
+/obj/landmark/bill_spawn,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "dVD" = (
 /obj/stool,
 /turf/simulated/floor/grime,
@@ -10430,9 +10563,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/staff_room)
 "dYk" = (
-/obj/spawner/clone_rack,
-/turf/simulated/floor/greenwhite,
-/area/station/medical/medbay/cloner)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "dYm" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -10542,16 +10680,14 @@
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "eca" = (
+/obj/machinery/chem_dispenser/chemical,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/mail{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/light/incandescent{
-	dir = 4
-	},
-/turf/simulated/floor/purplewhite{
-	dir = 4
-	},
+/turf/simulated/floor/white,
 /area/station/science/chemistry)
 "ect" = (
 /obj/cable{
@@ -10785,21 +10921,29 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"eiZ" = (
+/obj/iv_stand,
+/obj/item/reagent_containers/iv_drip/saline,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "ejk" = (
-/obj/cable{
-	icon_state = "9-10"
+/obj/storage/secure/closet/medical/cloning,
+/turf/simulated/floor/greenwhite{
+	dir = 9
 	},
-/obj/disposalpipe/segment/morgue,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/medical/medbay/cloner)
 "ejt" = (
-/obj/cable{
-	icon_state = "0-4"
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/cable,
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/robotics)
+/turf/simulated/floor/greenwhite/corner{
+	dir = 4
+	},
+/area/station/medical/medbay)
 "ejA" = (
 /obj/table/auto,
 /obj/item/device/gps{
@@ -10828,14 +10972,10 @@
 /turf/simulated/floor/purplewhite,
 /area/station/science/lobby)
 "ejW" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	autoclose = 0;
-	dir = 1
-	},
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/storage/emergency)
+/obj/table/auto/desk,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "eke" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -10853,19 +10993,6 @@
 /obj/blind_switch/area/south,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
-"eln" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
-/obj/item/reagent_containers/iv_drip/saline,
-/obj/iv_stand,
-/turf/simulated/floor/redwhite{
-	dir = 5
-	},
-/area/station/medical/medbay/surgery)
 "elv" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -10955,16 +11082,13 @@
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/ai_upload)
 "enG" = (
-/obj/item/device/radio/intercom/medical{
-	dir = 4
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-4"
 	},
-/obj/shrub{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant";
-	level = 1.9
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "enZ" = (
 /obj/cable/reinforced{
 	icon_state = "1-4-thick"
@@ -11098,25 +11222,10 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "esb" = (
-/obj/item/device/radio/intercom/medical{
-	dir = 8
-	},
-/obj/item/device/radio/headset/medical{
-	pixel_y = -1;
-	pixel_x = -2
-	},
-/obj/item/device/radio/headset/medical{
-	pixel_y = -3
-	},
-/obj/machinery/phone{
-	pixel_x = 1;
-	pixel_y = -2
-	},
-/obj/table/auto,
-/turf/simulated/floor/bluewhite{
-	dir = 4
-	},
-/area/station/medical/medbay)
+/obj/machinery/dialysis,
+/obj/disposalpipe/segment,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "esy" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 5
@@ -11143,14 +11252,16 @@
 	},
 /area/station/engine/inner)
 "esW" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/mapping_helper/airlock/cycler{
-	name = "Upload Space";
-	enter_id = "outer";
-	cycle_id = "uploadsps"
+/obj/cable{
+	icon_state = "0-8"
 	},
+/obj/cable{
+	dir = null
+	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/medical/robotics)
 "esX" = (
 /obj/critter/parrot/random,
 /obj/cable{
@@ -11201,14 +11312,11 @@
 	},
 /area/station/chapel/sanctuary)
 "evq" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/purplewhite/corner{
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4
 	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "evr" = (
 /obj/disposalpipe/segment/mail{
@@ -11221,10 +11329,13 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "evZ" = (
-/obj/machinery/clonepod,
-/obj/cable,
-/turf/simulated/floor/greenwhite,
-/area/station/medical/medbay/cloner)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 9
+	},
+/area/station/chapel/sanctuary)
 "ewn" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -11297,12 +11408,26 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "ezO" = (
+/obj/table/auto,
+/obj/item/storage/box/panic_buttons/medicalalert{
+	pixel_x = 9;
+	pixel_y = 14
+	},
+/obj/item/bandage{
+	pixel_y = -5
+	},
+/obj/item/bandage{
+	pixel_x = -2
+	},
+/obj/item/storage/box/stma_kit{
+	pixel_y = 15
+	},
 /obj/disposalpipe/segment/mail{
-	dir = 8;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "ezT" = (
 /obj/cable,
 /obj/cable{
@@ -11323,11 +11448,9 @@
 	},
 /area/station/crew_quarters/courtroom)
 "eAu" = (
-/obj/submachine/cargopad/robotics,
-/turf/simulated/floor/blueblack/corner{
-	dir = 1
-	},
-/area/station/medical/robotics)
+/obj/disposalpipe/segment,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "eBf" = (
 /obj/cable{
 	icon_state = "6-8"
@@ -11455,30 +11578,42 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "eEV" = (
-/obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/morgue,
-/obj/machinery/door/airlock/pyro/medical{
-	name = "Morgue"
+/obj/table/auto,
+/obj/item/device/analyzer/healthanalyzer{
+	pixel_x = 10;
+	pixel_y = 8
 	},
+/obj/item/device/analyzer/healthanalyzer{
+	pixel_x = 9
+	},
+/obj/item/clothing/mask/surgical_shield{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/clothing/mask/surgical_shield{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/turf/simulated/floor/redwhite{
+	dir = 1
+	},
+/area/station/medical/medbay/surgery)
+"eEW" = (
+/obj/item/instrument/large/organ,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 10
+	},
+/area/station/chapel/sanctuary)
+"eFV" = (
+/obj/machinery/door/airlock/pyro/glass/med,
+/obj/mapping_helper/access/medical,
+/obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
-"eEW" = (
-/obj/cable{
-	icon_state = "2-4";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"eFV" = (
-/obj/stool/chair/comfy/wheelchair{
-	dir = 8
-	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/medbay/cloner)
 "eGg" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -11529,17 +11664,10 @@
 /turf/simulated/floor/plating,
 /area/station/chapel/sanctuary)
 "eIn" = (
-/obj/cable{
-	icon_state = "2-10"
+/turf/simulated/floor/blue/side{
+	dir = 5
 	},
-/obj/cable{
-	icon_state = "6-8"
-	},
-/obj/landmark/start{
-	name = "predator"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/hallway/primary/central)
 "eIr" = (
 /obj/disposalpipe/segment/mail{
 	dir = 8;
@@ -11548,17 +11676,25 @@
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "eII" = (
-/obj/cable{
-	icon_state = "4-10"
+/obj/machinery/power/apc/autoname_north,
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "eIL" = (
-/obj/cable{
-	icon_state = "5-8"
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = -12;
+	tag = ""
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/greenwhite{
+	dir = 8
+	},
+/area/station/medical/research)
 "eIV" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -11723,6 +11859,12 @@
 	},
 /turf/space,
 /area/station/engine/proto)
+"eQU" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/medical/medbay/pharmacy)
 "eRb" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -11977,6 +12119,10 @@
 	c_tag = "AI Module";
 	pixel_x = -10
 	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -12025,19 +12171,6 @@
 	tag = "icon-grass1"
 	},
 /area/station/hydroponics/bay)
-"fbm" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "fbI" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor,
@@ -12163,15 +12296,13 @@
 	},
 /area/station/hallway/secondary/exit)
 "fgS" = (
-/obj/cable,
-/obj/machinery/power/apc/autoname_south,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/turf/simulated/floor/bluewhite{
-	dir = 10
+/obj/cable{
+	icon_state = "4-8"
 	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay)
 "fhe" = (
 /obj/machinery/door/airlock/pyro/engineering{
@@ -12190,25 +12321,17 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
-"fhw" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/science/lobby)
 "fhB" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/machinery/door/airlock/pyro/medical{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
+/obj/mapping_helper/access/medical,
+/obj/mapping_helper/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/specialroom/medbay,
+/area/station/hangar/medical)
 "fhD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -12224,15 +12347,10 @@
 /turf/simulated/wall/auto/supernorn,
 /area/ghostdrone_factory)
 "fhO" = (
-/obj/cable{
-	icon_state = "2-9"
-	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/light/small/broken{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/machinery/power/apc/autoname_south,
+/obj/cable,
+/turf/simulated/floor/redwhite,
+/area/station/medical/medbay/surgery)
 "fjk" = (
 /turf/simulated/floor/specialroom/chapel{
 	dir = 9
@@ -12247,6 +12365,15 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
 /area/station/security/hos)
+"fjF" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "fjU" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -12257,14 +12384,12 @@
 	},
 /area/station/hallway/secondary/exit)
 "fkd" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "blue";
-	icon_state = "bedsheet-blue"
+/obj/stool/chair/blue{
+	dir = 1
 	},
-/obj/landmark/start/job/medical_director,
-/turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/crew_quarters/md)
+/obj/landmark/start/job/geneticist,
+/turf/simulated/floor/blue/checker,
+/area/station/medical/research)
 "fkE" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Bridge Storage";
@@ -12306,6 +12431,10 @@
 	},
 /turf/simulated/floor/auto/dirt,
 /area/station/ranch)
+"fnf" = (
+/obj/landmark/random_room/size3x3,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "fnm" = (
 /obj/mesh/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
@@ -12413,6 +12542,12 @@
 	dir = 4
 	},
 /area/station/science/lab)
+"frx" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "frK" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -12490,7 +12625,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "ftN" = (
-/obj/machinery/traymachine/morgue,
+/obj/blind_switch/area/east,
+/obj/machinery/traymachine/morgue{
+	dir = 8
+	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "ftQ" = (
@@ -12746,24 +12884,21 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
+"fCy" = (
+/obj/machinery/camera/directional/south{
+	pixel_x = 10
+	},
+/turf/simulated/floor/engine,
+/area/station/hangar/medical)
 "fCz" = (
 /obj/disposalpipe/segment/morgue{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4;
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
 /area/station/hallway/primary/central)
-"fDs" = (
-/obj/cable{
-	icon_state = "5-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "fDu" = (
 /obj/machinery/power/smes{
 	charge = 1e+006;
@@ -12835,18 +12970,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "fFw" = (
-/obj/storage/crate,
-/obj/item/clothing/head/wig,
-/obj/item/dye_bottle,
-/obj/item/dye_bottle,
-/obj/item/clothing/under/misc/barber,
-/obj/item/scissors,
-/obj/item/razor_blade,
-/obj/machinery/light/small{
-	dir = 4
+/obj/cable{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor,
-/area/station/maintenance/east)
+/obj/machinery/power/apc/autoname_east,
+/obj/machinery/chem_master{
+	dir = 8
+	},
+/turf/simulated/floor/blueblack{
+	dir = 5
+	},
+/area/station/medical/medbay/pharmacy)
 "fFB" = (
 /obj/mesh/catwalk{
 	dir = 4
@@ -12871,14 +13005,18 @@
 /area/station/crew_quarters/supplylobby)
 "fGD" = (
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/specialroom/chapel{
+	dir = 4
+	},
+/area/station/chapel/sanctuary)
 "fGE" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/cable,
+/obj/machinery/power/apc/autoname_south,
+/obj/machinery/genetics_scanner,
+/turf/simulated/floor/greenwhite,
+/area/station/medical/research)
 "fGI" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 1
@@ -12887,32 +13025,16 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen/freezer)
 "fHv" = (
-/obj/stool/chair/office{
+/obj/machinery/door/firedoor/pyro,
+/turf/simulated/floor/blue/side{
 	dir = 4
 	},
-/obj/landmark/start/job/pharmacist,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/blueblack{
-	dir = 1
-	},
-/area/station/medical/medbay/pharmacy)
+/area/station/hallway/primary/central)
 "fHA" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/door/airlock/pyro/glass/sci{
-	dir = 4
-	},
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/purplewhite{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
+/obj/machinery/chem_dispenser/chemical,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/simulated/floor/caution/south,
+/area/station/science/chemistry)
 "fIj" = (
 /obj/cable/yellow{
 	icon_state = "4-8"
@@ -13059,15 +13181,19 @@
 /turf/simulated/floor/blue,
 /area/station/science/lab)
 "fQa" = (
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/morgue,
+/obj/machinery/door/airlock/pyro/medical{
+	name = "Morgue"
+	},
 /obj/cable{
-	icon_state = "6-9"
+	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "fQl" = (
 /obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/plating,
@@ -13184,6 +13310,10 @@
 "fTO" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/cafeteria)
+"fUK" = (
+/obj/machinery/computer/operating/small,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "fVa" = (
 /obj/lattice{
 	dir = 5;
@@ -13198,9 +13328,11 @@
 	},
 /area/station/hallway/secondary/entry)
 "fVK" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/white,
-/area/station/science/chemistry)
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/grime,
+/area/station/medical/robotics)
 "fVM" = (
 /turf/simulated/floor/escape{
 	dir = 9
@@ -13255,6 +13387,10 @@
 	dir = 1
 	},
 /area/station/hydroponics/bay)
+"fYL" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/hangar/medical)
 "fYR" = (
 /obj/machinery/vending/kitchen,
 /turf/simulated/floor/specialroom/cafeteria,
@@ -13321,9 +13457,12 @@
 	},
 /area/station/medical/medbay/surgery)
 "gbE" = (
-/obj/decal/cleanable/paper,
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "gcn" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/cable,
@@ -13478,11 +13617,14 @@
 	},
 /area/station/crew_quarters/cafeteria)
 "gjS" = (
-/obj/storage/secure/closet/medical/chemical,
-/turf/simulated/floor/blueblack{
-	dir = 10
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/area/station/medical/medbay/pharmacy)
+/turf/simulated/floor/redwhite{
+	dir = 1
+	},
+/area/station/medical/medbay/surgery)
 "gkA" = (
 /obj/storage/crate{
 	name = "Spare Parts"
@@ -13565,6 +13707,10 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
+"gmx" = (
+/obj/landmark/random_room/size3x5,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "gmA" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/green/corner{
@@ -13667,34 +13813,11 @@
 /turf/simulated/floor/plating/damaged3,
 /area/station/maintenance/west)
 "gpH" = (
-/obj/item/paper_bin{
-	pixel_x = -6;
-	pixel_y = 6
+/obj/cable{
+	icon_state = "1-9"
 	},
-/obj/item/clipboard{
-	pixel_x = 6
-	},
-/obj/item/paper{
-	pixel_x = 6
-	},
-/obj/item/pen{
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/obj/item/pen{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/table/auto,
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 12;
-	tag = ""
-	},
-/turf/simulated/floor/greenwhite{
-	dir = 4
-	},
-/area/station/medical/research)
+/turf/simulated/floor/blue/side,
+/area/station/hallway/primary/central)
 "gpP" = (
 /obj/decal/cleanable/oil,
 /obj/cable{
@@ -13802,6 +13925,12 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/qm)
+"gsP" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "gtR" = (
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 8
@@ -13853,8 +13982,8 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "gwT" = (
 /obj/machinery/turret{
 	dir = 1
@@ -13880,6 +14009,12 @@
 	dir = 9
 	},
 /area/station/security/main)
+"gya" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "gyb" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -13915,14 +14050,8 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "gzX" = (
-/obj/machinery/computer/operating/small,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
-/turf/simulated/floor/redblack{
-	dir = 1
-	},
-/area/station/medical/robotics)
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/head)
 "gzZ" = (
 /obj/stool/chair/office/purple{
 	dir = 1
@@ -14005,10 +14134,6 @@
 	icon_state = "fgreen3"
 	},
 /area/station/bridge)
-"gBh" = (
-/obj/decal/poster/wallsign/medbay_right,
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/south)
 "gBy" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0;
@@ -14036,12 +14161,11 @@
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/arrivals)
 "gCJ" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/shrub,
+/turf/simulated/floor/bluewhite{
+	dir = 6
 	},
-/turf/simulated/floor/plating,
-/area/station/medical/medbay/surgery)
+/area/station/medical/head)
 "gDe" = (
 /obj/stool/chair/green{
 	dir = 8
@@ -14072,23 +14196,10 @@
 	},
 /area/station/hydroponics/bay)
 "gDO" = (
-/obj/table/auto,
-/obj/machinery/networked/printer{
-	print_id = "Medbay"
+/turf/simulated/floor/greenwhite{
+	dir = 8
 	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/item/storage/box/panic_buttons/medicalalert{
-	pixel_x = 9;
-	pixel_y = 14
-	},
-/turf/simulated/floor/bluewhite/corner,
-/area/station/medical/medbay)
+/area/station/medical/medbay/cloner)
 "gEd" = (
 /obj/storage/crate{
 	desc = "A private crate that isn't yours.";
@@ -14135,6 +14246,11 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"gEA" = (
+/obj/mapping_helper/wingrille_spawn/auto,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "gES" = (
 /turf/simulated/floor/plating,
 /area/space)
@@ -14203,10 +14319,7 @@
 /obj/item/device/radio/intercom/medical{
 	dir = 1
 	},
-/obj/machinery/computer/operating/small,
-/turf/simulated/floor/redwhite{
-	dir = 6
-	},
+/turf/simulated/floor/redwhite,
 /area/station/medical/medbay/surgery)
 "gHG" = (
 /obj/cable{
@@ -14233,15 +14346,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
 "gIK" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/cable{
-	icon_state = "1-4"
+/obj/machinery/traymachine/morgue{
+	dir = 8
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
@@ -14359,14 +14465,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"gMh" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/greenwhite{
-	dir = 8
-	},
-/area/station/medical/research)
 "gMO" = (
 /obj/cable,
 /obj/cable{
@@ -14412,19 +14510,22 @@
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/private)
 "gOF" = (
-/obj/stool/chair{
+/obj/cable{
+	icon_state = "1-10"
+	},
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/landmark/start/job/geneticist,
-/turf/simulated/floor/greenwhite{
-	dir = 1
-	},
-/area/station/medical/research)
-"gOR" = (
-/turf/simulated/floor/bluewhite/corner{
-	dir = 4
-	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
+"gOR" = (
+/mob/living/carbon/human/npc/monkey,
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "gOS" = (
 /obj/machinery/sink/slim{
 	dir = 4;
@@ -14484,6 +14585,18 @@
 	},
 /turf/simulated/floor/grass/random,
 /area/station/garden/owlery)
+"gRA" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "chemistry";
+	name = "Chemistry Privacy Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/science/chemistry)
 "gSj" = (
 /obj/table/wood/auto,
 /obj/item/wrapping_paper,
@@ -14498,6 +14611,14 @@
 	dir = 6
 	},
 /area/station/hallway/primary/central)
+"gSG" = (
+/obj/machinery/chem_master,
+/obj/machinery/camera/directional/north{
+	c_tag = "Chemistry Department";
+	pixel_x = -10
+	},
+/turf/simulated/floor/caution/corner/sw,
+/area/station/science/chemistry)
 "gSQ" = (
 /obj/machinery/cell_charger,
 /obj/table/auto,
@@ -14511,24 +14632,19 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "gSY" = (
-/obj/decal/tile_edge/stripe/extra_big,
-/obj/cable{
-	icon_state = "2-4";
-	pixel_y = 0
+/mob/living/critter/small_animal/bat/doctor,
+/turf/simulated/floor/bluewhite{
+	dir = 6
 	},
-/turf/simulated/floor/redwhite,
-/area/station/medical/medbay/surgery)
+/area/station/medical/head)
 "gTa" = (
 /obj/machinery/computer/teleporter,
 /turf/simulated/floor/orangeblack,
 /area/station/teleporter)
 "gTj" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "gUr" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	req_access = null
@@ -14536,11 +14652,11 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "gUM" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbay)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "gUT" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -14558,11 +14674,14 @@
 /turf/simulated/wall/auto/supernorn,
 /area/ghostdrone_factory)
 "gVd" = (
-/obj/machinery/light/small/frostedred{
-	dir = 4
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/med{
+	id = "cloning_exit"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/mapping_helper/access/medical,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "gVi" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet,
@@ -14612,6 +14731,15 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
+"gXZ" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/specialroom/medbay,
+/area/station/maintenance/east)
 "gYH" = (
 /obj/storage/crate,
 /turf/simulated/floor/plating,
@@ -14659,7 +14787,9 @@
 /obj/machinery/light/incandescent{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/blue/side{
+	dir = 1
+	},
 /area/station/hallway/primary/central)
 "hae" = (
 /obj/machinery/light_switch{
@@ -14695,20 +14825,8 @@
 /turf/simulated/floor/carpet/green/fancy,
 /area/station/crew_quarters/hop)
 "haL" = (
-/obj/landmark/bill_spawn,
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
-"haW" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/stool/chair/pew/center{
-	dir = 4
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 4
-	},
-/area/station/chapel/sanctuary)
+/turf/simulated/floor/specialroom/medbay,
+/area/station/maintenance/east)
 "haY" = (
 /obj/disposalpipe/segment,
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon7,
@@ -14801,14 +14919,6 @@
 /obj/shrub,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"hde" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/research)
 "hdX" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -14882,6 +14992,14 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/autolathe)
+"hgN" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/obj/warp_beacon/medbay,
+/turf/space,
+/area/space)
 "hgQ" = (
 /obj/disposalpipe/switch_junction/left/east{
 	mail_tag = "bridge";
@@ -15012,12 +15130,6 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
-"hmP" = (
-/obj/mapping_helper/access/medical,
-/obj/mapping_helper/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/med,
-/turf/simulated/floor/blue,
-/area/station/medical/medbay/surgery)
 "hmQ" = (
 /obj/machinery/light/incandescent,
 /obj/decal/stripe_delivery,
@@ -15047,21 +15159,8 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "hop" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/white,
-/area/station/science/chemistry)
+/turf/simulated/wall/auto/supernorn,
+/area/station/hangar/medical)
 "hov" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -15170,25 +15269,10 @@
 /obj/machinery/weapon_stand/rifle_rack/recharger,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"hrz" = (
-/obj/submachine/chem_extractor,
-/obj/item/device/reagentscanner,
-/turf/simulated/floor/caution/corner/nw{
-	dir = 1
-	},
-/area/station/science/chemistry)
 "hrH" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "chemistry";
-	name = "Chemistry Privacy Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/science/chemistry)
+/obj/decal/tile_edge/stripe/big,
+/turf/simulated/floor/specialroom/medbay,
+/area/station/hangar/medical)
 "hsb" = (
 /obj/machinery/power/data_terminal,
 /obj/cable/blue{
@@ -15214,12 +15298,12 @@
 /turf/simulated/floor,
 /area/station/science/hall)
 "hsp" = (
-/obj/machinery/chem_dispenser/chemical,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/caution/north{
-	dir = 8
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
 	},
-/area/station/science/chemistry)
+/turf/simulated/floor/engine,
+/area/station/hangar/medical)
 "hsv" = (
 /obj/stool/chair/green{
 	dir = 1
@@ -15248,6 +15332,13 @@
 "hti" = (
 /turf/simulated/floor/purple/checker,
 /area/station/science/teleporter)
+"htI" = (
+/obj/decal/tile_edge/stripe/big,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/specialroom/medbay,
+/area/station/maintenance/east)
 "htK" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -15258,6 +15349,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
+"htW" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/redwhite{
+	dir = 1
+	},
+/area/station/medical/medbay/surgery)
 "huf" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -15268,32 +15367,12 @@
 	},
 /area/station/bridge)
 "hul" = (
-/obj/rack,
-/obj/item/storage/box/stma_kit{
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/obj/item/clothing/suit/hazard/paramedic{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/clothing/suit/hazard/paramedic{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/item/storage/belt/medical{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/item/storage/belt/medical{
-	pixel_x = 4;
-	pixel_y = -1
-	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	icon_state = "1-8"
+	dir = null
 	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbay)
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/surgery)
 "huw" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -15341,12 +15420,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
-"hwc" = (
-/obj/storage/secure/closet/medical{
-	name = "locker"
-	},
-/turf/simulated/floor/greenwhite,
-/area/station/medical/medbay/cloner)
 "hwj" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light/incandescent,
@@ -15526,20 +15599,19 @@
 /turf/space,
 /area/station/engine/proto)
 "hDF" = (
-/obj/landmark/start/job/medical_doctor,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 9
+/obj/machinery/camera/directional/north{
+	c_tag = "Robotics Laboratory";
+	pixel_x = -10
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/machinery/light_switch{
+	name = "N light switch";
+	pixel_y = 24
 	},
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/portable_reclaimer,
+/turf/simulated/floor/blueblack/corner{
+	dir = 1
 	},
-/turf/simulated/floor/redwhite{
-	dir = 9
-	},
-/area/station/medical/medbay/surgery)
+/area/station/medical/robotics)
 "hDU" = (
 /obj/machinery/door_timer/solitary/new_walls/south,
 /turf/simulated/floor/red/side,
@@ -15605,10 +15677,13 @@
 	},
 /area/station/bridge)
 "hHk" = (
-/turf/simulated/floor/bluewhite{
+/obj/item/device/radio/intercom/medical{
+	dir = 4
+	},
+/turf/simulated/floor/redwhite{
 	dir = 8
 	},
-/area/station/medical/medbay)
+/area/station/medical/medbay/surgery)
 "hHZ" = (
 /obj/cable,
 /obj/cable{
@@ -15632,11 +15707,6 @@
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/central)
-"hJf" = (
-/turf/simulated/floor/bluewhite{
-	dir = 6
-	},
-/area/station/medical/research)
 "hKu" = (
 /obj/decal/stripe_delivery,
 /obj/machinery/light/incandescent{
@@ -15663,9 +15733,14 @@
 	},
 /area/station/hallway/primary/south)
 "hKS" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/robotics)
+/obj/machinery/camera/directional/south{
+	pixel_x = 10
+	},
+/obj/machinery/computer/genetics{
+	dir = 1
+	},
+/turf/simulated/floor/greenwhite,
+/area/station/medical/research)
 "hKV" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -15786,10 +15861,29 @@
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "hQH" = (
-/turf/simulated/floor/blue/side{
-	dir = 1
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/area/station/hallway/primary/south)
+/obj/cable{
+	icon_state = "6-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-9"
+	},
+/obj/cable{
+	icon_state = "9-10"
+	},
+/obj/stool/chair/pew/right{
+	dir = 4
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 5
+	},
+/area/station/chapel/sanctuary)
 "hQO" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable,
@@ -15866,14 +15960,13 @@
 	},
 /area/station/science/lab)
 "hUc" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "2-6"
+/turf/simulated/floor/blackwhite{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
+/area/station/medical/medbay/lobby)
 "hUd" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -15882,16 +15975,46 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "hUu" = (
-/obj/machinery/door/airlock/pyro,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/maintenance/east)
-"hUy" = (
-/obj/shrub,
-/turf/simulated/floor/blue/side{
-	dir = 1
+/obj/table/auto,
+/obj/item/clothing/gloves/latex{
+	pixel_x = -12;
+	pixel_y = -4
 	},
-/area/station/hallway/primary/south)
+/obj/item/device/analyzer/healthanalyzer{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/surgical{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = 13;
+	pixel_y = 11
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/item/device/reagentscanner{
+	pixel_x = -15;
+	pixel_y = 10
+	},
+/turf/simulated/floor/redwhite{
+	dir = 4
+	},
+/area/station/medical/medbay/surgery)
+"hUy" = (
+/obj/cable{
+	icon_state = "1-9"
+	},
+/obj/cable{
+	icon_state = "8-9"
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 5
+	},
+/area/station/chapel/sanctuary)
 "hVe" = (
 /obj/submachine/weapon_vendor/fishing/portable,
 /turf/simulated/floor/grass{
@@ -15900,17 +16023,9 @@
 	},
 /area/station/hydroponics/bay)
 "hVl" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/light/emergency{
-	dir = 1
-	},
-/obj/stool/chair/comfy/wheelchair{
-	dir = 8
-	},
-/turf/simulated/floor/blackwhite{
-	dir = 5
-	},
-/area/station/medical/medbay/lobby)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "hVn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -15957,10 +16072,13 @@
 /turf/simulated/floor,
 /area/station/engine/inner)
 "hXL" = (
-/turf/simulated/floor/blue/side{
-	dir = 5
+/obj/disposalpipe/switch_junction/left/north{
+	mail_tag = "genetics";
+	name = "Mail Junction - Genetics";
+	dir = 4
 	},
-/area/station/hallway/primary/south)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "hYk" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -16077,10 +16195,17 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "ibI" = (
-/turf/simulated/floor/bluewhite/corner{
-	dir = 8
+/obj/storage/secure/closet/command/medical_director,
+/obj/blind_switch/area/east,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/bluewhite{
+	dir = 6
+	},
+/area/station/medical/head)
 "ibJ" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "AI Upload";
@@ -16089,10 +16214,10 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "ibY" = (
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/computer/announcement/station/medical,
-/turf/simulated/floor/carpet/blue/fancy/edge/ne,
-/area/station/crew_quarters/md)
+/turf/simulated/floor/greenwhite{
+	dir = 5
+	},
+/area/station/medical/research)
 "ice" = (
 /obj/cable{
 	icon_state = "2-9"
@@ -16105,24 +16230,23 @@
 	},
 /turf/simulated/floor/bluegreen,
 /area/station/crew_quarters/lounge)
-"icn" = (
-/obj/health_scanner/floor{
-	dir = 4;
-	find_in_range = 0;
-	id = "lobby"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
 "icr" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "icY" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/bluewhite{
-	dir = 9
+/obj/cable{
+	icon_state = "1-2"
 	},
-/area/station/medical/medbay/lobby)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "ide" = (
 /obj/storage/closet/law,
 /turf/simulated/floor/black/side{
@@ -16131,7 +16255,7 @@
 /area/station/crew_quarters/courtroom)
 "idi" = (
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "4-10"
@@ -16140,8 +16264,8 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "idy" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating/random,
@@ -16165,6 +16289,12 @@
 	dir = 9
 	},
 /area/station/chapel/sanctuary)
+"ifi" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "ifO" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -16189,10 +16319,6 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/proto)
-"igQ" = (
-/obj/landmark/start/job/medical_doctor,
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
 "igW" = (
 /obj/machinery/light/small/sticky/frostedred,
 /turf/simulated/floor/plating,
@@ -16214,26 +16340,33 @@
 /obj/lattice,
 /turf/space,
 /area/station/engine/proto)
+"ihv" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/blue/side{
+	dir = 1
+	},
+/area/station/hallway/primary/central)
 "iiL" = (
-/obj/cable{
-	icon_state = "1-2"
+/turf/simulated/floor/blackwhite/corner{
+	dir = 8
 	},
-/turf/simulated/floor/bluewhite{
-	dir = 9
-	},
-/area/station/medical/research)
+/area/station/medical/medbay/lobby)
 "ijd" = (
 /obj/storage/secure/closet/security/forensics,
 /obj/item/device/radio/intercom/brig,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "ijm" = (
-/obj/item/storage/wall/fire{
-	dir = 1;
-	pixel_y = 32
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "2-4";
+	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
@@ -16349,6 +16482,7 @@
 /turf/simulated/floor/plating/airless,
 /area/station/engine/proto)
 "inG" = (
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "iof" = (
@@ -16398,9 +16532,17 @@
 /turf/simulated/floor,
 /area/station/janitor/supply)
 "ipb" = (
-/obj/machinery/light/small,
-/turf/simulated/floor,
-/area/station/maintenance/east)
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Robotics Laboratory";
+	pixel_x = -10
+	},
+/obj/machinery/vending/snack,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "ipk" = (
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
@@ -16488,8 +16630,13 @@
 	},
 /area/station/engine/engineering/private)
 "isW" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/table/reinforced,
+/obj/mapping_helper/access/research,
+/obj/item/storage/box/beakerbox,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/storage/box/beakerbox,
+/turf/simulated/floor/white,
 /area/station/science/chemistry)
 "ite" = (
 /obj/mesh/catwalk,
@@ -16601,9 +16748,12 @@
 /turf/simulated/floor/grime,
 /area/station/mining/magnet)
 "ixW" = (
-/obj/critter/bat/doctor,
-/turf/simulated/floor/carpet/blue/fancy,
-/area/station/crew_quarters/md)
+/obj/mapping_helper/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "iyb" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Teleporter";
@@ -16626,25 +16776,24 @@
 	},
 /area/station/hydroponics/bay)
 "izA" = (
-/obj/mapping_helper/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/medical{
-	name = "Robotics";
-	req_access = null;
+/obj/disposalpipe/segment/morgue{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
+"izE" = (
+/obj/table/auto,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = 9;
+	pixel_y = -3
+	},
+/obj/item/cloneModule/genepowermodule,
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/mapping_helper/access/robotics,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/blueblack/corner,
-/area/station/medical/robotics)
-"izE" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/carpet/blue/fancy/edge/south,
-/area/station/crew_quarters/md)
+/turf/simulated/floor/greenwhite,
+/area/station/medical/research)
 "izZ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -16719,12 +16868,13 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "iBJ" = (
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/camera/directional/south{
+	pixel_x = 10
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
+/turf/simulated/floor/bluewhite{
+	dir = 9
+	},
+/area/station/medical/head)
 "iBL" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -16839,15 +16989,10 @@
 /obj/machinery/portableowl/judgementowl,
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
-"iIq" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/overfloor{
-	dir = 1
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
+"iHQ" = (
+/obj/machinery/vehicle/miniputt/armed,
+/turf/simulated/floor/engine,
+/area/station/hangar/medical)
 "iIt" = (
 /obj/storage/closet/fire,
 /obj/item/crowbar,
@@ -16858,10 +17003,6 @@
 	dir = 10
 	},
 /area/station/hallway/arrivals)
-"iII" = (
-/obj/reagent_dispensers/foamtank,
-/turf/simulated/floor,
-/area/station/maintenance/east)
 "iIJ" = (
 /obj/machinery/light/small/floor,
 /obj/cable{
@@ -16936,12 +17077,11 @@
 	},
 /area/station/hallway/secondary/entry)
 "iKs" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/decal/tile_edge/stripe/big{
+	dir = 1
 	},
-/mob/living/critter/small_animal/opossum/morty,
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
+/turf/simulated/floor/specialroom/medbay,
+/area/station/maintenance/east)
 "iKt" = (
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai_upload)
@@ -16994,8 +17134,9 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "iLH" = (
-/obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/med,
+/obj/mapping_helper/access/medical,
 /turf/simulated/floor,
 /area/station/storage/emergency)
 "iMt" = (
@@ -17039,31 +17180,15 @@
 /turf/space,
 /area/space)
 "iNE" = (
-/obj/machinery/disposal/small{
-	dir = 4
-	},
-/obj/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/table/auto,
-/obj/item/storage/box/stma_kit{
-	pixel_y = 15
-	},
-/obj/item/bandage{
-	pixel_x = -2
-	},
-/obj/item/bandage{
-	pixel_y = -5
-	},
-/obj/machinery/light{
+/obj/disposalpipe/segment{
 	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/bluewhite{
-	dir = 9
+/obj/cable{
+	icon_state = "1-4"
 	},
-/area/station/medical/medbay)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "iNW" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/engine,
@@ -17181,18 +17306,14 @@
 /turf/simulated/floor/engine,
 /area/station/hangar/engine)
 "iRM" = (
-/obj/decal/tile_edge/stripe/extra_big,
-/obj/disposalpipe/segment,
-/obj/iv_stand,
-/obj/item/reagent_containers/iv_drip/saline,
-/turf/simulated/floor/redwhite{
-	dir = 10
+/obj/stool/chair/comfy/wheelchair{
+	dir = 8
 	},
-/area/station/medical/medbay/surgery)
-"iRQ" = (
-/obj/machinery/firealarm/directional/south,
-/turf/simulated/floor/purple/side,
-/area/station/hallway/primary/south)
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/greenwhite{
+	dir = 6
+	},
+/area/station/medical/medbay)
 "iRX" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -17231,9 +17352,11 @@
 /turf/simulated/floor,
 /area/station/storage/warehouse)
 "iTd" = (
-/obj/item/crowbar,
-/turf/simulated/floor/plating/scorched,
-/area/station/chapel/sanctuary)
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/blue/side,
+/area/station/hallway/primary/central)
 "iTx" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -17545,9 +17668,11 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "jeA" = (
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "jeR" = (
 /obj/machinery/computer/camera_viewer{
 	dir = 8
@@ -17563,6 +17688,7 @@
 /area/station/security/hos)
 "jfe" = (
 /obj/disposalpipe/junction/right/west,
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon10,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "jfJ" = (
@@ -17593,13 +17719,14 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "jhx" = (
-/obj/machinery/light/incandescent{
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/junction/right/west,
+/turf/simulated/floor/redwhite{
 	dir = 8
 	},
-/turf/simulated/floor/bluewhite{
-	dir = 8
-	},
-/area/station/medical/medbay)
+/area/station/medical/medbay/surgery)
 "jhz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -17658,19 +17785,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
-"jiI" = (
-/obj/machinery/disposal/morgue{
-	desc = "A pneumatic chute used to transport corpses.";
-	name = "mortician's chute"
-	},
-/obj/disposalpipe/trunk/morgue{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
 "jiP" = (
 /obj/lattice{
 	dir = 6;
@@ -17705,15 +17819,10 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
 "jkp" = (
-/obj/table/reinforced/auto,
-/obj/machinery/cashreg,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	autoclose = 0;
-	dir = 1
-	},
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/storage/emergency)
+/obj/table/auto,
+/obj/machinery/defib_mount,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "jkz" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/field_generator,
@@ -17752,26 +17861,11 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
-"jlr" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "jlz" = (
-/obj/machinery/manufacturer/medical,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 1
-	},
-/area/station/medical/medbay)
+/obj/stool/chair/blue,
+/obj/landmark/start/job/geneticist,
+/turf/simulated/floor/blue/checker,
+/area/station/medical/research)
 "jlE" = (
 /obj/stool/bench/red/auto,
 /turf/simulated/floor,
@@ -17803,15 +17897,15 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
 "jnJ" = (
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon10,
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "joM" = (
 /obj/fitness/speedbag/syndie,
 /turf/simulated/floor{
@@ -17863,12 +17957,9 @@
 	dir = 4
 	},
 /area/station/security/processing)
-"jqV" = (
-/obj/decal/cleanable/writing{
-	words = "Erik wuz here!! 2k16"
-	},
-/turf/simulated/floor/plating,
-/area/space)
+"jpU" = (
+/turf/simulated/floor/engine,
+/area/station/hangar/medical)
 "jqY" = (
 /obj/machinery/conveyor/WE{
 	id = "qmin"
@@ -17879,20 +17970,15 @@
 /turf/space,
 /area/station/quartermaster/office)
 "jrg" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "jrT" = (
 /obj/decal/tile_edge/floorguide/security{
 	dir = 1
@@ -17925,15 +18011,15 @@
 /turf/simulated/floor/plating/jen,
 /area/station/engine/singcore)
 "jsN" = (
-/obj/machinery/door/airlock/pyro/glass/med,
-/obj/mapping_helper/access/medical,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/blue,
-/area/station/medical/medbay/surgery)
-"jsO" = (
-/obj/machinery/firealarm/directional/south,
-/turf/simulated/floor/redwhite,
-/area/station/medical/medbay/surgery)
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "2-9"
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "jtb" = (
 /obj/lattice{
 	dir = 9;
@@ -17981,21 +18067,39 @@
 /area/station/security/brig)
 "juW" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/redwhite{
-	dir = 1
+/obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/area/station/medical/medbay/surgery)
-"jvc" = (
+/obj/mapping_helper/access/medical,
+/obj/cable,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
+	},
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4;
+	id = "medbay_entrance"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/dome)
+"jvc" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "jvm" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -18061,38 +18165,21 @@
 /area/station/engine/inner)
 "jzN" = (
 /obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
+	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "jAq" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/vending/medical_public,
-/obj/machinery/camera/directional/west{
-	c_tag = "Medbay Lobby";
-	pixel_y = 10
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/obj/machinery/optable,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "jAS" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/robotics)
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/greenwhite/corner,
+/area/station/medical/medbay)
 "jBk" = (
 /obj/machinery/power/data_terminal,
 /obj/cable/blue{
@@ -18113,11 +18200,11 @@
 	},
 /area/station/hallway/primary/west)
 "jBU" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/item/clothing/suit/cardboard_box/head_surgeon,
+/turf/simulated/floor/bluewhite{
+	dir = 6
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
+/area/station/medical/head)
 "jCc" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -18151,7 +18238,11 @@
 	},
 /area/station/engine/inner)
 "jCN" = (
-/obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/medical{
+	dir = 8
+	},
+/obj/mapping_helper/access/morgue,
+/obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "jDH" = (
@@ -18196,6 +18287,18 @@
 	dir = 4
 	},
 /area/mining/magnet)
+"jFt" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
+/obj/cable{
+	icon_state = "4-6"
+	},
+/turf/simulated/floor/blue/side{
+	dir = 1
+	},
+/area/station/hallway/primary/central)
 "jFM" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -18212,14 +18315,6 @@
 /obj/item/reagent_containers/food/snacks/ingredient/egg/critter/sheep,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"jGq" = (
-/obj/machinery/computer/genetics{
-	dir = 4
-	},
-/turf/simulated/floor/greenwhite{
-	dir = 10
-	},
-/area/station/medical/research)
 "jGs" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/machinery/door/poddoor/pyro{
@@ -18246,7 +18341,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/blue/side,
 /area/station/hallway/primary/central)
 "jHp" = (
@@ -18267,9 +18361,7 @@
 /area/station/maintenance/southwest)
 "jHV" = (
 /obj/lattice,
-/obj/warp_beacon{
-	name = "Hangar Beacon"
-	},
+/obj/warp_beacon/arrivals,
 /turf/space,
 /area/space)
 "jIe" = (
@@ -18278,14 +18370,6 @@
 	dir = 9
 	},
 /area/station/hallway/secondary/exit)
-"jIs" = (
-/obj/table/wood/auto,
-/obj/table/wood/auto,
-/obj/random_item_spawner/med_tool,
-/obj/random_item_spawner/med_tool,
-/obj/random_item_spawner/desk_stuff,
-/turf/simulated/floor,
-/area/station/maintenance/east)
 "jIT" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/elect)
@@ -18398,14 +18482,11 @@
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "jMf" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/machinery/computer/genetics,
+/turf/simulated/floor/greenwhite{
+	dir = 1
 	},
-/obj/storage/secure/closet/command/medical_director,
-/turf/simulated/floor/carpet/blue/fancy/edge/nw,
-/area/station/crew_quarters/md)
+/area/station/medical/research)
 "jMp" = (
 /obj/landmark/spawner/artifact,
 /turf/simulated/floor/plating/airless,
@@ -18431,6 +18512,38 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"jMH" = (
+/obj/table/auto,
+/obj/item/storage/box/stma_kit{
+	pixel_x = -9;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/hypospray{
+	pixel_x = 5;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/hypospray{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/hand_labeler{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 9
+	},
+/obj/machinery/camera/directional/east{
+	pixel_y = -10
+	},
+/turf/simulated/floor/redwhite{
+	dir = 1
+	},
+/area/station/medical/medbay/surgery)
 "jMY" = (
 /obj/machinery/atmospherics/binary/passive_gate/opened{
 	target_pressure = 1e+031
@@ -18448,13 +18561,23 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria)
 "jNn" = (
+/obj/table/auto,
+/obj/machinery/cell_charger,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/clothing/head/helmet/welding,
+/obj/item/weldingtool,
+/obj/item/storage/toolbox/mechanical,
+/obj/cable{
+	icon_state = "1-6"
+	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/bluewhite{
-	dir = 4
-	},
-/area/station/medical/medbay)
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "jNE" = (
 /obj/machinery/disposal_pipedispenser,
 /turf/simulated/floor,
@@ -18687,7 +18810,6 @@
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai_upload)
 "jRL" = (
-/obj/storage/secure/closet/research/chemical,
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
@@ -18738,19 +18860,6 @@
 "jTk" = (
 /turf/simulated/floor/red/side,
 /area/station/security/processing)
-"jUd" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/dome)
 "jUS" = (
 /obj/stool/chair/pew/center{
 	dir = 4
@@ -18794,15 +18903,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/hangar/sec)
-"jYx" = (
-/obj/disposalpipe/segment/mail,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
 "jYD" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery)
@@ -18830,26 +18930,14 @@
 /turf/simulated/floor/grass/random,
 /area/station/garden/owlery)
 "jZn" = (
-/obj/disposalpipe/segment/mail{
+/obj/machinery/light/small{
 	dir = 8;
-	icon_state = "pipe-c"
+	tag = "icon-bulb1 (WEST)"
 	},
-/obj/cable{
-	icon_state = "6-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "2-9"
-	},
-/obj/cable{
-	icon_state = "9-10"
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 5
-	},
-/area/station/chapel/sanctuary)
+/obj/rack,
+/obj/item/clothing/mask/breath,
+/turf/simulated/floor/plating,
+/area/space)
 "jZG" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -18875,13 +18963,11 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
 "jZL" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/bluewhite{
+/obj/machinery/computer/announcement/station/medical{
 	dir = 8
 	},
-/area/station/medical/research)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "kak" = (
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/greenblack{
@@ -18923,6 +19009,9 @@
 /area/station/security/detectives_office)
 "kbr" = (
 /obj/landmark/gps_waypoint,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "kby" = (
@@ -19065,10 +19154,14 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/baroffice)
 "kit" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/medical/robotics)
+/obj/stool/chair/pew/left{
+	dir = 4
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 6
+	},
+/area/station/chapel/sanctuary)
 "kiv" = (
 /obj/decal/tile_edge/floorguide/evac,
 /obj/decal/tile_edge/floorguide/arrow_n{
@@ -19138,9 +19231,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "kka" = (
-/obj/machinery/computer/card/department/medical,
-/turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crew_quarters/md)
+/obj/machinery/genetics_scanner,
+/turf/simulated/floor/greenwhite{
+	dir = 1
+	},
+/area/station/medical/research)
 "kkD" = (
 /obj/item/device/radio/intercom/security{
 	dir = 1
@@ -19195,14 +19290,15 @@
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "kmJ" = (
-/obj/machinery/clone_scanner,
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
-/turf/simulated/floor/greenwhite{
+/turf/simulated/floor/blueblack/corner{
 	dir = 1
 	},
-/area/station/medical/medbay/cloner)
+/area/station/medical/robotics)
 "kmM" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -19219,9 +19315,12 @@
 /turf/simulated/floor/plating/airless,
 /area/station/engine/proto)
 "knh" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor/blueblack/corner,
-/area/station/medical/robotics)
+/obj/machinery/traymachine/morgue,
+/obj/machinery/light{
+	tag = ""
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "kny" = (
 /obj/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -19230,6 +19329,9 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/grass/random,
 /area/station/garden/owlery)
+"knN" = (
+/turf/space,
+/area/station/maintenance/southeast)
 "knR" = (
 /obj/item/storage/toilet/random{
 	dir = 8;
@@ -19258,6 +19360,15 @@
 	dir = 8
 	},
 /area/station/security/main)
+"koC" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/specialroom/medbay,
+/area/station/maintenance/east)
 "kqm" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -19291,18 +19402,17 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/engineering)
 "kra" = (
-/obj/machinery/computer/genetics{
-	dir = 8
+/obj/machinery/optable,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	icon_state = "xtra_bigstripe-edge2"
 	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 12;
-	tag = ""
-	},
-/turf/simulated/floor/greenwhite{
+/obj/machinery/drainage,
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/area/station/medical/research)
+/turf/simulated/floor/red/redblackchecker,
+/area/station/medical/robotics)
 "kru" = (
 /obj/lattice,
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -19366,18 +19476,6 @@
 	},
 /turf/simulated/floor/blue/corner,
 /area/station/science/lab)
-"kuG" = (
-/obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 4
-	},
-/area/station/chapel/sanctuary)
 "kuH" = (
 /obj/item/clothing/gloves/yellow,
 /obj/machinery/camera/directional/west{
@@ -19418,16 +19516,6 @@
 	tag = "icon-grass1"
 	},
 /area/station/crew_quarters/pool)
-"kwU" = (
-/obj/machinery/optable,
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
 "kxq" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -19519,8 +19607,13 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/disposalpipe/segment/mail,
+/mob/living/carbon/human/npc/monkey,
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "kAt" = (
 /obj/cable{
 	icon_state = "4-10"
@@ -19594,8 +19687,14 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hangar/main)
 "kDQ" = (
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "kEd" = (
 /obj/securearea{
 	desc = "A warning sign telling of the dangers of gravitational singularities.  Apparently they are dangerous.";
@@ -19614,12 +19713,15 @@
 	},
 /area/station/mining/magnet)
 "kEP" = (
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/power/apc/autoname_north,
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
-/obj/landmark/start{
-	name = "predator"
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -19705,21 +19807,17 @@
 	},
 /area/station/crew_quarters/supplylobby)
 "kHS" = (
-/obj/machinery/door_control{
-	id = "chemistry";
-	name = "Toggle Window Shutters";
-	pixel_x = 10;
-	pixel_y = 24
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/disposal/mail/small/autoname/research/chemistry/north{
-	pixel_x = -4
-	},
-/obj/disposalpipe/trunk/mail/south,
-/obj/machinery/vending/chemistry,
-/turf/simulated/floor/purplewhite{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/area/station/science/chemistry)
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "kHX" = (
 /turf/simulated/floor,
 /area/station/hangar/qm)
@@ -19766,20 +19864,32 @@
 /area/station/hydroponics/bay)
 "kIO" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/window_blinds/cog2/left{
-	dir = 4;
-	id = "HOS"
+/obj/window_blinds/cog2{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/md)
+/area/station/medical/research)
+"kJm" = (
+/obj/machinery/manufacturer/hangar,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/specialroom/medbay,
+/area/station/hangar/medical)
 "kJD" = (
 /turf/simulated/floor/yellow/corner{
 	dir = 4
 	},
 /area/station/engine/inner)
 "kJO" = (
-/turf/simulated/floor/purple/corner,
-/area/station/hallway/primary/south)
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/blue/side{
+	dir = 4
+	},
+/area/station/hallway/primary/central)
 "kJR" = (
 /obj/machinery/door/poddoor/pyro{
 	name = "Mixing Vent";
@@ -19809,21 +19919,24 @@
 /turf/simulated/floor,
 /area/station/hangar/qm)
 "kKc" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet,
-/obj/machinery/firealarm/directional/east,
-/turf/simulated/floor,
-/area/station/maintenance/east)
+/obj/machinery/camera/directional/east{
+	c_tag = "Medbay East";
+	pixel_y = 10
+	},
+/obj/machinery/chem_dispenser/chemical,
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/blueblack{
+	dir = 4
+	},
+/area/station/medical/medbay/pharmacy)
 "kKG" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/blue/side{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/southeast)
 "kKT" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Crew Quarters - Maint";
@@ -19887,8 +20000,15 @@
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "kNc" = (
-/turf/simulated/floor/purple/side,
-/area/station/hallway/primary/south)
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "kNx" = (
 /obj/machinery/light/incandescent,
 /obj/cable,
@@ -19900,29 +20020,9 @@
 /turf/simulated/floor,
 /area/station/storage/primary)
 "kNz" = (
-/obj/machinery/light/incandescent,
-/obj/random_item_spawner/med_kit{
-	pixel_x = -5
-	},
-/obj/item/storage/firstaid/oxygen{
-	pixel_x = 6
-	},
-/obj/item/clothing/glasses/healthgoggles{
-	pixel_y = 5
-	},
-/obj/item/clothing/glasses/healthgoggles{
-	pixel_y = 7
-	},
-/obj/item/clothing/glasses/healthgoggles{
-	pixel_y = 9
-	},
-/obj/table/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/vending/medical,
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbay)
+/obj/lattice,
+/turf/space,
+/area/station/maintenance/east)
 "kOV" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -19992,13 +20092,9 @@
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "kSG" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/dome)
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor/grime,
+/area/station/medical/robotics)
 "kSH" = (
 /obj/lattice,
 /turf/space,
@@ -20018,15 +20114,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "kTS" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/light/incandescent{
+	dir = 4
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
+/turf/simulated/floor/blue/corner{
+	dir = 4
 	},
-/turf/simulated/floor/purple/side,
-/area/station/hallway/primary/south)
+/area/station/hallway/primary/central)
 "kTX" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/yellow/side{
@@ -20034,14 +20128,19 @@
 	},
 /area/station/engine/inner)
 "kUy" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/md)
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2,
+/turf/simulated/floor/plating,
+/area/station/medical/research)
 "kVx" = (
 /obj/storage/secure/closet/fridge/blood,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
+	},
+/obj/machinery/light/incandescent{
+	dir = 4
 	},
 /turf/simulated/floor/redwhite{
 	dir = 5
@@ -20050,12 +20149,11 @@
 "kWd" = (
 /obj/machinery/light/emergency,
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/purple/side{
-	dir = 6
-	},
-/area/station/hallway/primary/south)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "kWR" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -20097,15 +20195,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "kXJ" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	icon_state = "1-2"
+	dir = null
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/surgery)
 "kXS" = (
 /obj/table/auto,
 /obj/item/screwdriver,
@@ -20191,10 +20289,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
-"laV" = (
-/obj/reagent_dispensers/fueltank,
-/turf/simulated/floor,
-/area/station/maintenance/east)
 "laY" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -20232,12 +20326,6 @@
 	dir = 4
 	},
 /area/station/hydroponics/bay)
-"lcD" = (
-/obj/cable{
-	icon_state = "5-8"
-	},
-/turf/simulated/floor/blueblack/corner,
-/area/station/medical/robotics)
 "lcI" = (
 /obj/storage/secure/closet/engineering/mechanic,
 /turf/simulated/floor/yellow,
@@ -20250,16 +20338,13 @@
 /turf/space,
 /area/space)
 "ldp" = (
-/obj/cable{
-	icon_state = "0-4"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/power/apc/autoname_west,
-/obj/machinery/manufacturer/robotics,
-/obj/decal/tile_edge/stripe/extra_big{
+/turf/simulated/floor/bluewhite{
 	dir = 6
 	},
-/turf/simulated/floor/darkblue,
-/area/station/medical/robotics)
+/area/station/medical/head)
 "ldH" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -20287,25 +20372,43 @@
 	},
 /area/station/hallway/primary/central)
 "lfe" = (
-/obj/machinery/light/incandescent,
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/cable{
+	icon_state = "1-10"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "lfq" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/surgery_tray,
+/obj/item/suture{
+	pixel_y = 5
 	},
-/obj/decal/tile_edge/floorguide/science{
-	dir = 1
+/obj/item/hemostat{
+	pixel_x = 3;
+	pixel_y = -5
 	},
-/turf/simulated/floor/purplewhite,
-/area/station/medical/medbay/lobby)
+/obj/item/scissors/surgical_scissors{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/scalpel{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/circular_saw{
+	pixel_y = 11
+	},
+/obj/item/suture{
+	pixel_y = 5
+	},
+/obj/item/staple_gun{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "lfI" = (
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
@@ -20329,7 +20432,13 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/toolbox/emergency,
 /obj/item/reagent_containers/glass/oilcan,
-/obj/machinery/camera/directional/west,
+/obj/machinery/camera/directional/west{
+	pixel_y = -14
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/blueblack/corner,
 /area/station/medical/robotics)
 "lgj" = (
@@ -20400,13 +20509,10 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "lhp" = (
-/obj/machinery/disposal/mail/autoname/medbay/genetics,
-/obj/disposalpipe/trunk/mail/north{
-	dir = 8
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/greenwhite{
-	dir = 8
-	},
+/turf/simulated/floor/blue/checker,
 /area/station/medical/research)
 "lht" = (
 /obj/cable{
@@ -20416,14 +20522,32 @@
 /turf/unsimulated/floor/arrival,
 /area/station/hallway/arrivals)
 "lix" = (
-/obj/cable{
-	icon_state = "1-6"
+/obj/rack,
+/obj/item/storage/box/stma_kit{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/item/clothing/suit/hazard/paramedic{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/clothing/suit/hazard/paramedic{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/item/storage/belt/medical{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/storage/belt/medical{
+	pixel_x = 4;
+	pixel_y = -1
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/bluewhite,
+/area/station/medical/medbay)
 "liJ" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -20442,7 +20566,18 @@
 /turf/unsimulated/floor/arrival,
 /area/station/hallway/arrivals)
 "lkP" = (
-/turf/simulated/floor/plating/scorched,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 10
+	},
 /area/station/chapel/sanctuary)
 "llc" = (
 /obj/cable/yellow{
@@ -20571,25 +20706,32 @@
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "lpx" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/medbay/pharmacy)
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	dir = null
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"lqi" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/light/small/sticky/frostedred,
+/turf/simulated/floor/grime,
+/area/station/medical/robotics)
 "lqj" = (
-/obj/table/auto/desk,
-/obj/item/paper_bin{
-	pixel_x = -5
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/obj/item/paper/book/from_file/pharmacopia,
-/obj/mapping_helper/access/medical,
-/obj/item/paper_bin{
-	pixel_x = -5
-	},
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
-	},
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/blue,
-/area/station/medical/medbay)
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "lqB" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -20661,6 +20803,13 @@
 /obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/plating/airless,
 /area/station/engine/proto)
+"ltp" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "ltL" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -20679,6 +20828,17 @@
 /obj/item/stamp,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
+"lue" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
+"lug" = (
+/obj/decal/tile_edge/stripe/big,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/specialroom/medbay,
+/area/station/hangar/medical)
 "luh" = (
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -20690,6 +20850,16 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/storage)
+"luv" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "luK" = (
 /turf/simulated/floor/yellow/corner{
 	dir = 1
@@ -20701,28 +20871,10 @@
 /turf/simulated/floor,
 /area/station/storage/warehouse)
 "lvi" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/mapping_helper/firedoor_spawn,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/secscanner{
-	dir = 4;
-	pixel_x = -20
-	},
-/obj/mapping_helper/access/medical,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/airlock/pyro/glass/med{
-	dir = 4;
-	id = "medbay_entrance"
-	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbay)
+/obj/machinery/door/firedoor/pyro,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "lvP" = (
 /obj/stool/chair{
 	dir = 4
@@ -20734,11 +20886,17 @@
 	},
 /area/station/crew_quarters/fitness)
 "lwi" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/door_control{
+	id = "cloning_exit";
+	name = "Cloning Exit Door Control";
+	pixel_x = -24;
+	pixel_y = 0
 	},
-/turf/simulated/floor/grass,
-/area/station/medical/dome)
+/obj/storage/secure/closet/medical/cloning,
+/turf/simulated/floor/greenwhite{
+	dir = 8
+	},
+/area/station/medical/medbay/cloner)
 "lwp" = (
 /obj/landmark/start/job/security_assistant,
 /obj/stool/chair/red,
@@ -20759,7 +20917,14 @@
 /area/station/engine/engineering/private)
 "lxi" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "8-10"
+	},
+/obj/cable{
+	icon_state = "1-10"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
@@ -20818,22 +20983,17 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "2-4";
-	pixel_y = 0
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "5-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "lze" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/cable{
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
-/area/station/medical/medbay)
+/area/space)
 "lBa" = (
 /obj/machinery/conveyor/EW{
 	id = "ghostdrone"
@@ -20842,12 +21002,7 @@
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "lBg" = (
-/obj/cable{
-	icon_state = "2-9"
-	},
-/obj/machinery/door/airlock/pyro,
-/obj/mapping_helper/access/chapel_office,
-/turf/simulated/floor/black,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/chapel/sanctuary)
 "lBK" = (
 /obj/decal/tile_edge/stripe/big,
@@ -20926,22 +21081,26 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
-"lEt" = (
-/obj/storage/secure/closet/medical/medicine,
-/turf/simulated/floor/bluewhite{
-	dir = 1
+"lDT" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay)
-"lEE" = (
-/obj/landmark/start{
-	name = "predator"
+"lEt" = (
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/disposalpipe/segment/morgue,
-/obj/machinery/light/small/broken{
-	dir = 4
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "lFn" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/engineering/private)
@@ -20988,13 +21147,13 @@
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "lHv" = (
-/obj/cable{
-	icon_state = "2-4";
-	pixel_y = 0
+/obj/machinery/light/emergency{
+	dir = 1
 	},
-/obj/machinery/light/small/sticky/frostedred,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/blue/side{
+	dir = 1
+	},
+/area/station/hallway/primary/central)
 "lIE" = (
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
@@ -21098,12 +21257,12 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "lMj" = (
-/obj/machinery/door/airlock/pyro/glass{
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4
 	},
-/obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/chapel/sanctuary)
 "lMm" = (
 /turf/simulated/floor/stairs/wide/other,
 /area/station/hydroponics/bay)
@@ -21131,16 +21290,6 @@
 	},
 /turf/simulated/floor/bluegreen,
 /area/station/crew_quarters/lounge)
-"lNh" = (
-/obj/cable{
-	icon_state = "2-4";
-	pixel_y = 0
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
 "lNm" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/storage)
@@ -21151,13 +21300,20 @@
 	},
 /area/station/hydroponics/bay)
 "lNt" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk,
-/obj/machinery/light/incandescent{
-	dir = 1
+/obj/table/auto,
+/obj/item/storage/box/diskbox{
+	pixel_x = -8;
+	pixel_y = 13
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/obj/item/extinguisher,
+/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat,
+/obj/machinery/light/incandescent{
+	dir = 8
+	},
+/turf/simulated/floor/greenwhite{
+	dir = 10
+	},
+/area/station/medical/medbay/cloner)
 "lOa" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -21266,20 +21422,11 @@
 /obj/item/extinguisher,
 /turf/simulated/floor,
 /area/station/storage/emergency)
-"lPK" = (
-/obj/cable{
-	icon_state = "4-10"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "lQq" = (
-/obj/disposalpipe/segment/mail,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 4
+	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
 "lQs" = (
@@ -21379,14 +21526,28 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
 "lVl" = (
+/obj/table/auto,
+/obj/item/scalpel{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/scissors/surgical_scissors{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/circular_saw{
+	pixel_y = 11
+	},
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/storage/crate/robotparts,
-/turf/simulated/floor/blueblack/corner,
-/area/station/medical/robotics)
+/obj/item/hemostat,
+/obj/item/suture,
+/obj/item/staple_gun,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "lVs" = (
 /mob/living/critter/small_animal/bird/owl{
 	desc = "You've heard that this owl is a real jerk.";
@@ -21425,15 +21586,19 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "lWi" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/light/incandescent{
+	dir = 4
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/decal/tile_edge/floorguide/arrow_e{
+	dir = 1
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/obj/decal/tile_edge/floorguide/medbay{
+	dir = 4
+	},
+/turf/simulated/floor/blue/side{
+	dir = 4
+	},
+/area/station/hallway/primary/central)
 "lWr" = (
 /obj/stool/chair/yellow,
 /obj/landmark/start/job/engineer,
@@ -21454,14 +21619,12 @@
 	},
 /area/station/solar/aisat)
 "lWH" = (
+/obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "2-8"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/surgery)
 "lWR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -21473,10 +21636,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "lXv" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable,
+/obj/landmark/start{
+	name = "predator"
+	},
 /turf/simulated/floor/plating,
-/area/station/medical/research)
+/area/station/maintenance/east)
+"lXE" = (
+/obj/machinery/door/airlock/pyro/medical,
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/medical,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "lXN" = (
 /obj/mesh/catwalk,
 /obj/cable/yellow{
@@ -21515,10 +21685,13 @@
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "lZt" = (
-/turf/simulated/floor/bluewhite{
-	dir = 1
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2{
+	layer = 2.9;
+	pixel_y = 13
 	},
-/area/station/medical/medbay)
+/turf/simulated/floor/plating,
+/area/station/medical/head)
 "lZB" = (
 /obj/table/wood/auto,
 /obj/item/clothing/under/shorts/blue{
@@ -21555,11 +21728,13 @@
 	},
 /area/station/science/lab)
 "lZV" = (
-/obj/reagent_dispensers/fueltank,
-/turf/simulated/floor/blueblack/corner{
-	dir = 1
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 1;
+	tag = "icon-pipe-t (NORTH)"
 	},
-/area/station/medical/robotics)
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "maw" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -21569,12 +21744,13 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "maN" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/cable{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/greenwhite{
+	dir = 1
+	},
+/area/station/medical/research)
 "maU" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -21622,18 +21798,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/west)
-"mct" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8
-	},
-/obj/table/auto,
-/obj/machinery/defib_mount,
-/obj/machinery/power/apc/autoname_south,
-/obj/cable,
-/turf/simulated/floor/redwhite{
-	dir = 10
-	},
-/area/station/medical/medbay/surgery)
 "mcH" = (
 /obj/cable/yellow{
 	icon_state = "2-8"
@@ -21821,6 +21985,13 @@
 "miW" = (
 /turf/simulated/floor/bluegreen,
 /area/station/crew_quarters/lounge)
+"mjb" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "mje" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -22051,7 +22222,11 @@
 /turf/simulated/floor/yellow/checker,
 /area/station/engine/ptl)
 "mrv" = (
-/obj/mapping_helper/wingrille_spawn/auto,
+/obj/storage/secure/closet/research/chemical,
+/turf/simulated/floor/white,
+/area/station/science/chemistry)
+"mrR" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
 "mrS" = (
@@ -22107,6 +22282,15 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor,
 /area/station/teleporter)
+"muy" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "muT" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -22149,12 +22333,9 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/kitchen)
 "mwA" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-4"
-	},
+/obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
-/area/station/science/lobby)
+/area/station/maintenance/east)
 "mwX" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -22168,6 +22349,13 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"mxX" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "myA" = (
 /obj/disposalpipe/segment/bent,
 /turf/simulated/floor/neutral/side,
@@ -22236,7 +22424,9 @@
 /area/station/mining/magnet)
 "mBf" = (
 /obj/machinery/firealarm/directional/east,
-/turf/simulated/floor,
+/turf/simulated/floor/blue/side{
+	dir = 4
+	},
 /area/station/hallway/primary/central)
 "mBq" = (
 /obj/cable{
@@ -22247,12 +22437,18 @@
 	},
 /area/station/engine/gravity)
 "mBC" = (
-/obj/cable{
-	icon_state = "0-8"
+/obj/item/robodefibrillator,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical_shield,
+/obj/item/device/analyzer/healthanalyzer,
+/obj/item/clothing/mask/surgical,
+/obj/machinery/recharger/defibrillator{
+	pixel_y = 8
 	},
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/table/auto,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "mCe" = (
 /obj/machinery/camera/directional/east{
 	pixel_y = 10
@@ -22260,9 +22456,14 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "mDc" = (
-/obj/mapping_helper/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/blind_switch/area/south,
+/obj/disposalpipe/trunk/mail/east,
+/obj/machinery/disposal/mail/autoname{
+	mail_tag = "pharmacy";
+	mailgroup = "medical"
+	},
+/turf/simulated/floor/blueblack,
+/area/station/medical/medbay/pharmacy)
 "mDi" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
@@ -22272,10 +22473,8 @@
 /area/station/science/storage)
 "mEh" = (
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/purple/side{
-	dir = 6
-	},
-/area/station/hallway/primary/south)
+/turf/simulated/floor/carpet,
+/area/station/chapel/sanctuary)
 "mFj" = (
 /obj/table/wood/auto,
 /obj/item/hand_labeler,
@@ -22397,11 +22596,12 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "mKh" = (
-/obj/machinery/info_map,
-/turf/simulated/floor/blue/side{
-	dir = 1
+/obj/item/storage/wall/fire{
+	dir = 1;
+	pixel_y = 32
 	},
-/area/station/hallway/primary/south)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "mKo" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
@@ -22416,6 +22616,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
+"mLR" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
+	},
+/obj/mapping_helper/airlock/cycler{
+	enter_id = "outer";
+	cycle_id = "secsps";
+	name = "Security Space"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "mMp" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -22428,8 +22639,12 @@
 	},
 /area/station/chapel/sanctuary)
 "mMZ" = (
-/obj/cable{
-	icon_state = "1-8"
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
+/obj/machinery/light/emergency{
+	dir = 1
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -22512,22 +22727,6 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/bathroom)
-"mPX" = (
-/mob/living/critter/small_animal/dog/george,
-/obj/cable{
-	icon_state = "2-10"
-	},
-/obj/cable{
-	icon_state = "8-10"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/stool/chair/pew/center{
-	dir = 4
-	},
-/turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/sanctuary)
 "mQj" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -22622,13 +22821,14 @@
 	},
 /area/station/hydroponics/bay)
 "mSV" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
 	},
-/turf/simulated/floor/grass,
-/area/station/medical/dome)
+/obj/cable{
+	icon_state = "6-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "mTm" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/captain)
@@ -22669,14 +22869,14 @@
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "mVc" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 1
 	},
 /obj/machinery/light/small/frostedred{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "2-9"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
@@ -22719,14 +22919,9 @@
 	},
 /area/station/security/processing)
 "mXz" = (
-/obj/mapping_helper/access/medlab,
-/obj/machinery/door/airlock/pyro/glass/med,
-/obj/mapping_helper/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/research)
+/obj/machinery/manufacturer/robotics,
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "mXG" = (
 /obj/storage/secure/closet/civilian/bartender,
 /obj/machinery/firealarm/directional/north,
@@ -22747,6 +22942,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
+"mYn" = (
+/obj/cable{
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "mYq" = (
 /obj/mesh/grille/steel,
 /obj/cable/yellow{
@@ -22769,14 +22970,6 @@
 	dir = 1
 	},
 /area/station/security/processing)
-"naj" = (
-/mob/living/carbon/human/npc/monkey,
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/grass,
-/area/station/medical/dome)
 "naB" = (
 /turf/simulated/floor/plating/random,
 /area/space)
@@ -22786,14 +22979,17 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/lounge)
 "nbl" = (
-/obj/cable{
-	icon_state = "6-8"
+/obj/machinery/sleeper/port_a_medbay{
+	dir = 8
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "nbq" = (
 /obj/machinery/light/incandescent{
 	dir = 8
@@ -22828,14 +23024,9 @@
 /area/station/hydroponics/bay)
 "ncb" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
+/obj/cable,
 /turf/simulated/floor/plating,
-/area/station/science/lobby)
+/area/station/medical/dome)
 "ncf" = (
 /obj/disposalpipe/trunk{
 	dir = 8
@@ -22867,10 +23058,13 @@
 /area/station/security/brig)
 "ncn" = (
 /obj/machinery/firealarm/directional/south,
-/turf/simulated/floor/purple/side{
-	dir = 10
+/obj/machinery/computer3/generic/med_data{
+	dir = 4
 	},
-/area/station/hallway/primary/south)
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
+/area/station/chapel/sanctuary)
 "ncv" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -22901,15 +23095,10 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "ncP" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/turf/simulated/floor/bluewhite{
+	dir = 9
 	},
-/obj/machinery/dialysis,
-/obj/disposalpipe/segment,
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/medical/medbay/surgery)
+/area/station/medical/head)
 "ncU" = (
 /turf/space,
 /area/station/engine/proto)
@@ -22920,21 +23109,12 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "ndK" = (
-/obj/table/auto,
-/obj/machinery/cell_charger,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/item/clothing/head/helmet/welding,
-/obj/item/weldingtool,
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/manifold/overfloor,
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor/blueblack/corner,
-/area/station/medical/robotics)
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "ndU" = (
 /obj/stool/chair/boxingrope_corner{
 	dir = 6
@@ -22981,6 +23161,11 @@
 	icon_state = "blue2"
 	},
 /area/station/bridge)
+"neX" = (
+/obj/stool/bench/blue/auto,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "nfi" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -23122,15 +23307,17 @@
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "niq" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/mapping_helper/access/maint,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	icon_state = "1-2"
+	dir = null
 	},
-/obj/disposalpipe/segment/morgue,
-/obj/mapping_helper/firedoor_spawn,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/window_blinds/cog2/right,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/medical/medbay/pharmacy)
 "niu" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
@@ -23245,18 +23432,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"nmV" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/grass,
-/area/station/medical/dome)
 "nmX" = (
 /obj/cable{
 	icon_state = "8-9"
@@ -23315,12 +23490,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
-"nov" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grass,
-/area/station/medical/dome)
 "noz" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -23345,14 +23514,16 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "npb" = (
-/obj/machinery/vending/player/chemicals,
-/obj/disposalpipe/trunk/mail{
+/obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/turf/simulated/floor/blueblack{
-	dir = 9
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "medspsl";
+	enter_id = "outer";
+	name = "Medical Space Lower"
 	},
-/area/station/medical/medbay/pharmacy)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "npM" = (
 /mob/living/critter/small_animal/walrus,
 /turf/simulated/floor/pool/no_animate,
@@ -23411,13 +23582,12 @@
 /turf/simulated/floor/purple,
 /area/station/science/hall)
 "nsq" = (
+/obj/landmark/start/job/medical_doctor,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/bluewhite{
-	dir = 10
-	},
-/area/station/medical/research)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "nsV" = (
 /obj/machinery/camera/directional/north{
 	icon_state = "camera";
@@ -23525,15 +23695,19 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "nwg" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4;
+	id = "medbay_entrance"
 	},
 /obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/mapping_helper/access/medical,
+/obj/machinery/secscanner{
+	dir = 4;
+	pixel_x = -20
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "nwn" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -23616,9 +23790,26 @@
 	dir = 1
 	},
 /area/station/science/artifact)
+"nAp" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "nAq" = (
-/turf/simulated/floor,
-/area/station/maintenance/east)
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	dir = null
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/window_blinds/cog2/right{
+	layer = 2.9;
+	pixel_y = 13
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/pharmacy)
 "nAs" = (
 /turf/simulated/floor/purplewhite{
 	dir = 5
@@ -23659,8 +23850,14 @@
 	},
 /area/station/bridge)
 "nCH" = (
-/turf/simulated/floor/carpet/blue/fancy,
-/area/station/crew_quarters/md)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "nDr" = (
 /obj/item/sheet/glass{
 	amount = 10
@@ -23720,12 +23917,10 @@
 /turf/simulated/floor,
 /area/station/hangar/engine)
 "nEH" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-2"
+/turf/simulated/floor/redwhite{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/station/medical/medbay)
+/area/station/medical/medbay/surgery)
 "nEQ" = (
 /obj/machinery/light/incandescent{
 	dir = 4
@@ -23779,40 +23974,42 @@
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "nFR" = (
-/obj/machinery/vending/jobclothing/medical,
-/turf/simulated/floor/bluewhite{
-	dir = 4
+/obj/machinery/light/incandescent{
+	dir = 8
 	},
-/area/station/medical/medbay)
+/turf/simulated/floor/redwhite{
+	dir = 9
+	},
+/area/station/medical/medbay/surgery)
 "nFU" = (
-/obj/rack,
-/obj/item/clothing/shoes/black,
-/obj/item/clothing/suit/hazard/fire,
-/obj/item/clothing/mask/gas/emergency,
-/obj/item/clothing/glasses/sunglasses,
-/turf/simulated/floor,
-/area/station/maintenance/east)
+/obj/table/glass/auto,
+/obj/item/plate{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/food/snacks/plant/apple{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/machinery/recharger/defibrillator{
+	pixel_y = 6
+	},
+/obj/item/kitchen/food_box/lollipop{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "nFV" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff,
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "nGI" = (
-/obj/cable{
-	icon_state = "1-8"
+/turf/simulated/floor/bluewhite{
+	dir = 6
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
-"nHJ" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/landmark/gps_waypoint,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
+/area/station/medical/head)
 "nHP" = (
 /obj/decal/tile_edge/stripe/big{
 	dir = 9;
@@ -23823,10 +24020,6 @@
 	dir = 1
 	},
 /area/station/engine/inner)
-"nHZ" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
 "nIg" = (
 /obj/disposalpipe/segment/mail,
 /obj/reagent_dispensers/watertank/fountain,
@@ -23893,6 +24086,12 @@
 "nJv" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/inner)
+"nJE" = (
+/obj/cable{
+	icon_state = "4-10"
+	},
+/turf/simulated/floor/black,
+/area/station/medical/medbay/pharmacy)
 "nKd" = (
 /obj/blind_switch/area/west{
 	id = "HOS"
@@ -23903,19 +24102,26 @@
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "nKM" = (
-/obj/stool/chair/office/blue{
-	dir = 8
+/obj/machinery/light/incandescent,
+/obj/random_item_spawner/med_kit{
+	pixel_x = -5
 	},
-/obj/machinery/door_control{
-	id = "medbay_entrance";
-	name = "Medbay Door Control";
-	pixel_x = -32;
-	pixel_y = 20
+/obj/item/storage/firstaid/oxygen{
+	pixel_x = 6
 	},
-/obj/landmark/start/job/medical_doctor,
-/turf/simulated/floor/bluewhite{
-	dir = 8
+/obj/item/clothing/glasses/healthgoggles{
+	pixel_y = 5
 	},
+/obj/item/clothing/glasses/healthgoggles{
+	pixel_y = 7
+	},
+/obj/item/clothing/glasses/healthgoggles{
+	pixel_y = 9
+	},
+/obj/table/auto,
+/obj/machinery/vending/medical,
+/obj/machinery/firealarm/directional/east,
+/turf/simulated/floor/white,
 /area/station/medical/medbay)
 "nKO" = (
 /obj/disposalpipe/segment{
@@ -24020,32 +24226,6 @@
 	dir = 4
 	},
 /area/station/crew_quarters/courtroom)
-"nOy" = (
-/obj/table/auto,
-/obj/item/scalpel{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/scissors/surgical_scissors{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/circular_saw{
-	pixel_y = 11
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/item/hemostat,
-/obj/item/suture,
-/obj/item/staple_gun,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
 "nOL" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4;
@@ -24121,11 +24301,10 @@
 	},
 /area/station/crew_quarters/pool)
 "nRw" = (
-/obj/machinery/door/airlock/pyro/maintenance{
+/turf/simulated/floor/blackwhite{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/medical/medbay/lobby)
 "nRB" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -24385,14 +24564,8 @@
 /turf/simulated/floor/blueblack,
 /area/station/crew_quarters/captain)
 "obu" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/grime,
+/area/station/medical/robotics)
 "obw" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -24418,6 +24591,9 @@
 /obj/machinery/firealarm/directional/south,
 /obj/storage/secure/closet/research/chemical/pharmacy,
 /obj/item/paper/book/from_file/pharmacopia,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/medbay/pharmacy)
 "odi" = (
@@ -24453,27 +24629,6 @@
 	},
 /turf/space,
 /area/station/engine/proto)
-"odZ" = (
-/obj/table/auto,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -5
-	},
-/obj/item/paper/cryo{
-	pixel_x = 5
-	},
-/obj/item/wrench,
-/turf/simulated/floor/bluewhite{
-	dir = 4
-	},
-/area/station/medical/medbay)
 "oem" = (
 /obj/machinery/camera/directional/north{
 	pixel_x = -10
@@ -24518,9 +24673,15 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "ofS" = (
-/obj/landmark/random_room/size3x5,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/machinery/camera/directional/east{
+	c_tag = "Habitation Ring East";
+	pixel_y = 10
+	},
+/obj/machinery/vending/medical_public,
+/turf/simulated/floor/blackwhite{
+	dir = 1
+	},
+/area/station/medical/medbay/lobby)
 "ofW" = (
 /obj/machinery/light/incandescent,
 /obj/table/reinforced/industrial/auto{
@@ -24534,9 +24695,17 @@
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "ogj" = (
-/obj/landmark/random_room/size5x3,
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
+/obj/mapping_helper/access/morgue,
+/obj/mapping_helper/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/medical{
+	name = "Morgue"
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "ogy" = (
 /obj/machinery/light_switch/south{
 	pixel_x = 8
@@ -24569,18 +24738,21 @@
 /turf/simulated/floor,
 /area/station/security/interrogation)
 "ogZ" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Medical Director's Quarters";
-	req_access = null
-	},
-/obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/medical_director,
+/obj/cable,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/white,
-/area/station/crew_quarters/md)
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4;
+	id = "medbay_entrance"
+	},
+/obj/mapping_helper/access/medlab,
+/obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/medical/research)
 "ohl" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -24712,22 +24884,12 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
-"okt" = (
-/obj/shrub,
-/obj/item/item_box/medical_patches/mini_styptic,
-/turf/simulated/floor/purplewhite{
-	dir = 9
-	},
-/area/station/science/lobby)
 "okA" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
 	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/purplewhite{
-	dir = 1
-	},
-/area/station/science/lobby)
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "okR" = (
 /turf/simulated/floor/grasstodirt{
 	dir = 1
@@ -24760,14 +24922,11 @@
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/comdish)
 "olZ" = (
-/obj/machinery/light/incandescent,
-/obj/machinery/atmospherics/unary/cryo_cell{
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/greenwhite{
 	dir = 1
 	},
-/turf/simulated/floor/bluewhite{
-	dir = 6
-	},
-/area/station/medical/medbay)
+/area/station/medical/medbay/cloner)
 "omb" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -24783,11 +24942,9 @@
 /turf/simulated/floor/black,
 /area/station/engine/inner)
 "omO" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor/purplewhite{
-	dir = 1
-	},
-/area/station/science/lobby)
+/obj/landmark/antagonist/blob,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "onm" = (
 /obj/machinery/light_switch{
 	name = "S light switch";
@@ -24805,13 +24962,9 @@
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "onw" = (
-/obj/random_item_spawner/desk_stuff,
-/obj/table/glass/auto,
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/purplewhite{
-	dir = 5
-	},
-/area/station/science/lobby)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "onF" = (
 /obj/shrub{
 	dir = 8
@@ -24837,11 +24990,9 @@
 	},
 /area/station/science/hall)
 "ooq" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/central)
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "oow" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/mapping_helper/access/tox_storage,
@@ -24857,15 +25008,14 @@
 	},
 /area/station/security/processing)
 "opw" = (
-/obj/disposalpipe/segment/mail,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
+/obj/machinery/computer/card/department/medical,
+/obj/decal/poster/wallsign/framed_award/mdlicense{
+	pixel_y = 27
 	},
-/obj/machinery/computer/operating/small,
-/turf/simulated/floor/redwhite{
-	dir = 1
+/turf/simulated/floor/bluewhite{
+	dir = 9
 	},
-/area/station/medical/medbay/surgery)
+/area/station/medical/head)
 "opC" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -24874,28 +25024,11 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/supplylobby)
 "oqp" = (
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = -4
+/obj/cable{
+	icon_state = "1-9"
 	},
-/obj/item/stamp{
-	pixel_y = 1
-	},
-/obj/item/pen{
-	pixel_x = 4
-	},
-/obj/item/clipboard{
-	pixel_y = 3;
-	pixel_x = 10
-	},
-/obj/machinery/recharger/defibrillator{
-	pixel_y = 7
-	},
-/obj/table/auto,
-/turf/simulated/floor/bluewhite{
-	dir = 4
-	},
-/area/station/medical/medbay)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "oqx" = (
 /obj/machinery/camera/directional/west{
 	pixel_y = 10
@@ -25016,16 +25149,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "otX" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
+/obj/machinery/door/airlock/pyro/maintenance,
+/obj/mapping_helper/access/maint,
+/obj/mapping_helper/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/redwhite{
-	dir = 1
-	},
-/area/station/medical/medbay/surgery)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "ouU" = (
 /turf/simulated/floor/carpet{
 	icon_state = "carpetE"
@@ -25047,6 +25178,12 @@
 "ovz" = (
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
+"ovL" = (
+/obj/cable{
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "ovM" = (
 /obj/machinery/atmospherics/binary/pump/active{
 	dir = 4;
@@ -25111,7 +25248,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment,
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/sci_alt,
 /turf/simulated/floor/white,
@@ -25196,9 +25332,10 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "oEa" = (
-/obj/disposalpipe/segment/mail,
+/obj/table/wood/auto,
+/obj/candle_light,
 /turf/simulated/floor/specialroom/chapel{
-	dir = 6
+	dir = 9
 	},
 /area/station/chapel/sanctuary)
 "oEU" = (
@@ -25263,14 +25400,6 @@
 /obj/storage/secure/closet/research/uniform,
 /turf/simulated/floor/purple,
 /area/station/science/hall)
-"oGN" = (
-/obj/machinery/atmospherics/pipe/simple/overfloor{
-	dir = 10
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 4
-	},
-/area/station/medical/medbay)
 "oGO" = (
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -25318,8 +25447,16 @@
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "oJx" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4;
+	id = "medbay_entrance"
+	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/medical,
+/obj/machinery/secscanner{
+	dir = 4;
+	pixel_x = -20
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -25327,9 +25464,8 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "oJz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -25341,12 +25477,8 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "oJW" = (
-/obj/disposalpipe/segment/morgue,
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/greenwhite,
+/area/station/medical/medbay)
 "oKk" = (
 /obj/storage/closet/emergency,
 /obj/disposalpipe/segment/mail{
@@ -25437,6 +25569,9 @@
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
@@ -25591,6 +25726,10 @@
 	},
 /obj/machinery/light/incandescent{
 	dir = 1
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -25857,12 +25996,13 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/storage)
 "oXa" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/window_blinds/cog2/left{
-	id = "RD"
+/obj/mapping_helper/access/medlab,
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/md)
+/turf/simulated/floor/white,
+/area/station/medical/research)
 "oXd" = (
 /obj/landmark/antagonist/blob,
 /turf/simulated/floor/plating,
@@ -25880,16 +26020,16 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/fitness)
 "oXp" = (
-/obj/cable{
-	icon_state = "1-2"
+/mob/living/carbon/human/npc/monkey,
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "2-4";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "oXB" = (
 /obj/railing/orange/reinforced{
 	dir = 8
@@ -25932,23 +26072,17 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "oYe" = (
-/obj/disposalpipe/junction/middle/west,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/medical/medbay/surgery)
-"oYY" = (
-/obj/disposalpipe/segment/mail{
+/obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "1-10"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/mapping_helper/firedoor_spawn,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"oYY" = (
+/obj/storage/crate/robotparts,
+/obj/submachine/cargopad/robotics,
+/turf/simulated/floor/grime,
+/area/station/medical/robotics)
 "oZl" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/office)
@@ -26086,6 +26220,11 @@
 "pcb" = (
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"pch" = (
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/medbay_horizontal/vertical,
+/obj/machinery/r_door_control/podbay/medbay/new_walls/north,
+/turf/simulated/floor/engine,
+/area/station/hangar/medical)
 "pcp" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/mapping_helper/access/maint,
@@ -26164,15 +26303,16 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/warehouse)
 "pec" = (
-/obj/cable{
-	icon_state = "5-8"
+/obj/table/auto/desk,
+/obj/machinery/cashreg,
+/obj/item/kitchen/food_box/lollipop,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
 	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/medical,
+/turf/simulated/floor/greenwhite,
+/area/station/medical/medbay)
 "pen" = (
 /obj/machinery/vehicle/escape_pod{
 	dir = 4
@@ -26181,18 +26321,12 @@
 /turf/simulated/floor/engine,
 /area/station/hallway/secondary/exit)
 "pep" = (
-/obj/cable{
-	icon_state = "1-10"
+/obj/table/wood/auto,
+/obj/machinery/loudspeaker,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 10
 	},
-/obj/cable{
-	icon_state = "8-10"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/chapel/sanctuary)
 "peK" = (
 /turf/simulated/floor{
 	icon_state = "L6";
@@ -26271,14 +26405,11 @@
 	},
 /area/station/chapel/sanctuary)
 "pht" = (
-/obj/table/auto,
-/obj/item/instrument/bagpipe,
-/obj/item/paper_bin,
-/obj/machinery/light/small/frostedred{
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/blueblack/corner{
 	dir = 1
 	},
-/turf/simulated/floor/plating/damaged1,
-/area/station/chapel/sanctuary)
+/area/station/medical/robotics)
 "phv" = (
 /obj/machinery/chem_master{
 	dir = 4
@@ -26317,9 +26448,15 @@
 	},
 /area/station/hydroponics/bay)
 "pim" = (
-/obj/machinery/light/small/sticky/frostedred,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "piq" = (
 /obj/machinery/camera/directional/north{
 	pixel_x = -10
@@ -26346,13 +26483,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/processing)
-"piA" = (
-/obj/table/wood/auto,
-/obj/candle_light,
-/turf/simulated/floor/specialroom/chapel{
-	dir = 4
-	},
-/area/station/chapel/sanctuary)
 "pjo" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
@@ -26399,19 +26529,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "pjO" = (
-/obj/table/auto,
-/obj/item/storage/firstaid/brain,
-/obj/machinery/firealarm/directional/north,
-/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat,
-/obj/item/extinguisher,
-/obj/item/storage/box/diskbox{
-	pixel_x = -8;
-	pixel_y = 13
-	},
-/turf/simulated/floor/greenwhite{
-	dir = 1
-	},
-/area/station/medical/medbay/cloner)
+/obj/machinery/vending/medical,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "pkh" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -26529,6 +26649,14 @@
 /obj/cable,
 /turf/simulated/floor/red/redblackchecker,
 /area/station/security/processing)
+"pnR" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/bluewhite{
+	dir = 9
+	},
+/area/station/medical/head)
 "por" = (
 /obj/storage/secure/closet/civilian/kitchen,
 /obj/machinery/light/incandescent{
@@ -26538,11 +26666,12 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "poQ" = (
-/obj/stool,
-/turf/simulated/floor/specialroom/chapel{
-	dir = 10
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "4-6"
 	},
-/area/station/chapel/sanctuary)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "poU" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/decal/cleanable/dirt,
@@ -26599,6 +26728,18 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
+"pqF" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/incandescent{
+	dir = 1
+	},
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "pqT" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -26611,11 +26752,45 @@
 /turf/simulated/floor/plating/jen,
 /area/station/engine/singcore)
 "pqU" = (
-/obj/machinery/light/small/broken{
-	dir = 8
+/obj/item/storage/wall/office,
+/obj/rack,
+/obj/item/robodefibrillator{
+	pixel_x = -5;
+	pixel_y = 6
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/item/reagent_containers/hypospray{
+	pixel_x = -11;
+	pixel_y = 2
+	},
+/obj/item/storage/box/health_upgrade_kit{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/hypospray{
+	pixel_x = -5
+	},
+/obj/item/item_box/medical_patches/mini_synthflesh{
+	pixel_x = -9;
+	pixel_y = -7
+	},
+/obj/item/clothing/gloves/latex/random{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/gloves/latex/random{
+	pixel_x = 8;
+	pixel_y = -7
+	},
+/obj/decal/tile_edge/stripe/big,
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/obj/item/clothing/gloves/latex/random{
+	pixel_x = 8;
+	pixel_y = -7
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "prz" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -26684,6 +26859,13 @@
 /obj/storage/closet/welding_supply,
 /turf/simulated/floor,
 /area/station/hangar/qm)
+"pta" = (
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "ptB" = (
 /obj/machinery/atmospherics/unary/outlet_injector/active{
 	dir = 8
@@ -26759,11 +26941,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "pwp" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/landmark/spawner/artifact/one_in_ten,
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "pwB" = (
@@ -26794,12 +26972,6 @@
 	icon_state = "fgreen3"
 	},
 /area/station/bridge)
-"pxQ" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
 "pxY" = (
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen3"
@@ -26969,20 +27141,27 @@
 /turf/simulated/floor/red,
 /area/station/security/processing)
 "pCI" = (
-/obj/decal/cleanable/vomit,
-/obj/cable{
-	icon_state = "2-9"
-	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2,
 /turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
+/area/station/medical/head)
 "pCX" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
 	},
-/turf/simulated/floor/bluewhite,
-/area/station/hallway/primary/south)
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
+"pDw" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/specialroom/medbay,
+/area/station/maintenance/east)
 "pDx" = (
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -27058,6 +27237,7 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
 	},
+/obj/mapping_helper/access/maint,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
 "pFz" = (
@@ -27093,10 +27273,11 @@
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
 "pGw" = (
-/turf/simulated/floor/purplewhite{
-	dir = 1
+/obj/stool/chair/office/blue{
+	dir = 8
 	},
-/area/station/science/lobby)
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "pHq" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -27217,14 +27398,9 @@
 	},
 /area/station/crew_quarters/hor)
 "pJd" = (
-/obj/machinery/disposal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/disposalpipe/segment/mail,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "pJD" = (
@@ -27266,6 +27442,9 @@
 	icon_state = "4-8"
 	},
 /obj/landmark/kudzu,
+/obj/cable{
+	icon_state = "8-9"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "pKB" = (
@@ -27305,14 +27484,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
-"pLv" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/greenwhite{
-	dir = 1
-	},
-/area/station/medical/research)
 "pLV" = (
 /obj/submachine/ATM{
 	pixel_x = 30
@@ -27370,11 +27541,6 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/hall)
-"pNz" = (
-/turf/simulated/floor/blue/side{
-	dir = 1
-	},
-/area/station/hallway/primary/central)
 "pNE" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor{
@@ -27383,14 +27549,11 @@
 	},
 /area/station/crew_quarters/fitness)
 "pOD" = (
-/obj/cable,
-/obj/machinery/power/apc/autoname_south,
-/obj/landmark/start/job/geneticist,
-/obj/stool/chair{
-	dir = 8;
-	tag = "icon-chair (WEST)"
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2{
+	dir = 4
 	},
-/turf/simulated/floor/greenwhite,
+/turf/simulated/floor/plating,
 /area/station/medical/research)
 "pOJ" = (
 /obj/cable{
@@ -27399,12 +27562,11 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "pOX" = (
-/obj/machinery/door/airlock/pyro/glass/med{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/bluewhite,
-/area/station/hallway/primary/south)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "pPd" = (
 /obj/machinery/light/incandescent{
 	dir = 8
@@ -27442,11 +27604,13 @@
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "pQe" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/light/incandescent{
+	dir = 4
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
+/turf/simulated/floor/blackwhite{
+	dir = 4
+	},
+/area/station/medical/medbay/lobby)
 "pQv" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -27592,12 +27756,6 @@
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/neutral,
 /area/station/storage/emergency)
-"pVT" = (
-/obj/machinery/atmospherics/unary/cryo_cell{
-	dir = 1
-	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbay)
 "pWK" = (
 /obj/securearea{
 	desc = "A warning sign which reads 'COLLISION HAZARD'";
@@ -27673,11 +27831,13 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "qae" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/table/reinforced/chemistry/auto,
+/obj/machinery/glass_recycler{
+	glass_amt = 5;
+	pixel_y = 4
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/medbay/surgery)
+/turf/simulated/floor/blueblack,
+/area/station/medical/medbay/pharmacy)
 "qag" = (
 /turf/simulated/floor/greenblack,
 /area/station/hydroponics/bay)
@@ -27726,13 +27886,14 @@
 /turf/simulated/floor/auto/dirt,
 /area/station/ranch)
 "qbR" = (
+/obj/mapping_helper/access/medlab,
+/obj/machinery/door/airlock/pyro/glass/med,
+/obj/mapping_helper/firedoor_spawn,
 /obj/cable{
-	icon_state = "5-10"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/blueblack/corner{
-	dir = 1
-	},
-/area/station/medical/robotics)
+/turf/simulated/floor/blue/checker,
+/area/station/medical/research)
 "qbU" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/engine,
@@ -27815,11 +27976,23 @@
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "qev" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/table/auto,
+/obj/item/clipboard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/stamp,
+/obj/item/decoration/ashtray,
+/obj/item/remote/porter/port_a_medbay,
+/obj/item/reagent_containers/food/drinks/tea,
+/obj/item/stamp/md,
+/obj/cable{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
+/obj/machinery/power/apc/autoname_east,
+/turf/simulated/floor/bluewhite{
+	dir = 6
+	},
+/area/station/medical/head)
 "qew" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/airlock/cycler{
@@ -27923,6 +28096,16 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
+"qig" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "qiI" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Genetics Research West";
@@ -27966,17 +28149,24 @@
 "qks" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
-"qkQ" = (
+"qkG" = (
+/obj/machinery/light/small/floor,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/light/incandescent{
-	dir = 8
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
+"qkQ" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
 	},
-/turf/simulated/floor/blue/side{
-	dir = 9
+/obj/mapping_helper/airlock/cycler{
+	cycle_id = "medspsl";
+	enter_id = "inner";
+	name = "Medical Space Lower"
 	},
-/area/station/hallway/primary/south)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "qkU" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
@@ -28057,14 +28247,13 @@
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "qmn" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/green,
-/area/station/medical/medbay/cloner)
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
+/area/station/chapel/sanctuary)
 "qmv" = (
 /obj/mesh/catwalk{
 	dir = 4
@@ -28240,6 +28429,15 @@
 	dir = 1
 	},
 /area/station/security/processing)
+"qsO" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "qsU" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -28270,6 +28468,15 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/proto)
+"qtU" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "quL" = (
 /obj/item/device/radio/intercom{
 	dir = 8
@@ -28355,6 +28562,13 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/turret_protected/Zeta)
+"qxh" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "qxU" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 5
@@ -28398,7 +28612,9 @@
 	c_tag = "Habitation Ring East";
 	pixel_y = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/blue/side{
+	dir = 4
+	},
 /area/station/hallway/primary/central)
 "qyW" = (
 /obj/disposalpipe/segment{
@@ -28456,14 +28672,11 @@
 	},
 /area/station/science/hall)
 "qAv" = (
-/obj/machinery/light/small/broken{
+/obj/machinery/light/small/frostedred{
 	dir = 4
 	},
-/obj/disposalpipe/segment{
-	dir = 1
-	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/area/station/maintenance/east)
 "qAA" = (
 /obj/cable,
 /obj/cable{
@@ -28477,11 +28690,15 @@
 	},
 /area/station/science/hall)
 "qAX" = (
-/obj/machinery/camera/directional/south{
-	pixel_x = 10
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/greenwhite,
-/area/station/medical/research)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "qBf" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -28595,25 +28812,9 @@
 /turf/space,
 /area/station/turret_protected/armory_outside)
 "qEV" = (
-/obj/table/reinforced,
-/obj/item/storage/box/beakerbox,
-/obj/item/storage/box/beakerbox,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "chemistry";
-	name = "Chemistry Privacy Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
-	},
-/obj/mapping_helper/access/research,
 /obj/decal/stripe_caution,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
@@ -28859,14 +29060,6 @@
 	tag = "icon-0,6"
 	},
 /area/station/crew_quarters/fitness)
-"qNH" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/window_blinds/cog2/middle,
-/turf/simulated/floor/plating,
-/area/station/medical/morgue)
 "qNM" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /turf/simulated/floor/plating/airless,
@@ -28957,14 +29150,13 @@
 	},
 /area/station/science/artifact)
 "qPI" = (
-/obj/decal/tile_edge/floorguide/science{
-	dir = 1
+/obj/disposalpipe/segment/morgue{
+	dir = 1;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
 	},
-/obj/decal/tile_edge/floorguide/arrow_e{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "qQh" = (
 /obj/cable,
 /obj/cable{
@@ -28998,14 +29190,13 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/armory)
 "qRe" = (
-/obj/disposalpipe/segment{
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/medical,
+/obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail,
-/obj/decal/stripe_delivery,
-/obj/item/device/radio/beacon,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/medbay/cloner)
 "qRj" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -29042,6 +29233,18 @@
 	layer = 2
 	},
 /area/station/solar/aisat)
+"qRC" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "qRM" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
@@ -29115,14 +29318,21 @@
 /obj/cable{
 	icon_state = "1-6"
 	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/machinery/light/incandescent{
+	dir = 8
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "qTQ" = (
-/obj/item/cable_coil,
-/obj/machinery/printing_press,
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4
+	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "qUb" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/market)
@@ -29156,15 +29366,34 @@
 /turf/simulated/floor/neutral,
 /area/station/storage/emergency)
 "qVa" = (
-/obj/cable{
-	icon_state = "2-9"
+/obj/machinery/camera/directional/south{
+	pixel_x = 10
 	},
-/obj/disposalpipe/segment/morgue{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/storage/crate/freezer{
+	name = "Freezer - Spare Parts"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/item/reagent_containers/food/snacks/ingredient/meatpaste{
+	desc = "Gross.";
+	name = "old kidney"
+	},
+/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/grody,
+/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/grody,
+/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/grody,
+/obj/item/organ/heart{
+	desc = "A human heart, grody. How long has it been in that freezer?";
+	name = "funky ol' heart"
+	},
+/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat,
+/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat,
+/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat,
+/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat,
+/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat,
+/obj/machinery/sink/slim{
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/simulated/floor/sanitary,
+/area/station/medical/morgue)
 "qVk" = (
 /obj/pool/perspective{
 	dir = 4;
@@ -29383,12 +29612,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai_upload)
-"rbd" = (
-/obj/table/wood/auto,
-/turf/simulated/floor/specialroom/chapel{
-	dir = 1
-	},
-/area/station/chapel/sanctuary)
 "rbC" = (
 /obj/stool,
 /obj/railing/boxing{
@@ -29423,25 +29646,17 @@
 	},
 /area/station/security/processing)
 "rcq" = (
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4;
+	id = "medbay_entrance"
+	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/robotics,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/medbay/surgery)
-"rcv" = (
-/obj/disposalpipe/segment,
-/obj/cable{
-	icon_state = "2-4";
-	pixel_y = 0
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/robotics)
 "rcM" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/plating/random,
@@ -29486,12 +29701,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/proto)
-"rec" = (
-/obj/cable{
-	icon_state = "8-9"
-	},
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
 "rek" = (
 /obj/lattice{
 	dir = 4;
@@ -29548,6 +29757,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
+"rga" = (
+/obj/storage/closet/welding_supply,
+/turf/simulated/floor/specialroom/medbay,
+/area/station/hangar/medical)
 "rgs" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -29581,6 +29794,11 @@
 	tag = "icon-carpet2 (WEST)"
 	},
 /area/station/crew_quarters/cafeteria)
+"rhf" = (
+/turf/simulated/floor/blue/side{
+	dir = 1
+	},
+/area/station/hallway/primary/central)
 "rhT" = (
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
@@ -29615,17 +29833,11 @@
 	},
 /area/station/hallway/primary/west)
 "rjg" = (
-/obj/machinery/portable_reclaimer,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
 	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/darkblue,
-/area/station/medical/robotics)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "rjy" = (
 /obj/lattice{
 	dir = 1;
@@ -29757,9 +29969,6 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "rnf" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -29828,14 +30037,13 @@
 	},
 /area/station/quartermaster/office)
 "rpN" = (
-/obj/machinery/light/incandescent,
-/obj/cable{
-	icon_state = "0-8"
+/obj/machinery/door_control/podbay/medbay/new_walls/south{
+	pixel_y = 19
 	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/power/apc/autoname_south,
-/turf/simulated/floor/white,
-/area/station/science/chemistry)
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/specialroom/medbay,
+/area/station/hangar/medical)
 "rqf" = (
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/engine,
@@ -29894,6 +30102,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"rrM" = (
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/power/apc/autoname_south,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/white,
+/area/station/science/chemistry)
 "rsb" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -29908,14 +30127,14 @@
 	},
 /area/station/science/lobby)
 "rsV" = (
-/obj/cable{
-	icon_state = "0-4"
+/obj/machinery/door/airlock/pyro/medical{
+	name = "Robotics";
+	req_access = null
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
+/obj/mapping_helper/access/robotics,
+/obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/grime,
 /area/station/medical/robotics)
 "rum" = (
 /obj/machinery/power/solar/aisat,
@@ -30098,16 +30317,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
-"ryR" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/dome)
 "ryU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -30395,22 +30604,21 @@
 	},
 /area/station/crew_quarters/supplylobby)
 "rEi" = (
-/obj/cable{
-	icon_state = "2-8"
+/turf/simulated/floor/greenwhite{
+	dir = 4
 	},
-/obj/disposalpipe/junction/right/south,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/medbay/cloner)
 "rEI" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hangar/qm)
 "rEL" = (
-/obj/disposalpipe/segment/mail,
-/obj/machinery/light{
-	tag = ""
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
+/obj/window_blinds/cog2,
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/pharmacy)
 "rFa" = (
 /obj/cable{
 	icon_state = "8-10"
@@ -30546,12 +30754,10 @@
 /turf/simulated/floor/orangeblack,
 /area/station/science/hall)
 "rJf" = (
-/obj/disposalpipe/junction/left/south,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2,
+/turf/simulated/floor/plating,
+/area/station/medical/morgue)
 "rJr" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -30612,12 +30818,6 @@
 /obj/cable{
 	icon_state = "4-9"
 	},
-/obj/decal/tile_edge/floorguide/medbay{
-	dir = 4
-	},
-/obj/decal/tile_edge/floorguide/arrow_e{
-	dir = 1
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "rLD" = (
@@ -30671,17 +30871,6 @@
 "rMh" = (
 /turf/simulated/floor,
 /area/station/crew_quarters/supplylobby)
-"rMj" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 8
-	},
-/area/station/medical/research)
 "rMS" = (
 /obj/cable{
 	icon_state = "6-9"
@@ -30691,6 +30880,12 @@
 "rMW" = (
 /turf/simulated/floor/neutral/corner,
 /area/station/hallway/primary/central)
+"rNz" = (
+/obj/machinery/light/small/frostedred{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "rNC" = (
 /turf/simulated/floor/black,
 /area/station/science/lab)
@@ -30801,13 +30996,9 @@
 /turf/simulated/floor/circuit/red,
 /area/station/turret_protected/ai)
 "rRn" = (
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/landmark/pest,
+/obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/chapel/sanctuary)
 "rRo" = (
 /obj/machinery/info_map,
 /turf/simulated/floor,
@@ -30851,9 +31042,11 @@
 	},
 /area/station/crew_quarters/jazz)
 "rRY" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/medbay/surgery)
+/obj/storage/cart/medcart/crash,
+/turf/simulated/floor/bluewhite{
+	dir = 6
+	},
+/area/station/medical/head)
 "rSy" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -30944,22 +31137,27 @@
 /turf/simulated/floor/red/side,
 /area/station/security/processing)
 "rVp" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "1-2"
+	dir = null
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/surgery)
 "rVU" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Medical Wing Entrance";
-	pixel_x = -10
+/obj/cable{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/purple/side,
-/area/station/hallway/primary/south)
+/obj/machinery/power/apc/autoname_south,
+/turf/simulated/floor/carpet{
+	icon_state = "carpetN"
+	},
+/area/station/chapel/sanctuary)
 "rWa" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 9
@@ -31020,13 +31218,9 @@
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "rXQ" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/mapping_helper/access/maint,
-/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/medical/medbay/lobby)
 "rXT" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -31122,15 +31316,12 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "scg" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/disposalpipe/switch_junction/right/south,
 /obj/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/dome)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "scw" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -31178,30 +31369,13 @@
 /obj/disposalpipe/segment/produce,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
-"ser" = (
-/obj/cable{
-	icon_state = "1-9"
-	},
-/obj/cable{
-	icon_state = "8-9"
-	},
-/obj/stool/chair/pew/right{
+"ses" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
 	dir = 4
 	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 5
-	},
-/area/station/chapel/sanctuary)
-"ses" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk,
-/obj/machinery/camera/directional/north{
-	pixel_x = 10
-	},
-/turf/simulated/floor/greenwhite{
-	dir = 1
-	},
-/area/station/medical/medbay/cloner)
+/turf/simulated/floor/plating,
+/area/station/medical/head)
 "set" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -31247,6 +31421,9 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
+"sgT" = (
+/turf/simulated/wall/false_wall,
+/area/station/maintenance/east)
 "sha" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -31358,15 +31535,15 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4
+	},
 /turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/chapel/sanctuary)
 "skg" = (
 /obj/stool/bench/red/auto,
 /obj/machinery/light/incandescent,
@@ -31436,12 +31613,15 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "smB" = (
-/obj/disposalpipe/switch_junction/left/north{
-	mail_tag = "genetics";
-	name = "Mail Junction - Genetics"
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "smJ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -31465,23 +31645,16 @@
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "snm" = (
-/obj/machinery/computer/cloning,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/light_switch{
-	name = "N light switch";
-	pixel_y = 24
-	},
-/turf/simulated/floor/greenwhite{
-	dir = 1
-	},
-/area/station/medical/medbay/cloner)
+/obj/window_blinds/cog2/left,
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/pharmacy)
 "snp" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -31579,6 +31752,9 @@
 /obj/disposalpipe/segment,
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass/med,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/white/side,
 /area/station/medical/robotics)
 "sqm" = (
@@ -31672,6 +31848,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"svg" = (
+/obj/machinery/vehicle/pod_smooth/light,
+/turf/simulated/floor/engine,
+/area/station/hangar/medical)
 "svE" = (
 /obj/mesh/grille/steel,
 /turf/simulated/floor/plating/airless,
@@ -31756,21 +31936,16 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
 "sxy" = (
-/obj/machinery/secscanner{
-	dir = 4;
-	pixel_x = -20
-	},
-/obj/mapping_helper/access/medical,
-/obj/mapping_helper/firedoor_spawn,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "2-4";
+	pixel_y = 0
 	},
-/obj/machinery/door/airlock/pyro/glass/med{
-	dir = 4;
-	id = "medbay_entrance"
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbay)
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "sxO" = (
 /obj/machinery/light/incandescent{
 	dir = 1
@@ -31868,6 +32043,15 @@
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
+"sAK" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "sBj" = (
 /obj/lattice,
 /obj/machinery/atmospherics/unary/portables_connector,
@@ -32014,16 +32198,13 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "0-4"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "sIe" = (
 /obj/storage/secure/closet/civilian/hydro,
 /turf/simulated/floor/grass{
@@ -32036,11 +32217,10 @@
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "sIv" = (
-/obj/cable{
-	icon_state = "1-2"
+/turf/simulated/floor/greenwhite{
+	dir = 10
 	},
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
+/area/station/medical/research)
 "sIz" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -32086,12 +32266,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"sKj" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/hall)
 "sKq" = (
 /obj/cable,
 /obj/cable{
@@ -32133,11 +32307,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "sLo" = (
-/obj/cable{
-	icon_state = "6-9"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "sLv" = (
 /obj/storage/closet/biohazard,
 /turf/simulated/floor/purple/side{
@@ -32148,6 +32320,12 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"sLG" = (
+/obj/cable{
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "sLV" = (
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -32188,12 +32366,9 @@
 /turf/simulated/floor/purple/side,
 /area/station/science/hall)
 "sMw" = (
-/obj/table/wood/auto,
-/obj/item/card_box/tarot{
-	pixel_y = 3
-	},
-/turf/simulated/floor/black,
-/area/station/chapel/sanctuary)
+/obj/stool/bench/blue/auto,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "sMF" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -32386,6 +32561,10 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
+"sRo" = (
+/obj/machinery/door/airlock/pyro/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "sSe" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/table/reinforced,
@@ -32436,6 +32615,12 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/circuit/off,
 /area/station/turret_protected/ai)
+"sSB" = (
+/obj/cable{
+	icon_state = "8-10"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "sSY" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -32489,17 +32674,6 @@
 /obj/machinery/drone_recharger/factory,
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
-"sUs" = (
-/obj/mapping_helper/access/medlab,
-/obj/mapping_helper/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/med{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
 "sUz" = (
 /obj/cable/yellow{
 	icon_state = "4-8"
@@ -32618,15 +32792,12 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/bathroom/extra1)
 "sXs" = (
-/obj/machinery/defib_mount,
-/obj/table/auto,
-/obj/item/device/radio/intercom/medical{
-	dir = 4
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/redwhite{
-	dir = 9
-	},
-/area/station/medical/medbay/surgery)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "sXH" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -32685,18 +32856,28 @@
 /obj/cable{
 	icon_state = "2-5"
 	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "sZh" = (
-/obj/cable{
-	icon_state = "5-8"
+/obj/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -6;
+	pixel_y = -8
 	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
+/obj/item/storage/belt/utility{
+	pixel_x = -6;
+	pixel_y = 2
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/item/storage/belt/utility{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/oilcan{
+	pixel_x = 9;
+	pixel_y = 1
+	},
+/turf/simulated/floor/grime,
+/area/station/medical/robotics)
 "sZp" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -32765,17 +32946,12 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/courtroom)
 "tcm" = (
-/obj/machinery/optable,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/light{
-	tag = ""
-	},
-/turf/simulated/floor/redblack{
-	dir = 1
-	},
-/area/station/medical/robotics)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "tcv" = (
 /obj/machinery/sim/vr_bed{
 	dir = 8
@@ -33036,15 +33212,8 @@
 /turf/space,
 /area/station/engine/proto)
 "tkt" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/mapping_helper/access/maint,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southeast)
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/dome)
 "tkx" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -33140,6 +33309,9 @@
 	dir = 8;
 	tag = "icon-chair (WEST)"
 	},
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
+	},
 /turf/simulated/floor/blue/side,
 /area/station/hallway/primary/central)
 "tmn" = (
@@ -33155,12 +33327,12 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
 "tno" = (
-/obj/disposalpipe/segment,
-/obj/decal/tile_edge/floorguide/arrow_s{
-	dir = 8
+/obj/machinery/camera/directional/south{
+	pixel_x = 10
 	},
-/turf/simulated/floor/purplewhite,
-/area/station/medical/medbay/lobby)
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "tnA" = (
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/ai)
@@ -33213,14 +33385,9 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/bay)
 "toF" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
+/obj/decal/tile_edge/stripe/big,
+/turf/simulated/floor/specialroom/medbay,
+/area/station/maintenance/east)
 "toK" = (
 /obj/storage/closet/fire,
 /obj/item/crowbar,
@@ -33299,10 +33466,21 @@
 	},
 /area/station/hallway/primary/south)
 "tpW" = (
-/obj/machinery/light/incandescent,
-/obj/machinery/optable,
-/turf/simulated/floor/redwhite,
-/area/station/medical/medbay/surgery)
+/obj/machinery/door_control{
+	id = "chemistry";
+	name = "Toggle Window Shutters";
+	pixel_x = 10;
+	pixel_y = 24
+	},
+/obj/machinery/disposal/mail/small/autoname/research/chemistry/north{
+	pixel_x = -4
+	},
+/obj/disposalpipe/trunk/mail/south,
+/obj/machinery/vending/chemistry,
+/turf/simulated/floor/purplewhite{
+	dir = 4
+	},
+/area/station/science/chemistry)
 "tqn" = (
 /obj/machinery/door/unpowered/wood/stall{
 	dir = 1
@@ -33406,8 +33584,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "twm" = (
-/turf/simulated/floor/carpet/blue/fancy/edge/east,
-/area/station/crew_quarters/md)
+/obj/blind_switch/area/east,
+/turf/simulated/floor/greenwhite{
+	dir = 4
+	},
+/area/station/medical/research)
 "twr" = (
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
@@ -33465,12 +33646,10 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/arrivals)
 "tzl" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/blueblack/corner,
-/area/station/medical/robotics)
+/obj/machinery/manufacturer/medical,
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "tzn" = (
 /obj/cable{
 	icon_state = "2-5"
@@ -33494,14 +33673,12 @@
 /turf/simulated/floor,
 /area/station/engine/power)
 "tzI" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Robotics East";
-	pixel_y = 10
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/blueblack/corner{
-	dir = 1
-	},
-/area/station/medical/robotics)
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "tzJ" = (
 /obj/machinery/hair_dye_dispenser,
 /turf/simulated/floor/specialroom/cafeteria,
@@ -33566,12 +33743,9 @@
 /turf/simulated/floor/purple,
 /area/station/science/hall)
 "tAQ" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/machinery/firealarm/directional/west,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "tBb" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor/purple,
@@ -33614,13 +33788,36 @@
 /turf/simulated/floor,
 /area/station/storage/emergency)
 "tCi" = (
-/obj/disposalpipe/segment/mail{
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay Lobby";
+	pixel_y = 10
+	},
+/obj/item/device/radio/intercom/medical{
 	dir = 4
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 1
+/obj/table/auto,
+/obj/item/clipboard{
+	pixel_x = 6
 	},
-/area/station/hallway/primary/south)
+/obj/item/paper{
+	pixel_x = 6
+	},
+/obj/item/pen{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/turf/simulated/floor/greenwhite{
+	dir = 8
+	},
+/area/station/medical/research)
 "tDb" = (
 /obj/cable{
 	dir = null
@@ -33692,6 +33889,10 @@
 	},
 /turf/simulated/floor/green/side,
 /area/station/hallway/primary/south)
+"tFR" = (
+/obj/landmark/random_room/size5x3,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "tFV" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 10
@@ -33746,22 +33947,12 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "tIo" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "cloning_exit";
-	name = "Cloning Exit Door Control";
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/greenwhite/corner{
-	dir = 8
-	},
-/area/station/medical/medbay/cloner)
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "tIt" = (
 /obj/disposalpipe/segment/mail{
 	dir = 8;
@@ -33803,13 +33994,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/west)
-"tJs" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/morgue,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "tJA" = (
 /obj/machinery/door/airlock/pyro/command{
 	name = "Computer Core"
@@ -33824,32 +34008,35 @@
 	},
 /area/station/turret_protected/Zeta)
 "tJE" = (
-/obj/health_scanner/wall{
-	dir = 4;
-	find_in_range = 0;
-	id = "lobby";
-	name = "lobby health status screen";
-	pixel_x = -22;
-	pixel_y = -2
+/turf/unsimulated/floor/redwhite/corner{
+	dir = 4
 	},
-/obj/machinery/light/incandescent{
-	dir = 8
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 8
-	},
-/area/station/medical/medbay)
+/area/station/medical/medbay/surgery)
 "tKf" = (
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "tKs" = (
-/obj/mapping_helper/access/morgue,
-/obj/mapping_helper/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/medical{
-	dir = 4
+/obj/surgery_tray,
+/obj/item/staple_gun{
+	pixel_x = 4;
+	pixel_y = 9
 	},
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
+/obj/item/circular_saw{
+	pixel_y = 11
+	},
+/obj/item/scissors/surgical_scissors{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/hemostat{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/item/suture{
+	pixel_y = 5
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "tKE" = (
 /obj/stool/chair{
 	dir = 8;
@@ -33858,28 +34045,18 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "tKS" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/bluewhite{
+/obj/machinery/dialysis,
+/turf/simulated/floor/redwhite{
 	dir = 8
 	},
-/area/station/medical/medbay)
+/area/station/medical/medbay/surgery)
 "tKT" = (
-/obj/disposalpipe/junction/middle/west,
-/obj/cable{
-	icon_state = "0-4"
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon11,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "tKY" = (
 /obj/disposalpipe/segment{
 	dir = 1
@@ -33993,12 +34170,20 @@
 	},
 /area/station/security/processing)
 "tNT" = (
-/obj/stool/barber_chair{
-	desc = "A traditional barbershop chair, obviously a very old one at that.  What it is doing on a space station you haven't the foggiest.";
-	name = "Old Barber Chair"
+/obj/stool/chair/office{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/maintenance/east)
+/obj/landmark/start/job/pharmacist,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/blueblack{
+	dir = 1
+	},
+/area/station/medical/medbay/pharmacy)
 "tOI" = (
 /obj/overlay{
 	anchored = 1;
@@ -34034,13 +34219,6 @@
 "tPE" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/kitchen)
-"tPI" = (
-/obj/landmark/gps_waypoint,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
 "tPO" = (
 /obj/landmark/start{
 	name = "predator"
@@ -34157,11 +34335,18 @@
 /turf/space,
 /area/shuttle/merchant_shuttle/left_station/cogmap)
 "tUr" = (
-/obj/stool/chair{
-	dir = 1
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/blue,
+/obj/machinery/door_control/bolter/new_walls/east{
+	pixel_y = 6;
+	id = "quarters_mdir";
+	pixel_x = 23
 	},
-/turf/simulated/floor,
-/area/station/maintenance/east)
+/obj/machinery/light,
+/turf/simulated/floor/bluewhite{
+	dir = 6
+	},
+/area/station/medical/head)
 "tUH" = (
 /obj/submachine/seed_manipulator,
 /obj/noticeboard/persistent/botany/directional/west,
@@ -34179,18 +34364,7 @@
 /area/station/hallway/primary/north)
 "tVJ" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "chemistry";
-	name = "Chemistry Privacy Shutters";
-	opacity = 0
-	},
+/obj/window_blinds/cog2,
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "tVY" = (
@@ -34245,6 +34419,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
+"tXD" = (
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/medbay_horizontal/vertical,
+/turf/simulated/floor/engine,
+/area/station/hangar/medical)
 "tXF" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -34300,33 +34478,13 @@
 	},
 /area/station/bridge)
 "uaC" = (
-/obj/surgery_tray,
-/obj/item/staple_gun{
-	pixel_x = 4;
-	pixel_y = 9
+/obj/cable{
+	icon_state = "0-4"
 	},
-/obj/item/circular_saw{
-	pixel_y = 11
-	},
-/obj/item/scissors/surgical_scissors{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/scalpel{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/hemostat{
-	pixel_x = 3;
-	pixel_y = -5
-	},
-/obj/item/suture{
-	pixel_y = 5
-	},
-/turf/simulated/floor/redwhite{
-	dir = 4
-	},
-/area/station/medical/medbay/surgery)
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2,
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "uaO" = (
 /obj/table/wood/auto,
 /obj/item/card/id/gold/captains_spare,
@@ -34469,9 +34627,9 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hangar/qm)
 "ufl" = (
-/obj/submachine/slot_machine,
-/turf/simulated/floor/plating/damaged2,
-/area/station/chapel/sanctuary)
+/obj/machinery/atmospherics/unary/cryo_cell,
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "ufJ" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -34515,19 +34673,10 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/main)
 "uhx" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "chemistry";
-	name = "Chemistry Privacy Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/white,
 /area/station/science/chemistry)
 "uhA" = (
 /obj/cable{
@@ -34665,20 +34814,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "unp" = (
-/obj/landmark/gps_waypoint,
+/obj/cable{
+	icon_state = "6-9"
+	},
 /turf/simulated/floor/blueblack/corner{
 	dir = 1
 	},
 /area/station/medical/robotics)
 "unB" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/firealarm/directional/south,
-/turf/simulated/floor/purplewhite/corner{
-	dir = 1
-	},
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "unH" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/north{
 	pixel_y = -10
@@ -34688,11 +34837,25 @@
 	},
 /area/station/engine/inner)
 "uoe" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/mapping_helper/access/maint,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "5-8"
+	},
+/obj/cable{
+	icon_state = "2-4";
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "1-10"
+	},
+/obj/cable{
+	icon_state = "4-6"
+	},
+/obj/stool/chair/pew/center{
+	dir = 4
+	},
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "uon" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -34757,21 +34920,6 @@
 	},
 /turf/space,
 /area/station/turret_protected/armory_outside)
-"upt" = (
-/obj/cable{
-	icon_state = "2-9"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "2-5"
-	},
-/obj/cable{
-	icon_state = "4-9"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "upu" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/courtroom)
@@ -34804,6 +34952,12 @@
 "upT" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/clown)
+"upW" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "upX" = (
 /obj/machinery/vending/cards,
 /turf/simulated/floor,
@@ -35036,18 +35190,26 @@
 /obj/machinery/chem_shaker/large/chemistry,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
-"uBy" = (
-/obj/cable{
-	icon_state = "4-8"
+"uzp" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
 	},
+/obj/table/reinforced/auto,
+/obj/item/cable_coil,
+/obj/item/sheet/glass,
+/turf/simulated/floor/specialroom/medbay,
+/area/station/hangar/medical)
+"uBu" = (
 /obj/disposalpipe/segment,
-/obj/decal/tile_edge/floorguide/arrow_s{
-	dir = 8
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/glass/sci,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/purple,
-/area/station/science/lobby)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
+"uBy" = (
+/obj/machinery/atmospherics/unary/cold_sink/freezer/cryo,
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "uCl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/teleporter)
@@ -35193,40 +35355,23 @@
 	tag = "icon-grass1"
 	},
 /area/station/hydroponics/bay)
-"uFJ" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/station/chapel/sanctuary)
 "uFM" = (
-/turf/simulated/floor/bluewhite{
-	dir = 5
+/obj/stool,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 6
 	},
-/area/station/medical/research)
+/area/station/chapel/sanctuary)
 "uFR" = (
 /obj/landmark/start/job/bartender,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "uGI" = (
 /obj/landmark/pest,
+/obj/cable{
+	icon_state = "6-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"uGN" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable,
-/turf/simulated/floor/blue/side{
-	dir = 8
-	},
-/area/station/hallway/primary/south)
 "uHy" = (
 /obj/stool/chair/office{
 	dir = 8
@@ -35339,7 +35484,7 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/md)
+/area/station/medical/research)
 "uJT" = (
 /obj/item/storage/box/beakerbox{
 	pixel_x = -5;
@@ -35374,17 +35519,12 @@
 	},
 /area/station/hallway/secondary/entry)
 "uLm" = (
-/obj/mapping_helper/firedoor_spawn,
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/mapping_helper/access/medical,
-/obj/machinery/door/airlock/pyro/glass/med{
-	dir = 4;
-	id = "cloning_exit"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/turf/simulated/floor/blue,
+/area/station/medical/medbay)
 "uLP" = (
 /obj/cable/blue{
 	icon_state = "6-10"
@@ -35456,11 +35596,12 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "uOv" = (
-/obj/cable{
-	icon_state = "4-6"
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
 	},
-/obj/machinery/light/emergency{
-	dir = 1
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -35487,6 +35628,12 @@
 	dir = 8
 	},
 /area/station/hallway/arrivals)
+"uPh" = (
+/obj/cable{
+	icon_state = "6-9"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "uPz" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -35515,11 +35662,6 @@
 	icon_state = "fgreen3"
 	},
 /area/station/bridge)
-"uQS" = (
-/obj/table/wood/auto,
-/obj/machinery/loudspeaker,
-/turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/sanctuary)
 "uRe" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -35563,7 +35705,6 @@
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2/right{
-	id = "capoffice";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -35639,43 +35780,18 @@
 /turf/space,
 /area/station/engine/proto)
 "uUi" = (
-/obj/table/auto,
-/obj/item/storage/box/evidence{
-	pixel_x = -9;
-	pixel_y = 15
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/item/storage/box/evidence{
-	pixel_x = -6;
-	pixel_y = 15
+/obj/cable{
+	icon_state = "2-8"
 	},
-/obj/item/storage/box/evidence{
-	pixel_x = -3;
-	pixel_y = 15
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "2-4"
 	},
-/obj/item/storage/box/evidence{
-	pixel_y = 15
-	},
-/obj/item/storage/box/evidence{
-	pixel_x = 3;
-	pixel_y = 15
-	},
-/obj/item/body_bag{
-	pixel_x = -11;
-	pixel_y = 5
-	},
-/obj/item/body_bag{
-	pixel_x = -10;
-	pixel_y = 3
-	},
-/obj/item/body_bag{
-	pixel_x = -9;
-	pixel_y = 1
-	},
-/obj/table/auto,
-/obj/item/reagent_containers/glass/bottle/formaldehyde,
-/obj/item/reagent_containers/syringe,
-/turf/simulated/floor/sanitary/white,
-/area/station/medical/morgue)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "uUr" = (
 /obj/rack,
 /obj/item/crowbar,
@@ -35726,11 +35842,10 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
 "uWt" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/redwhite{
+	dir = 8
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/medbay)
+/area/station/medical/medbay/surgery)
 "uWw" = (
 /obj/fitness/speedbag/captain,
 /turf/simulated/floor{
@@ -35827,39 +35942,41 @@
 	},
 /area/station/hallway/primary/central)
 "vak" = (
-/obj/machinery/door/airlock/pyro/external{
+/obj/machinery/sleeper{
 	dir = 4
 	},
-/obj/mapping_helper/airlock/cycler{
-	name = "Upload Space";
-	enter_id = "inner";
-	cycle_id = "uploadsps"
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	dir = null
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/machinery/light/incandescent{
+	dir = 8
+	},
+/turf/simulated/floor/greenwhite{
+	dir = 10
+	},
+/area/station/medical/medbay/lobby)
+"vaq" = (
+/obj/decal/tile_edge/stripe/big,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/specialroom/medbay,
+/area/station/hangar/medical)
 "vav" = (
-/obj/machinery/optable,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/machinery/computer3/generic/med_data,
+/turf/simulated/floor/bluewhite{
+	dir = 6
 	},
-/turf/simulated/floor/redwhite{
+/area/station/medical/head)
+"vaH" = (
+/obj/stool/chair/office/blue{
 	dir = 1
 	},
-/area/station/medical/medbay/surgery)
-"vaH" = (
-/obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/bluewhite{
+	dir = 9
 	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
-	},
-/turf/simulated/floor/redwhite{
-	dir = 4
-	},
-/area/station/medical/medbay/surgery)
+/area/station/medical/head)
 "vaL" = (
 /obj/machinery/door/unpowered/wood/stall,
 /obj/window/reinforced{
@@ -36055,6 +36172,13 @@
 	icon_state = "carpetS"
 	},
 /area/station/security/detectives_office)
+"vhQ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/blue/side,
+/area/station/hallway/primary/central)
 "vig" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -36185,10 +36309,15 @@
 /area/station/bridge/customs)
 "vla" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/turf/simulated/wall/false_wall,
-/area/station/chapel/sanctuary)
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2,
+/turf/simulated/floor/plating,
+/area/station/medical/robotics)
 "vlk" = (
 /obj/machinery/power/stats_meter{
 	name = "Hot Loop Inlet Meter";
@@ -36292,20 +36421,12 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "vor" = (
-/obj/item/robodefibrillator,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical_shield,
-/obj/item/device/analyzer/healthanalyzer,
-/obj/item/clothing/mask/surgical,
-/obj/machinery/recharger/defibrillator{
-	pixel_y = 8
+/obj/machinery/sink/slim{
+	dir = 1;
+	pixel_y = -3
 	},
-/obj/table/auto,
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/bluewhite{
-	dir = 6
-	},
-/area/station/medical/medbay)
+/turf/simulated/floor/redwhite,
+/area/station/medical/medbay/surgery)
 "voz" = (
 /turf/simulated/floor,
 /area/station/storage/emergency)
@@ -36384,6 +36505,10 @@
 	pixel_y = 5;
 	pixel_x = 7
 	},
+/obj/item/device/analyzer/gravity_scanner{
+	pixel_y = -7;
+	pixel_x = 7
+	},
 /turf/simulated/floor/yellow/corner{
 	dir = 8
 	},
@@ -36444,6 +36569,17 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/cafeteria)
+"vsN" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/specialroom/medbay,
+/area/station/maintenance/east)
 "vsS" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -36498,20 +36634,23 @@
 /turf/simulated/floor,
 /area/station/hangar/main)
 "vup" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/surgery)
 "vuE" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/blue/fancy/edge/se,
-/area/station/crew_quarters/md)
+/turf/simulated/floor/greenwhite{
+	dir = 6
+	},
+/area/station/medical/research)
 "vuG" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -36685,30 +36824,26 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "vzC" = (
-/obj/landmark/start/job/medical_doctor,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 6
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
+	},
+/obj/window_blinds/cog2/left{
+	layer = 2.9;
+	pixel_y = 13
 	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/redwhite{
-	dir = 6
-	},
-/area/station/medical/medbay/surgery)
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/pharmacy)
 "vzJ" = (
 /obj/storage/closet/fire,
 /turf/simulated/floor/neutral,
 /area/station/storage/emergency)
 "vzW" = (
-/obj/table/wood/auto,
-/obj/item/ghostboard,
-/obj/item/device/microphone,
-/obj/item/bible,
-/turf/simulated/floor/specialroom/chapel{
-	dir = 9
-	},
+/turf/space,
 /area/station/chapel/sanctuary)
 "vAd" = (
 /obj/table/reinforced/auto,
@@ -36733,16 +36868,14 @@
 	},
 /area/station/hallway/primary/west)
 "vAw" = (
-/obj/cable{
-	icon_state = "1-4"
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/blueblack{
-	dir = 1
-	},
-/area/station/medical/medbay/pharmacy)
+/obj/machinery/manufacturer/robotics,
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "vAX" = (
 /obj/machinery/light/incandescent{
 	dir = 1
@@ -36874,19 +37007,14 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/red,
 /area/station/security/main)
-"vGD" = (
-/obj/landmark/pest,
+"vGQ" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
-"vGQ" = (
-/obj/storage/crate,
-/obj/item/clothing/under/misc/barber,
-/obj/item/clothing/shoes/brown,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/blueblack/corner{
+	dir = 1
+	},
+/area/station/medical/robotics)
 "vGZ" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -37005,9 +37133,11 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/bridge/customs)
 "vMS" = (
-/obj/machinery/genetics_booth,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/obj/spawner/clone_rack,
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/greenwhite,
+/area/station/medical/medbay/cloner)
 "vNm" = (
 /turf/simulated/floor/grass{
 	name = "astroturf";
@@ -37017,6 +37147,10 @@
 "vNJ" = (
 /turf/space,
 /area/supply/spawn_point)
+"vNW" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "vOX" = (
 /obj/mapping_helper/access/research_foyer,
 /obj/cable{
@@ -37049,12 +37183,18 @@
 /turf/simulated/floor/purple,
 /area/station/turret_protected/Zeta)
 "vPD" = (
-/obj/machinery/light/small{
-	dir = 4;
-	tag = "icon-bulb1 (EAST)"
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable{
+	dir = null
+	},
+/obj/window_blinds/cog2/middle{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/medical/medbay/pharmacy)
 "vPJ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37184,13 +37324,22 @@
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/central)
-"vTW" = (
-/obj/machinery/camera/directional/south{
-	pixel_x = 10
+"vTN" = (
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/grass,
-/area/station/medical/dome)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
+"vTW" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-6"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "vUg" = (
 /turf/unsimulated/floor/arrival{
 	dir = 8
@@ -37225,6 +37374,15 @@
 /obj/item/aiModule/hologram_expansion/clown,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)
+"vVg" = (
+/obj/table/wood/auto,
+/obj/item/ghostboard,
+/obj/item/device/microphone,
+/obj/item/bible,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 5
+	},
+/area/station/chapel/sanctuary)
 "vVm" = (
 /obj/shrub,
 /obj/machinery/light/incandescent,
@@ -37299,11 +37457,12 @@
 	},
 /area/station/engine/inner)
 "vXR" = (
+/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/false_wall,
-/area/station/hallway/primary/central)
+/turf/simulated/floor/plating,
+/area/station/maintenance/southeast)
 "vYF" = (
 /obj/machinery/computer3/generic/secure_data,
 /obj/cable{
@@ -37321,15 +37480,10 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen)
 "vZE" = (
-/obj/machinery/vending/port_a_nanomed,
-/obj/cable{
-	icon_state = "0-8"
+/turf/simulated/floor/airless/bluewhite/corner{
+	dir = 4
 	},
-/obj/machinery/power/apc/autoname_east,
-/turf/simulated/floor/bluewhite{
-	dir = 5
-	},
-/area/station/medical/medbay)
+/area/station/medical/medbay/lobby)
 "vZV" = (
 /turf/simulated/floor/blueblack{
 	dir = 8
@@ -37356,12 +37510,9 @@
 	},
 /area/station/security/processing)
 "wbZ" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/medbay/cloner)
+/obj/disposalpipe/segment,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "wca" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37382,12 +37533,8 @@
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "wcH" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/window_blinds/cog2/right{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/md)
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/research)
 "wcI" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37416,18 +37563,50 @@
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "wdq" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/blackwhite{
-	dir = 9
+/obj/machinery/camera/directional/south{
+	pixel_x = 10
 	},
-/area/station/medical/medbay/lobby)
+/obj/table/auto,
+/obj/item/reagent_containers/glass/beaker/large/burn{
+	pixel_x = -9;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/glass/beaker/large/brute{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/glass/beaker/large/epinephrine{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/large/antitox{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/storage/belt/medical{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/hypospray{
+	pixel_x = 7;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/hypospray{
+	pixel_x = 10;
+	pixel_y = 11
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "wdt" = (
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "weD" = (
-/obj/machinery/light/small/broken{
-	dir = 4
+/obj/cable{
+	icon_state = "2-6"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -37438,33 +37617,27 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "wfu" = (
-/obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment/morgue{
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/left{
+	id = "capoffice";
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/sanitary/white,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
-"wfD" = (
-/obj/storage/secure/closet/medical/medkit,
-/turf/simulated/floor/bluewhite{
-	dir = 1
-	},
-/area/station/medical/medbay)
 "wgd" = (
 /turf/simulated/floor/neutral/corner{
 	dir = 1
 	},
 /area/station/crew_quarters/courtroom)
 "wgj" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	id = "quarters_mdir"
 	},
-/obj/disposalpipe/junction/left/west,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/obj/mapping_helper/access/medical_director,
+/turf/simulated/floor/blue,
+/area/station/medical/head)
 "wgw" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -37496,10 +37669,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "whg" = (
-/obj/table/wood/auto,
-/obj/candle_light,
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/stool/chair/pew/center{
+	dir = 4
+	},
 /turf/simulated/floor/specialroom/chapel{
-	dir = 5
+	dir = 4
 	},
 /area/station/chapel/sanctuary)
 "whr" = (
@@ -37507,20 +37688,6 @@
 /obj/lattice,
 /turf/space,
 /area/space)
-"whz" = (
-/obj/machinery/door/airlock/pyro/glass/med{
-	dir = 4
-	},
-/obj/mapping_helper/access/medical,
-/obj/mapping_helper/firedoor_spawn,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/surgery)
 "whD" = (
 /obj/cable{
 	icon_state = "2-5"
@@ -37559,14 +37726,11 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/north)
 "wkk" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/mapping_helper/access/maint,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/obj/submachine/chem_extractor,
+/obj/item/device/reagentscanner,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/science/chemistry)
 "wlp" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -37638,6 +37802,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
+"wqJ" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/plating,
+/area/station/medical/morgue)
 "wrc" = (
 /obj/cable,
 /obj/cable{
@@ -37663,18 +37833,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"wrS" = (
-/obj/machinery/light/emergency{
-	dir = 1
-	},
-/obj/storage/secure/closet/medical/medkit,
-/obj/machinery/light/emergency{
-	dir = 1
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 1
-	},
-/area/station/medical/medbay)
 "wrX" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -37737,12 +37895,11 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/south)
 "wuw" = (
-/obj/machinery/clonegrinder,
-/obj/machinery/light/incandescent,
-/obj/cable,
-/obj/machinery/power/apc/autoname_south,
-/turf/simulated/floor/greenwhite,
-/area/station/medical/medbay/cloner)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "wuW" = (
 /obj/lattice,
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
@@ -37791,16 +37948,12 @@
 	},
 /area/station/crew_quarters/hor)
 "wwh" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8
-	},
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "1-10"
 	},
-/turf/simulated/floor/redwhite{
-	dir = 8
-	},
-/area/station/medical/medbay/surgery)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "wwl" = (
 /obj/item/spraybottle/cleaner,
 /obj/item/spraybottle/cleaner,
@@ -37916,10 +38069,8 @@
 	},
 /area/station/crew_quarters/pool)
 "wAt" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/window_blinds/cog2/middle,
-/turf/simulated/floor/plating,
-/area/station/medical/morgue)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/medical/head)
 "wAC" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37970,11 +38121,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "wCP" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/mapping_helper/access/maint,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/medical/medbay/lobby)
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "2-4";
+	pixel_y = 0
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "wCX" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/processing)
@@ -38022,10 +38178,9 @@
 /turf/simulated/floor/red/redblackchecker,
 /area/station/security/main)
 "wES" = (
+/obj/machinery/info_map,
 /obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -38245,14 +38400,6 @@
 	icon_state = "fblue1"
 	},
 /area/station/bridge)
-"wMi" = (
-/obj/stool/chair,
-/obj/machinery/light_switch{
-	name = "W light switch";
-	pixel_x = -24
-	},
-/turf/simulated/floor,
-/area/station/maintenance/east)
 "wMj" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -38285,15 +38432,13 @@
 /turf/simulated/floor/plating,
 /area/station/security/processing)
 "wNN" = (
-/obj/cable{
-	icon_state = "0-4"
+/obj/machinery/door/airlock/pyro/medical{
+	name = "Robotics";
+	req_access = null
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/mapping_helper/access/robotics,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/medical/robotics)
 "wNO" = (
 /obj/table/wood/auto,
 /obj/item/handcuffs,
@@ -38353,13 +38498,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai)
 "wPV" = (
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/turf/simulated/floor/redwhite{
-	dir = 4
+/obj/cable{
+	icon_state = "4-10"
 	},
-/area/station/medical/medbay/surgery)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "wQw" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -38375,12 +38521,14 @@
 /turf/simulated/floor,
 /area/station/storage/primary)
 "wQJ" = (
-/obj/disposalpipe/segment,
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/clonepod,
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/obj/machinery/firealarm/directional/south,
+/turf/simulated/floor/greenwhite{
+	dir = 6
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/medbay/cloner)
 "wQV" = (
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -38481,24 +38629,12 @@
 	},
 /area/station/hallway/primary/central)
 "wWy" = (
-/obj/cable{
-	icon_state = "0-4"
+/obj/machinery/disposal/mail/autoname/medbay/genetics,
+/obj/disposalpipe/trunk/mail/north{
+	dir = 4
 	},
-/obj/machinery/power/apc/autoname_west,
-/obj/table/wood/auto,
-/obj/item/robodefibrillator,
-/obj/item/device/analyzer/healthanalyzer/upgraded{
-	pixel_y = -5
-	},
-/obj/item/reagent_containers/hypospray{
-	pixel_x = -8
-	},
-/obj/item/clothing/glasses/healthgoggles{
-	pixel_y = 7;
-	pixel_x = 4
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/sw,
-/area/station/crew_quarters/md)
+/turf/simulated/floor/greenwhite,
+/area/station/medical/research)
 "wWU" = (
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -38506,6 +38642,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"wXq" = (
+/obj/decal/tile_edge/stripe/big,
+/obj/machinery/camera/directional/south{
+	pixel_x = 10
+	},
+/turf/simulated/floor/specialroom/medbay,
+/area/station/maintenance/east)
 "wXW" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -38515,6 +38658,12 @@
 	},
 /turf/simulated/floor/industrial,
 /area/station/storage/warehouse)
+"wYb" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/specialroom/medbay,
+/area/station/maintenance/east)
 "wYj" = (
 /obj/item/device/radio/intercom/catering,
 /obj/item/device/radio/beacon,
@@ -38686,17 +38835,24 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "xem" = (
-/obj/machinery/door/airlock/pyro/glass/med,
-/obj/mapping_helper/access/pharmacy,
-/obj/mapping_helper/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/light/incandescent{
+	dir = 4
 	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbay/pharmacy)
+/turf/simulated/floor/redwhite{
+	dir = 6
+	},
+/area/station/medical/medbay/surgery)
 "xen" = (
 /turf/space,
 /area/station/turret_protected/AIbaseoutside)
+"xev" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/bluewhite{
+	dir = 9
+	},
+/area/station/medical/head)
 "xez" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -38749,6 +38905,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"xft" = (
+/obj/machinery/light/small/frostedred,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "xfu" = (
 /obj/cable{
 	icon_state = "2-4";
@@ -38779,14 +38939,11 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "xgK" = (
-/obj/cable{
-	icon_state = "5-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/disposalpipe/segment{
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
@@ -38840,10 +38997,6 @@
 	dir = 1
 	},
 /area/station/security/main)
-"xiY" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/research)
 "xjf" = (
 /obj/machinery/turret,
 /obj/decal/stripe_delivery,
@@ -38880,10 +39033,11 @@
 /area/station/hallway/primary/central)
 "xkk" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "xkn" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -38915,29 +39069,15 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "xkP" = (
-/obj/item/remote/porter/port_a_medbay{
-	pixel_x = 5
+/obj/machinery/light/incandescent{
+	dir = 4
 	},
-/obj/item/remote/porter/port_a_nanomed{
-	pixel_x = 10
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/item/stamp/md{
-	rand_pos = 0;
-	pixel_y = -17;
-	pixel_x = -5
-	},
-/obj/table/wood/auto,
-/obj/item/reagent_containers/food/drinks/tea{
-	pixel_x = -5
-	},
-/obj/blind_switch/area/west{
-	pixel_y = 5
-	},
-/obj/machinery/light_switch/west{
-	pixel_y = -5
-	},
-/turf/simulated/floor/carpet/blue/fancy/edge/west,
-/area/station/crew_quarters/md)
+/turf/simulated/floor/blackwhite/corner,
+/area/station/medical/medbay/lobby)
 "xlB" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -38964,55 +39104,19 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
 "xnk" = (
-/obj/machinery/camera/directional/south{
-	pixel_x = 10
-	},
 /obj/table/auto,
-/obj/item/reagent_containers/glass/beaker/large/burn{
-	pixel_x = -9;
-	pixel_y = 15
-	},
-/obj/item/reagent_containers/glass/beaker/large/brute{
-	pixel_x = -7;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/glass/beaker/large/epinephrine{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/glass/beaker/large/antitox{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/item/storage/belt/medical{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/hypospray{
-	pixel_x = 7;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/hypospray{
-	pixel_x = 10;
-	pixel_y = 11
-	},
+/obj/machinery/defib_mount,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbay)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "xnm" = (
 /obj/machinery/door/airlock/pyro/command/alt,
 /obj/mapping_helper/access/ai_upload,
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
-"xno" = (
-/obj/cable{
-	icon_state = "1-6"
-	},
-/turf/simulated/floor/plating/damaged1,
-/area/station/chapel/sanctuary)
 "xnD" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -39135,11 +39239,13 @@
 /area/station/janitor/supply)
 "xrB" = (
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/obj/landmark/pest,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
+/area/station/maintenance/southeast)
 "xrR" = (
 /obj/decal/tile_edge/floorguide/qm{
 	dir = 8
@@ -39185,16 +39291,6 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
-"xsM" = (
-/obj/cable{
-	icon_state = "4-10"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/landmark/antagonist/blob,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "xsV" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/processing)
@@ -39365,33 +39461,14 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "xyy" = (
-/obj/surgery_tray,
-/obj/item/circular_saw{
-	pixel_x = 3;
-	pixel_y = 12
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/item/suture,
-/obj/item/scalpel,
-/obj/item/hemostat,
-/obj/item/staple_gun{
-	pixel_x = 4;
-	pixel_y = 9
+/obj/cable{
+	icon_state = "2-8"
 	},
-/obj/item/scissors/surgical_scissors{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 9
-	},
-/obj/machinery/light_switch{
-	name = "S light switch";
-	pixel_y = -24
-	},
-/turf/simulated/floor/redblack{
-	dir = 9
-	},
-/area/station/medical/robotics)
+/turf/simulated/floor/white,
+/area/station/science/chemistry)
 "xyI" = (
 /obj/machinery/weapon_stand/phaser_rack,
 /turf/simulated/floor/engine,
@@ -39478,8 +39555,8 @@
 /area/station/maintenance/southwest)
 "xBo" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/east)
+/turf/simulated/floor/plating,
+/area/station/medical/medbay)
 "xBp" = (
 /obj/stool/chair/purple,
 /turf/simulated/floor/carpet{
@@ -39755,17 +39832,16 @@
 	},
 /area/station/hallway/primary/central)
 "xHl" = (
+/obj/mapping_helper/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/command/alt{
+	id = "quarters_mdir"
+	},
+/obj/mapping_helper/access/medical_director,
 /obj/cable{
-	icon_state = "2-4";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/overfloor{
-	dir = 6
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 8
-	},
-/area/station/medical/medbay)
+/turf/simulated/floor/blue,
+/area/station/medical/head)
 "xHv" = (
 /obj/mesh/catwalk{
 	dir = 9
@@ -39880,10 +39956,11 @@
 /area/station/ranch)
 "xKP" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "xLd" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/teleporter)
@@ -39926,14 +40003,13 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
+/obj/machinery/door/airlock/pyro/medical{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/obj/mapping_helper/access/medical,
+/obj/mapping_helper/firedoor_spawn,
+/turf/simulated/floor/plating,
+/area/station/medical/dome)
 "xMO" = (
 /obj/cable{
 	icon_state = "2-9"
@@ -40051,12 +40127,20 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "xQR" = (
-/obj/decal/poster/wallsign/medbay_text,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/md)
+/turf/simulated/floor/blackwhite{
+	dir = 1
+	},
+/area/station/medical/medbay)
 "xRl" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "2-4";
+	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
@@ -40128,11 +40212,12 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "xTK" = (
-/obj/machinery/computer/chem_requester/science,
-/turf/simulated/floor/purplewhite{
-	dir = 1
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 8
 	},
-/area/station/science/lobby)
+/turf/simulated/floor/blueblack/corner,
+/area/station/medical/robotics)
 "xTN" = (
 /obj/machinery/vehicle/pod_smooth/light,
 /turf/simulated/floor/shuttlebay,
@@ -40238,10 +40323,17 @@
 	},
 /area/station/engine/gas)
 "xWX" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/window_blinds/cog2/right,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/md)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "xXf" = (
 /obj/table/auto,
 /obj/item/device/flash,
@@ -40252,6 +40344,10 @@
 "xXH" = (
 /obj/machinery/light/incandescent{
 	dir = 1
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
 	},
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -40388,20 +40484,27 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/arcade)
 "ydm" = (
-/obj/machinery/power/data_terminal,
-/obj/computer3frame{
-	anchored = 1;
-	dir = 4;
-	state = 1
+/mob/living/carbon/human/npc/monkey,
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "0-5"
-	},
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
+/turf/simulated/floor/grass,
+/area/station/medical/dome)
 "yea" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/office)
+"yeP" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
+/area/station/chapel/sanctuary)
 "yfS" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable/yellow{
@@ -40432,16 +40535,14 @@
 /area/station/mining/magnet)
 "ygZ" = (
 /obj/cable{
-	icon_state = "4-9"
+	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "8-9"
+/obj/disposalpipe/switch_junction/left/west{
+	mail_tag = "pharmacy";
+	name = "Mail Junction - Pharmacy"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "yhp" = (
 /obj/machinery/firealarm/directional/north,
 /obj/disposalpipe/segment{
@@ -40532,10 +40633,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"yiA" = (
-/obj/decal/cleanable/oil,
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
 "yiB" = (
 /obj/machinery/chem_dispenser/alcohol,
 /obj/item/clothing/glasses/spectro,
@@ -40629,16 +40726,6 @@
 	dir = 5
 	},
 /area/station/mining/staff_room)
-"ylJ" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -12;
-	tag = ""
-	},
-/turf/simulated/floor/bluewhite{
-	dir = 8
-	},
-/area/station/medical/medbay)
 "ylM" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -80974,9 +81061,9 @@ apk
 sOO
 ccL
 dtM
-xRT
+ipY
 aaa
-wuu
+mrR
 qwM
 iBV
 gAg
@@ -81276,9 +81363,9 @@ btw
 upT
 qzT
 duf
-xRT
+ipY
 aaa
-wuu
+mrR
 wde
 uSK
 joQ
@@ -81578,9 +81665,9 @@ xRT
 xRT
 dHl
 eYr
-xRT
+ipY
 viT
-wuu
+mrR
 eTh
 uSK
 joQ
@@ -86068,12 +86155,12 @@ bgR
 ahc
 aCs
 bxP
-lTR
-hml
-wlC
-yiZ
-anE
-aNf
+vzW
+vzW
+vzW
+vzW
+vzW
+vzW
 iAA
 uMk
 eWp
@@ -86370,12 +86457,12 @@ yhp
 aDX
 rxh
 rXT
-oEa
-kuG
-aJC
-jZn
-qOB
-rgs
+vzW
+vzW
+vzW
+vzW
+vzW
+vzW
 iQs
 rFE
 dlI
@@ -86672,12 +86759,12 @@ dSl
 eGg
 aCs
 uDz
-eYB
-aIS
-dUv
-dRf
-kaK
-scw
+vzW
+vzW
+vzW
+vzW
+vzW
+vzW
 pho
 jOF
 xLd
@@ -86714,10 +86801,10 @@ jkA
 bOO
 aqj
 ftM
-gBh
+wuu
 wES
 rKV
-qPI
+uSK
 uSK
 yjo
 uSK
@@ -86974,12 +87061,12 @@ aXI
 eGg
 aCs
 dgr
-npZ
-hjB
-ost
-oZr
-mhf
-qBf
+vzW
+vzW
+vzW
+vzW
+vzW
+vzW
 bvl
 qKT
 xLd
@@ -87013,14 +87100,14 @@ bit
 btB
 jkA
 jkA
-aqj
-aqj
-wuu
-wuu
-mrv
+aCs
+aCs
+aCs
+aCs
+aCs
 skd
 lMj
-mrv
+rRn
 bac
 vvY
 guF
@@ -87276,12 +87363,12 @@ amq
 oRw
 aCs
 bxP
-lTR
-aIU
-aJF
-bQv
-aDi
-aNn
+vzW
+vzW
+vzW
+vzW
+vzW
+vzW
 tkp
 qXp
 xLd
@@ -87315,13 +87402,13 @@ pdX
 vAX
 jkA
 jkA
-aqj
+aCs
 eEW
-fuR
-wkk
-qkQ
-uGN
-dtv
+hml
+wlC
+yiZ
+anE
+aNf
 ncn
 bac
 kLL
@@ -87578,12 +87665,12 @@ aiu
 uUr
 aCs
 mMp
-apr
-haW
-mPX
-ser
-nmX
-aNp
+vzW
+vzW
+vzW
+vzW
+vzW
+vzW
 kYy
 veJ
 xLd
@@ -87617,15 +87704,15 @@ pdX
 btB
 jkA
 jkA
-aqj
-bpR
-tPm
+rRn
+kit
+whg
 uoe
 hQH
-jlr
-uSK
-kNc
-ejW
+qOB
+rgs
+pGw
+bac
 voz
 vfs
 voz
@@ -87901,10 +87988,10 @@ jkA
 jkA
 wWU
 sXO
+aUx
+aUx
+lvi
 gdh
-jkA
-oWd
-jkA
 jkA
 jkA
 jkA
@@ -87919,15 +88006,15 @@ pdX
 btB
 jkA
 jkA
-aqj
-bpS
-tPm
-wuu
-hUy
-jlr
-uSK
-kNc
-jkp
+rRn
+eYB
+aIS
+dUv
+dRf
+kaK
+scw
+pho
+bac
 jxw
 tBZ
 jxw
@@ -88200,16 +88287,16 @@ wAC
 xJm
 iuO
 bRE
-oOi
+bRE
 qyN
-jkA
-coi
-jkA
-oWd
-jkA
-bfc
-bfY
-bhl
+bRE
+mBf
+bRE
+fHv
+kJO
+bRE
+bRE
+oOi
 jkA
 bji
 pdX
@@ -88221,13 +88308,13 @@ pdX
 sVx
 bKs
 bOO
-aqj
-tPm
-fvo
-wuu
-hQH
-jlr
-kJO
+rRn
+npZ
+hjB
+ost
+oZr
+mhf
+qBf
 mEh
 bac
 lPz
@@ -88500,18 +88587,18 @@ xLd
 xGD
 xjH
 tWo
-aqj
-aqj
-aqj
-aqj
-aqj
-ooq
-aqj
-aqj
-aqj
-aqj
-bfZ
-bhn
+kvV
+beh
+vPD
+bst
+kvV
+bpU
+rXQ
+bpU
+qTQ
+rXQ
+bpU
+rhf
 jkA
 bji
 pdX
@@ -88523,12 +88610,12 @@ pdX
 btB
 jkA
 huJ
-aqj
-lHv
-fDs
-wuu
-hQH
-jlr
+aCs
+lTR
+aIU
+aJF
+bQv
+aDi
 rVU
 bac
 bac
@@ -88783,37 +88870,37 @@ xut
 aBS
 aCs
 uTw
-piA
-uQS
-whg
+vzW
+vzW
+vzW
 dlI
 seG
 iQs
 iHb
 aMu
-aCs
-sMw
-aCs
-aCs
-qTQ
-aTd
-aqj
+lBg
+bVj
+bVj
+bVj
+qEV
+mrv
+tVJ
 wRJ
 sRg
 xvz
 mOy
-aqj
-tPm
-pqU
+snm
+cxt
+oNy
 bqx
-bpT
-crB
+dRJ
+bqO
 sZf
 qTz
 aYL
 bfd
-aqj
-bhp
+bpU
+lHv
 jkA
 bji
 pdX
@@ -88825,13 +88912,13 @@ pdX
 lfI
 ryr
 ryr
-aqj
-eIn
+aCs
+dlI
 fGD
-wuu
-kKG
-jnJ
-kNc
+agH
+hUy
+nmX
+aNp
 bac
 jyx
 baV
@@ -89086,36 +89173,36 @@ aBS
 aCs
 tqM
 vzW
-poQ
-rbd
+vzW
+vzW
 tqM
 ife
 vJM
 nVr
 wuZ
-aCs
-uFJ
-lyf
-aCs
-doY
-dpC
-aqj
+lBg
+wJL
+jRL
+mdZ
+oNi
+jRL
+pJd
 aNk
-fCz
+ihv
 cwn
-jGz
+vhQ
 niq
-tJs
-aZE
+cDb
+inG
+bge
 bap
-bap
-ejk
-bap
-lEE
+wwh
+vNW
+vNW
 bed
 bcB
-aqj
-jkA
+rXQ
+rhf
 jkA
 bjo
 bng
@@ -89127,13 +89214,13 @@ bng
 btE
 jkA
 jkA
-aqj
-tPm
-fvo
-wuu
-hQH
-joQ
-kNc
+rRn
+tqM
+oEa
+pep
+aNn
+yeP
+fjk
 iLH
 voz
 jxw
@@ -89396,27 +89483,27 @@ oGq
 vjY
 iQs
 lBg
-bVf
-bVf
-vla
-xno
-yiA
-aqj
-aqj
+cHc
+eYG
+eYG
+ebm
+rrM
+bVj
+iIU
 fas
-xvz
+bsY
 eZk
-aqj
-pFz
-pFz
+kvV
+chb
+nJE
 mDc
-mDc
-pFz
-pFz
-pFz
+kvV
+bCp
+bCp
+bpU
 bee
 bcB
-aqj
+rXQ
 gZY
 jkA
 jkA
@@ -89429,13 +89516,13 @@ jkA
 jkA
 jkA
 jkA
-aqj
-tPm
-bpR
-wuu
-hQH
-joQ
-kNc
+rRn
+iQs
+vVg
+uFM
+aJC
+pqF
+rFE
 bac
 xnN
 mXK
@@ -89697,47 +89784,47 @@ aCs
 eIb
 iIL
 iIL
-aCs
-aCs
-aCs
-aCs
-aRU
-aTg
-ydm
-aqj
-pNz
-xvz
-mOy
-aqj
-pFz
-wMi
-jIs
-tUr
-cHm
-pFz
+lBg
+uyW
+eYG
+dYm
+eVp
+adY
+eYG
+isW
+jFt
+vTW
+gpH
+jZH
+rnf
+eQU
+oda
+kvV
+sMw
+bqO
 bCp
-beh
+bcB
 bfe
-aqj
-jkA
-jkA
+rXQ
+eIn
+bRE
 qyN
-ehj
-jkA
+bRE
+lWi
+bRE
 mBf
-jkA
-jkA
-qyN
+bRE
+bRE
 btH
-ehj
-chb
-aqj
-tPm
-eIL
-wuu
-hQH
-joQ
-kNc
+kTS
+ssG
+aCs
+aTd
+luh
+qmn
+evZ
+lkP
+luh
 bac
 bac
 bac
@@ -89999,50 +90086,50 @@ tRx
 tRx
 tRx
 tRx
-tRx
-abm
-aCs
-xrB
-hUc
-dhZ
-nHZ
-aqj
+oxW
+eYG
+eYG
+ebm
+eYg
+xyy
+uhx
+oxW
 uOv
 pKh
-mOy
-aqj
+iTd
+bTJ
 aiw
-nAq
-nAq
-nAq
+kbr
+dTs
+vzC
 nFU
-pFz
-pFz
-llL
-bff
-aqj
-aqj
-aqj
-aqj
-aqj
+neX
+gEA
+qxh
+ygZ
+bpU
 rXQ
-aqj
-aqj
-aqj
-aqj
-aqj
-aqj
-aqj
-aqj
-eII
-uGI
-wuu
+rXQ
+bpU
+oYe
+rXQ
+evq
+bpU
+rXQ
+rXQ
+bpU
+bnT
+pOD
+bnT
+bnT
+bnT
+bnT
 kKG
 sHW
-agH
-wuu
+mGW
+mGW
 oKk
-swA
+poQ
 swA
 bDi
 efM
@@ -90301,48 +90388,48 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bqE
-aCs
-pht
-kDQ
-rec
-pCI
-vXR
+bVj
+gSG
+eYG
+ebo
+xsx
+fWB
+eYG
+tVJ
 mMZ
-bkL
+xvz
 mOy
-aqj
+rEL
 tNT
 aZH
+qae
 nAq
-nAq
-nAq
-hUu
-tPm
-pwn
+cyE
+bqO
+bsk
+bcB
 bfg
-bap
-oJW
+tAQ
+bqO
 biy
 bjq
-bap
+bqO
 boK
 bpM
-bqx
-bpT
+sZf
+lpx
 jeA
-tPm
+vak
 bPT
-tPm
-tPm
+tpn
+tCi
 eIL
-tPm
-wuu
-hQH
-joQ
-kNc
-wuu
+sIv
+csa
+urS
+xrB
+urS
+urS
 ijm
 lyG
 mVc
@@ -90350,7 +90437,7 @@ mSI
 tKY
 fBe
 jLv
-qAv
+tKY
 akj
 elY
 swh
@@ -90603,48 +90690,48 @@ aaa
 aaa
 aaa
 aaa
-aaa
-jtO
-aCs
-ufl
-lkP
-gbE
-iTd
-aqj
+bVj
+fHA
+eYG
+ebZ
+mfQ
+fWY
+alB
+bVj
 xXH
 kLR
 mOy
-aqj
+kvV
 fFw
 kKc
-nAq
-nAq
+bfy
+kvV
 ipb
-pFz
-tPm
-tPm
-crB
+jeA
+ixW
+gOF
+aYL
 bgc
-bfh
+wwh
 biz
 bjr
 bnh
 boM
 idi
-tPm
-vPD
-bIc
+bqO
+bqO
+bqO
 btI
 bSt
 clo
-btI
-tPm
+lhp
+lhp
 fGE
-wuu
+bnT
 mKh
-joQ
+axw
 kNc
-wuu
+vXR
 lxi
 dTT
 mGW
@@ -90652,7 +90739,7 @@ mGW
 mGW
 mGW
 mGW
-mGW
+upW
 urS
 jQA
 swA
@@ -90905,61 +90992,61 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aCs
-aCs
-aCs
-pxQ
-aCs
-aqj
-pNz
+bVj
+cUl
+eYG
+ebm
+eYG
+eYG
+hsU
+bVj
+fCz
 xvz
 mOy
-aqj
-aqj
-pFz
-laV
-iII
+kvV
+kvV
+kvV
+kvV
+kvV
 bbU
-pFz
-tPm
-pFz
-pFz
-pFz
+bqO
+bCp
+xkP
+dyu
+hUc
 nRw
-pFz
-pFz
-pFz
+pQe
+iiL
+vZE
 boN
-ygZ
-pFz
-pFz
-pFz
-pFz
-kUy
-kUy
-kUy
-kUy
-kUy
-kUy
-kKG
+kHS
+jeA
+jeA
+jeA
+btN
+qbR
+maN
+brp
+jlz
+hKS
+bnT
+cGx
 xMD
-iRQ
-wuu
-lNh
+mjb
+mGW
+urS
 xgK
 mGW
-vUh
-hfg
-sLa
-cte
+knN
+knN
+knN
+knN
+knN
+knN
+knN
 mGW
 mGW
-mGW
-mGW
-mGW
-mGW
+apr
 mGW
 mGW
 hwq
@@ -91207,62 +91294,62 @@ ahE
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aCs
-kDQ
-kDQ
-ogj
-aqj
-pNz
+bVj
+tpW
+wkk
+eca
+fai
+uJT
+jaq
+bVj
+fCz
 xvz
 bIs
 rLD
 aqj
+bej
+pwp
 pFz
-dMs
-dMs
-pFz
-pFz
-pim
-pFz
-tPm
-tPm
-tPm
-tPm
+pqU
+sLo
+ben
+ben
+aIx
+rcq
+dpC
+ben
 ofS
-pFz
-llL
-gwA
+bqO
+bqO
+muy
 xBo
-anA
-aaa
-bqF
-oXa
+pec
+amQ
+xBo
+bPT
 jMf
 fkd
-xkP
+brp
 wWy
 kUy
-hQH
+sXs
 jrg
-kTS
+unB
 tkt
-pep
+urS
 oLD
-mdR
-kmM
-ipa
-neD
-fEn
-aaa
-aaa
-aaa
+mGW
+knN
+knN
+knN
+knN
+knN
+knN
+knN
 ctu
-aaa
-aaa
-aaa
+jZn
+gES
+qSV
 mGW
 mGW
 mGW
@@ -91509,62 +91596,62 @@ aBT
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aCs
-kDQ
-kDQ
-kDQ
-aqj
+bVj
+gRA
+gRA
+gRA
+bVj
+gRA
+gRA
+bVj
 oPT
-xvz
-jkA
-mOy
-uoe
-tPm
-tPm
-tPm
-tPm
-tPm
-tPm
+dYk
+lFz
+jGz
+otX
+fuR
+bpT
 pFz
-tPm
-tPm
-tPm
-tPm
-tPm
-pFz
+ben
+ben
+bfi
+lgi
+jNn
+cLh
+gbE
+ben
+czC
+xBo
 nwg
 oJx
-pFz
-tRx
-jqV
-tRx
+czC
+coi
+dRA
+oJW
 uJo
 kka
-nCH
-ixW
+brp
+brp
 izE
-xQR
+bnT
 hXL
-joQ
+kzU
 kWd
-wuu
+tkt
 qqR
-urS
+txv
 mGW
-cuc
-xrz
-bKv
-cte
-aaa
-aaa
-aaa
+knN
+knN
+knN
+knN
+knN
+knN
+knN
 ctu
-aaa
-aaa
-aaa
+qSV
+mLR
+qSV
 aaa
 aaa
 mGW
@@ -91814,47 +91901,47 @@ aaa
 aaa
 aaa
 aaa
-aCs
-kDQ
-kDQ
-kDQ
+aaa
+aaa
+aaa
+aaa
 aqj
-pNz
+fCz
 hqX
 jkA
 sUL
 aqj
 tPm
 weD
-tPm
-tPm
-tPm
-uGI
-pFz
-tPm
-tPm
-tPm
-tPm
-tPm
-pFz
-llL
+oqp
+fkW
+kmJ
+pht
+bgh
+vGQ
+unp
+vGQ
+ejW
+xQR
+dRA
+bsl
 gwA
-xBo
-aaa
-bqF
-aaa
-xWX
+dRA
+jAS
+cem
+iRM
+bSt
 ibY
 twm
 cUZ
 vuE
-kUy
+bnT
 pCX
-joQ
-tCi
-wuu
+div
+ltp
+tkt
 mGW
-mGW
+fjF
 mGW
 cte
 cte
@@ -92116,61 +92203,61 @@ aaa
 aaa
 aaa
 aaa
-aCs
-kDQ
-kDQ
-kDQ
+aaa
+aaa
+aaa
+aaa
 aqj
 dQO
-xvz
-jkA
+nCH
+aRU
 tml
-aqj
-pFz
-pFz
-pFz
-vak
-pFz
-pFz
-pFz
-pFz
-pFz
-nRw
-pFz
-pFz
-pFz
-llL
+bhl
+rjg
+qPI
+fvo
+ben
+vAw
+ewP
+xgl
+kra
+tIo
+jsN
+spS
+aug
+qig
+qtU
 nbl
-pFz
-pFz
-pFz
-pFz
-kUy
-kUy
+dRA
+oJW
+eLZ
+eLZ
+wcH
+oXa
 wcH
 kIO
 ogZ
-kUy
+bnT
 pOX
 div
-fHA
-wuu
-okt
-pAK
-pAK
-rsO
-sqX
-uCl
-uCl
-uCl
-uCl
-uCl
-uCl
-uCl
-uCl
-uCl
-iNv
-iNv
+bkL
+tkt
+tPm
+bpR
+pFz
+vUh
+hfg
+sLa
+cte
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 mGW
 urS
 urS
@@ -92418,59 +92505,59 @@ aaa
 aaa
 aaa
 aaa
-aCs
-kDQ
-kDQ
-kDQ
+aaa
+aaa
+aaa
+aaa
 aqj
 kdG
 rde
 bRE
 gSs
 aqj
-abm
-bgd
-pFz
-pim
-pFz
-maN
-bap
-bap
-bge
-bhr
-bap
-bap
-bap
-boS
+dxC
+llL
+bpR
+ben
+hDF
+bgh
+bgh
+bts
+bjw
+crn
+ben
+bIc
+vTN
+jnJ
 lix
-sLo
-tPm
-tPm
-tPm
-tPm
-bpU
+dRA
+oJW
+eLZ
+ejk
+lwi
+gDO
 lNt
-jAq
+eLZ
 cGX
 enG
 gOR
 jvc
 unB
-bpU
-xTK
-ejE
-ejE
-ejE
-ejE
-wrn
-eRv
-rqf
-mXN
-nWp
-lPm
-lny
-wRm
-vtL
+tkt
+tPm
+bpR
+mdR
+kmM
+ipa
+neD
+fEn
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 mGW
@@ -92720,59 +92807,59 @@ aaa
 aaa
 aaa
 aaa
-aCs
-aCs
-aCs
-aCs
+aaa
+aaa
+aaa
+aaa
 wvY
 xZt
 nIO
 xZt
 wvY
-aqj
-aaa
-aaa
-esW
-tPm
+pFz
 pFz
 llL
-bej
-bfh
-aYL
-aYL
-fhO
+bpR
+uaC
+mXz
+ewP
+ewP
+bhQ
+bjv
+hwj
+ben
 bjs
 bfh
-aYL
+fgS
 ezO
-clo
+hVl
 bsb
 gVd
-tPm
-tPm
+olZ
+onw
 wCP
-bqO
-bse
-xkk
-bqO
-bqO
-jvc
-lfe
-mwA
-pGw
-ffs
-acH
-gWq
-ieK
-jGs
-cMx
-nWD
-wsx
-xtT
-wSt
-eIr
-ejA
-vtL
+bWx
+fdN
+bgD
+bhn
+ydm
+div
+bgD
+cGx
+tPm
+bpR
+pFz
+cuc
+xrz
+bKv
+cte
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93031,51 +93118,51 @@ iJg
 qhg
 iKt
 wvY
-giH
-aaa
-aaa
-pFz
-pFz
-pFz
-lPK
-fhB
+kNz
+dMs
+llL
+bpR
+vla
+bhE
+bgh
+bgh
+vGQ
+bjw
+bPX
 ben
-ben
-ben
-ben
-ben
-ben
-ben
-bpU
-bpU
-bpU
-bpU
-bpU
-bpU
-bpU
+uBy
+ndK
+qAX
+mBC
+hVl
+ejt
+fdN
+bzx
+bqd
+xRl
 vMS
-bse
-xkk
-dRJ
-ibI
-jvc
+eLZ
+bgD
+ccT
+pOX
+div
 btg
-fhw
-pGw
-dOX
-nIg
-bbC
-lVt
-wrn
-eRv
-bik
-eRv
-nWp
-hkm
-qlD
-hti
-uCl
-uCl
+cGx
+tPm
+bpR
+pFz
+cte
+cte
+cte
+cte
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93333,51 +93420,51 @@ hkD
 juN
 dnw
 wvY
-abm
-giH
-aaa
-aaa
-pFz
-vGQ
-obu
-bcB
-bfi
-csa
-rjg
-ldp
-lgi
+kNz
+dMs
+llL
+dtv
+vla
+uWJ
+xgl
+ewP
+dVo
+bjv
+ewP
+ben
+cMc
 ndK
-kit
+qkG
 wdq
-bqJ
-jYx
-bqJ
+dRA
+bsl
+eLZ
 btJ
-bqO
+sAK
 aDh
-bqO
+bGK
 bse
 xkk
-gOR
+uUi
 icY
 jzN
-lfq
+bgD
 cGx
-okA
-pBt
-qlN
-ruA
-sFc
-uCl
-wtt
-wtt
-wtt
-uCl
-hMw
-qlD
-hti
-eEk
-vtL
+tPm
+bpR
+dMs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93637,49 +93724,49 @@ wvY
 wvY
 wvY
 wvY
-aaa
-aaa
-pFz
-pwp
-pec
-ezO
-fkW
+wPV
+aZE
+esW
+wFo
 bgh
 bgh
-bgk
+vGQ
+cst
+dhZ
+ben
 bju
 bnH
-spS
+nAp
 bpW
-bqM
-bsd
-bqM
+dRA
+dRA
+eLZ
 btK
 bqM
 rEi
 wQJ
-rJf
-rcv
+fdN
+tOI
 oXp
 gTj
 tKT
 tno
-uBy
-omO
-nVz
-qnk
-rvb
-sHo
-uCl
-uHy
-wtG
-wtG
-hti
-xtZ
-qlD
-hti
-rQj
-vtL
+tkt
+rNz
+bpR
+dMs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93939,49 +94026,49 @@ ibJ
 mrS
 gwT
 wvY
-bkQ
-bkQ
-pFz
+kEP
+tPm
+ben
 cnf
-llL
-ben
-ben
-cst
+mxX
+blf
+dqJ
 ewP
-lcD
-bjv
+xTK
+ben
+ufl
 bnI
-hKS
+lDT
 bpX
-bqO
-bse
-bsY
-btL
-bTJ
+dRA
+dRA
+fdN
+eLZ
+fdN
 qRe
 bqJ
-bqJ
-lWi
+fdN
+bZv
 csk
-icn
-cGn
-evq
+roe
+roe
+bgD
 ncb
-onw
-uLY
-deE
-qbg
-sJf
-uCl
-uJa
-vHh
-xUF
-kja
-qgt
-pGr
-gzZ
-eEk
-vtL
+tPm
+bpR
+dMs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94242,48 +94329,48 @@ eYc
 cBc
 wvY
 dMz
-abm
-pFz
-nbl
-llL
+tPm
 ben
-cvK
-bgh
-qbR
-unp
-bjw
-crn
 ben
-hVl
-eFV
-bse
+bST
+ben
+ben
+ben
+ben
+ben
+czC
+czC
+eII
+dRA
+cxV
+dRA
 bta
-btN
-bpU
+xBo
+nFR
 uWt
 nEH
-sxy
-lvi
-czC
-cyE
+jYD
+tkt
+juW
+tkt
 lqj
-nEH
-lze
-dhy
-glJ
-glJ
-vOX
-bCZ
-uCl
-dXA
-vHB
-vHB
-vHB
-vHB
-vHB
-vHB
-vHB
-uCl
+cGx
+cGx
+tPm
+bpR
+dMs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94543,48 +94630,48 @@ mrS
 mrS
 dta
 wvY
-tRx
-tRx
-tAQ
-bcB
-upt
-ejt
-dVr
-bgj
-knh
-bhy
-tzl
-hwj
+qsO
+xft
 ben
-eLZ
-eLZ
+kSG
+lqi
+ben
+dVr
+rxS
+knh
+aOf
+tzl
+cPT
+qRC
+gsP
+smB
 uLm
-wbZ
-eLZ
-fdN
+uBu
+eFV
+gjS
 iNE
 tJE
 hHk
 tKS
 jhx
-nKM
-hHk
-ylJ
-xHl
-fgS
-glJ
-qrS
-ryY
-sMn
-niO
-nsj
-vHB
-wwd
-xxQ
-rZk
-hqr
-pIZ
-lUY
+qiI
+jYD
+tPm
+tPm
+frx
+gya
+pFz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94845,48 +94932,48 @@ mrS
 dja
 pxn
 wvY
-aaa
-aaa
-fbm
-oYY
-obu
-rsV
-bhE
-bgk
-bgh
-bgh
-bgh
-bPX
+qsO
+tPm
 ben
-kmJ
+oYY
+fVK
+ben
+xKP
+lue
+lue
+wqJ
+hVl
+hVl
+luv
+hVl
 bqU
-bsk
-tIo
-evZ
+boS
+dRA
 eLZ
+jMH
 lEt
-dRA
-dRA
+esb
+dln
 lWH
 vup
-pQe
-pQe
-pQe
-iIq
-pVT
-glJ
-hbw
-rzQ
-sMo
-jHs
-uNS
-oah
-wwB
-xyZ
-vRj
-vQR
-hdX
-vHB
+oEU
+lXE
+tPm
+mYn
+tPm
+tPm
+pFz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95147,48 +95234,48 @@ mrS
 mrS
 ram
 oXQ
-aaa
-aaa
+qsO
+tPm
 wNN
-bcB
 obu
+dei
 rsV
-uWJ
+sxy
 bgn
-xgl
-ewP
-ewP
-xyy
-ben
-snm
+pim
+ogj
+uBu
+scg
+bhy
+wbZ
 bqV
-bsl
+aLz
 btd
-wuw
-fdN
-wrS
-dRA
-dRA
-tPI
-kzU
-dRA
-dRA
-dRA
-aug
-dqJ
-glJ
-quR
-rzT
-sMU
-txK
-tGx
-vHB
-oRY
-xzm
-wOE
-rKw
-fRo
-lUY
+eLZ
+eEV
+kej
+jkp
+nsq
+ohT
+ohT
+vor
+jYD
+tPm
+bpR
+pFz
+pFz
+pFz
+pFz
+pFz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95449,48 +95536,48 @@ mrS
 cEt
 wvY
 qeZ
-aaa
-aaa
-mBC
-bcB
-sZh
-jAS
-wFo
-bgk
-bgh
-bgh
-bgh
-tcm
+qsO
+tPm
 ben
+doY
+sZh
+ben
+bVF
+bgk
+bVf
+rJf
+jZL
+tcm
+nKM
 pjO
-bqd
-qmn
-xRl
-dYk
+avm
+pta
+btd
 eLZ
-wfD
-dRA
-cxV
-vGD
-gDO
-esb
-oqp
-odZ
-oGN
-olZ
-glJ
-onV
-rzT
-sMU
-qLi
-qLi
-xiN
-lRs
-xBp
-kdf
-xtN
-tkc
-vHB
+wnO
+eiZ
+bCa
+lfq
+ohT
+ohT
+wwZ
+jYD
+tPm
+bpR
+sRo
+tPm
+tPm
+tFR
+pFz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95751,48 +95838,48 @@ wvY
 wvY
 wvY
 qeZ
-giH
-aaa
-pFz
-xsM
-llL
+bdR
+omO
+ben
+ben
+ben
 ben
 lVl
-bgn
-ewP
-ewP
-ewP
+bgo
+bVf
+aOf
+aOf
 gzX
-ben
+wAt
 ses
 cYc
 wgj
 bte
-hwc
-fdN
-cal
-cxV
-cxV
+wAt
+uyc
+kDQ
+bql
+xWX
 gUM
 xnk
-kvV
-lpx
-lpx
-lpx
-kvV
-glJ
-yhJ
-mdN
-eCd
-qLi
-qLi
-iRX
-wzw
-xCN
-tgv
-epg
-qla
-lUY
+fhO
+jYD
+tPm
+bpR
+pFz
+tPm
+tPm
+tPm
+dMs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96053,51 +96140,51 @@ nLx
 nLx
 nLx
 enu
-anA
-aaa
-pFz
-nbl
 pwn
+mSV
+rjg
+qPI
+aOf
 bet
-ben
+jAq
 bgo
 tzI
 eAu
 lZV
-jYD
-jYD
+pCI
+dgF
 rRY
-rRY
-whz
+ldp
+nGI
 gCJ
-rRY
+lZt
+rFk
+kej
+ooq
+nsq
+tKs
+bCa
+oEU
 jYD
-jlz
-dRA
-cxV
-xKP
-kNz
-kvV
-npb
-oNy
-gjS
-kvV
-pDP
-qAl
-rzT
-sNI
-tzO
-uSS
-uSS
-uSS
-uSS
-uSS
-uSS
-uSS
-uSS
-uSS
-uSS
-uSS
+rNz
+bpR
+dMs
+tPm
+tPm
+tPm
+dMs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96354,52 +96441,52 @@ pvK
 aaa
 aaa
 aaa
-jtO
-anw
-aaa
 pFz
-kEP
+mwA
+lXv
+fvo
+pwn
 fQa
-beu
-ben
+okA
+okA
 izA
-ben
-ben
-ben
-jYD
-sXs
-cem
-iRM
-oYe
+qks
+qks
+qks
+crB
 ncP
-qiI
-rRY
-cLh
-dRA
-igQ
-xKP
+ncP
+ncP
+xev
+pnR
+xHl
+htW
+ifi
+ohT
+kej
 bBS
-jZH
-rnf
-inG
-oda
-kvV
-pDV
-qAA
-rAf
-sNM
-tAJ
-uSS
-vLa
-fKw
-bVs
-eDO
-gdT
-ncL
-gkG
-gkG
-vcW
-uSS
+fUK
+gHC
+jYD
+tPm
+bpR
+dMs
+tPm
+tPm
+tPm
+dMs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 giH
 aaa
 aaa
@@ -96656,52 +96743,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bqE
 pFz
 pFz
 pFz
-bcB
+bpR
+tPm
+aOf
 qVa
-eEV
+qks
 gIK
 ftN
-rxS
-ftN
-aOf
+qks
+wuw
+pCI
 vav
 jBU
 gSY
+czA
 nGI
-qev
-oEU
-hmP
 lZt
+kVx
+dbJ
+hUu
+gbC
 aau
-dRA
-xKP
-dFv
+aau
 xem
-vAw
-kbr
-dTs
-kvV
-pDP
-qBG
-rAl
-sON
-tBb
-uSS
-ocl
-sTK
-ewn
-wIj
-kAt
-lCo
-qOE
-wCY
-bUg
-uSS
+jYD
+tPm
+bpR
+dMs
+tPm
+tPm
+tPm
+pFz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 anA
 aaa
 aaa
@@ -96958,52 +97045,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-abm
 nXj
 jPv
 jPM
-rRn
-aYL
+uGI
+tPm
+aOf
+aOf
 lQq
 wfu
+aOf
 jCN
-jCN
-rEL
-lQq
+aOf
+wAt
 opw
 vaH
-vzC
-smB
+ncP
+bbt
 iBJ
-oEU
-jsN
+wAt
+jYD
 dAF
-pQe
+kXJ
 rVp
 kXJ
 hul
-lpx
-fHv
-inG
-bST
-kvV
-rIJ
-qHx
-rzT
-pzU
-tBJ
-tJA
-vPb
-kiM
-bXS
-sOc
-jSM
-vFI
-hKy
-qxf
-vVy
-uSS
+jYD
+jYD
+tPm
+ovL
+dMs
+dMs
+pFz
+pFz
+pFz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 anA
 aaa
 aaa
@@ -97259,54 +97346,54 @@ aaa
 aaa
 aaa
 aaa
-aaa
 wwu
-abm
 pFz
 pFz
 pFz
-pFz
-pFz
-aOf
-jiI
-qks
-qks
-qks
-aOf
-wnO
-jBU
-kej
+tPm
+uPh
+tPm
+tPm
+tPm
+tPm
+iKs
+haL
+toF
+wAt
+ibI
+nGI
+bgj
 qev
-ohT
-wwZ
-rRY
-vZE
-dxC
-jNn
-nFR
-vor
-kvV
-dgF
-cfe
-bfy
-kvV
-vwT
-qHx
-rzT
-sPC
-tDf
-uSS
-rop
-rop
-xGl
-wIj
-vIL
-bAw
-vDG
-reQ
-rlH
-uSS
-anA
+tUr
+wAt
+tPm
+tPm
+tPm
+tPm
+tPm
+tPm
+anB
+frx
+lfe
+tPm
+pFz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97561,54 +97648,54 @@ aaa
 aaa
 aaa
 aaa
-aaa
 jtO
 abm
-abm
-abm
-abm
-tRx
-aaB
-aOf
-nOy
-qks
-haL
-qks
+bgd
+pFz
+tPm
+qAv
+sLG
+fuR
+fuR
+fuR
+gXZ
+pDw
+wXq
 wAt
-uyc
-jBU
-kej
-qev
-ohT
-jsO
-bVj
-bVj
-bVj
-qEV
-uhx
-tVJ
-bVj
-sKj
-glJ
-glJ
-glJ
-pIJ
-qHV
-rzT
-sPT
-tGx
-uSS
-lCm
-wIv
-xJQ
-wIj
-fdY
-lCo
-vqr
-fCi
-cde
-uSS
-anA
+wAt
+wAt
+wAt
+wAt
+wAt
+wAt
+tPm
+frx
+fuR
+fuR
+fuR
+lfe
+sSB
+tPm
+tPm
+tPm
+pFz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97866,51 +97953,51 @@ aaa
 aaa
 aaa
 jtO
-xkx
+pFz
+pFz
+pFz
+pFz
+cHm
+pFz
+pFz
+vsN
+koC
+htI
+fuR
+fuR
+fuR
+fuR
+fuR
+fuR
+fuR
+lfe
+tPm
+pFz
+pFz
+cHm
+pFz
+pFz
+qkQ
+pFz
+dMs
+pFz
 aaa
 aaa
 aaa
-bqE
-qNH
-kwU
-iKs
-sIv
-toF
-bVF
-juW
-nHJ
-adW
-hDF
-wwh
-mct
-bVj
-wJL
-mdZ
-oNi
-jRL
-pJd
-isW
-gkA
-lqB
-nje
-dKL
-pMv
-qIi
-rzT
-sMU
-cRm
-uSS
-hAH
-wIv
-mPq
-wIj
-lRa
-xMb
-emd
-iat
-xMQ
-uSS
-anA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98170,49 +98257,49 @@ aaa
 aaa
 aaa
 aaa
+qSV
+gES
+gES
+cvn
+pFz
+iKs
+wYb
+toF
+tPm
+tPm
+tPm
+tPm
+tPm
+tPm
+tPm
+qAv
+tPm
+pFz
+tPm
+tPm
+fnf
+pFz
+tPm
+pFz
 aaa
 aaa
-bqE
-aOf
-uUi
-qks
-amQ
-bGK
-wAt
-rFk
-jBU
-kej
-otX
-ohT
-tpW
-bVj
-cHc
-dYm
-eVp
-eYG
-hop
-oxW
-jHs
-jHs
-njK
-oGg
-oGg
-oGg
-rBQ
-sVA
-tLI
-uSS
-uSS
-uSS
-uSS
-uSS
-uSS
-uSS
-uSS
-uSS
-uSS
-uSS
-anA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98472,49 +98559,49 @@ aaa
 aaa
 aaa
 aaa
+qSV
+gES
+gES
+gES
+hop
+fYL
+fhB
+fYL
+hop
+hop
+hop
+pFz
+pFz
+cHm
+pFz
+pFz
+pFz
+pFz
+tPm
+tPm
+tPm
+pFz
+npb
+pFz
 aaa
 aaa
-jtO
-aOf
-aOf
-tKs
-aOf
-aOf
-aOf
-kVx
-wPV
-gbC
-eln
-uaC
-gHC
-bVj
-uyW
-ebm
-eYg
-fVK
-rpN
-isW
-wAW
-ltR
-nrZ
-ltR
-pNu
-qLi
-rDE
-sXd
-tMO
-uWX
-sXL
-uSl
-yjC
-hTc
-pIe
-mzk
-pSd
-pmW
-dvu
-iNv
-xkx
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98774,48 +98861,28 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-cdz
-bgD
-bgD
-naj
-bgD
-jYD
-jYD
-qae
-sUs
-rcq
-jYD
-jYD
-bVj
-adY
-ebo
-xsx
-fWB
-hrz
-bVj
-vvc
-fST
-nsj
-oGD
-pQE
-hsl
-rFj
-wEW
-qLi
-nsj
-sXL
-pdh
-fxV
-cof
-kER
-jwN
-lYL
-fpE
-oNg
-dzv
+qSV
+gES
+gES
+gES
+hop
+rga
+vaq
+jpU
+svg
+beu
+hop
+tPm
+tPm
+tPm
+tPm
+gmx
+sgT
+tPm
+tPm
+tPm
+tPm
+pFz
 aaa
 aaa
 aaa
@@ -98824,6 +98891,26 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+pAK
+pAK
+rsO
+sqX
+uCl
+uCl
+uCl
+uCl
+uCl
+uCl
+uCl
+uCl
+uCl
+iNv
+iNv
 aaa
 aaa
 aaa
@@ -99076,54 +99163,54 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-ryR
-mSV
-bhQ
-ccT
-vTW
-xiY
-tpn
-bWx
-gMh
-lhp
-bMy
-jGq
-bVj
-cUl
-ebZ
-mfQ
-fWY
-hsp
-bVj
-ivd
-ivd
-sil
-ivd
-ivd
-ivd
-ivd
-glJ
-qLi
-uXc
-sXL
-pgJ
-xyu
-cof
-kuE
-oGi
-ajx
-fpE
-ron
-pbq
+qSV
+lze
+lze
+lze
+hop
+kJm
+lug
+jpU
+jpU
+fCy
+hop
+tPm
+tPm
+tPm
+tPm
+tPm
+pFz
+pFz
+pFz
+pFz
+pFz
+pFz
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+ejE
+ejE
+ejE
+ejE
+wrn
+eRv
+rqf
+mXN
+nWp
+lPm
+lny
+wRm
+vtL
 aaa
 aaa
 aaa
@@ -99381,51 +99468,51 @@ aaa
 aaa
 aaa
 aaa
-ryR
-bgD
-cxt
-lwi
-bgD
-xiY
-pLv
-iiL
-rMj
-jZL
-nsq
-pOD
-bVj
-dbJ
-ebm
-eYG
-eYG
-hsU
-bVj
-jIX
-ghV
-nwn
-oGO
-pTp
-vbg
-rFx
-sXL
-xUA
-eLv
-sXL
-lZJ
-uPR
-fxV
-cXF
-tWD
-tWD
-tWD
-tWD
-tWD
-tWD
-tWD
-tWD
+aaa
+hop
+rpN
+hrH
+jpU
+jpU
+jpU
+hop
+tPm
+tPm
+tPm
+tPm
+tPm
+pFz
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+ffs
+acH
+gWq
+ieK
+jGs
+cMx
+nWD
+wsx
+xtT
+wSt
+eIr
+ejA
+vtL
 aaa
 aaa
 aaa
@@ -99683,52 +99770,52 @@ aaa
 aaa
 aaa
 aaa
-jUd
-nov
-nov
-nmV
-nov
-mXz
-cPT
-bzx
-brp
-brp
-dln
-qAX
-bVj
-kHS
-eca
-fai
-uJT
-jaq
-bVj
-jKz
-lBS
-nxF
-oIX
-pTJ
-qOd
-heo
-sXL
-xis
-sZp
-eJB
-ufZ
-eit
-qZj
-wYv
-tWD
-iQW
-gmw
-kRg
-taB
-kiJ
-poU
-tWD
+aaa
+hop
+uzp
+ajF
+jpU
+jpU
+iHQ
+hop
+pFz
+dMs
+dMs
+dMs
+pFz
+pFz
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+dOX
+nIg
+bbC
+lVt
+wrn
+eRv
+bik
+eRv
+nWp
+hkm
+qlD
+hti
+uCl
+uCl
 aaa
 aaa
 aaa
@@ -99985,52 +100072,52 @@ aaa
 aaa
 aaa
 aaa
-ryR
-tOI
-cxt
-bgD
-bgD
-xiY
-gOF
-uFM
-bst
-bst
-hJf
-bCa
-bVj
-hrH
-hrH
-bVj
-hrH
-hrH
-bVj
-jLz
-lFU
-nAh
-oKL
-oKL
-qOu
-rLT
-sXL
-sLv
-fxV
-orz
-eeg
-ezw
-eeg
-mzZ
-cKD
-ldH
-tKf
-tKf
-oow
-qwY
-qwY
-tWD
+aaa
+hop
+hsp
+jpU
+jpU
+jpU
+jpU
+hop
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+pBt
+qlN
+ruA
+sFc
+uCl
+wtt
+wtt
+wtt
+uCl
+hMw
+qlD
+hti
+eEk
+vtL
 aaa
 aaa
 aaa
@@ -100287,52 +100374,52 @@ aaa
 aaa
 aaa
 aaa
-ryR
-bZv
-bgD
-roe
-roe
-xiY
-bql
-kra
-cMV
-bDy
-gpH
-bts
-bnT
-abm
-abm
-tRx
-abm
-abm
-ivd
-wun
-lFU
-nAs
-oLv
-oLv
-qPH
-rOY
-sXL
-xsb
-nMw
-mAc
-fqX
-vBC
-vBC
-kFL
-tWD
-tWD
-tKf
-tKf
-taB
-xyL
-qwY
-tWD
+aaa
+hop
+pch
+tXD
+tXD
+tXD
+tXD
+hop
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+nVz
+qnk
+rvb
+sHo
+uCl
+uHy
+wtG
+wtG
+hti
+xtZ
+qlD
+hti
+rQj
+vtL
 aaa
 aaa
 aaa
@@ -100589,52 +100676,52 @@ aaa
 aaa
 aaa
 aaa
-scg
-kSG
-kSG
-kSG
-kSG
-hde
-hde
-hde
-hde
-hde
-hde
-lXv
-bnT
+aaa
+aaa
+aaa
+jtO
+aaB
+xkx
 aaa
 aaa
 aaa
 aaa
 aaa
-ivd
-jQi
-lGQ
-nIt
-oLO
-pTU
-qQh
-rXg
-sXL
-xEi
-yig
-uon
-xOl
-xEi
-rNC
-uon
-qnL
-tWD
-tWv
-kbF
-tWD
-tWD
-tWD
-tWD
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+uLY
+deE
+qbg
+sJf
+uCl
+uJa
+vHh
+xUF
+kja
+qgt
+pGr
+gzZ
+eEk
+vtL
 aaa
 aaa
 aaa
@@ -100895,6 +100982,7 @@ aaa
 aaa
 aaa
 aaa
+ctu
 aaa
 aaa
 aaa
@@ -100909,34 +100997,33 @@ aaa
 aaa
 aaa
 aaa
-ivd
-pFB
-jLz
-nIV
-jLz
-pUe
-qQj
-bPz
-sXL
-fPD
-yig
-kbB
-rNC
-uql
-rNC
-kbB
-ofW
-tWD
-gtR
-tKf
-mkq
-mkq
-tWD
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+glJ
+glJ
+vOX
+bCZ
+uCl
+dXA
+vHB
+vHB
+vHB
+vHB
+vHB
+vHB
+vHB
+uCl
 aaa
 aaa
 aaa
@@ -101197,6 +101284,7 @@ aaa
 aaa
 aaa
 aaa
+hgN
 aaa
 aaa
 aaa
@@ -101211,33 +101299,32 @@ aaa
 aaa
 aaa
 aaa
-ivd
-rWu
-ivd
-icr
-icr
-icr
-icr
-ivd
-sXL
-ovM
-khF
-uoU
-qKW
-aXK
-jix
-eBG
-pkC
-tWD
-loM
-tKf
-qKe
-qKe
-tWD
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+glJ
+qrS
+ryY
+sMn
+niO
+nsj
+vHB
+wwd
+xxQ
+rZk
+hqr
+pIZ
+lUY
 aaa
 aaa
 aaa
@@ -101513,33 +101600,33 @@ aaa
 aaa
 aaa
 aaa
-ivd
-jXg
-ivd
-aaa
-aaa
-jtO
-tRx
-aaB
-sXL
-kdy
-hfb
-kdy
-sXL
-kdy
-xkz
-kdy
-tWD
-tWD
-tKf
-tKf
-tNn
-tNn
-tWD
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+glJ
+hbw
+rzQ
+sMo
+jHs
+uNS
+oah
+wwB
+xyZ
+vRj
+vQR
+hdX
+vHB
 aaa
 aaa
 aaa
@@ -101815,33 +101902,33 @@ aaa
 aaa
 aaa
 aaa
-ivd
-jXE
-ivd
 aaa
 aaa
 aaa
 aaa
-jtO
-sXL
-ptB
-mch
-pjo
-sXL
-ptB
-mch
-oOE
-tWD
-sQi
-hxe
-tKf
-mEf
-mEf
-tWD
-giH
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+glJ
+quR
+rzT
+sMU
+txK
+tGx
+vHB
+oRY
+xzm
+wOE
+rKw
+fRo
+lUY
 aaa
 aaa
 aaa
@@ -102125,25 +102212,25 @@ aaa
 aaa
 aaa
 aaa
-sXL
-tWn
-tWn
-tWn
-kJR
-bmW
-tfy
-kPj
-luu
-pPR
-fvw
-tKf
-xra
-ttn
-mNM
-qRW
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+glJ
+onV
+rzT
+sMU
+qLi
+qLi
+xiN
+lRs
+xBp
+kdf
+xtN
+tkc
+vHB
 aaa
 aaa
 aaa
@@ -102427,25 +102514,25 @@ aaa
 aaa
 aaa
 aaa
-sXL
-tWn
-tWn
-tWn
-sXL
-jnb
-iHs
-kPj
-sjs
-ttn
-osP
-tXn
-oRW
-pAC
-tWD
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+glJ
+yhJ
+mdN
+eCd
+qLi
+qLi
+iRX
+wzw
+xCN
+tgv
+epg
+qla
+lUY
 aaa
 aaa
 aaa
@@ -102729,28 +102816,28 @@ aaa
 aaa
 aaa
 aaa
-sXL
-lyd
-lyd
-lyd
-sXL
-vna
-vna
-oVt
-tWD
-tWD
-tWD
-tWD
-tWD
-tWD
-tWD
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
+pDP
+qAl
+rzT
+sNI
+tzO
+uSS
+uSS
+uSS
+uSS
+uSS
+uSS
+uSS
+uSS
+uSS
+uSS
+uSS
 aaa
 aaa
 aaa
@@ -103037,22 +103124,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pDV
+qAA
+rAf
+sNM
+tAJ
+uSS
+vLa
+fKw
+bVs
+eDO
+gdT
+ncL
+gkG
+gkG
+vcW
+uSS
 aaa
 aaa
 aaa
@@ -103339,22 +103426,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pDP
+qBG
+rAl
+sON
+tBb
+uSS
+ocl
+sTK
+ewn
+wIj
+kAt
+lCo
+qOE
+wCY
+bUg
+uSS
 aaa
 aaa
 aaa
@@ -103641,22 +103728,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+rIJ
+qHx
+rzT
+pzU
+tBJ
+tJA
+vPb
+kiM
+bXS
+sOc
+jSM
+vFI
+hKy
+qxf
+vVy
+uSS
 aaa
 aaa
 aaa
@@ -103943,23 +104030,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vwT
+qHx
+rzT
+sPC
+tDf
+uSS
+rop
+rop
+xGl
+wIj
+vIL
+bAw
+vDG
+reQ
+rlH
+uSS
+anA
 aaa
 aaa
 aaa
@@ -104245,23 +104332,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pIJ
+qHV
+rzT
+sPT
+tGx
+uSS
+lCm
+wIv
+xJQ
+wIj
+fdY
+lCo
+vqr
+fCi
+cde
+uSS
+anA
 aaa
 aaa
 aaa
@@ -104543,27 +104630,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gkA
+lqB
+nje
+dKL
+pMv
+qIi
+rzT
+sMU
+cRm
+uSS
+hAH
+wIv
+mPq
+wIj
+lRa
+xMb
+emd
+iat
+xMQ
+uSS
+anA
 aaa
 aaa
 aaa
@@ -104845,27 +104932,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jHs
+jHs
+njK
+oGg
+oGg
+oGg
+rBQ
+sVA
+tLI
+uSS
+uSS
+uSS
+uSS
+uSS
+uSS
+uSS
+uSS
+uSS
+uSS
+uSS
+anA
 aaa
 aaa
 aaa
@@ -105147,27 +105234,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+wAW
+ltR
+nrZ
+ltR
+pNu
+qLi
+rDE
+sXd
+tMO
+uWX
+sXL
+uSl
+yjC
+hTc
+pIe
+mzk
+pSd
+pmW
+dvu
+iNv
+xkx
 aaa
 aaa
 aaa
@@ -105449,26 +105536,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vvc
+fST
+nsj
+oGD
+pQE
+hsl
+rFj
+wEW
+qLi
+nsj
+sXL
+pdh
+fxV
+cof
+kER
+jwN
+lYL
+fpE
+oNg
+dzv
 aaa
 aaa
 aaa
@@ -105751,26 +105838,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ivd
+ivd
+sil
+ivd
+ivd
+ivd
+ivd
+glJ
+qLi
+uXc
+sXL
+pgJ
+xyu
+cof
+kuE
+oGi
+ajx
+fpE
+ron
+pbq
 aaa
 aaa
 aaa
@@ -106053,29 +106140,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jIX
+ghV
+nwn
+oGO
+pTp
+vbg
+rFx
+sXL
+xUA
+eLv
+sXL
+lZJ
+uPR
+fxV
+cXF
+tWD
+tWD
+tWD
+tWD
+tWD
+tWD
+tWD
+tWD
 aaa
 aaa
 aaa
@@ -106355,29 +106442,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jKz
+lBS
+nxF
+oIX
+pTJ
+qOd
+heo
+sXL
+xis
+sZp
+eJB
+ufZ
+eit
+qZj
+wYv
+tWD
+iQW
+gmw
+kRg
+taB
+kiJ
+poU
+tWD
 aaa
 aaa
 aaa
@@ -106657,29 +106744,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jLz
+lFU
+nAh
+oKL
+oKL
+qOu
+rLT
+sXL
+sLv
+fxV
+orz
+eeg
+ezw
+eeg
+mzZ
+cKD
+ldH
+tKf
+tKf
+oow
+qwY
+qwY
+tWD
 aaa
 aaa
 aaa
@@ -106953,35 +107040,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abm
+abm
+tRx
+abm
+abm
+ivd
+wun
+lFU
+nAs
+oLv
+oLv
+qPH
+rOY
+sXL
+xsb
+nMw
+mAc
+fqX
+vBC
+vBC
+kFL
+tWD
+tWD
+tKf
+tKf
+taB
+xyL
+qwY
+tWD
 aaa
 aaa
 aaa
@@ -107260,30 +107347,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ivd
+jQi
+lGQ
+nIt
+oLO
+pTU
+qQh
+rXg
+sXL
+xEi
+yig
+uon
+xOl
+xEi
+rNC
+uon
+qnL
+tWD
+tWv
+kbF
+tWD
+tWD
+tWD
+tWD
 aaa
 aaa
 aaa
@@ -107562,29 +107649,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ivd
+pFB
+jLz
+nIV
+jLz
+pUe
+qQj
+bPz
+sXL
+fPD
+yig
+kbB
+rNC
+uql
+rNC
+kbB
+ofW
+tWD
+gtR
+tKf
+mkq
+mkq
+tWD
 aaa
 aaa
 aaa
@@ -107864,29 +107951,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ivd
+rWu
+ivd
+icr
+icr
+icr
+icr
+ivd
+sXL
+ovM
+khF
+uoU
+qKW
+aXK
+jix
+eBG
+pkC
+tWD
+loM
+tKf
+qKe
+qKe
+tWD
 aaa
 aaa
 aaa
@@ -108166,29 +108253,29 @@ aaa
 aaa
 aaa
 aaa
+ivd
+jXg
+ivd
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jtO
+tRx
+aaB
+sXL
+kdy
+hfb
+kdy
+sXL
+kdy
+xkz
+kdy
+tWD
+tWD
+tKf
+tKf
+tNn
+tNn
+tWD
 aaa
 aaa
 aaa
@@ -108468,30 +108555,30 @@ aaa
 aaa
 aaa
 aaa
+ivd
+jXE
+ivd
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jtO
+sXL
+ptB
+mch
+pjo
+sXL
+ptB
+mch
+oOE
+tWD
+sQi
+hxe
+tKf
+mEf
+mEf
+tWD
+giH
 aaa
 aaa
 aaa
@@ -108778,22 +108865,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sXL
+tWn
+tWn
+tWn
+kJR
+bmW
+tfy
+kPj
+luu
+pPR
+fvw
+tKf
+xra
+ttn
+mNM
+qRW
 aaa
 aaa
 aaa
@@ -109080,21 +109167,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sXL
+tWn
+tWn
+tWn
+sXL
+jnb
+iHs
+kPj
+sjs
+ttn
+osP
+tXn
+oRW
+pAC
+tWD
 aaa
 aaa
 aaa
@@ -109382,21 +109469,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sXL
+lyd
+lyd
+lyd
+sXL
+vna
+vna
+oVt
+tWD
+tWD
+tWD
+tWD
+tWD
+tWD
+tWD
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes Oshan's minimum voting threshold to 25, up from 14.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Oshan is a rather large map which can feel very empty without its more optimal population amounts. It also has geothermal without backup power solutions, which makes it frequently run into power issues on lowpop due to player willingness to do geothermal. Neon, with a backup option and a better, smaller area is better for these pops for when people do want a sea map.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
