### PR TITLE
Toggleable config to allow mentors to bypass the whitelist

### DIFF
--- a/code/client/gates/whitelist.dm
+++ b/code/client/gates/whitelist.dm
@@ -5,6 +5,9 @@
 		// Active admins are always allowed
 		if (C.client_auth_intent.admin && C.client_auth_intent.admin_rank != "Inactive") return TRUE
 
+		// Allow mentors through if their bypass is toggled on
+		if (config.mentors_bypass_whitelist && C.client_auth_intent.mentor) return TRUE
+
 		// Check if the client is on the whitelist
 		if (C.client_auth_intent.whitelisted) return TRUE
 

--- a/code/datums/configuration.dm
+++ b/code/datums/configuration.dm
@@ -92,6 +92,7 @@
 	var/whitelistEnabled = 0
 	var/baseWhitelistEnabled = 0 //! The config value of whitelistEnabled (actual value might be modified mid-round)
 	var/roundsLeftWithoutWhitelist = -1 //! How many rounds are left without the whitelist being enabled
+	var/mentors_bypass_whitelist = FALSE
 	var/whitelist_path = "config/whitelist.txt"
 
 	//Which server can ghosts join by clicking on an on-screen link
@@ -337,6 +338,9 @@
 
 			if ("whitelist_path")
 				config.whitelist_path = trimtext(value)
+
+			if ("mentors_bypass_whitelist")
+				config.mentors_bypass_whitelist = TRUE
 
 			if ("server_buddy_id")
 				config.server_buddy_id = trimtext(value)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -366,6 +366,7 @@ var/list/admin_verbs = list(
 		/client/proc/respawn_as,
 		/client/proc/whitelist_add_temp,
 		/client/proc/whitelist_toggle,
+		/client/proc/mentor_whitelist_toggle,
 		/client/proc/list_adminteract_buttons,
 
 		/client/proc/general_report,
@@ -2412,6 +2413,22 @@ proc/alert_all_ghosts(atom/target, message)
 		world.save_intra_round_value("whitelist_disabled", 0)
 
 	set_station_name(src.mob, manual=FALSE, name=station_name)
+
+/client/proc/mentor_whitelist_toggle()
+	SET_ADMIN_CAT(ADMIN_CAT_SERVER_TOGGLES)
+	set name = "Toggle whitelisted mentors"
+	set desc = "Toggle if Mentors bypass the whitelist"
+	ADMIN_ONLY
+	SHOW_VERB_DESC
+	DENY_TEMPMIN
+
+	var/current_status = config.mentors_bypass_whitelist ? "enabled" : "disabled"
+
+	if(tgui_alert(src, "Mentors bypassing the whitelist is currently [current_status]. Toggle for this round?", "Toggle whitelisted mentors?", list("Yes", "No")) != "Yes")
+		return
+	config.mentors_bypass_whitelist = !config.mentors_bypass_whitelist
+	message_admins("[src] has [config.mentors_bypass_whitelist ? "enabled" : "disabled"] mentors bypassing the whitelist for this round.")
+	logTheThing(LOG_ADMIN, src, "[config.mentors_bypass_whitelist ? "Enabled" : "Disabled"] mentors bypassing the whitelist for this round.")
 
 /client/proc/set_conspiracy_objective()
 	SET_ADMIN_CAT(ADMIN_CAT_SERVER)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a config option to allow mentors to bypass the whitelist if it is enabled. Admins can toggle this in the middle of a round at any time.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mentors have access to secret event channels and may want to test their planned events on the live dev server, this allows an admin to run an event test without needing to whitelist all the organisers.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Can't test properly locally, but the toggle command works.
<img width="542" height="505" alt="image" src="https://github.com/user-attachments/assets/6c3bf042-e00b-450b-b8de-42f5d3dab97b" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
Admin changelog to be done on merge.