### PR TITLE
Fixes ghostdrone being unable to use some machinery.

### DIFF
--- a/_std/defines/obj.dm
+++ b/_std/defines/obj.dm
@@ -13,6 +13,8 @@
 #define NO_GHOSTCRITTER (1<<4)
 /// allows for tables to be built under items they normally wouldn't be able to be built under, such as microwaves and personal computers
 #define NO_BLOCK_TABLE (1<<5)
+/// Whitelists ghostdrones.
+#define GHOSTDRONE_ALLOWED (1<<6)
 
 /// At which alpha do opague objects become see-through?
 #define MATERIAL_ALPHA_OPACITY 190

--- a/code/modules/atmospherics/portable/canister.dm
+++ b/code/modules/atmospherics/portable/canister.dm
@@ -7,7 +7,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/portable_atmospherics/canister, proc/toggle_
 	density = 1
 	var/health = 100
 	flags = CONDUCT | TGUI_INTERACTIVE
-	object_flags = NO_GHOSTCRITTER | NO_GHOSTCRITTER
+	object_flags = NO_GHOSTCRITTER | GHOSTDRONE_ALLOWED
 	p_class = 2
 	status = REQ_PHYSICAL_ACCESS
 

--- a/code/modules/atmospherics/portable/scrubber.dm
+++ b/code/modules/atmospherics/portable/scrubber.dm
@@ -11,6 +11,7 @@ TYPEINFO(/obj/machinery/portable_atmospherics/scrubber)
 	var/on = FALSE
 	var/inlet_flow = 100 // percentage
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER
+	object_flags = NO_GHOSTCRITTER | GHOSTDRONE_ALLOWED
 	volume = 1000
 	desc = "A device which filters out harmful air from an area."
 	p_class = 1.5

--- a/code/modules/disposals/disposal_chute.dm
+++ b/code/modules/disposals/disposal_chute.dm
@@ -24,6 +24,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 	anchored = ANCHORED
 	density = 1
 	flags = NOSPLASH | TGUI_INTERACTIVE
+	object_flags = NO_GHOSTCRITTER | GHOSTDRONE_ALLOWED
 	provides_grip = TRUE
 	var/datum/gas_mixture/air_contents	// internal reservoir
 	var/mode = DISPOSAL_CHUTE_CHARGING	// item mode 0=off 1=charging 2=charged

--- a/code/modules/interface/multiContext/multiContext.dm
+++ b/code/modules/interface/multiContext/multiContext.dm
@@ -5,7 +5,7 @@
 /mob/proc/checkContextActions(atom/target)
 	. = list()
 
-	if (isobj(target) && (isghostcritter(src) && target:object_flags & NO_GHOSTCRITTER))
+	if (isobj(target) && (isghostcritter(src) && target:object_flags & NO_GHOSTCRITTER && !(isghostdrone(src) && target:object_flags & GHOSTDRONE_ALLOWED)))
 		return
 
 	if(length(target?.contextActions))

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -17,7 +17,7 @@ var/global/datum/ui_state/tgui_default_state/tgui_default_state = new /datum/ui_
 		. = min(., loc.contents_ui_distance(src_object, src)) // Check the distance...
 	if(. == UI_INTERACTIVE) // Non-human living mobs can only look, not touch.
 		// Permit ghost drone access to ghost critter permitted UIs
-		if (!(isghostdrone(src) && !HAS_FLAG(src_object.object_flags, NO_GHOSTCRITTER)))
+		if (!(isghostdrone(src) && (!HAS_FLAG(src_object.object_flags, NO_GHOSTCRITTER) || HAS_FLAG(src_object.object_flags, GHOSTDRONE_ALLOWED))))
 			return UI_UPDATE
 
 /mob/living/carbon/human/default_can_use_topic(src_object)

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -390,6 +390,7 @@
 	mechanics_interaction = MECHANICS_INTERACTION_BLACKLISTED
 	//var/datum/electronics/electronics_items/link = null
 	req_access = list(access_captain, access_head_of_personnel, access_maxsec, access_engineering_chief)
+	object_flags = NO_GHOSTCRITTER | GHOSTDRONE_ALLOWED
 
 	var/processing = 0
 	var/net_id = null

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -36,6 +36,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 	/// req_access is used to lock out specific features and not limit deconstruction therefore DECON_NO_ACCESS is required
 	req_access = list(access_heads)
 	event_handler_flags = NO_MOUSEDROP_QOL
+	object_flags = NO_GHOSTCRITTER | GHOSTDRONE_ALLOWED
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL | DECON_NO_ACCESS
 	flags = NOSPLASH | FLUID_SUBMERGE
 	layer = STORAGE_LAYER

--- a/code/obj/machinery/pipe/pipe_dispenser.dm
+++ b/code/obj/machinery/pipe/pipe_dispenser.dm
@@ -21,6 +21,7 @@ var/static/list/obj/machinery/disposal_pipedispenser/availdisposalpipes = list(
 	density = 1
 	anchored = ANCHORED
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS
+	object_flags = NO_GHOSTCRITTER | GHOSTDRONE_ALLOWED
 
 	var/dispenser_ready = TRUE
 	var/dispenser_delay = 5 DECI SECONDS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a GHOSTDRONE_ALLOWED flag, which whitelists a ghostdrone to use an object.
TGUI and context actions are allowed for ghostdrones when this flag is on the object.
Adds the flag to scrubbers, ruck, manufacturers, disposal units, disposal pipe makers, and canisters.

Fixes #20791

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
i can use those machine now
<img width="590" height="543" alt="image" src="https://github.com/user-attachments/assets/1ad05054-6ba1-4722-8284-374a28837dd8" />
