### PR TITLE
Gives soda cans slightly clearer indication they've been opened

### DIFF
--- a/code/modules/cooking/food_and_drink/drinks.dm
+++ b/code/modules/cooking/food_and_drink/drinks.dm
@@ -334,7 +334,8 @@
 		if (src.is_sealed)
 			is_sealed = 0
 			src.set_open_container(TRUE)
-			src.desc += "<br>Its seal has been opened."
+			src.desc += " Its seal has been opened."
+			tooltip_rebuild = TRUE
 			can_chug = 1
 			splash_all_contents = TRUE
 			incompatible_with_chem_dispensers = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[feature] [objects]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Opening a soda can will now add a line to its description stating it's been opened. Also fixes a grammatical error and a typo in the flavor text for being sprayed in the face by a shaken soda.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, soda cans have no indication as to whether they've been opened or not, and considering this is something your character could reasonably tell by looking at the top of the can, it should probably be visible to the player too. Whether this bothers anybody asides from myself, I don't know, but I feel there's no harm in fixing it anyways.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="445" height="210" alt="Screenshot (496)" src="https://github.com/user-attachments/assets/13cc9107-877e-4920-a51a-35fdf4f49797" />
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
