### PR TITLE
items init now uses by_cat instead of in world

### DIFF
--- a/_std/types.dm
+++ b/_std/types.dm
@@ -211,6 +211,7 @@ var/list/list/by_cat = list()
 #define TR_CAT_TIMING_TIMERS "timing_timers" //item timers that are actively timing right now
 #define TR_CAT_GRAVITY_TETHERS "gravity_tethers" //! Station, single-area, and multi-area gravity tethers
 #define TR_CAT_SHUTTLE_COMPUTERS "shuttle_computer" //! Shuttle computers
+#define TR_CAT_ROUNDSTART_INIT "roundstart_init" // for initing objects at roundstart
 
 // powernets? processing_items?
 // mobs? ai-mobs?

--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -890,6 +890,7 @@ var/obj/manta_speed_lever/mantaLever = null
 	name = "glowing sea anemone"
 	icon_state = "anemone_lit"
 	database_id = "sea_plant_lit_anemone"
+	needs_roundstart_initialisation = TRUE
 	var/datum/light/point/light = 0
 	var/init = 0
 

--- a/code/WorkInProgress/ud5/urs_dungeon.dm
+++ b/code/WorkInProgress/ud5/urs_dungeon.dm
@@ -1,5 +1,6 @@
 
 /obj/adventurepuzzle/multi_element_link
+	needs_roundstart_initialisation = TRUE
 
 	// Look, please don't break this. okay? Please please please don't break this. This is very breakable. You promise? Good.
 

--- a/code/datums/controllers/process/items.dm
+++ b/code/datums/controllers/process/items.dm
@@ -13,23 +13,23 @@
 		// plus i like watching number go up
 		var/itemcount = 0
 		var/lasttime = 0
-
-		// Zamu here -- I checked and this doesn't even register as 1 on a timeofday check
-		var/totalcount = 0
-		for(var/obj/object in world)
-			totalcount++
+		rustg_time_reset("items")
+		var/totalcount = length(by_cat[TR_CAT_ROUNDSTART_INIT])
 
 		logTheThing(LOG_DEBUG, src, "Starting main /obj initialize loop")
 
-		for(var/obj/object in world)
+		for(var/obj/object as anything in by_cat[TR_CAT_ROUNDSTART_INIT])
 			object.initialize(FALSE)
 			itemcount++
 			if (game_start_countdown)
-				if (lasttime != world.timeofday)
-					lasttime = world.timeofday
-					game_start_countdown.update_status("Initializing items\n([itemcount], [round(itemcount / totalcount * 100)]%)")
+				if (lasttime != world.time)
+					lasttime = world.time
+					game_start_countdown.update_status("Initializing items\n([itemcount] out of [totalcount], [round(itemcount / totalcount * 100)]%)")
 
 			LAGCHECK_IF_LIVE(LAG_INIT)
+
+		by_cat[TR_CAT_ROUNDSTART_INIT]?.len = 0
+		boutput(world, SPAN_ALERT("Initialised [totalcount] objects in [rustg_time_microseconds("items")/1000000] seconds!"))
 
 		logTheThing(LOG_DEBUG, src, "Main /obj initialize loop completed")
 

--- a/code/modules/admin/buildmodes/adventure/element_link.dm
+++ b/code/modules/admin/buildmodes/adventure/element_link.dm
@@ -1,4 +1,5 @@
 /obj/adventurepuzzle/element_link
+	needs_roundstart_initialisation = TRUE
 
 	var/triggerer_id = null
 	var/triggerable_id = null

--- a/code/modules/disposals/disposal.dm
+++ b/code/modules/disposals/disposal.dm
@@ -633,6 +633,7 @@
 	isauto = TRUE
 	name = "disposal pipe spawner"
 	icon_state = "pipe-spawner"
+	needs_roundstart_initialisation = TRUE
 	var/trunk_type = /obj/disposalpipe/trunk/regular
 	dpdir = 0
 	regular
@@ -837,6 +838,7 @@
 /obj/disposalpipe/junction/auto
 	isauto = TRUE
 	dir = SOUTH
+	needs_roundstart_initialisation = TRUE
 	icon_state = "pipe-j-spawner"
 	dpdir = 0
 

--- a/code/modules/fluids/fluid_pipes.dm
+++ b/code/modules/fluids/fluid_pipes.dm
@@ -13,6 +13,7 @@ ABSTRACT_TYPE(/obj/fluid_pipe)
 	density = FALSE
 	level = UNDERFLOOR
 	pass_unstable = FALSE
+	needs_roundstart_initialisation = TRUE
 	var/capacity = DEFAULT_FLUID_CAPACITY
 	/// What directions are valid for connections.
 	var/initialize_directions

--- a/code/modules/items/instruments/instruments.dm
+++ b/code/modules/items/instruments/instruments.dm
@@ -19,6 +19,7 @@
 	stamina_damage = 10
 	stamina_cost = 10
 	stamina_crit_chance = 5
+	needs_roundstart_initialisation = TRUE
 	var/note_time = 10 SECONDS
 	var/randomized_pitch = 1
 	var/pitch_set = 1

--- a/code/modules/mapping/_helper_parent.dm
+++ b/code/modules/mapping/_helper_parent.dm
@@ -12,10 +12,11 @@ ABSTRACT_TYPE(/obj/mapping_helper)
 	anchored = ANCHORED_ALWAYS
 	invisibility = INVIS_ALWAYS
 	layer = OBJ_LAYER + 1 // yeah let's consistently be above doors
+	needs_roundstart_initialisation = TRUE
 
 	New()
 		..()
-		if (global.current_state >= GAME_STATE_WORLD_INIT)
+		if (global.current_state >= GAME_STATE_PREGAME)
 			src.initialize()
 
 	initialize()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -443,6 +443,7 @@
 	var/cable_type = /obj/cable
 	/// cable_surr uses the unique ordinal dirs to save directions as it needs to store up to 8 at once
 	var/cable_surr = 0
+	needs_roundstart_initialisation = TRUE
 
 /obj/cable/auto/node
 	name = "node cable spawner"
@@ -463,7 +464,7 @@
 
 /obj/cable/auto/New()
 	..()
-	if(current_state >= GAME_STATE_WORLD_INIT && !src.disposed)
+	if(current_state >= GAME_STATE_PREGAME && !src.disposed)
 		SPAWN(1 SECONDS)
 			if(!src.disposed)
 				initialize()

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -23,9 +23,12 @@
 
 	/// if gun/bullet related, forensic profile of it
 	var/forensic_ID = null
+	var/needs_roundstart_initialisation = FALSE
 
 	New()
 		. = ..()
+		if (src.needs_roundstart_initialisation && global.current_state <= GAME_STATE_WORLD_NEW)
+			START_TRACKING_CAT(TR_CAT_ROUNDSTART_INIT)
 		if (HAS_FLAG(object_flags, HAS_DIRECTIONAL_BLOCKING))
 			var/turf/T = get_turf(src)
 			T?.UpdateDirBlocks()
@@ -116,6 +119,7 @@
 				set_opacity(1)
 
 	disposing()
+		STOP_TRACKING_CAT(TR_CAT_ROUNDSTART_INIT)
 		for(var/mob/M in src.contents)
 			M.set_loc(src.loc)
 		tag = null

--- a/code/obj/decal/tile_edge.dm
+++ b/code/obj/decal/tile_edge.dm
@@ -8,6 +8,7 @@
 	icon_state = "tile_edge"
 	layer = TURF_LAYER + 0.1 // it should basically be part of a turf
 	plane = PLANE_FLOOR // hence, they should be on the same plane!
+	needs_roundstart_initialisation = TRUE
 	var/merge_with_turf = 1
 
 	initialize()

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -657,6 +657,7 @@ TYPEINFO(/obj/shrub/syndicateplant)
 	opacity = 0
 	layer = EFFECTS_LAYER_UNDER_3 // below lights, above windoors
 	default_material = "plastic"
+	needs_roundstart_initialisation = TRUE
 	var/base_state = "blindsH"
 	var/open = 1
 	var/id = null
@@ -795,6 +796,7 @@ TYPEINFO(/obj/shrub/syndicateplant)
 	icon_state = "blind1"
 	anchored = ANCHORED
 	density = 0
+	needs_roundstart_initialisation = TRUE
 	var/working = TRUE
 	var/on = 0
 	var/id = null
@@ -928,6 +930,7 @@ TYPEINFO(/obj/shrub/syndicateplant)
 	icon_state = "light0"
 	anchored = ANCHORED
 	density = 0
+	needs_roundstart_initialisation = TRUE
 	var/on = FALSE
 	var/id = null
 

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -20,6 +20,7 @@ TYPEINFO(/obj/item/device/radio/intercom)
 	use_speech_bubble = TRUE
 	forced_maptext = TRUE
 	speaker_range = 7
+	needs_roundstart_initialisation = TRUE
 
 	HELP_MESSAGE_OVERRIDE("Stand next to an intercom and use the prefix <B> :in </B> to speak directly into it.")
 

--- a/code/obj/landmark.dm
+++ b/code/obj/landmark.dm
@@ -454,12 +454,13 @@ var/global/list/job_start_locations = list()
 	name = "spawner"
 	add_to_landmarks = FALSE
 	deleted_on_start = FALSE
+	needs_roundstart_initialisation = TRUE
 	/// Type this landmark should spawn. Do not edit this on a map instance. Create a subtype.
 	var/type_to_spawn = null
 	var/spawnchance = 100
 
 	New()
-		if(current_state >= GAME_STATE_WORLD_INIT && prob(spawnchance) && !src.disposed)
+		if(current_state >= GAME_STATE_PREGAME && prob(spawnchance) && !src.disposed)
 			SPAWN(6 SECONDS) // bluh, replace with some `initialize` variant later when someone makes it (needs to work with dmm loader)
 				if(!src.disposed)
 					initialize()

--- a/code/obj/lattice.dm
+++ b/code/obj/lattice.dm
@@ -266,6 +266,7 @@
 /// lattice spawners, for mapping large quantities of lattice at once.
 /// They auto connect in four directions depending on the lattices around them, plus you can set them to connect to certain turfs.
 /obj/lattice/auto
+	needs_roundstart_initialisation = TRUE
 	dirmask = NORTH | SOUTH | EAST | WEST // so others will connect to us during init
 	/// makes the lattices connect to walls too
 	var/attach_to_wall = FALSE
@@ -282,7 +283,7 @@
 	attach_to_all_turfs = TRUE
 
 /obj/lattice/auto/New()
-	if(current_state >= GAME_STATE_WORLD_INIT && !src.disposed)
+	if(current_state >= GAME_STATE_PREGAME && !src.disposed)
 		// this delay in theory lets regular lattices get placed in world first.
 		SPAWN(0.1 SECONDS)
 			if(!src.disposed)

--- a/code/obj/machinery.dm
+++ b/code/obj/machinery.dm
@@ -14,6 +14,7 @@
 	flags = FLUID_SUBMERGE | TGUI_INTERACTIVE
 	object_flags = NO_GHOSTCRITTER
 	pass_unstable = FALSE // Machines hopefully are stable.
+	needs_roundstart_initialisation = TRUE
 	var/status = 0
 	var/power_usage = 0
 	var/power_channel = EQUIP

--- a/code/obj/sealab_objects.dm
+++ b/code/obj/sealab_objects.dm
@@ -130,6 +130,7 @@
 	database_id = "sea_plant_lit_anemone"
 	var/datum/light/point/light = 0
 	var/init = 0
+	needs_roundstart_initialisation = TRUE
 
 	disposing()
 		light = 0

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -677,6 +677,7 @@ TYPEINFO(/obj/storage/crate/chest)
 	icon_state = "rustedcrate"
 	icon_opened = "rustedcrate_open"
 	icon_closed = "rustedcrate"
+	needs_roundstart_initialisation = TRUE
 
 	var/datum/light/point/light = 0
 	var/init = 0

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -38,6 +38,7 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 	gas_impermeable = TRUE
 	anchored = ANCHORED
 	material_amt = 0.1
+	needs_roundstart_initialisation = TRUE
 	HELP_MESSAGE_OVERRIDE(null)
 
 	the_tuff_stuff
@@ -60,7 +61,7 @@ ADMIN_INTERACT_PROCS(/obj/window, proc/smash)
 			src.health = src.health_max
 			//DEBUG ("[src.name] [log_loc(src)] has [health] health / [health_max] max health ([health_multiplier] multiplier).")
 
-		if(current_state >= GAME_STATE_WORLD_INIT)
+		if(current_state >= GAME_STATE_PREGAME)
 			SPAWN(0)
 				initialize()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Roundstart object initialisation now uses by_cat.
Items with `needs_roundstart_initialisation = TRUE` in definition are added to this list, meaning we no longer initialise every single object in the world even if initialisation actually does nothing for it, cutting down objects processed on cog1 from like 30-40k to 8k.
Object initialisation looks fancier now.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
slow bad. fancy good.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
cog2
<img width="667" height="465" alt="image" src="https://github.com/user-attachments/assets/fa627b84-b643-44c0-824d-d62db73d45b7" />

<img width="328" height="185" alt="image" src="https://github.com/user-attachments/assets/b87d9122-2bdd-42f4-9b50-b4428f7d8678" />
<img width="289" height="30" alt="image" src="https://github.com/user-attachments/assets/9089b7ee-0d4f-4c65-ad58-275c85b905f7" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)cringe
(+)Item initialisation thingy fancier now.
```
