### PR TITLE
Optimises minimaps

### DIFF
--- a/code/modules/minimap/minimaps/_area_minimap.dm
+++ b/code/modules/minimap/minimaps/_area_minimap.dm
@@ -1,6 +1,8 @@
 /datum/minimap/area_map
 	/// A bitflag that determines which areas and minimap markers are to be rendered on the minimap. For available flags, see `_std/defines/minimap.dm`.
 	var/minimap_type
+	/// Cache of focal points.
+	var/static/list/minimap_cache
 
 	/// A list of minimap render icons, indexed by z-level.
 	var/list/icon/map_icons_by_z_level
@@ -26,6 +28,8 @@
 
 	for (var/atom/marker_target as anything in global.minimap_marker_targets)
 		SEND_SIGNAL(marker_target, COMSIG_NEW_MINIMAP_MARKER, src)
+
+	LAZYLISTINIT(src.minimap_cache)
 
 	src.find_focal_point()
 
@@ -63,41 +67,36 @@
 		var/datum/minimap_marker/minimap/minimap_marker = src.minimap_markers[target]
 		src.set_marker_position(minimap_marker, minimap_marker.target.x, minimap_marker.target.y, minimap_marker.target.z)
 
-/// Checks whether a turf is rendered on this minimap type.
-/datum/minimap/area_map/proc/valid_turf(turf/T)
-	if (!T.loc)
-		return FALSE
-
-	var/area/A = T.loc
-	if (!(src.minimap_type & A.minimaps_to_render_on))
-		return FALSE
-
-	return TRUE
-
 /// Locate the focal point of the map by using the furthest valid turf in each direction.
 /datum/minimap/area_map/proc/find_focal_point()
 	if (!src.x_max || !src.x_min || !src.y_max || !src.y_min || !src.z_level)
 		return
 
-	if (!src.centre_focus_x || !src.centre_focus_y || !src.centre_scale)
+	var/list/cache = src.minimap_cache[jointext(list(src.x_min,src.y_min,src.x_max,src.y_max,src.z_level,src.minimap_type), ",")]
+	if (cache)
+		src.centre_focus_x = cache[1]
+		src.centre_focus_y = cache[2]
+		src.centre_scale = cache[3]
+	else
 		var/max_x = src.x_min
 		var/min_x = src.x_max
 		var/max_y = src.y_min
 		var/min_y = src.y_max
 
-		for (var/turf/T as anything in block(locate(src.x_min, src.y_min, src.z_level), locate(src.x_max, src.y_max, src.z_level)))
-			if (!src.valid_turf(T))
+		for (var/area/A in world)
+			if (!(A.z == src.z_level && src.minimap_type & A.minimaps_to_render_on))
 				continue
 
-			max_x = max(max_x, T.x)
-			min_x = min(min_x, T.x)
-			max_y = max(max_y, T.y)
-			min_y = min(min_y, T.y)
+			max_x = max(max_x, A.contents[length(A.contents)].x)
+			min_x = min(min_x, A.x)
+			max_y = max(max_y, A.contents[length(A.contents)].y)
+			min_y = min(min_y, A.y)
 
 		src.centre_focus_x = ((max_x + min_x) - 1) / 2
 		src.centre_focus_y = ((max_y + min_y) - 1) / 2
 
 		src.centre_scale = min(world.maxx / ((max_x - min_x) + src.border_width), world.maxy / ((max_y - min_y) + src.border_width))
+		src.minimap_cache[jointext(list(src.x_min,src.y_min,src.x_max,src.y_max,src.z_level,src.minimap_type), ",")] = list(src.centre_focus_x, src.centre_focus_y, src.centre_scale)
 
 	src.centre_on_point(src.centre_scale, src.centre_focus_x, src.centre_focus_y)
 

--- a/code/modules/minimap/minimaps/_radar_minimap.dm
+++ b/code/modules/minimap/minimaps/_radar_minimap.dm
@@ -1,4 +1,11 @@
 /datum/minimap/radar_map
+	var/static/rendered = FALSE
+
+/datum/minimap/radar_map/New()
+	if (!src.rendered)
+		global.minimap_renderer.render_radar_minimap()
+		src.rendered = TRUE
+	..()
 
 /datum/minimap/radar_map/initialise_minimap_render()
 	src.map = new()

--- a/code/modules/minimap/renderer/minimap_renderer.dm
+++ b/code/modules/minimap/renderer/minimap_renderer.dm
@@ -37,7 +37,6 @@ var/list/minimap_z_levels = list(Z_LEVEL_STATION, Z_LEVEL_DEBRIS, Z_LEVEL_MINING
 	sortList(src.minimap_modifiers, GLOBAL_PROC_REF(cmp_minimap_modifiers))
 
 	src.render_minimaps()
-	src.render_radar_minimap()
 
 /// Set up all `/obj/minimap`, `/obj/minimap_controller`, and `/datum/minimap_marker/render` types.
 /datum/minimap_renderer/proc/initialise_minimaps()
@@ -130,6 +129,7 @@ var/list/minimap_z_levels = list(Z_LEVEL_STATION, Z_LEVEL_DEBRIS, Z_LEVEL_MINING
 		// Iterates through all turfs on the map, creating a list for each minimap type required, this minimap type list itself containing lists of turfs to be drawn to an icon.
 		for (var/turf/T as anything in block(locate(1, 1, z_level), locate(world.maxx, world.maxy, z_level)))
 			src.update_radar_map(T, FALSE)
+			LAGCHECK(LAG_LOW)
 
 		src.radar_minimap_objects_by_z_level["[z_level]"].icon = icon(src.radar_minimaps_by_z_level["[z_level]"])
 
@@ -176,9 +176,6 @@ var/list/minimap_z_levels = list(Z_LEVEL_STATION, Z_LEVEL_DEBRIS, Z_LEVEL_MINING
 
 /// Determine the colour of a turf on the minimap.
 /datum/minimap_renderer/proc/turf_color(turf/T)
-	if (!T.loc)
-		return
-
 	// Not a modifier to cut down on proccalls
 	if (istype(T, /turf/space))
 		return src.render_space_color || "#000000"


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Focal points on area minimaps are now cached.
Focal points are now calculated by going through areas and using their lowest leftmost turf and upper rightmost turf, instead of going through every single turf.
Radar minimaps are now only calculated when needed, which only happens when there is a phoenix.

<img width="1094" height="256" alt="image" src="https://github.com/user-attachments/assets/8a546be2-ae67-4489-85b8-8f77d884444b" />
Along with the 900ms from radar minimaps gone, this cuts init time by about 4.82 seconds for me.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
slow bad


## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
the minimaps still work. the radar minimap still works.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
