### PR TITLE
You will no longer attack catwalks (excluding snipping tools) if not on HARM intent

### DIFF
--- a/code/obj/mesh.dm
+++ b/code/obj/mesh.dm
@@ -498,7 +498,6 @@ TYPEINFO_NEW(/obj/mesh/catwalk)
 	connects_to_obj = typecacheof(list(/obj/mesh/catwalk, /obj/machinery/door))
 /obj/mesh/catwalk
 	name = "catwalk surface"
-	HELP_MESSAGE_OVERRIDE("")
 	icon = 'icons/obj/catwalk.dmi'
 	icon_state = "C15-0"
 	layer = CATWALK_LAYER


### PR DESCRIPTION
[QoL][Player Actions]

## About the PR 
if not using the wires or the pliers, then  you willnot hit cat walk with random thingies unless yourew on HARM intent. 
(wire cutter still cut in all intent)
also add helping text to explain cutting + HARM inteijnting

## Why's this needed? 
zooblar think ofit! Good idea!
<img width="1267" height="327" alt="nibreason" src="https://github.com/user-attachments/assets/cfc332f6-1074-4a22-9eaf-55565f5c2f1a" />

## Testing 
<img width="1967" height="1053" alt="testing" src="https://github.com/user-attachments/assets/cdc13148-4a65-47a4-92ba-96be31669a11" />
<img width="837" height="445" alt="helptext" src="https://github.com/user-attachments/assets/63d2d7be-5c07-42c9-8a83-b0d633a56a64" />



## Changelog 

```changelog
(u)NibChocolateeny
(+)Spacemen, Spacewomen, Spacethems, and all others have decided to stop needlessly brutalizing catwalks; you'll need to use HARM intent to bash them with random objects now.
```
