### PR TITLE
Adds the Genebooth to the Genetics Kit from Cargo

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1994,10 +1994,11 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 
 /datum/supply_packs/complex/genetics_kit
 	name = "Genetics kit"
-	desc = "x1 DNA Modifier Circuitboard, x1 DNA Scanner Circuitboard."
+	desc = "x1 Genetics Console Circuitboard, x1 Genetek Scanner frame, x1 Genebooth frame."
 	category = "Medical Department"
 	contains = list(/obj/item/circuitboard/genetics)
-	frames = list(/obj/machinery/genetics_scanner)
+	frames = list(/obj/machinery/genetics_scanner,
+					/obj/machinery/genetics_booth)
 	cost = PAY_DOCTORATE*10
 	containertype = /obj/storage/crate
 	containername = "Genetics kit"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the Gene booth to the Genetics Kit from cargo.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The Genekits Kit doesnt have it and there is no way to replace the booth if it gets destroyed if its not scanned by engineering before hand.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="293" height="226" alt="Screenshot 2026-03-28 172423" src="https://github.com/user-attachments/assets/82b6290b-aae2-4827-8253-e06fc8374208" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bork
(+) adds the genebooth to the genetics cargo crate.
```
