### PR TITLE
Emotes on living objects

### DIFF
--- a/code/mob/living/object.dm
+++ b/code/mob/living/object.dm
@@ -338,6 +338,132 @@
 	get_hud()
 		return src.hud
 
+/mob/living/object/emote(var/act, var/voluntary = 0)
+	..()
+	var/param = null
+	if (src.hasStatus("paralysis"))
+		return //aaaa
+	if (findtext(act, " ", 1, null))
+		var/t1 = findtext(act, " ", 1, null)
+		param = copytext(act, t1 + 1, length(act) + 1)
+		act = copytext(act, 1, t1)
+
+	var/maptext_out = 0
+	var/message = specific_emotes(act, param, voluntary)
+	var/m_type = specific_emote_type(act)
+	var/custom = 0 //Sorry, gotta make this for chat groupings.
+
+
+	if (!message)
+		switch (lowertext(act))
+			if ("salute","bow","hug","wave","glare","stare","look","leer","nod")
+				if (src.emote_check(voluntary, 10))
+					// visible targeted emotes
+					if (!src.restrained())
+						var/M = null
+						if (param)
+							for (var/mob/A in view(null, null))
+								if (ckey(param) == ckey(A.name))
+									M = A
+									break
+						if (!M)
+							param = null
+
+						act = lowertext(act)
+						if (param)
+							switch(act)
+								if ("bow","wave","nod")
+									message = "<B>[src]</B> [act]s to [param]."
+									maptext_out = "<I>[act]s to [M]</I>"
+								if ("glare","stare","look","leer")
+									message = "<B>[src]</B> [act]s at [param]."
+									maptext_out = "<I>[act]s at [M]</I>"
+								else
+									message = "<B>[src]</B> [act]s [param]."
+									maptext_out = "<I>[act]s [M]</I>"
+						else
+							switch(act)
+								if ("hug")
+									message = "<B>[src]</b> [act]s itself."
+									maptext_out = "<I>[act]s itself</I>"
+								else
+									message = "<B>[src]</b> [act]s."
+									maptext_out = "<I>[act]s [M]</I>"
+					else
+						message = "<B>[src]</B> struggles to move."
+						maptext_out = "<I>[src] struggles to move</I>"
+					m_type = 1
+			if ("smile","grin","smirk","frown","scowl","grimace","sulk","pout","blink","nod","shrug","think","ponder","contemplate")
+				// basic visible single-word emotes
+				if (src.emote_check(voluntary, 10))
+					message = "<B>[src]</B> [act]s."
+					maptext_out = "<I>[act]s</I>"
+					m_type = 1
+			if ("gasp","cough","laugh","giggle","sigh")
+				// basic hearable single-word emotes
+				if (src.emote_check(voluntary, 10))
+					message = "<B>[src]</B> [act]s."
+					maptext_out = "<I>[act]s</I>"
+					m_type = 2
+			if ("customv")
+				if (!param)
+					param = input("Choose an emote to display.")
+					if(!param) return
+				param = html_encode(sanitize(param))
+				message = "<b>[src]</b> [param]"
+				maptext_out = "<I>[regex({"(&#34;.*?&#34;)"}, "g").Replace(param, "</i>$1<i>")]</I>"
+				custom = copytext(param, 1, 10)
+				m_type = 1
+			if ("customh")
+				if (!param)
+					param = input("Choose an emote to display.")
+					if(!param) return
+				param = html_encode(sanitize(param))
+				message = "<b>[src]</b> [param]"
+				maptext_out = "<I>[regex({"(&#34;.*?&#34;)"}, "g").Replace(param, "</i>$1<i>")]</I>"
+				custom = copytext(param, 1, 10)
+				m_type = 2
+			if ("me")
+				if (!param)
+					return
+				param = html_encode(sanitize(param))
+				message = "<b>[src]</b> [param]"
+				maptext_out = "<I>[regex({"(&#34;.*?&#34;)"}, "g").Replace(param, "</i>$1<i>")]</I>"
+				custom = copytext(param, 1, 10)
+				m_type = 1
+			if ("flip")
+				if (src.emote_check(voluntary, 50))
+					if (isobj(src.loc))
+						var/obj/container = src.loc
+						container.mob_flip_inside(src)
+					else
+						message = "<b>[src]</B> does a flip!"
+						animate_spin(src, pick("L", "R"), 1, 0)
+
+	if (!message)
+		return
+
+	var/list/mob/recipients = list()
+	if (m_type & 1)
+		recipients = viewers(src, null)
+
+	else if (m_type & 2)
+		recipients = hearers(src, null)
+
+	else if (!isturf(src.loc))
+		var/atom/A = src.loc
+		for (var/mob/M in A.contents)
+			recipients += M
+
+	log_emote(src, message, voluntary)
+	act = lowertext(act)
+	for (var/mob/M as anything in recipients)
+		M.show_message(SPAN_EMOTE("[message]"), m_type, group = "[src]_[act]_[custom]")
+
+	if (maptext_out && !ON_COOLDOWN(src, "emote maptext", 0.5 SECONDS))
+		DISPLAY_MAPTEXT(src, recipients, MAPTEXT_MOB_RECIPIENTS_WITH_OBSERVERS, /image/maptext/emote, maptext_out)
+
+
 /mob/living/object/ai_controlled
 	is_npc = TRUE
 

--- a/code/mob/living/object.dm
+++ b/code/mob/living/object.dm
@@ -338,6 +338,12 @@
 	get_hud()
 		return src.hud
 
+/mob/living/object/proc/specific_emotes(var/act, var/param = null, var/voluntary = 0)
+	return null
+
+/mob/living/object/proc/specific_emote_type(var/act)
+	return 1
+
 /mob/living/object/emote(var/act, var/voluntary = 0)
 	..()
 	var/param = null

--- a/code/mob/living/object.dm
+++ b/code/mob/living/object.dm
@@ -356,7 +356,7 @@
 
 	var/maptext_out = 0
 	var/message = specific_emotes(act, param, voluntary)
-	var/m_type = specific_emote_type(act)
+	var/message_type = specific_emote_type(act)
 	var/custom = 0 //Sorry, gotta make this for chat groupings.
 
 
@@ -398,19 +398,19 @@
 					else
 						message = "<B>[src]</B> struggles to move."
 						maptext_out = "<I>[src] struggles to move</I>"
-					m_type = 1
+					message_type = 1
 			if ("smile","grin","smirk","frown","scowl","grimace","sulk","pout","blink","nod","shrug","think","ponder","contemplate")
 				// basic visible single-word emotes
 				if (src.emote_check(voluntary, 10))
 					message = "<B>[src]</B> [act]s."
 					maptext_out = "<I>[act]s</I>"
-					m_type = 1
+					message_type = 1
 			if ("gasp","cough","laugh","giggle","sigh")
 				// basic hearable single-word emotes
 				if (src.emote_check(voluntary, 10))
 					message = "<B>[src]</B> [act]s."
 					maptext_out = "<I>[act]s</I>"
-					m_type = 2
+					message_type = 2
 			if ("customv")
 				if (!param)
 					param = input("Choose an emote to display.")
@@ -419,7 +419,7 @@
 				message = "<b>[src]</b> [param]"
 				maptext_out = "<I>[regex({"(&#34;.*?&#34;)"}, "g").Replace(param, "</i>$1<i>")]</I>"
 				custom = copytext(param, 1, 10)
-				m_type = 1
+				message_type = 1
 			if ("customh")
 				if (!param)
 					param = input("Choose an emote to display.")
@@ -428,7 +428,7 @@
 				message = "<b>[src]</b> [param]"
 				maptext_out = "<I>[regex({"(&#34;.*?&#34;)"}, "g").Replace(param, "</i>$1<i>")]</I>"
 				custom = copytext(param, 1, 10)
-				m_type = 2
+				message_type = 2
 			if ("me")
 				if (!param)
 					return
@@ -436,7 +436,7 @@
 				message = "<b>[src]</b> [param]"
 				maptext_out = "<I>[regex({"(&#34;.*?&#34;)"}, "g").Replace(param, "</i>$1<i>")]</I>"
 				custom = copytext(param, 1, 10)
-				m_type = 1
+				message_type = 1
 			if ("flip")
 				if (src.emote_check(voluntary, 50))
 					if (isobj(src.loc))
@@ -450,10 +450,10 @@
 		return
 
 	var/list/mob/recipients = list()
-	if (m_type & 1)
+	if (message_type & 1)
 		recipients = viewers(src, null)
 
-	else if (m_type & 2)
+	else if (message_type & 2)
 		recipients = hearers(src, null)
 
 	else if (!isturf(src.loc))
@@ -464,7 +464,7 @@
 	log_emote(src, message, voluntary)
 	act = lowertext(act)
 	for (var/mob/M as anything in recipients)
-		M.show_message(SPAN_EMOTE("[message]"), m_type, group = "[src]_[act]_[custom]")
+		M.show_message(SPAN_EMOTE("[message]"), message_type, group = "[src]_[act]_[custom]")
 
 	if (maptext_out && !ON_COOLDOWN(src, "emote maptext", 0.5 SECONDS))
 		DISPLAY_MAPTEXT(src, recipients, MAPTEXT_MOB_RECIPIENTS_WITH_OBSERVERS, /image/maptext/emote, maptext_out)

--- a/code/mob/living/object.dm
+++ b/code/mob/living/object.dm
@@ -338,12 +338,6 @@
 	get_hud()
 		return src.hud
 
-/mob/living/object/proc/specific_emotes(var/act, var/param = null, var/voluntary = 0)
-	return null
-
-/mob/living/object/proc/specific_emote_type(var/act)
-	return 1
-
 /mob/living/object/emote(var/act, var/voluntary = 0)
 	..()
 	var/param = null
@@ -355,8 +349,8 @@
 		act = copytext(act, 1, t1)
 
 	var/maptext_out = 0
-	var/message = specific_emotes(act, param, voluntary)
-	var/message_type = specific_emote_type(act)
+	var/message = null
+	var/message_type = 1
 	var/custom = 0 //Sorry, gotta make this for chat groupings.
 
 

--- a/code/modules/speech/say_wrappers.dm
+++ b/code/modules/speech/say_wrappers.dm
@@ -8,7 +8,7 @@
 /mob/verb/say_verb(message as text)
 	set name = "say"
 	// death to DM, trying to allow emotes to go through
-	if (!src.can_use_say and not findtext(message,"*",1,1)))
+	if (!src.can_use_say && !(findtext(message,"*",1,2)))
 		boutput(src, SPAN_ALERT("You can not speak!"))
 		return
 

--- a/code/modules/speech/say_wrappers.dm
+++ b/code/modules/speech/say_wrappers.dm
@@ -7,8 +7,8 @@
 
 /mob/verb/say_verb(message as text)
 	set name = "say"
-
-	if (!src.can_use_say)
+	// death to DM, trying to allow emotes to go through
+	if (!src.can_use_say and not findtext(message,"*",1,1)))
 		boutput(src, SPAN_ALERT("You can not speak!"))
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows emotes for living objects, such as ones made out of soulsteel.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows better RP as living objects, instead of them just pretty much being able to attack, and being expected to RP like that.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
All emotes should work, flip is kinda weird.
<img width="1069" height="580" alt="image" src="https://github.com/user-attachments/assets/106f9462-98d4-43b6-a949-29e452d4bd99" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Soulware
(+)You can now emote as a living object!
```
