### PR TITLE
Flamethrowers/the WA-V3 no longer permanently embed reagents inside of the floors

### DIFF
--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -1421,6 +1421,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 			special_data["burn_temp"] -= special_data["burn_temp"] * special_data["temp_pct_loss_atom"]
 			special_data["burn_temp"] = max(special_data["burn_temp"], T0C)
 		chemR.remove_any(amt_to_emit)
+		T.reagents.clear_reagents() // Prevents welding fuel/space cleaner from getting stuck in the turf's reagentholder.
 
 	post_setup(obj/projectile/P)
 		var/list/cross2 = list()


### PR DESCRIPTION
[Bug][Chemistry]

## About the PR
after trying to make bug fixing for long time, @TobleroneSwordfish say maybe i should make it so /datum/projectile/special/shotchem delete reagent after applying chemicals to floor tile/doing reaction. shotchem is projectile use for flame thrower and wav3.

what it does BEFORE is it put reagent into floor turf...not ON, not into puddle or some thing - into, inside, in metal floorplate. then it does reaction to apply chemicals and do burning if thereis burning. but! if there is no burning, reagent in floortile never ever go away, unless try to clean with sponge/set on fire (but it is not pudddle, cannot see it - chemicals are invisible with out scanner)

so NOW, it put reagent into floor, do reactingness and burning, then delete floor reagent (inside floor! not puddle on floor, I check)

## Why's this needed?
Fixes #20379 

## Testing 
i do tset of wa-v3 and flamethroweri to see if reagent get put into floor - do not see it anymore. flame thrower adn wav3 also work normally for burning/cleaning, i think.
<img width="1911" height="683" alt="testingmore" src="https://github.com/user-attachments/assets/3524a4bd-600d-49dc-98b8-24a26c342410" />
also do testingness of flame thrower over puddle/decal of blood. blood stay, do not get deleted.

## warning!
maybe can cause problems if part of balansing is putting ragent in floor for trap/long time burning, but it is not so commmon to do it...

also, if ever is a time where reagejt are in floor on purpose, using flame throw/cleanmachine will delete floor reagent!

also also, probably better way of fixing/implemetning this, but i am too confused to do it. sorri. :<