### PR TITLE
Make Psychiatrist a permanent role

### DIFF
--- a/code/datums/jobs/jobs_medical.dm
+++ b/code/datums/jobs/jobs_medical.dm
@@ -107,3 +107,20 @@ ABSTRACT_TYPE(/datum/job/medical)
 	slot_eyes = list(/obj/item/clothing/glasses/spectro)
 	items_in_backpack = list(/obj/item/storage/box/beakerbox, /obj/item/beaker_lid, /obj/item/reagent_containers/injector_filler)
 	wiki_link = "https://wiki.ss13.co/Pharmacist"
+
+/datum/job/medical/psychiatrist
+	name = "Psychiatrist"
+	wages = PAY_DOCTORATE
+	limit = 1 // limited workspace
+	trait_list = list("training_therapy")
+	access_string = "Psychiatrist"
+	slot_eyes = list(/obj/item/clothing/glasses/regular)
+	slot_belt = list(/obj/item/device/pda2/medical)
+	slot_foot = list(/obj/item/clothing/shoes/brown)
+	slot_jump = list(/obj/item/clothing/under/shirt_pants)
+	slot_suit = list(/obj/item/clothing/suit/labcoat)
+	slot_ears = list(/obj/item/device/radio/headset/medical)
+	slot_poc1 = list(/obj/item/reagent_containers/food/drinks/tea)
+	slot_poc2 = list(/obj/item/reagent_containers/food/drinks/bottle/gin)
+	items_in_backpack = list(/obj/item/luggable_computer/personal, /obj/item/clipboard/with_pen, /obj/item/paper_bin, /obj/item/stamp, /obj/item/storage/firstaid/mental)
+	alt_names = list("Psychiatrist", "Psychologist", "Psychotherapist", "Therapist", "Counselor", "Life Coach") // All with slightly different connotations

--- a/code/datums/jobs/special/jobs_random.dm
+++ b/code/datums/jobs/special/jobs_random.dm
@@ -365,27 +365,6 @@ ABSTRACT_TYPE(/datum/job/special/random)
 	items_in_backpack = list(/obj/item/fishing_rod/basic)
 	email_group = MGD_CIVILIAN
 
-
-/datum/job/special/random/psychiatrist
-	name = "Psychiatrist"
-	ui_colour = /datum/job/medical::ui_colour
-	wages = PAY_DOCTORATE
-	request_limit = 1 // limited workspace
-	trait_list = list("training_therapy")
-	access_string = "Psychiatrist"
-	slot_eyes = list(/obj/item/clothing/glasses/regular)
-	slot_card = /obj/item/card/id/medical
-	slot_belt = list(/obj/item/device/pda2/medical)
-	slot_foot = list(/obj/item/clothing/shoes/brown)
-	slot_jump = list(/obj/item/clothing/under/shirt_pants)
-	slot_suit = list(/obj/item/clothing/suit/labcoat)
-	slot_ears = list(/obj/item/device/radio/headset/medical)
-	slot_poc1 = list(/obj/item/reagent_containers/food/drinks/tea)
-	slot_poc2 = list(/obj/item/reagent_containers/food/drinks/bottle/gin)
-	items_in_backpack = list(/obj/item/luggable_computer/personal, /obj/item/clipboard/with_pen, /obj/item/paper_bin, /obj/item/stamp, /obj/item/storage/firstaid/mental)
-	alt_names = list("Psychiatrist", "Psychologist", "Psychotherapist", "Therapist", "Counselor", "Life Coach") // All with slightly different connotations
-	email_group = MGD_MEDICAL
-
 /datum/job/special/random/artist
 	name = "Artist"
 	wages = PAY_UNTRAINED

--- a/code/map.dm
+++ b/code/map.dm
@@ -822,10 +822,6 @@ var/global/list/mapNames = list(
 		"the mining staff room" = list(/area/station/mining/staff_room))
 		//"the radio lab" = list(/area/station/crew_quarters/radio))
 
-	job_limits_override = list(
-		/datum/job/special/random/psychiatrist = 1
-	)
-
 /datum/map_settings/nadir
 	name = "NADIR"
 	display_name = "Nadir Extraction Site"


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Swapped Psychiatrist from being a gimmick role that only appears periodically to a permanent one.
- Removed the now-redundant guaranteed Psychiatrist slot from Oshan.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Players within the RP community have expressed a love for rounds that feature a Psychiatrist/Therapist, and several players have stated in the past that they'd happily join more often if the role was available full-time. On top of that: the majority of maps already feature a Therapist's office that generally goes unused if the role isn't available in the round. These reasons, combined with the [recent changes to therapy,](https://github.com/goonstation/goonstation/pull/24824) leads me to believe that RP would benefit from this change.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
- Ensured I could spawn correctly when latejoining and with Psychiatrist as my favorite role at round-start.
- Verified that access remains the same,
- Ensured that the latejoin menu reflects the change and lists Psychiatrist under the Medical category.

<img width="409" height="242" alt="Psychiatrist Latejoin" src="https://github.com/user-attachments/assets/8cac3c71-50c3-4bea-8b05-24911c104947" />


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

```changelog
(u)Driftered
(*)Psychiatrist is now a permanent role. Go get some help for your tortured characters.
```
