### PR TITLE
Fixes SMES Human and Mass Emesis

### DIFF
--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -154,8 +154,8 @@
 		. = ..()
 		if(ismob(owner))
 			if(src.power > 1)
-				APPLY_ATOM_PROPERTY(owner, PROP_MOB_DISORIENT_RESIST_BODY, src, 40)
-				APPLY_ATOM_PROPERTY(owner, PROP_MOB_DISORIENT_RESIST_BODY_MAX, src, 40)
+				REMOVE_ATOM_PROPERTY(owner, PROP_MOB_DISORIENT_RESIST_BODY, src)
+				REMOVE_ATOM_PROPERTY(owner, PROP_MOB_DISORIENT_RESIST_BODY_MAX, src)
 
 	heal
 		id = "resist_electric_heal"

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -1940,6 +1940,15 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 	ability_path = /datum/targetable/geneticsAbility/bigpuke
 	var/range = 3
 
+	onPowerChange(oldval, newval)
+		. = ..()
+		var/datum/targetable/geneticsAbility/bigpuke/our_gene = src.ability
+		if(ismob(owner))
+			if(oldval > 1)
+				our_gene.puke_reagents = list("vomit" = 20)
+			if(newval > 1)
+				our_gene.puke_reagents = list("vomit" = 40)
+
 /datum/targetable/geneticsAbility/bigpuke
 	name = "Mass Emesis"
 	desc = "BLAAAAAAAARFGHHHHHGHH"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[Bug][Medical]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes two minor bugs:
SMES Human: Properly removes disorient resist atom property on removal
Mass Emesis: Doubles vomit amount so it'll actually spawn pools when you puke far away when it's empowered

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug bad. I squash. Also the SMES thing is exploitable since you can just give someone empowered SMES then remove it to get the 40% disorient resist for no downside.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Used bioEffectManager to add and empower and remove the genes and, indeed, they now work as expected

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Nexusuxen
(+)Vomiting far away with empowered Mass Emesis will now actually spawn vomit pools.
```
