### PR TITLE
Adds I_HATE_WAITING_FOR_GENES to __build.dm

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -54,6 +54,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define I_WANNA_DO_CRIME ROLE_TRAITOR // Spawn as the matching antagonist role as defined in _std\defines\roles.dm
 //#define NO_ADMIN_SPEECH_MODULES // Loads the admin speech and listen module trees without any modules.
 //#define NO_PREGAME_HTML // Don't spawn the HTML pregame browser lobby screen
+//#define I_HATE_WAITING_FOR_GENES // Marks nearly all genes as researched, gives chromosomes/materials/autodecryptors, increases gene storage cap, and removes time/cost limitations on the gene console
 
 //#define STOP_DISTRACTING_ME //All of the below
 
@@ -75,7 +76,6 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define GHOSTDRONES_ON_STRIKE // prevents ghostdrone factory objs from doing stuff
 //#define STOP_BREAKING_THE_FUCKING_LIGHTS_I_WANT_TO_SEE_SHIT // Stops lights from breaking or burning out when spawning or turning on/off
 //#define NO_ANTAG_POPUPS_I_DONT_CARE // Stops antag popups from coming up at the start of every game
-//#define I_HATE_WAITING_FOR_GENES // Marks nearly all genes as researched, gives chromosomes/materials/autodecryptors, increases gene storage cap, and removes time/cost limitations on the gene console
 
 //#define Z_LOG_ENABLE 1  // Enable additional world.log logging
 

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -75,6 +75,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define GHOSTDRONES_ON_STRIKE // prevents ghostdrone factory objs from doing stuff
 //#define STOP_BREAKING_THE_FUCKING_LIGHTS_I_WANT_TO_SEE_SHIT // Stops lights from breaking or burning out when spawning or turning on/off
 //#define NO_ANTAG_POPUPS_I_DONT_CARE // Stops antag popups from coming up at the start of every game
+//#define I_HATE_WAITING_FOR_GENES // Marks nearly all genes as researched, gives chromosomes/materials/autodecryptors, increases gene storage cap, and removes time/cost limitations on the gene console
 
 //#define Z_LOG_ENABLE 1  // Enable additional world.log logging
 

--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -49,6 +49,23 @@
 	START_TRACKING
 	SPAWN(0.5 SECONDS)
 		connection_scan()
+	#ifdef I_HATE_WAITING_FOR_GENES
+		var/list/chromosome_types = list(
+			/datum/dna_chromosome/, //stabilizer
+			/datum/dna_chromosome/anti_mutadone,
+			/datum/dna_chromosome/reclaimer,
+			/datum/dna_chromosome/stealth,
+			/datum/dna_chromosome/power_enhancer,
+			/datum/dna_chromosome/cooldown_reducer,
+			/datum/dna_chromosome/safety
+		)
+		for (var/chrom_path in chromosome_types)
+			for (var/i, i<20, i++)
+				var/datum/dna_chromosome/C = new chrom_path(src)
+				src.saved_chromosomes += C
+		genResearch.lock_breakers = 999
+		genResearch.researchMaterial = 999
+	#endif
 
 /obj/machinery/computer/genetics/connection_scan()
 	src.scanner = locate(/obj/machinery/genetics_scanner, orange(1,src))

--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -59,8 +59,9 @@
 			/datum/dna_chromosome/cooldown_reducer,
 			/datum/dna_chromosome/safety
 		)
+		var/how_many_chromosomes = 20
 		for (var/chrom_path in chromosome_types)
-			for (var/i, i<20, i++)
+			for (var/i, i<how_many_chromosomes, i++)
 				var/datum/dna_chromosome/C = new chrom_path(src)
 				src.saved_chromosomes += C
 		genResearch.lock_breakers = 999

--- a/code/modules/medical/genetics/geneticsResearch.dm
+++ b/code/modules/medical/genetics/geneticsResearch.dm
@@ -47,7 +47,13 @@ var/datum/geneticsResearchManager/genResearch = new()
 		//THIS FUCKING ABOMINATION stays here as a memory of someone's shame.
 		//researchTreeTiered = bubblesort(researchTreeTiered)
 		sortList(researchTreeTiered, /proc/cmp_text_asc)
-		return
+#ifdef I_HATE_WAITING_FOR_GENES
+		src.debug_SetResearchLevel()
+		src.debug_mode = TRUE
+		src.see_secret = TRUE
+		src.mutations_researched = 100
+		src.max_save_slots = 59
+#endif
 
 	proc/isResearched(var/type)
 		. = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new convenience option for testing, `I_HATE_WAITING_FOR_GENES`, which removes nearly all time/resource limitations on gene research.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I am impatient and do not want to either wait for mutation storage to unlock or manually go into the gene research datum to varedit my way to victory.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Used this for testing during the chromosome refactor and yeah it works pretty well.
<img width="749" height="562" alt="image" src="https://github.com/user-attachments/assets/e493d8bd-727b-4f95-a41f-59497ebf58e1" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
