### PR TITLE
Showers no longer cease producing water.

### DIFF
--- a/code/obj/machinery/shower.dm
+++ b/code/obj/machinery/shower.dm
@@ -62,10 +62,11 @@
 	proc/spray()
 		src.last_spray = world.time
 		if (src?.default_reagent)
-			src.reagents.add_reagent(default_reagent,240)
+			var/fill_percent = max(0, (320 - src.reagents.total_volume)/320)
+			src.reagents.add_reagent(default_reagent, fill_percent*240)
 			//also add some water for ~wet floor~ immersion
 			if (src.add_water)
-				src.reagents.add_reagent("water",80)
+				src.reagents.add_reagent("water",fill_percent*80)
 
 		if (src?.reagents.total_volume)
 			var/datum/effects/system/steam_spread/steam = new /datum/effects/system/steam_spread


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #26277
works by lowering production the fuller the shower gets, stopping production at 320u so that showers no longer clog with space cleaner.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
it dont run out anymore