### PR TITLE
Makes building and modifying mail junctions possible

### DIFF
--- a/code/modules/disposals/disposal-construction.dm
+++ b/code/modules/disposals/disposal-construction.dm
@@ -146,7 +146,7 @@
 					return
 
 				if("Add mailtag")
-					var/new_tag = sanitize(input(user, "Add a new mailtag", "Edit Mailtags", null))
+					var/new_tag = sanitize(input(user, "Add a new mailtag (Case sensitive!)", "Edit Mailtags", null))
 					if(isnull(new_tag) || (new_tag == ""))
 						return
 					if(new_tag in src.mail_tag)

--- a/code/modules/disposals/disposal-construction.dm
+++ b/code/modules/disposals/disposal-construction.dm
@@ -15,6 +15,7 @@
 		You can use a <b>wrench</b> to (un)anchor the pipe segment,
 		a <b>crowbar</b> to rotate it,
 		a <b>screwdriver</b> to disassemble it,
+		a <b>multitool</b> to edit mailtags (if possible),
 		and a <b>welding tool</b> to turn it into a functional immovable pipe."})
 
 	var/ptype = 0
@@ -22,7 +23,7 @@
 
 	var/dpdir = 0	// directions as disposalpipe
 	var/base_state = "pipe-s"
-	var/mail_tag = null //For pipes that use mail filtering
+	var/list/mail_tag = null //For pipes that use mail filtering
 	var/filter_type = null //For pipes that filter objects passing through.
 
 	// update iconstate and dpdir due to dir and type
@@ -135,6 +136,51 @@
 			qdel(src)
 			return
 
+		if(ispulsingtool(I))
+			if((src.ptype != 6) && (src.ptype != 7))
+				boutput(user, SPAN_ALERT("[src] doesn't support mailtags!"))
+				return
+			var/action = input(user, "What would you like to do?", "Edit Mailtags", null) in list("Add mailtag", "Remove mailtag", "*CANCEL*")
+			switch(action)
+				if("*CANCEL*")
+					return
+
+				if("Add mailtag")
+					var/new_tag = sanitize(input(user, "Add a new mailtag", "Edit Mailtags", null))
+					if(isnull(new_tag) || (new_tag == ""))
+						return
+					if(new_tag in src.mail_tag)
+						boutput(user, SPAN_ALERT("[new_tag] is already included in the mailtags!"))
+						return
+					if(contains_chars(new_tag, list("*")))
+						boutput(user, SPAN_ALERT("\"*\" cannot be used in mailtags!"))
+						return
+					if(is_blank_string(new_tag))
+						boutput(user, SPAN_ALERT("You can't have an empty mailtag, doofus!"))
+						return
+					if(isnull(src.mail_tag))
+						src.mail_tag = list(new_tag)
+					else
+						src.mail_tag.Add(new_tag)
+					boutput(user, SPAN_ALERT("'[new_tag]' added to [src]'s mailtags!"))
+
+				if("Remove mailtag")
+					if(isnull(src.mail_tag))
+						boutput(user, SPAN_ALERT("[src] has no mailtags!"))
+						return
+					if(src.mail_tag.len == 0)
+						boutput(user, SPAN_ALERT("[src] has no mailtags!"))
+						return
+					var/list/input_list = src.mail_tag
+					input_list.Add("*CANCEL*")
+					var/to_remove = input(user, "Edit Mailtags", "Which mailtag would you like to remove?", null) in src.mail_tag
+					if(!to_remove)
+						return
+					if(to_remove == "*CANCEL*")
+						return
+					else
+						src.mail_tag.Remove(to_remove)
+			return
 		var/turf/T = src.loc
 		if(T.intact && (iswrenchingtool(I) || isweldingtool(I))) //to stop it from screaming about it when rotating the pipe with crowbar
 			boutput(user, "You can only attach the pipe if the floor plating is removed.")

--- a/code/modules/disposals/disposal.dm
+++ b/code/modules/disposals/disposal.dm
@@ -912,6 +912,13 @@
 	var/switch_dir = 0 //Direction of secondary port
 					//Same-tag holders are sent out this one.
 
+	attackby(obj/item/W, mob/user)
+		if(..(W, user)) return
+		if(ispulsingtool(W))
+			boutput(user, SPAN_ALERT("[src]'s mailtags can't be edited while anchored!"))
+			// This is 95% because I don't wanna copy/paste the mailtag-editing code, but also
+			// it makes it *marginally* harder to maliciously mess with mailtags
+
 	left
 		name = "mail junction"
 		icon_state = "pipe-sj1"
@@ -940,23 +947,27 @@
 
 	New()
 		..()
-		if(icon_state == "pipe-sj1")
-			switch_dir = turn(dir, -90)
-			dpdir = dir | switch_dir | turn(dir,180)
-		else if(icon_state == "pipe-sj2")
-			switch_dir = turn(dir, 90)
-			dpdir = dir | turn(dir, 90) | turn(dir,180)
-		else
-			switch_dir = turn(dir, 90)
-			dpdir = dir | turn(dir,90) | turn(dir, -90)
-		update()
-
-		if (src.mail_tag)
-			if (islist(src.mail_tag))
-				src.name = "mail junction (multiple destinations)"
+		// i didnt wanna do this but i dont see a good way to get this to work short of reworking disposal construction
+		SPAWN(0 SECONDS)
+			if (src.mail_tag)
+				if (islist(src.mail_tag))
+					if (src.mail_tag.len > 1)
+						src.name = "mail junction (multiple destinations)"
+					else
+						src.name = "mail junction ([src.mail_tag[1]])"
+				else
+					src.name = "mail junction ([src.mail_tag])"
+					src.mail_tag = params2list(src.mail_tag)
+			if(icon_state == "pipe-sj1")
+				switch_dir = turn(dir, -90)
+				dpdir = dir | switch_dir | turn(dir,180)
+			else if(icon_state == "pipe-sj2")
+				switch_dir = turn(dir, 90)
+				dpdir = dir | turn(dir, 90) | turn(dir,180)
 			else
-				src.name = "mail junction ([src.mail_tag])"
-				src.mail_tag = params2list(src.mail_tag)
+				switch_dir = turn(dir, 90)
+				dpdir = dir | turn(dir,90) | turn(dir, -90)
+			update()
 		return
 
 

--- a/code/obj/machinery/pipe/pipe_dispenser.dm
+++ b/code/obj/machinery/pipe/pipe_dispenser.dm
@@ -8,6 +8,8 @@ var/static/list/obj/machinery/disposal_pipedispenser/availdisposalpipes = list(
 	"Junction" = 2,
 	"Flipped Junction" = 3,
 	"Y-Junction" = 4,
+	"Switch Junction" = 6,
+	"Flipped Switch Junction" = 7,
 	"Trunk" = 5,
 )
 


### PR DESCRIPTION
[Fix][Feature][Engineering]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it possible to build and edit mail junctions.
- Fixed an issue where mail junctions wouldn't have their settings properly updated when welded, which resulted in them failing to connect to any pipes.
- Pipe dispensers now can dispense switch junctions - aka mail junctions
- Multitools can now edit the mailtags of these junctions. This uses a very simple `input()` interface. It's not elegant, but it works fine.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Woe, hotspot be upon ye. May your mail forever fail to deliver. (It's really really annoying to have a relatively important system be easily broken *and* impossible to fully fix)

## Testing
More tests were done beyond what's demonstrated here, but this demonstrates that the new features do work as intended.

https://github.com/user-attachments/assets/6253b522-22ea-454a-ae2d-19263b03cd68

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Nexusuxen
(*)You can now edit and build switch junctions (AKA mail junctions). More details in minor changes.
(+)Use a multitool on an unanchored switch junction to add/remove mailtags.
(+) Pipe dispensers can now dispense switch junctions.
```
