### PR TITLE
Gives security and engineering the ability to rig TC

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -150,6 +150,8 @@ ABSTRACT_TYPE(/obj/item)
 
 	var/list/tooltip_options = list()
 
+	var/is_bomb = FALSE
+
 	/// This is the safe way of changing 2-handed-ness at runtime. Use this please.
 	proc/setTwoHanded(var/twohanded = 1)
 		if(ismob(src.loc))
@@ -1888,3 +1890,6 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 	if(key != "material")
 		return
 	src.worn_material_texture_image = src.getTexturedWornImage(texture, blendMode)
+
+/obj/proc/getbombpower()
+	return 0 //this should never get called but just in case.

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -723,13 +723,25 @@
 
 	else if (istype(C, /obj/item/uplink_telecrystal/trick))
 		if (src.uplink && src.uplink.active)
-			boutput(user, SPAN_ALERT("The [C] explodes!"))
-			var/turf/T = get_turf(C.loc)
-			if(T)
-				T.hotspot_expose(700,125)
-				explosion(C, T, -1, -1, 2, 3) //about equal to a PDA bomb
+			var/obj/item/uplink_telecrystal/trick/B = C
+			var/p = B.power
+			boutput(user, SPAN_ALERT("The [B] explodes!"))
+			var/turf/T = get_turf(B.loc)
+			if (!T)
+				return
+				//fixing ghost coin crash
+			if (ismob(B.loc))
+				var/mob/M = B.loc
+				M.u_equip(B)
+				if (hascall(M, "update_inhands"))
+					M.update_inhands()
+
 			C.set_loc(user.loc)
-			qdel(C)
+			T.hotspot_expose(700,125)
+			explosion(C, T, p * 0.9, p * 0.18, p * 0.4, p * 0.7, flash_radiation_multiplier=0.1)
+			SPAWN(0)
+				if (B)
+					qdel(B)
 
 	else if (istype(C, /obj/item/uplink_telecrystal))
 		if (src.uplink && src.uplink.active)

--- a/code/obj/item/device/transfer_valve.dm
+++ b/code/obj/item/device/transfer_valve.dm
@@ -25,6 +25,7 @@ TYPEINFO(/obj/item/device/transfer_valve)
 	var/image/tank_two_image_under = null
 	///if true, allows adding cable to wear on back. TODO: refactor this out
 	var/allow_wearable = TRUE
+	is_bomb = TRUE //needs getpower proc
 
 	w_class = W_CLASS_GIGANTIC /// HEH
 	p_class = 3 /// H E H
@@ -433,6 +434,60 @@ TYPEINFO(/obj/item/device/transfer_valve)
 		c_state()
 			return
 
+	getbombpower() //not fun
+
+		if (!tank_one || !tank_two)
+			return 0
+		if (!tank_one.air_contents || !tank_two.air_contents)
+			return 0
+
+		//fake it
+		var/datum/gas_mixture/g1 = new
+		var/datum/gas_mixture/g2 = new
+
+		g1.volume = src.tank_one.air_contents.volume
+		g2.volume = src.tank_two.air_contents.volume
+
+		g1.merge(src.tank_one.air_contents)
+		g2.merge(src.tank_two.air_contents)
+		var/datum/gas_mixture/temp = g1.remove_ratio(1)
+
+		g2.volume = g1.volume
+		g2.merge(temp)
+		var/transfer_ratio = g1.volume / (g1.volume + g2.volume)
+		temp = g2.remove_ratio(transfer_ratio)
+		g1.merge(temp)
+		g1.react()
+		g1.react()
+		g1.react()
+		g1.react()
+		g1.react()
+		g1.react()
+		g1.react(mult=0.5)
+		g2.react()
+		g2.react()
+		g2.react()
+		g2.react()
+		g2.react()
+		g2.react()
+		g2.react(mult=0.5)
+
+		var/p1 = MIXTURE_PRESSURE(g1)
+		var/p2 = MIXTURE_PRESSURE(g2)
+		var/pressure = max(p1, p2)
+
+
+		var/volume_scale = (g1.volume / 70) ** (1/4)
+		boutput(usr, "volume scale: [volume_scale]")
+		var/range = (pressure - TANK_FRAGMENT_PRESSURE) * volume_scale / TANK_FRAGMENT_SCALE
+		boutput(usr, "rangepreclamp: [range]")
+
+		range = clamp(range, 0, 12)
+		qdel(g1)
+		qdel(g2)
+		if (temp)
+			qdel(temp)
+		return range
 //Prox sensor handling.
 
 	Move()

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -43,6 +43,7 @@ ADMIN_INTERACT_PROCS(/obj/item/old_grenade, proc/detonate)
 	///damage when loaded into a 40mm convesion chamber
 	var/launcher_damage = 25
 	var/detonating = FALSE
+	is_bomb =  TRUE
 	HELP_MESSAGE_OVERRIDE({"You can use a <b>screwdriver</b> to adjust the detonation time."})
 
 	New()
@@ -57,6 +58,11 @@ ADMIN_INTERACT_PROCS(/obj/item/old_grenade, proc/detonate)
 		UnregisterSignal(src, COMSIG_ITEM_ASSEMBLY_APPLY)
 		..()
 
+	getbombpower()
+		return 0.5
+
+
+
 	/// ----------- Trigger/Applier/Target-Assembly-Related Procs -----------
 
 	proc/assembly_setup(var/manipulated_grenade, var/obj/item/assembly/parent_assembly, var/mob/user, var/is_build_in)
@@ -69,6 +75,8 @@ ADMIN_INTERACT_PROCS(/obj/item/old_grenade, proc/detonate)
 		parent_assembly.qdel_on_tear_apart = TRUE
 		parent_assembly.expended = TRUE
 		src.detonate()
+
+
 
 	/// ----------------------------------------------
 
@@ -2451,3 +2459,4 @@ ADMIN_INTERACT_PROCS(/obj/item/gimmickbomb, proc/arm, proc/detonate)
 	if (istype(hero))
 		src.visible_message(SPAN_COMBAT("<B>[hero] dives onto [src], covering it with [his_or_her(hero)] body!</B>"))
 	return hero
+

--- a/code/obj/item/traitorcoins.dm
+++ b/code/obj/item/traitorcoins.dm
@@ -5,7 +5,7 @@
 	icon_state = "telecrystal_pure"
 	max_stack = INFINITY
 	var/icon_stack_value = 0 //! Used for updating the icon_state as stack amount changes
-
+	var/power = 1 //default 1, scale in bombs for more explodey in the end.
 	New()
 		..()
 		_update_stack_appearance()
@@ -17,6 +17,47 @@
 				user.put_in_hand(src)
 			boutput(user, SPAN_NOTICE("You add the [src] to the stack. It now has [src.amount] [src]."))
 			return
+		else if(W.is_bomb)
+			if(user?.traitHolder?.hasTrait("training_security")) //only security gets to rig bombs
+				var/obj/item/uplink_telecrystal/trick/T
+				if (W.getbombpower() <= 0)
+					return
+				if (!istype(src, /obj/item/uplink_telecrystal/trick))
+					T = new /obj/item/uplink_telecrystal/trick(get_turf(user))
+					T.power = W.getbombpower()
+					user.put_in_hand_or_drop(T)
+					qdel(W)
+				else
+					T = src
+					T.power = W.getbombpower() + src.power
+				user.put_in_hand_or_drop(T)
+				T.add_fingerprint(user)
+				boutput(user, SPAN_NOTICE("You rig the Telecrystal with the [W.name]"))
+				return
+			else if(user?.traitHolder?.hasTrait("training_engineer")) //engineering can jerryrig too lol. With glue
+				var/obj/item/uplink_telecrystal/trick/T
+				if (W.getbombpower() <= 0)
+					return
+				if (!istype(src, /obj/item/uplink_telecrystal/trick))
+					T = new /obj/item/uplink_telecrystal/trick(get_turf(user))
+					T.power = W.getbombpower()
+					user.put_in_hand_or_drop(T)
+					qdel(src)
+				else
+					T = src
+					T.power = W.getbombpower() + src.power
+				W.AddComponent(/datum/component/glued, T)
+				W.vis_flags &= ~(VIS_INHERIT_LAYER | VIS_INHERIT_PLANE)
+				W.plane = T.plane
+				W.layer = OBJ_LAYER - 0.1
+				W.remove_filter("glued_outline")
+				W.pixel_x = rand(-7, 7)
+				W.pixel_y = rand(-7, -1)
+				user.put_in_hand_or_drop(T)
+				T.add_fingerprint(user)
+				boutput(user, SPAN_NOTICE("You rig the Telecrystal with the [W.name]"))
+				return
+//T._AddComponent(/datum/component/glued,W)
 		else ..()
 
 	attack_hand(mob/user)

--- a/code/obj/item/uplinks/uplink_parent.dm
+++ b/code/obj/item/uplinks/uplink_parent.dm
@@ -244,13 +244,29 @@
 		if(src.locked)
 			return
 		if (istype(W, /obj/item/uplink_telecrystal/trick))
-			boutput(user, SPAN_ALERT("The [W] explodes!"))
-			var/turf/T = get_turf(W.loc)
-			if(T)
-				T.hotspot_expose(700,125)
-				explosion(W, T, -1, -1, 2, 3) //about equal to a PDA bomb
-			W.set_loc(user.loc)
-			qdel(W)
+			var/obj/item/uplink_telecrystal/trick/B = W
+			var/p = B.power
+			var/turf/T = get_turf(src)
+			if (!T)
+				return
+
+			boutput(user, SPAN_ALERT("The [B] explodes!"))
+
+			// Force-remove from whoever is holding it. Fixes annoying crash.
+			if (ismob(B.loc))
+				var/mob/M = B.loc
+				M.u_equip(B)
+				if (hascall(M, "update_inhands"))
+					M.update_inhands()
+
+			B.set_loc(T)
+			T.hotspot_expose(700, 125)
+			explosion(B, T, p * 0.9, p * 0.18, p * 0.4, p * 0.7, flash_radiation_multiplier=0.1)
+
+			SPAWN(0)
+				if (B)
+					qdel(B)
+			return
 		else if (istype(W, /obj/item/uplink_telecrystal))
 			var/crystal_amount = W.amount
 			uses = uses + crystal_amount


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## This PR is to give security and Engineering the option to stick bombs to TC. when security does it, there is no way to tell. However when an engineer does it, the TC clearly has bombs attached to it. 

##  Adds more interdepartmental coordination. Gives toxins another reason for life. Someone gets TC? now they can rig it and make the traitor explode.  



<img width="241" height="238" alt="image" src="https://github.com/user-attachments/assets/7e93b413-2987-43be-a2c5-3cb3cb315d13" />

![boomsplosion](https://github.com/user-attachments/assets/9a948fb5-b2cb-456c-b27d-df2805362564)



## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Froggit Dogget
(*)Security and Engineering can rig bombs to Traitor Crystals.

```
