### PR TITLE
Gang crates are no longer straight up named "gang crates"

### DIFF
--- a/code/obj/storage/gang_crate.dm
+++ b/code/obj/storage/gang_crate.dm
@@ -119,7 +119,7 @@
 		..()
 		START_TRACKING_CAT(TR_CAT_GHOST_OBSERVABLES)
 		src.light = image('icons/obj/large_storage.dmi',"gangcratefulllight")
-		src.name = pick(list("Legitimate Business Crate", "Legal Supply Crate", "Humanitarian Aid Crate"))
+		src.name = pick(list("Legitimate Business Crate", "Legal Supply Crate", "Digestive Biscuit Supply Crate", "Innocuous Goods Crate", "Inconspicuous Crate"))
 		if (locked)
 			SPAWN(GANG_CRATE_LOCK_TIME/3)
 				src.light = image('icons/obj/large_storage.dmi',"gangcratehalflight")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[GAMEMODES] [GAME-OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gang crates are now randomly named "Legitimate Business Crate", "Legal Supply Crate", or "Humanitarian Aid Crate"

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The gang crate is very important to the balance of the round. On RP, Security often seizes the crate before it is even opened (fair enough as it is literally named "gang crate"), leaving both sides under equipped and often forcing them to focus on security instead of fighting each other. This change is intended to discourage instantly seizing the crate by giving gangs some more plausable deniability/opening up some RP opportunities. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested on local by spawning gang crate, works. 
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bamlord
(+)The "Gang Crate" is no longer named the "Gang Crate". 
```
