### PR TITLE
Handspider Snapping Corrections

### DIFF
--- a/code/mob/living/critter/changeling_critters.dm
+++ b/code/mob/living/critter/changeling_critters.dm
@@ -155,6 +155,10 @@ TYPEINFO(/mob/living/critter/changeling)
 			src.icon_prefix = "robo"
 			src.UpdateIcon()
 
+		// Grant crystal snaps if the mob we (presumably) spawn from has "dactyl crystalization".
+		if (hivemind_owner && hivemind_owner.owner.bioHolder.HasEffect("chime_snaps"))
+			src.sound_fingersnap = 'sound/musical_instruments/WeirdChime_5.ogg'
+
 		RegisterSignal(src, COMSIG_MOB_PICKUP, PROC_REF(stop_sprint))
 		RegisterSignal(src, COMSIG_MOB_DROPPED, PROC_REF(enable_sprint))
 
@@ -222,9 +226,10 @@ TYPEINFO(/mob/living/critter/changeling)
 
 					return message
 			if ("snap","snapfingers","fingersnap","click","clickfingers")
-				message = "The <b>[src.name]</b> snaps [his_or_her(src)] fingers."
-				playsound(src.loc, src.sound_fingersnap, 50, TRUE, channel=VOLUME_CHANNEL_EMOTE)
-				return message
+				if (src.emote_check(voluntary, 3 SECONDS)) // "Dactyl crystalization" is accounted for on `New()`.
+					message = "The <b>[src.name]</b> snaps [his_or_her(src)] fingers."
+					playsound(src.loc, src.sound_fingersnap, 50, TRUE, channel=VOLUME_CHANNEL_EMOTE)
+					return message
 		return null
 
 	specific_emote_type(var/act)

--- a/code/mob/living/critter/changeling_critters.dm
+++ b/code/mob/living/critter/changeling_critters.dm
@@ -155,7 +155,7 @@ TYPEINFO(/mob/living/critter/changeling)
 			src.icon_prefix = "robo"
 			src.UpdateIcon()
 
-		// Grant crystal snaps if the mob we (presumably) spawn from has "dactyl crystalization".
+		// Grant crystal snaps if the mob we (presumably) spawn from has "dactyl crystallization".
 		if (hivemind_owner && hivemind_owner.owner.bioHolder.HasEffect("chime_snaps"))
 			src.sound_fingersnap = 'sound/musical_instruments/WeirdChime_5.ogg'
 
@@ -226,7 +226,7 @@ TYPEINFO(/mob/living/critter/changeling)
 
 					return message
 			if ("snap","snapfingers","fingersnap","click","clickfingers")
-				if (src.emote_check(voluntary, 3 SECONDS)) // "Dactyl crystalization" is accounted for on `New()`.
+				if (src.emote_check(voluntary, 3 SECONDS)) // "Dactyl crystallization" is accounted for on `New()`.
 					message = "The <b>[src.name]</b> snaps [his_or_her(src)] fingers."
 					playsound(src.loc, src.sound_fingersnap, 50, TRUE, channel=VOLUME_CHANNEL_EMOTE)
 					return message


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[CRITTERS] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR ensures that handspiders have a snapping cooldown. As a small bit of detailing, I've also made it such that handspiders spawned from a mob with dactyl crystallization have crystal snaps.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
In PR #25455 I incorrectly attributed a debug handspider being able to snap constantly to the fact that admins have no emote cooldown. While partly true, it seems non-admin-controlled handspiders can do much the same thing. This PR corrects that oversight and adds a small (crystalline) detail to handspider snapping.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
After setting `admin_bypass` on `/mob/proc/emote_check()` to default to `FALSE`, I launched a debug build of the codebase. Prior to these changes, a human mob couldn't snap constantly whereas a handspider could. After these changes, handspiders could no longer snap constantly.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
