### PR TITLE
Remove foam artifact chemical bombs.

### DIFF
--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -245,8 +245,8 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 
 	post_setup()
 		. = ..()
-		payload_type = rand(0,3)
-		var/payload_type_name = "unknown"
+		payload_type = rand(1,3)// replace the 1 with 0 to enable foam bombs
+ 		var/payload_type_name = "unknown"
 		switch (payload_type)
 			if (CHEMBOMB_FOAMY)
 				payload_type_name = "foam"

--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -246,7 +246,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 	post_setup()
 		. = ..()
 		payload_type = rand(1,3)// replace the 1 with 0 to enable foam bombs
- 		var/payload_type_name = "unknown"
+		var/payload_type_name = "unknown"
 		switch (payload_type)
 			if (CHEMBOMB_FOAMY)
 				payload_type_name = "foam"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Disables foam-based chemical artifact bombs. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Chemical artbombs are probably my favorite artifact subtype, but foam bombs basically just make the floor slippery. I get that not all artifacts are meant to be super interesting, but foam bombs are just disappointing.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
sorry didn't test it yet i'll do that later
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)grasswitch
(+)Removed foam-based chemical artifact bombs. 
```
