### PR TITLE
Drag stack building materials

### DIFF
--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -352,6 +352,78 @@ MATERIAL
 
 		.["itemList"] = availableRecipes
 
+	mouse_drop(atom/over_object, src_location, over_location) //src dragged onto over_object
+		if (isobserver(usr))
+			boutput(usr, SPAN_ALERT("Quit that! You're dead!"))
+			return
+		if(isintangible(usr))
+			boutput(usr,SPAN_ALERT("You need hands to do that. Do you have hands? No? Then stop it."))
+			return
+
+		if(!istype(over_object, /atom/movable/screen/hud))
+			if (BOUNDS_DIST(usr, src) > 0)
+				boutput(usr, SPAN_ALERT("You're too far away from it to do that."))
+				return
+			if (BOUNDS_DIST(usr, over_object) > 0)
+				boutput(usr, SPAN_ALERT("You're too far away from it to do that."))
+				return
+
+		if (istype(over_object,/obj/item/sheet) && isturf(over_object.loc)) //piece to piece only if on ground
+			var/obj/item/targetObject = over_object
+			if(targetObject.stack_item(src))
+				usr.visible_message(SPAN_NOTICE("[usr.name] stacks \the [src]s!"))
+		else if(isturf(over_object)) //piece to turf. piece loc doesnt matter.
+			if(src.amount > 1) //split stack.
+				usr.visible_message(SPAN_NOTICE("[usr.name] splits the stack of [src]s!"))
+				var/toSplit = round(amount / 2)
+				var/atom/movable/splitStack = split_stack(toSplit)
+				if(splitStack)
+					splitStack.set_loc(over_object)
+			else
+				if(isturf(src.loc))
+					src.set_loc(over_object)
+				for(var/obj/item/I in view(1,usr))
+					if (!I || I == src)
+						continue
+					if (!src.check_valid_stack(I))
+						continue
+					src.stack_item(I)
+				usr.visible_message(SPAN_NOTICE("[usr.name] stacks \the [src]s!"))
+		else if(istype(over_object, /atom/movable/screen/hud))
+			var/atom/movable/screen/hud/H = over_object
+			var/mob/living/carbon/human/stacker = usr
+			switch(H.id)
+				if("lhand")
+					if(stacker.l_hand)
+						if(stacker.l_hand == src) return
+						else if (istype(stacker.l_hand, /obj/item/sheet))
+							var/obj/item/sheet/DP = stacker.l_hand
+							DP.stack_item(src)
+							usr.visible_message(SPAN_NOTICE("[usr.name] stacks \the [DP]s!"))
+					else if(amount > 1)
+						var/toSplit = round(amount / 2)
+						var/atom/movable/splitStack = split_stack(toSplit)
+						if(splitStack)
+							usr.visible_message(SPAN_NOTICE("[usr.name] splits the stack of [src]s!"))
+							splitStack.set_loc(stacker)
+							stacker.put_in_hand(splitStack, 1)
+				if("rhand")
+					if(stacker.r_hand)
+						if(stacker.r_hand == src) return
+						else if (istype(stacker.r_hand, /obj/item/sheet))
+							var/obj/item/sheet/DP = stacker.r_hand
+							DP.stack_item(src)
+							usr.visible_message(SPAN_NOTICE("[usr.name] stacks \the [DP]s!"))
+					else if(amount > 1)
+						var/toSplit = round(amount / 2)
+						var/atom/movable/splitStack = split_stack(toSplit)
+						if(splitStack)
+							usr.visible_message(SPAN_NOTICE("[usr.name] splits the stack of [src]s!"))
+							splitStack.set_loc(stacker)
+							stacker.put_in_hand(splitStack, 0)
+		else
+			..()
+
 	ui_act(action, params)
 		. = ..()
 		if(.)
@@ -1075,6 +1147,78 @@ MATERIAL
 			W.add_fingerprint(user)
 			W.tooltip_rebuild = TRUE
 		return
+
+	mouse_drop(atom/over_object, src_location, over_location) //src dragged onto over_object
+		if (isobserver(usr))
+			boutput(usr, SPAN_ALERT("Quit that! You're dead!"))
+			return
+		if(isintangible(usr))
+			boutput(usr,SPAN_ALERT("You need hands to do that. Do you have hands? No? Then stop it."))
+			return
+
+		if(!istype(over_object, /atom/movable/screen/hud))
+			if (BOUNDS_DIST(usr, src) > 0)
+				boutput(usr, SPAN_ALERT("You're too far away from it to do that."))
+				return
+			if (BOUNDS_DIST(usr, over_object) > 0)
+				boutput(usr, SPAN_ALERT("You're too far away from it to do that."))
+				return
+
+		if (istype(over_object,/obj/item/tile) && isturf(over_object.loc)) //piece to piece only if on ground
+			var/obj/item/targetObject = over_object
+			if(targetObject.stack_item(src))
+				usr.visible_message(SPAN_NOTICE("[usr.name] stacks \the [src]s!"))
+		else if(isturf(over_object)) //piece to turf. piece loc doesnt matter.
+			if(src.amount > 1) //split stack.
+				usr.visible_message(SPAN_NOTICE("[usr.name] splits the stack of [src]s!"))
+				var/toSplit = round(amount / 2)
+				var/atom/movable/splitStack = split_stack(toSplit)
+				if(splitStack)
+					splitStack.set_loc(over_object)
+			else
+				if(isturf(src.loc))
+					src.set_loc(over_object)
+				for(var/obj/item/I in view(1,usr))
+					if (!I || I == src)
+						continue
+					if (!src.check_valid_stack(I))
+						continue
+					src.stack_item(I)
+				usr.visible_message(SPAN_NOTICE("[usr.name] stacks \the [src]s!"))
+		else if(istype(over_object, /atom/movable/screen/hud))
+			var/atom/movable/screen/hud/H = over_object
+			var/mob/living/carbon/human/stacker = usr
+			switch(H.id)
+				if("lhand")
+					if(stacker.l_hand)
+						if(stacker.l_hand == src) return
+						else if (istype(stacker.l_hand, /obj/item/tile))
+							var/obj/item/tile/DP = stacker.l_hand
+							DP.stack_item(src)
+							usr.visible_message(SPAN_NOTICE("[usr.name] stacks \the [DP]s!"))
+					else if(amount > 1)
+						var/toSplit = round(amount / 2)
+						var/atom/movable/splitStack = split_stack(toSplit)
+						if(splitStack)
+							usr.visible_message(SPAN_NOTICE("[usr.name] splits the stack of [src]s!"))
+							splitStack.set_loc(stacker)
+							stacker.put_in_hand(splitStack, 1)
+				if("rhand")
+					if(stacker.r_hand)
+						if(stacker.r_hand == src) return
+						else if (istype(stacker.r_hand, /obj/item/tile))
+							var/obj/item/tile/DP = stacker.r_hand
+							DP.stack_item(src)
+							usr.visible_message(SPAN_NOTICE("[usr.name] stacks \the [DP]s!"))
+					else if(amount > 1)
+						var/toSplit = round(amount / 2)
+						var/atom/movable/splitStack = split_stack(toSplit)
+						if(splitStack)
+							usr.visible_message(SPAN_NOTICE("[usr.name] splits the stack of [src]s!"))
+							splitStack.set_loc(stacker)
+							stacker.put_in_hand(splitStack, 0)
+		else
+			..()
 
 	before_stack(atom/movable/O as obj, mob/user as mob)
 		user.visible_message(SPAN_NOTICE("[user] begins stacking [src]!"))

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -721,6 +721,78 @@ MATERIAL
 		UpdateStackAppearance()
 		boutput(user, SPAN_NOTICE("You finish gathering rods."))
 
+	mouse_drop(atom/over_object, src_location, over_location) //src dragged onto over_object
+		if (isobserver(usr))
+			boutput(usr, SPAN_ALERT("Quit that! You're dead!"))
+			return
+		if(isintangible(usr))
+			boutput(usr,SPAN_ALERT("You need hands to do that. Do you have hands? No? Then stop it."))
+			return
+
+		if(!istype(over_object, /atom/movable/screen/hud))
+			if (BOUNDS_DIST(usr, src) > 0)
+				boutput(usr, SPAN_ALERT("You're too far away from it to do that."))
+				return
+			if (BOUNDS_DIST(usr, over_object) > 0)
+				boutput(usr, SPAN_ALERT("You're too far away from it to do that."))
+				return
+
+		if (istype(over_object,/obj/item/rods) && isturf(over_object.loc)) //piece to piece only if on ground
+			var/obj/item/targetObject = over_object
+			if(targetObject.stack_item(src))
+				usr.visible_message(SPAN_NOTICE("[usr.name] stacks \the [src]s!"))
+		else if(isturf(over_object)) //piece to turf. piece loc doesnt matter.
+			if(src.amount > 1) //split stack.
+				usr.visible_message(SPAN_NOTICE("[usr.name] splits the stack of [src]s!"))
+				var/toSplit = round(amount / 2)
+				var/atom/movable/splitStack = split_stack(toSplit)
+				if(splitStack)
+					splitStack.set_loc(over_object)
+			else
+				if(isturf(src.loc))
+					src.set_loc(over_object)
+				for(var/obj/item/I in view(1,usr))
+					if (!I || I == src)
+						continue
+					if (!src.check_valid_stack(I))
+						continue
+					src.stack_item(I)
+				usr.visible_message(SPAN_NOTICE("[usr.name] stacks \the [src]s!"))
+		else if(istype(over_object, /atom/movable/screen/hud))
+			var/atom/movable/screen/hud/H = over_object
+			var/mob/living/carbon/human/stacker = usr
+			switch(H.id)
+				if("lhand")
+					if(stacker.l_hand)
+						if(stacker.l_hand == src) return
+						else if (istype(stacker.l_hand, /obj/item/rods))
+							var/obj/item/rods/DP = stacker.l_hand
+							DP.stack_item(src)
+							usr.visible_message(SPAN_NOTICE("[usr.name] stacks \the [DP]s!"))
+					else if(amount > 1)
+						var/toSplit = round(amount / 2)
+						var/atom/movable/splitStack = split_stack(toSplit)
+						if(splitStack)
+							usr.visible_message(SPAN_NOTICE("[usr.name] splits the stack of [src]s!"))
+							splitStack.set_loc(stacker)
+							stacker.put_in_hand(splitStack, 1)
+				if("rhand")
+					if(stacker.r_hand)
+						if(stacker.r_hand == src) return
+						else if (istype(stacker.r_hand, /obj/item/rods))
+							var/obj/item/rods/DP = stacker.r_hand
+							DP.stack_item(src)
+							usr.visible_message(SPAN_NOTICE("[usr.name] stacks \the [DP]s!"))
+					else if(amount > 1)
+						var/toSplit = round(amount / 2)
+						var/atom/movable/splitStack = split_stack(toSplit)
+						if(splitStack)
+							usr.visible_message(SPAN_NOTICE("[usr.name] splits the stack of [src]s!"))
+							splitStack.set_loc(stacker)
+							stacker.put_in_hand(splitStack, 0)
+		else
+			..()
+
 	examine()
 		. = ..()
 		. += "There are [src.amount] rod\s on this stack."


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lovingly steals the mousedrop functionality from `code\modules\materials\Mat_RawMaterials.dm` in order to make it easier to stack piles of sheets, rods, and floor tiles. The code works a bit cleaner in `RawMaterials.dm` since the bars and ores are all subtypes as opposed to how `code\obj\item\building_materials.dm` does it, but the functionality is the same.
- Have a pile of materials (like replacing floors and being left over with a bunch of steel floor tiles)
- Click and hold on one material
- Drag your mouse onto an adjacent tile

Anything matching the material type (i.e. steel floor tiles or glass sheets) will stack themselves neatly on the tile you dragged onto. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having to stack big piles of items by having one in your hand and then repeatedly dragging the piles onto your hand is such a drag.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
- Manufactured piles of sheets, rods, and floor tiles of various material types
- Ensured that only _matching_ materials would stack together
- Split and combined stacks repeatedly from both hands to ensure no errors occurred

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

```changelog
(u)Driftered
(*)Building materials such as floor tiles, rods, and sheets can now be stacked by click-dragging onto nearby tiles.
```
[A-Game-Objects] [C-QoL]