### PR TITLE
Latex glove fingerprints no longer show partial prints by default

### DIFF
--- a/code/modules/forensics/forensic_data.dm
+++ b/code/modules/forensics/forensic_data.dm
@@ -113,8 +113,6 @@
 			return fprint_text + fibers_text
 		else if(src.print_mask?.id == FORENSIC_GLOVE_MASK_FINGERLESS)
 			return src.print?.id
-		else if(src.fibers && startswith(src.fibers.id, "latex rubber"))
-			return "([get_masked_print()])"
 
 			// Not including the fibers for now because they were taking up too much room in the forensic report.
 			//var/fprint_text = get_masked_print()


### PR DESCRIPTION
## About the PR 
- Latex glove partial prints are no longer visible by default. They now require silver nitrate just like other glove types.
- Changed from #24879

## Why's this needed?
- The original PR had latex glove partial prints be visible by default. The idea was that they could act as an introduction to partial fingerprints for new players without the need for silver nitrate. However, having latex gloves as an exception was probably more confusing than anything else. It also prevented the glove ID from being visible which is not ideal.

## Testing
Before (no silver nitrate):
<img width="1117" height="632" alt="Screenshot 2026-04-09 054315" src="https://github.com/user-attachments/assets/6ac5196c-2bc0-4c06-8f46-66004de99208" />
After (with silver nitrate):
<img width="1120" height="535" alt="Screenshot 2026-04-09 054611" src="https://github.com/user-attachments/assets/ebe18cb7-e640-49f1-a466-988e7140fefa" />

```changelog
(u)Lorrmaster
(+)Latex gloves now block fingerprints in the same way all other gloves do.
```