### PR TITLE
UpdateDialog uses in_interact_range

### DIFF
--- a/code/obj/objDialog.dm
+++ b/code/obj/objDialog.dm
@@ -59,7 +59,7 @@ var/global/list/objects_using_dialogs
 		for(var/x in clients_operating)
 			C = x
 			if (C?.mob)
-				if (BOUNDS_DIST(C.mob, src) == 0)
+				if (in_interact_range(src, C.mob))
 					src.Attackhand(C.mob)
 				else
 					if (C.mob.mob_flags & USR_DIALOG_UPDATES_RANGE)
@@ -73,7 +73,7 @@ var/global/list/objects_using_dialogs
 		for(var/x in clients_operating)
 			C = x
 			if (C?.mob)
-				if (BOUNDS_DIST(C.mob, src) == 0)
+				if (in_interact_range(src, C.mob))
 					src.Attackhand(C.mob)
 				else
 					src.remove_dialog(C.mob)
@@ -83,7 +83,7 @@ var/global/list/objects_using_dialogs
 /obj/item/proc/updateSelfDialogFromTurf()	//It's weird, yes. only used for spy stickers as of now
 	if (length(clients_operating))
 		for(var/client/C in clients_operating)
-			if (C.mob && BOUNDS_DIST(C.mob, src) == 0)
+			if (C.mob && in_interact_range(src, C.mob))
 				src.AttackSelf(C.mob)
 
 		for_by_tcl(M, /mob/living/silicon/ai)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the direct range check on dialog updates to an in_interact_range check,

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows ranged uses of dialogs (such as silicon or admin interaction) to properly update their dialogs

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Interacting from further than 1 tile away as AI or with admin ghost interaction properly updated the dialog. Attempting to interact as a  hum