### PR TITLE
Plastic & synthrubber default materials for reagent containers

### DIFF
--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -573,6 +573,7 @@ proc/ui_describe_reagents(atom/A)
 	initial_volume = 120
 	flags = OPENCONTAINER | SUPPRESSATTACK
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
+	default_material = "plastic"
 	can_recycle = FALSE
 	var/helmet_bucket_type = /obj/item/clothing/head/helmet/bucket
 	var/hat_bucket_type = /obj/item/clothing/head/helmet/bucket/hat
@@ -746,6 +747,8 @@ proc/ui_describe_reagents(atom/A)
 	icon = 'icons/obj/items/chemistry_glassware.dmi'
 	icon_state = "lid"
 	w_class = W_CLASS_TINY
+	default_material = "synthrubber_blue"
+	material_amt = 0.2
 
 	attackby(obj/item/reagent_containers/container, mob/user)
 		if (istype(container))
@@ -1557,6 +1560,7 @@ proc/ui_describe_reagents(atom/A)
 /obj/item/reagent_containers/glass/vial/plastic
 	name = "plastic vial"
 	desc = "A 3D-printed vial. Can hold up to 5 units. Barely."
+	default_material = "plastic"
 	can_recycle = FALSE
 
 	New()

--- a/code/modules/chemistry/tools/bottles.dm
+++ b/code/modules/chemistry/tools/bottles.dm
@@ -22,6 +22,7 @@
 /obj/item/reagent_containers/glass/bottle/plastic
 	name = "plastic bottle"
 	desc = "A small 3D-printed bottle."
+	default_material = "plastic"
 	can_recycle = FALSE
 
 	New()

--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -889,6 +889,7 @@ TYPEINFO(/obj/reagent_dispensers/watertank/fountain)
 	item_state = "flask"
 	initial_volume = 500
 	w_class = W_CLASS_BULKY
+	default_material = "plastic"
 	incompatible_with_chem_dispensers = 1
 	can_chug = 0
 

--- a/code/modules/chemistry/tools/iv_drips.dm
+++ b/code/modules/chemistry/tools/iv_drips.dm
@@ -15,6 +15,7 @@
 	w_class = W_CLASS_TINY
 	flags = TABLEPASS | SUPPRESSATTACK | OPENCONTAINER
 	rc_flags = RC_VISIBLE | RC_FULLNESS | RC_SPECTRO
+	default_material = "plastic"
 	amount_per_transfer_from_this = 5
 	initial_volume = 250//100
 	var/image/fluid_image = null

--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -21,6 +21,8 @@
 	var/image/image_inj_dr
 	rc_flags = RC_SCALE | RC_VISIBLE | RC_SPECTRO
 	hide_attack = ATTACK_PARTIALLY_HIDDEN
+	default_material = "plastic"
+	material_amt = 0.2
 
 	New()
 		..()

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -551,6 +551,7 @@ TYPEINFO(/obj/item/clothing/head/that/gold)
 	icon_state = "plunger"
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	item_state = "plunger"
+	default_material = "synthrubber"
 	setupProperties()
 		..()
 		setProperty("meleeprot_head", 2)

--- a/code/obj/mopbucket.dm
+++ b/code/obj/mopbucket.dm
@@ -7,6 +7,7 @@
 	pass_unstable = TRUE
 	pressure_resistance = ONE_ATMOSPHERE
 	flags = TABLEPASS | OPENCONTAINER | ACCEPTS_MOUSEDROP_REAGENTS
+	default_material = "plastic"
 	HELP_MESSAGE_OVERRIDE("You can drag and drop yourself to move onto the bucket.<br>The bucket has 7 storage slots inside of it.<br>To pour reagents into the bucket from a <b>cup</b> or similar, drag and drop the cup to the bucket.")
 	var/rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	var/image/fluid_image


### PR DESCRIPTION
## About the PR
- Adds plastic and synthrubber default materials for various items. Mostly ones containing reagents.
- Intended to be merged with #26373

## Why's this needed?
- Adds item default materials not included in #25634

## Testing
<img width="228" height="252" alt="Screenshot 2026-04-11 023616" src="https://github.com/user-attachments/assets/a0c1d2cd-da24-4b75-8e9a-243ca13f41fe" />
