### PR TITLE
You can now use a Butcher Knife to commit mail fraud

### DIFF
--- a/code/WorkInProgress/zamu_mail.dm
+++ b/code/WorkInProgress/zamu_mail.dm
@@ -75,7 +75,7 @@
 
 	attackby(obj/item/I, mob/user)
 		// You know, like a letter opener. It opens letters.
-		if ((istype(I, /obj/item/kitchen/utensil/knife) || istype(I, /obj/item/dagger)) && src.target_dna)
+		if ((istype(I, /obj/item/kitchen/utensil/knife) || istype(I, /obj/item/dagger) || istype(I, /obj/item/knife)) && src.target_dna)
 			actions.start(new /datum/action/bar/icon/mail_lockpick(src, I, 5 SECONDS), user)
 			return
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #26358 by allowing butcher's knives to open mail that isn't yours.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The butcher knife should by all accounts be able to cut open mail, it's sharp.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spawned multiple letters and respawned as a new character, new character could use both the existing knives to open them as well as the butcher knife.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Hawke
(+)Butcher knives can now be used to cut open mail.
```
