### PR TITLE
Adds new mechcomp options for airlock/door control

### DIFF
--- a/_std/defines/door.dm
+++ b/_std/defines/door.dm
@@ -22,3 +22,10 @@
 #define AIRLOCK_WIRE_AI_CONTROL 8
 #define AIRLOCK_WIRE_ELECTRIFY 9
 #define AIRLOCK_WIRE_SAFETY 10
+
+/// If mechcomp signals are wholly rejected, regardless of access
+#define DOOR_MECHCOMP_FAILED 1
+/// If a mechcomp signal was denied due to access issues
+#define DOOR_MECHCOMP_DENIED 2
+/// If a mechcomp signal is allowed to act on the door
+#define DOOR_MECHCOMP_SUCCESS 3

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -54,6 +54,8 @@ var/global/list/cycling_airlocks = list()
 	var/has_panel = TRUE
 	var/hackMessage = ""
 	var/net_access_code = null
+	/// Keeps track of the next time mechcomp signals can trigger play_deny()
+	var/next_allowed_mech_deny_play = 0
 
 	var/no_access = 0
 
@@ -87,6 +89,9 @@ var/global/list/cycling_airlocks = list()
 		if (!isnull(A))
 			src.name = A.name
 	src.net_access_code = rand(1, NET_ACCESS_OPTIONS)
+	SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"toggle bolts", PROC_REF(mech_toggle_lock))
+	SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"bolt", PROC_REF(mech_lock))
+	SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"unbolt", PROC_REF(mech_unlock))
 	START_TRACKING
 
 
@@ -104,6 +109,71 @@ var/global/list/cycling_airlocks = list()
 		return 0
 	.= ..()
 
+/obj/machinery/door/airlock/try_mech_signal(var/datum/mechanicsMessage/input)
+	if (!src.arePowerSystemsOn() || (src.status & NOPOWER))
+		. = -1
+	else
+		. = ..()
+	if (. != 0)
+		return
+	if (!src.requiresID())
+		return 1
+	var/access_code = text2num(input.signal)
+	if (src.net_access_code == access_code)
+		return 1
+	else
+		if (world.time > next_allowed_mech_deny_play)
+			src.play_deny()
+			next_allowed_mech_deny_play = world.time + 50
+			// solely to make it not-trivial to make a machine that spams the loud-as-fuck deny sound
+		else if (src.density) //only play if it's closed
+			play_animation("deny")
+
+
+/obj/machinery/door/airlock/proc/mech_lock(var/datum/mechanicsMessage/input)
+	if(src.try_mech_signal(input) == 1)
+		if(!src.locked)
+			src.set_locked()
+
+/obj/machinery/door/airlock/proc/mech_unlock(var/datum/mechanicsMessage/input)
+	if(src.try_mech_signal(input) == 1)
+		if(src.locked)
+			src.set_unlocked()
+
+/obj/machinery/door/airlock/proc/mech_toggle_lock(var/datum/mechanicsMessage/input)
+	if(src.try_mech_signal(input) == 1)
+		if(src.locked)
+			src.set_unlocked()
+		else
+			src.set_locked()
+
+/*/obj/machinery/door/airlock/toggleinput(var/datum/mechanicsMessage/input)
+	if(src.operating == -1)
+		return
+	if(src.cant_emag)
+		if (src.density) //only play if it's closed
+			play_animation("deny")
+		return
+	var/list/signal_list = params2complexlist(input.signal)
+	var/command = null
+	if(signal_list.Find("command"))
+		command = signal_list["command"]
+	var/access_code = null
+	if(signal_list.Find("access_code"))
+		access_code = text2num(signal_list["access_code"])
+	if(src.req_access && (src.net_access_code != access_code))
+		src.play_deny()
+		return
+	// if we're here, we can safely assume access_code is either correct or irrelevant
+	if(command)
+		src.execute_signal_command(command)
+		return
+	// we'll leave the below here to keep the old toggle functionality
+	if(density)
+		open()
+	else
+		close()
+*/
 // ================= airlock wire panel procs ==================
 
 /*

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -147,33 +147,6 @@ var/global/list/cycling_airlocks = list()
 		else
 			src.set_locked()
 
-/*/obj/machinery/door/airlock/toggleinput(var/datum/mechanicsMessage/input)
-	if(src.operating == -1)
-		return
-	if(src.cant_emag)
-		if (src.density) //only play if it's closed
-			play_animation("deny")
-		return
-	var/list/signal_list = params2complexlist(input.signal)
-	var/command = null
-	if(signal_list.Find("command"))
-		command = signal_list["command"]
-	var/access_code = null
-	if(signal_list.Find("access_code"))
-		access_code = text2num(signal_list["access_code"])
-	if(src.req_access && (src.net_access_code != access_code))
-		src.play_deny()
-		return
-	// if we're here, we can safely assume access_code is either correct or irrelevant
-	if(command)
-		src.execute_signal_command(command)
-		return
-	// we'll leave the below here to keep the old toggle functionality
-	if(density)
-		open()
-	else
-		close()
-*/
 // ================= airlock wire panel procs ==================
 
 /*

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -54,8 +54,6 @@ var/global/list/cycling_airlocks = list()
 	var/has_panel = TRUE
 	var/hackMessage = ""
 	var/net_access_code = null
-	/// Keeps track of the next time mechcomp signals can trigger play_deny()
-	var/next_allowed_mech_deny_play = 0
 
 	var/no_access = 0
 
@@ -111,37 +109,36 @@ var/global/list/cycling_airlocks = list()
 
 /obj/machinery/door/airlock/try_mech_signal(var/datum/mechanicsMessage/input)
 	if (!src.arePowerSystemsOn() || (src.status & NOPOWER))
-		. = -1
+		. = DOOR_MECHCOMP_FAILED
 	else
 		. = ..()
-	if (. != 0)
+	if (. != DOOR_MECHCOMP_DENIED)
 		return
 	if (!src.requiresID())
-		return 1
+		return DOOR_MECHCOMP_SUCCESS
 	var/access_code = text2num(input.signal)
 	if (src.net_access_code == access_code)
-		return 1
+		return DOOR_MECHCOMP_SUCCESS
 	else
-		if (world.time > next_allowed_mech_deny_play)
+		if(!ON_COOLDOWN(src, "mechcomp_play_deny", 50)) // 5 second cooldown seems reasonable
 			src.play_deny()
-			next_allowed_mech_deny_play = world.time + 50
 			// solely to make it not-trivial to make a machine that spams the loud-as-fuck deny sound
 		else if (src.density) //only play if it's closed
 			play_animation("deny")
 
 
 /obj/machinery/door/airlock/proc/mech_lock(var/datum/mechanicsMessage/input)
-	if(src.try_mech_signal(input) == 1)
+	if(src.try_mech_signal(input) == DOOR_MECHCOMP_SUCCESS)
 		if(!src.locked)
 			src.set_locked()
 
 /obj/machinery/door/airlock/proc/mech_unlock(var/datum/mechanicsMessage/input)
-	if(src.try_mech_signal(input) == 1)
+	if(src.try_mech_signal(input) == DOOR_MECHCOMP_SUCCESS)
 		if(src.locked)
 			src.set_unlocked()
 
 /obj/machinery/door/airlock/proc/mech_toggle_lock(var/datum/mechanicsMessage/input)
-	if(src.try_mech_signal(input) == 1)
+	if(src.try_mech_signal(input) == DOOR_MECHCOMP_SUCCESS)
 		if(src.locked)
 			src.set_unlocked()
 		else

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -173,7 +173,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 	..()
 	UnsubscribeProcess()
 	AddComponent(/datum/component/mechanics_holder)
-	SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"toggle", PROC_REF(toggleinput))
+	SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"toggle open/close", PROC_REF(mech_toggle))
+	SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"open", PROC_REF(mech_open))
+	SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"close", PROC_REF(mech_close))
 	AddComponent(/datum/component/bullet_holes, 15, src.hardened ? 999 : 5) // no bullet holes if hardened; wouldn't want to get their hopes up
 	src.update_nearby_tiles(need_rebuild=1)
 	START_TRACKING
@@ -197,16 +199,35 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 	if(src.dir != NORTH)
 		garland.dir = src.dir
 
-/obj/machinery/door/proc/toggleinput()
-	if(src.cant_emag || (src.req_access && !(src.operating == -1)))
+/// Checks if we should listen to a mechcomp signal, and handles signal failure
+/// Returns -1 if door broke/inherently ignores mechcomp, 0 if access denied, 1 if successful
+/obj/machinery/door/proc/try_mech_signal(var/datum/mechanicsMessage/input)
+	. = 0
+	if(src.cant_emag)
 		if (src.density) //only play if it's closed
 			play_animation("deny")
-		return
-	if(density)
-		open()
-	else
-		close()
-	return
+		return -1
+	if(src.operating == -1)
+		return -1
+	if(!src.req_access)
+		return 1
+
+/obj/machinery/door/proc/mech_toggle(var/datum/mechanicsMessage/input)
+	if(src.try_mech_signal(input) == 1)
+		if(src.density)
+			open()
+		else
+			close()
+
+/obj/machinery/door/proc/mech_open(var/datum/mechanicsMessage/input)
+	if(src.try_mech_signal(input) == 1)
+		if(src.density)
+			open()
+
+/obj/machinery/door/proc/mech_close(var/datum/mechanicsMessage/input)
+	if(src.try_mech_signal(input) == 1)
+		if(!src.density)
+			close()
 
 /obj/machinery/door/meteorhit(obj/M as obj)
 	if (isrestrictedz(src.z))

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -202,30 +202,30 @@ ADMIN_INTERACT_PROCS(/obj/machinery/door, proc/open, proc/close, proc/break_me_c
 /// Checks if we should listen to a mechcomp signal, and handles signal failure
 /// Returns -1 if door broke/inherently ignores mechcomp, 0 if access denied, 1 if successful
 /obj/machinery/door/proc/try_mech_signal(var/datum/mechanicsMessage/input)
-	. = 0
+	. = DOOR_MECHCOMP_DENIED
 	if(src.cant_emag)
 		if (src.density) //only play if it's closed
 			play_animation("deny")
-		return -1
+		return DOOR_MECHCOMP_FAILED
 	if(src.operating == -1)
-		return -1
+		return DOOR_MECHCOMP_FAILED
 	if(!src.req_access)
-		return 1
+		return DOOR_MECHCOMP_SUCCESS
 
 /obj/machinery/door/proc/mech_toggle(var/datum/mechanicsMessage/input)
-	if(src.try_mech_signal(input) == 1)
+	if(src.try_mech_signal(input) == DOOR_MECHCOMP_SUCCESS)
 		if(src.density)
 			open()
 		else
 			close()
 
 /obj/machinery/door/proc/mech_open(var/datum/mechanicsMessage/input)
-	if(src.try_mech_signal(input) == 1)
+	if(src.try_mech_signal(input) == DOOR_MECHCOMP_SUCCESS)
 		if(src.density)
 			open()
 
 /obj/machinery/door/proc/mech_close(var/datum/mechanicsMessage/input)
-	if(src.try_mech_signal(input) == 1)
+	if(src.try_mech_signal(input) == DOOR_MECHCOMP_SUCCESS)
 		if(!src.density)
 			close()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[FEATURE] [STATION SYSTEMS] [WIKI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Expands the range of options for controlling airlocks with MechComp, and adds support for using an airlock's access code in your signal. Just set the signal as the access code if needed.
<img width="322" height="324" alt="image" src="https://github.com/user-attachments/assets/687e6d39-1652-4b42-aa88-6d97eeb2c481" />

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If you wanna do anything fancier than toggling a public/hacked door open/close with MechComp, you need a wifi component and some packet stuff, which is unnecessary boilerplate when doors already can interact with MechComp. This just makes it easier/faster/simpler to set up door controls (and could be used in the future to make those door buttons you find in places like Medbay player-buildable.)

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/881dfd30-adae-4e5f-9a4a-ff846b9252ad

Also did some tests to make sure that cutting ID scan removes the need for the access code, and cutting door power makes signals not do anything - same with emagging the door

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Nexusuxen
(*)New options for MechComp door control. Also, sending an airlock its access code via MechComp signal will allow it to work on doors that require access.
```
