### PR TITLE
Move minimap initialization after random room setup in init

### DIFF
--- a/code/world/initialization/3_init.dm
+++ b/code/world/initialization/3_init.dm
@@ -167,11 +167,6 @@
 		bust_lights()
 		master_mode = "disaster" // heh pt. 2
 
-	UPDATE_TITLE_STATUS("Generating minimaps")
-	Z_LOG_DEBUG("World/Init", "Generating minimaps...")
-	minimap_renderer = new /datum/minimap_renderer()
-	minimap_renderer.initialise_minimaps()
-
 	UPDATE_TITLE_STATUS("Lighting up")
 	Z_LOG_DEBUG("World/Init", "RobustLight2 init...")
 	RL_Start()
@@ -182,6 +177,11 @@
 	buildRandomRooms()
 	makepowernets()
 	#endif
+
+	UPDATE_TITLE_STATUS("Generating minimaps")
+	Z_LOG_DEBUG("World/Init", "Generating minimaps...")
+	minimap_renderer = new /datum/minimap_renderer()
+	minimap_renderer.initialise_minimaps()
 
 	#ifdef SECRETS_ENABLED
 	UPDATE_TITLE_STATUS("Loading gallery artwork")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[INTERNAL][FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Moves the "Generating minimaps" stage of world initialization after the random room setup stage.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The station alterations from random room application should probably be visible on the minimap, especially in the "fancier" use cases like engine rooms.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Looked ingame and random room alterations now show up on the minimap where appropriate.