### PR TITLE
Penlights do not constrict the eyes of the dead

### DIFF
--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -985,11 +985,10 @@ TYPEINFO(/obj/item/device/light/flashlight/penlight)
 
 					var/the_brain = H.get_organ("brain") // don't need to know anything about it other than "is it there?"
 					var/braind = H.get_brain_damage()
-					var/actually_dead = isdead(H) //Are they full on dead? If they're braindead but their body is alive, that gets addressed later.
-
+					var/unresponsive = isdead(H) //Tracks being regular dead or braindead - neither should respond to the penlight.
 					if (!the_brain || isnum(braind))
-						if (!the_brain || braind >= BRAIN_DAMAGE_LETHAL || actually_dead) // braindead as heck
-							actually_dead = TRUE // It will be soon. Also used to prevent eyes from constricting after death.
+						if (!the_brain || braind >= BRAIN_DAMAGE_LETHAL || unresponsive) // braindead as heck
+							unresponsive = TRUE
 							if(!rpstatus) rpstatus = " The pupil " // If you have drugs in your system, keep the description of the pupils.
 							if(!lpstatus) lpstatus = " The pupil "
 							if (leye)
@@ -1015,7 +1014,7 @@ TYPEINFO(/obj/item/device/light/flashlight/penlight)
 						lmove = SPAN_ALERT("[He_She] has no left eye!")
 						lpstatus = null
 						lpreact = null
-					else if(!actually_dead)
+					else if(!unresponsive)
 						if (!lmove) lmove = "[His_Her] left eye follows the light easily."
 						if (!lpstatus) lpstatus = " The pupil "
 						if (!lpreact) lpreact = "constricts normally."
@@ -1024,7 +1023,7 @@ TYPEINFO(/obj/item/device/light/flashlight/penlight)
 						rmove = SPAN_ALERT("[He_She] has no right eye!")
 						rpstatus = null
 						rpreact = null
-					else if(!actually_dead)
+					else if(!unresponsive)
 						if (!rmove) rmove = "[His_Her] right eye follows the light easily."
 						if (!rpstatus) rpstatus = " The pupil "
 						if (!rpreact) rpreact = "constricts normally."

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -985,13 +985,19 @@ TYPEINFO(/obj/item/device/light/flashlight/penlight)
 
 					var/the_brain = H.get_organ("brain") // don't need to know anything about it other than "is it there?"
 					var/braind = H.get_brain_damage()
+					var/actually_dead = isdead(H) //Are they full on dead? If they're braindead but their body is alive, that gets addressed later.
+
 					if (!the_brain || isnum(braind))
-						if (!the_brain || braind >= BRAIN_DAMAGE_LETHAL) // braindead as heck
-							if (leye) lmove = "[His_Her] left eye doesn't follow the light at all!"
-							if (reye) rmove = "[His_Her] right eye doesn't follow the light at all!"
-							if (!the_brain)
-								if (leye) lpreact = "doesn't react to the light at all!"
-								if (reye) rpreact = "doesn't react to the light at all!"
+						if (!the_brain || braind >= BRAIN_DAMAGE_LETHAL || actually_dead) // braindead as heck
+							actually_dead = TRUE // It will be soon. Also used to prevent eyes from constricting after death.
+							if(!rpstatus) rpstatus = " The pupil " // If you have drugs in your system, keep the description of the pupils.
+							if(!lpstatus) lpstatus = " The pupil "
+							if (leye)
+								lmove = "[His_Her] left eye doesn't follow the light at all!"
+								lpreact = "doesn't react to the light at all!"
+							if (reye)
+								rmove = "[His_Her] right eye doesn't follow the light at all!"
+								rpreact = "doesn't react to the light at all!"
 						else if (braind >= BRAIN_DAMAGE_MAJOR) // when one becomes a gibbering mess
 							if (reye)
 								rmove = "[His_Her] right eye doesn't follow the light at all!"
@@ -1009,7 +1015,7 @@ TYPEINFO(/obj/item/device/light/flashlight/penlight)
 						lmove = SPAN_ALERT("[He_She] has no left eye!")
 						lpstatus = null
 						lpreact = null
-					else
+					else if(!actually_dead)
 						if (!lmove) lmove = "[His_Her] left eye follows the light easily."
 						if (!lpstatus) lpstatus = " The pupil "
 						if (!lpreact) lpreact = "constricts normally."
@@ -1018,7 +1024,7 @@ TYPEINFO(/obj/item/device/light/flashlight/penlight)
 						rmove = SPAN_ALERT("[He_She] has no right eye!")
 						rpstatus = null
 						rpreact = null
-					else
+					else if(!actually_dead)
 						if (!rmove) rmove = "[His_Her] right eye follows the light easily."
 						if (!rpstatus) rpstatus = " The pupil "
 						if (!rpreact) rpreact = "constricts normally."


### PR DESCRIPTION
[Bug][Medical]

## About the PR 
If youer patient is braindead or actually dead, using of the pen lihgt no longer say "The pupil constricts normally." instead will say it "doesn't react to the light at all!" alsso, if there are droogas in person affectimg eyes (methamfetamine was tested), pupil stay in dilated/constricted mode but donot react to light.
part of fixing was so pupil do not react to light if braindead, no brain, or dead - i think used to be only do not react if there is brain before? Little confused...

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #26382
here is link saying pupil not react if brain is dead.
https://www.quora.com/Do-dead-peoples-pupils-still-constrict-or-react-when-a-bright-light-is-shone-into-it
maybe it is not righjt, please mention if thereis problem.

## Testing 
imaje of dead people with drug+braindead, braindead, and braindead+misssing eye. Text works, i think
<img width="2177" height="897" alt="Penlightfeature" src="https://github.com/user-attachments/assets/4ab605d2-3c5b-467d-9bc2-db0524f71310" />


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->
not needing, ithink.
