### PR TITLE
Stopping or missing heart stops bleeding and slowly damages all organs

### DIFF
--- a/code/modules/medical/diseases/malady.dm
+++ b/code/modules/medical/diseases/malady.dm
@@ -564,6 +564,7 @@
 				H.take_brain_damage(1 * mult)
 
 		H.bleeding = 0
+		H.bleeding_internal = 0
 		H.changeStatus("knockdown", 6 * mult SECONDS)
 		H.losebreath+=20 * mult
 		H.take_oxygen_deprivation(20 * mult)

--- a/code/modules/medical/diseases/malady.dm
+++ b/code/modules/medical/diseases/malady.dm
@@ -517,7 +517,8 @@
 		if (!H.organHolder.heart)
 			H.cure_disease(D)
 			return
-		else if (H.organHolder.heart && H.organHolder.heart.robotic && !H.organHolder.heart.broken && !D.robo_restart)
+
+		if (H.organHolder.heart.robotic && !H.organHolder.heart.broken && !D.robo_restart)
 			boutput(H, SPAN_ALERT("Your cyberheart detects a cardiac event and attempts to return to its normal rhythm!"))
 
 			if (probmult(20) && H.organHolder.heart.emagged)
@@ -562,7 +563,11 @@
 			else if (prob(10))
 				H.take_brain_damage(1 * mult)
 
+		H.bleeding = 0
 		H.changeStatus("knockdown", 6 * mult SECONDS)
 		H.losebreath+=20 * mult
 		H.take_oxygen_deprivation(20 * mult)
-		H.organHolder?.damage_organ(tox=1 * mult, organ="heart")
+		if (prob(50))
+			H.organHolder?.damage_organ(tox=1 * mult, organ="heart")
+		else // blood ain't gettin to those other organs
+			H.organHolder?.damage_organs(tox=1 * mult, organs=H.organHolder.organ_list)

--- a/code/modules/scanners/health.dm
+++ b/code/modules/scanners/health.dm
@@ -93,7 +93,7 @@
 					bp_col = "#CC7A1D"
 				if (666 to INFINITY) // very high (160/100)
 					bp_col = "red"
-			if (isdead(L))
+			if (isdead(L) || L.find_ailment_by_type(/datum/ailment/malady/flatline) || length(L.organHolder?.get_missing_organs("heart")))
 				blood_data = "Blood Pressure: [SPAN_ALERT("NO PULSE")]"
 			else
 				blood_data = "Blood Pressure: <span style='color:[bp_col]'>[L.blood_pressure["rendered"]] ([L.blood_pressure["status"]])</span>"

--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -444,6 +444,7 @@
 			if ("heart")
 				if (!isvampire(src.donor))
 					src.donor.bleeding = 0
+					src.donor.bleeding_internal = 0
 					if (prob(50))
 						src.donor.organHolder?.damage_organs(tox=1 * mult, organs=src.donor.organHolder?.organ_list)
 			//Missing lungs is handled in it's own proc right now. I'll probably move it here eventually, but that's how I did it originally before I thought of a thing for handling missing organs in the organholder and I'm not rewriting such a tedious thing now.

--- a/code/obj/item/organ_holder.dm
+++ b/code/obj/item/organ_holder.dm
@@ -441,6 +441,11 @@
 					return
 				if (donor.mob_flags & SHOULD_HAVE_A_TAIL) // Only become clumsy if you should have a tail and are not a shapeshifting alien
 					donor.bioHolder?.AddEffect("clumsy", 0, 0, 0, 1)
+			if ("heart")
+				if (!isvampire(src.donor))
+					src.donor.bleeding = 0
+					if (prob(50))
+						src.donor.organHolder?.damage_organs(tox=1 * mult, organs=src.donor.organHolder?.organ_list)
 			//Missing lungs is handled in it's own proc right now. I'll probably move it here eventually, but that's how I did it originally before I thought of a thing for handling missing organs in the organholder and I'm not rewriting such a tedious thing now.
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The empowered anaerobic metabolism gene restores a lot of missing OXY damage every tick, and this overpowers the oxygen loss effects from heart flat-lining. I envision the gene working as your body able to generate o2 and put it into blood circulation, not that every cell in your body does not require or generates its own o2.

In cases of heart flat-line or removal, then, blood stops delivering oxygen to other organs, causing them to slowly rot (take 1 TOX damage). It also follows that the lack of blood flow would prevent further bleeding, just like if you were dead.

Health analyzers now also show NO PULSE for victims of heart flat-line or for missing hearts.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes heart issues stun-locking players with forever with no way out aside from suicide command; instead, death comes. 

Fix #26363

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(+)A stopped or missing heart stops bleeding, and causes your organs to slowly die.
```
