### PR TITLE
Kudzu conversion buffs

### DIFF
--- a/code/datums/controllers/process/kudzu.dm
+++ b/code/datums/controllers/process/kudzu.dm
@@ -45,7 +45,7 @@
 			H.set_body_icon_dirty()
 			return
 		if(H.hasStatus("kudzuwalk") && !iskudzuman(H))
-			src.conversion_progress += CONVERT_REQUIRED
+			src.grant_conversion()
 		else
 			src.conversion_progress += rand(CONVERT_PER_CORPSE_MINIMUM, CONVERT_PER_CORPSE_MAXIMUM)
 		if(src.conversion_progress < CONVERT_REQUIRED)
@@ -65,6 +65,9 @@
 			H.abilityHolder.dispose()
 			H.abilityHolder = null
 		H.mind?.add_antagonist(ROLE_KUDZUPERSON, source = ANTAGONIST_SOURCE_CONVERTED, respect_mutual_exclusives = FALSE)
+
+	proc/grant_conversion()
+		src.conversion_progress += CONVERT_REQUIRED
 
 /mob/living/carbon/human/proc/infect_kudzu()
 	var/obj/icecube/kudzu/cube = new /obj/icecube/kudzu(get_turf(src), src)

--- a/code/datums/controllers/process/kudzu.dm
+++ b/code/datums/controllers/process/kudzu.dm
@@ -44,7 +44,10 @@
 			H.decomp_stage = DECOMP_STAGE_SKELETONIZED
 			H.set_body_icon_dirty()
 			return
-		src.conversion_progress += rand(CONVERT_PER_CORPSE_MINIMUM, CONVERT_PER_CORPSE_MAXIMUM)
+		if(H.hasStatus("kudzuwalk"))
+			src.conversion_progress += CONVERT_REQUIRED
+		else
+			src.conversion_progress += rand(CONVERT_PER_CORPSE_MINIMUM, CONVERT_PER_CORPSE_MAXIMUM)
 		if(src.conversion_progress < CONVERT_REQUIRED)
 			H.decomp_stage = DECOMP_STAGE_SKELETONIZED
 			H.set_body_icon_dirty()

--- a/code/datums/controllers/process/kudzu.dm
+++ b/code/datums/controllers/process/kudzu.dm
@@ -44,7 +44,7 @@
 			H.decomp_stage = DECOMP_STAGE_SKELETONIZED
 			H.set_body_icon_dirty()
 			return
-		if(H.hasStatus("kudzuwalk"))
+		if(H.hasStatus("kudzuwalk") && !iskudzuman(H))
 			src.conversion_progress += CONVERT_REQUIRED
 		else
 			src.conversion_progress += rand(CONVERT_PER_CORPSE_MINIMUM, CONVERT_PER_CORPSE_MAXIMUM)

--- a/code/modules/events/gimmick/kudzu.dm
+++ b/code/modules/events/gimmick/kudzu.dm
@@ -28,7 +28,7 @@
 			boutput(user, "You plant the [src] on the [A].")
 			logTheThing(LOG_STATION, user, "plants [src] (kudzu) at [log_loc(src)].")
 			user.setStatus("kudzuwalk", INFINITE_STATUS)
-			global.get_master_kudzu_controller().conversion_progress += 100 //Equal to CONVERT_REQUIRED in process/kudzu.dm. E.G. one free corpse conversion per seed
+			global.get_master_kudzu_controller().grant_conversion()
 			message_admins("[key_name(user)] planted kudzu at [log_loc(src)].")
 			message_ghosts("<b>Kudzu</b> has been planted at [log_loc(src.loc, ghostjump=TRUE)].")
 			user.u_equip(src)

--- a/code/modules/events/gimmick/kudzu.dm
+++ b/code/modules/events/gimmick/kudzu.dm
@@ -28,6 +28,7 @@
 			boutput(user, "You plant the [src] on the [A].")
 			logTheThing(LOG_STATION, user, "plants [src] (kudzu) at [log_loc(src)].")
 			user.setStatus("kudzuwalk", INFINITE_STATUS)
+			global.get_master_kudzu_controller().conversion_progress += 100 //Equal to CONVERT_REQUIRED in process/kudzu.dm. E.G. one free corpse conversion per seed
 			message_admins("[key_name(user)] planted kudzu at [log_loc(src)].")
 			message_ghosts("<b>Kudzu</b> has been planted at [log_loc(src.loc, ghostjump=TRUE)].")
 			user.u_equip(src)
@@ -400,6 +401,7 @@
 		return
 
 /proc/get_master_kudzu_controller()
+	RETURN_TYPE(/datum/controller/process/kudzu)
 	for (var/datum/controller/process/kudzu/K in processScheduler.processes)
 		return K
 	return null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Grants two sources of guaranteed conversions to the kudzu
- Planting a kudzu seed will guarantee the next corpse is converted.
- Having the kudzuwalk status effect and not being a kudzuperson (i.e, already converted) will guarantee you are converted.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hopefully encourage antagonists to work with their kudzu more by granting them a guaranteed kudzuperson if they get a kill for the kudzu and a guaranteed revive if they die in the kudzu.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Before implementing the kudzuwalk change, planted a seed, died, got converted
After the kudzuwalk changed applied the status effect to myself manually, died, got converted, died again as kudzuperson, did not get converted.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Each kudzu seed planted now grants a guaranteed conversion to the kudzu (e.g. your first kill is guaranteed to be converted). Having the Kudzuwalk status effect (e.g. you planted the kudzu) will guarantee you get converted to a kudzuperson if you aren't already a kudzuperson.
```
