### PR TITLE
Neon hydroponics rework

### DIFF
--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -31943,6 +31943,10 @@
 	},
 /obj/landmark/start/job/botanist,
 /obj/machinery/light/incandescent,
+/obj/item/paper/book/from_file/hydroponicsguide{
+	pixel_y = 5;
+	pixel_x = 14
+	},
 /turf/simulated/floor/green/side{
 	dir = 9
 	},

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -74,8 +74,10 @@
 /turf/simulated/floor/plating,
 /area/tech_outpost)
 "add" = (
-/obj/machinery/disposal/mail/small/autoname/hydroponics/north,
-/obj/disposalpipe/trunk/mail/south,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "adP" = (
@@ -840,15 +842,6 @@
 /obj/decal/cleanable/blood/splatter,
 /turf/simulated/wall/auto/reinforced/old,
 /area/evilreaver/genetics)
-"aDl" = (
-/obj/stool/chair/couch{
-	dir = 4
-	},
-/obj/landmark/start/job/botanist,
-/turf/simulated/floor/green/side{
-	dir = 5
-	},
-/area/station/hydroponics/bay)
 "aDO" = (
 /obj/fakeobject/pipe{
 	color = "b4b4b4";
@@ -900,11 +893,8 @@
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "aEY" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/plantpot,
-/obj/machinery/light_switch/west,
+/obj/machinery/camera/directional/west,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "aFl" = (
@@ -1063,17 +1053,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"aJT" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/plantpot,
-/obj/machinery/light/incandescent,
-/obj/machinery/camera/directional/west{
-	pixel_y = 10
-	},
-/turf/simulated/floor/grass/random,
-/area/station/hydroponics/bay)
 "aKn" = (
 /obj/table/reinforced/auto,
 /obj/item/boardgame/chess,
@@ -1094,9 +1073,10 @@
 /turf/simulated/floor/scorched2,
 /area/diner/kitchen)
 "aLf" = (
-/obj/submachine/chem_extractor,
-/obj/machinery/light/incandescent,
-/turf/simulated/floor,
+/obj/submachine/seed_manipulator,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
 /area/station/hydroponics/bay)
 "aLj" = (
 /obj/cable{
@@ -1652,14 +1632,11 @@
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/west,
 /area/station/crew_quarters/ce)
-"bjZ" = (
-/obj/machinery/door/airlock/pyro/glass/botany,
-/obj/mapping_helper/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
+"bki" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/green/side{
+	dir = 10
 	},
-/obj/mapping_helper/access/hydro,
-/turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "bkk" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -1808,6 +1785,18 @@
 "brh" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
+"bsF" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/produce{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/hydroponics/bay)
 "bsK" = (
 /obj/table/wood/auto,
 /turf/simulated/floor/specialroom/chapel,
@@ -2523,6 +2512,10 @@
 /obj/bubble_vent/oxygen,
 /turf/space/fluid,
 /area/space)
+"bWI" = (
+/obj/disposalpipe/segment/bent/east,
+/turf/simulated/floor/green/corner,
+/area/station/hydroponics/bay)
 "bWL" = (
 /obj/decal/cleanable/oil,
 /obj/disposalpipe/segment{
@@ -2871,6 +2864,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"ckM" = (
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg{
+	rand_pos = 0
+	},
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "ckY" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/bluewhite{
@@ -4050,6 +4051,12 @@
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
+"cZJ" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/green/side,
+/area/station/hydroponics/bay)
 "cZT" = (
 /obj/disposalpipe/segment/morgue,
 /obj/mesh/grille/steel,
@@ -4762,13 +4769,6 @@
 /obj/machinery/navbeacon/guardbot_buddytime,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
-"dyf" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/grass/random,
-/area/station/hydroponics/bay)
 "dyC" = (
 /obj/machinery/computer/announcement/station/captain,
 /obj/machinery/door_control/bolter/new_walls/north{
@@ -5275,6 +5275,16 @@
 	dir = 4
 	},
 /area/station/security/processing)
+"dOc" = (
+/obj/table/reinforced/auto,
+/obj/item/bee_egg_carton{
+	pixel_y = 5;
+	pixel_x = -1
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/hydroponics/bay)
 "dOJ" = (
 /obj/machinery/bot/firebot,
 /turf/simulated/floor/grime,
@@ -5696,6 +5706,13 @@
 	},
 /turf/simulated/floor/shuttle/flock,
 /area/flock_trader)
+"eff" = (
+/obj/stool/chair/office/green{
+	dir = 8
+	},
+/obj/landmark/start/job/botanist,
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
 "efm" = (
 /obj/machinery/door/poddoor/pyro{
 	dir = 1;
@@ -6410,7 +6427,10 @@
 "eAu" = (
 /obj/reagent_dispensers/foamtank,
 /obj/item/storage/pill_bottle/cyberpunk,
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "eAP" = (
@@ -6817,6 +6837,15 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"eNm" = (
+/obj/machinery/chem_master{
+	dir = 8
+	},
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/green/side{
+	dir = 6
+	},
+/area/station/hydroponics/bay)
 "eNu" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency{
@@ -6910,12 +6939,7 @@
 /obj/railing/orange/reinforced{
 	dir = 8
 	},
-/obj/machinery/disposal/small/south,
-/obj/disposalpipe/trunk/north,
 /obj/storage/secure/closet/civilian/ranch,
-/obj/item/device/radio/intercom/catering{
-	dir = 1
-	},
 /turf/simulated/floor/grasstodirt{
 	dir = 8
 	},
@@ -7825,6 +7849,7 @@
 /obj/machinery/camera/ranch/directional/west{
 	pixel_y = 10
 	},
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "fwf" = (
@@ -8465,6 +8490,11 @@
 /obj/map/light/screen,
 /turf/simulated/floor/white,
 /area/evilreaver/genetics)
+"fTD" = (
+/obj/chicken_nesting_box,
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "fTY" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -9170,12 +9200,8 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light_switch/south{
-	pixel_x = -6
-	},
-/obj/blind_switch/area/south{
-	pixel_x = 6
-	},
+/obj/machinery/disposal/small/south,
+/obj/disposalpipe/trunk/north,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "gqL" = (
@@ -9364,14 +9390,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/north)
-"gwM" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/storage/secure/closet/civilian/hydro,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "gwR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -9976,6 +9994,10 @@
 	dir = 8
 	},
 /area/station/turret_protected/ai)
+"gSz" = (
+/obj/machinery/vending/hydroponics,
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
 "gSD" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -10231,12 +10253,24 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "hcS" = (
-/obj/machinery/disposal/small/north{
-	pixel_y = 32
+/obj/table/auto,
+/obj/item/device/light/lava_lamp{
+	pixel_x = 6;
+	pixel_y = 8
 	},
-/obj/disposalpipe/trunk/west,
-/obj/machinery/plantpot,
-/turf/simulated/floor/grass/random,
+/obj/item/reagent_containers/food/snacks/sandwich/meat_m{
+	name = "100% synthetic freerange monkey sandwich";
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/glass/water_pipe{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/device/radio/intercom,
+/turf/simulated/floor/green/side{
+	dir = 5
+	},
 /area/station/hydroponics/bay)
 "hey" = (
 /obj/machinery/launcher_loader/west,
@@ -10877,6 +10911,11 @@
 /obj/item/clothing/mask/gas/emergency,
 /turf/simulated/floor/grime,
 /area/iss)
+"hHL" = (
+/obj/machinery/hydro_mister,
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/grass/random,
+/area/station/hydroponics/bay)
 "hHY" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor,
@@ -10959,7 +10998,7 @@
 /turf/space/fluid,
 /area/evilreaver)
 "hKo" = (
-/obj/machinery/light/incandescent,
+/obj/reagent_dispensers/watertank/big,
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
@@ -11485,6 +11524,12 @@
 /obj/chicken_nesting_box,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"ida" = (
+/obj/disposalpipe/segment/bent/south,
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/hydroponics/bay)
 "idP" = (
 /obj/table/auto,
 /obj/item/cigpacket/menthol,
@@ -11710,9 +11755,11 @@
 /turf/simulated/floor/grime,
 /area/iss)
 "ikA" = (
-/obj/submachine/seed_manipulator,
-/obj/item/device/radio/intercom/catering,
-/turf/simulated/floor,
+/obj/machinery/plantpot,
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
 /area/station/hydroponics/bay)
 "ikC" = (
 /obj/storage/secure/closet/command/medical_director,
@@ -11733,9 +11780,8 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "ilz" = (
-/obj/machinery/vending/hydroponics,
 /turf/simulated/floor/green/side{
-	dir = 6
+	dir = 8
 	},
 /area/station/hydroponics/bay)
 "ilF" = (
@@ -11759,15 +11805,6 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
-"img" = (
-/obj/stool/chair/couch{
-	dir = 8
-	},
-/obj/landmark/start/job/botanist,
-/turf/simulated/floor/green/side{
-	dir = 9
-	},
-/area/station/hydroponics/bay)
 "imo" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -12327,6 +12364,13 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
 /area/station/ai_monitored/storage/eva)
+"iGJ" = (
+/obj/disposalpipe/chicken_disposal_pipe/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "iGM" = (
 /obj/table/wood/round/auto,
 /obj/item/kitchen/food_box/donut_box{
@@ -12406,6 +12450,12 @@
 "iJU" = (
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
 /area/iss)
+"iKa" = (
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/green/side{
+	dir = 6
+	},
+/area/station/hydroponics/bay)
 "iKd" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor,
@@ -12522,13 +12572,11 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "iOs" = (
-/obj/table/reinforced/auto,
-/obj/item/bee_egg_carton,
-/obj/item/reagent_containers/glass/water_pipe{
-	pixel_x = 7;
-	pixel_y = 5
+/obj/machinery/light/incandescent,
+/obj/machinery/disposal/botany,
+/turf/simulated/floor/green/side{
+	dir = 9
 	},
-/turf/simulated/floor,
 /area/station/hydroponics/bay)
 "iOt" = (
 /obj/cable{
@@ -12538,6 +12586,11 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"iOT" = (
+/obj/machinery/disposal/mail/small/autoname/hydroponics/south,
+/obj/disposalpipe/trunk/west,
+/turf/simulated/floor/green/side,
+/area/station/hydroponics/bay)
 "iOX" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -12901,14 +12954,6 @@
 "jdY" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay)
-"jel" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/hydroponics/bay)
 "jeo" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/door/airlock/pyro{
@@ -13426,10 +13471,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/ce)
-"jvb" = (
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "jvc" = (
 /obj/machinery/conveyor_switch{
 	id = "garbage";
@@ -14310,8 +14351,12 @@
 /turf/simulated/floor/purple/side,
 /area/station/hallway/primary/south)
 "jTK" = (
-/obj/machinery/hydro_growlamp,
-/turf/simulated/floor/grass/random,
+/obj/stool/chair/office/green{
+	dir = 4
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
 /area/station/hydroponics/bay)
 "jTX" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -14441,15 +14486,6 @@
 /obj/item/device/radio/intercom,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
-"jXT" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/hallway/primary/south)
 "jXW" = (
 /obj/disposalpipe/block_sensing_outlet{
 	dir = 4
@@ -15206,12 +15242,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
-"kCU" = (
-/obj/machinery/door/airlock/pyro/alt,
-/obj/mapping_helper/access/hydro,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
 "kDa" = (
 /obj/machinery/firealarm/directional/north,
 /obj/table/wood/auto,
@@ -15650,11 +15680,6 @@
 "kTr" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
-"kTs" = (
-/obj/disposalpipe/segment/vertical,
-/obj/machinery/navbeacon/mule/hydroponics_north,
-/turf/simulated/floor/grass/random,
-/area/station/hydroponics/bay)
 "kTz" = (
 /obj/decal/cleanable/generic,
 /obj/machinery/light/incandescent/warm/very,
@@ -15922,10 +15947,14 @@
 /turf/simulated/floor/grime,
 /area/iss)
 "lbr" = (
-/obj/disposalpipe/segment/produce{
-	dir = 4
+/obj/machinery/sink/slim{
+	dir = 4;
+	pixel_x = -8
 	},
-/turf/simulated/floor,
+/obj/machinery/drainage,
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
 /area/station/hydroponics/bay)
 "lbB" = (
 /obj/table/reinforced/auto,
@@ -16736,15 +16765,6 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
-"lFs" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4;
-	req_access = null
-	},
-/obj/mapping_helper/access/hydro,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
 "lFu" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -16884,6 +16904,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "lJy" = (
@@ -16955,10 +16978,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/hop)
 "lMH" = (
-/obj/disposalpipe/segment/horizontal,
-/obj/reagent_dispensers/compostbin,
-/obj/item/device/radio/intercom/catering,
-/turf/simulated/floor/grass/random,
+/obj/stool/chair/couch{
+	dir = 4
+	},
+/obj/landmark/start/job/botanist,
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
 /area/station/hydroponics/bay)
 "lNg" = (
 /turf/simulated/floor/escape{
@@ -17424,6 +17451,10 @@
 /obj/machinery/camera/directional/north{
 	pixel_x = -10
 	},
+/obj/machinery/light_switch/north{
+	pixel_x = 10
+	},
+/obj/blind_switch/area/north,
 /turf/simulated/floor/grasstodirt{
 	dir = 8
 	},
@@ -17728,10 +17759,10 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/disposalpipe/segment/produce{
+	icon_state = "pipe-c";
+	dir = 1
 	},
-/obj/disposalpipe/segment/produce,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "mni" = (
@@ -17800,12 +17831,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"mql" = (
-/obj/machinery/plantpot,
-/obj/item/device/radio/intercom{
+"mri" = (
+/obj/submachine/chem_extractor{
+	dir = 8
+	},
+/turf/simulated/floor/green/side{
 	dir = 4
 	},
-/turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "mrm" = (
 /obj/fakeobject/flock/antenna/end{
@@ -18170,9 +18202,6 @@
 /obj/table/reinforced/bar/auto,
 /obj/machinery/light/incandescent/warm,
 /obj/random_item_spawner/tableware,
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "mFr" = (
@@ -18586,6 +18615,7 @@
 /obj/decal/tile_edge/floorguide/arrow_e{
 	dir = 1
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -18740,9 +18770,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/north)
 "ncd" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	req_access = null
-	},
+/obj/machinery/door/airlock/pyro/medical/alt,
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/rancher,
 /turf/simulated/floor,
@@ -19576,9 +19604,12 @@
 /turf/simulated/floor/grime,
 /area/diner/kitchen)
 "nIK" = (
-/obj/machinery/light/incandescent,
-/obj/machinery/plantpot,
-/turf/simulated/floor/grass/random,
+/obj/submachine/seed_manipulator{
+	dir = 8
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
 /area/station/hydroponics/bay)
 "nIR" = (
 /obj/decal/cleanable/molten_item,
@@ -19973,6 +20004,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"nZw" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/hydroponics/bay)
 "nZB" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
@@ -19992,19 +20029,16 @@
 	dir = 4
 	},
 /area/station/engine/engineering)
+"nZI" = (
+/obj/mapping_helper/wingrille_spawn/auto,
+/obj/machinery/status_display,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/bar)
 "nZN" = (
 /obj/machinery/fluid_canister,
 /obj/machinery/light/small/floor/cool,
 /turf/simulated/floor/plating,
 /area/iss)
-"nZQ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/hydroponics/bay)
 "oai" = (
 /obj/machinery/disposal/mail/small/autoname/public/crew/north,
 /obj/disposalpipe/trunk/mail/west,
@@ -20155,10 +20189,6 @@
 /area/station/hallway/primary/south)
 "odN" = (
 /obj/fishing_pool/portable,
-/obj/disposalpipe/segment/produce{
-	icon_state = "pipe-c";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "odP" = (
@@ -20392,7 +20422,9 @@
 /turf/simulated/floor,
 /area/station/security/evidence)
 "okB" = (
-/obj/disposalpipe/segment/produce,
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "olE" = (
@@ -21019,15 +21051,6 @@
 "oLP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/research_outpost)
-"oLV" = (
-/obj/submachine/seed_vendor,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/hydroponics/bay)
 "oMb" = (
 /turf/simulated/floor/martian,
 /area/evilreaver)
@@ -21174,6 +21197,9 @@
 /mob/living/critter/martian/warrior,
 /turf/simulated/floor/martian,
 /area/evilreaver/storage/tools)
+"oRY" = (
+/turf/simulated/floor/green/side,
+/area/station/hydroponics/bay)
 "oRZ" = (
 /obj/machinery/door/airlock/pyro/classic,
 /turf/simulated/floor/plating,
@@ -21635,9 +21661,12 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
@@ -21993,12 +22022,6 @@
 /obj/item/clothing/mask/medical,
 /turf/simulated/floor/circuit/red,
 /area/space)
-"pwn" = (
-/obj/stool/chair/green{
-	dir = 4
-	},
-/turf/simulated/floor/grass/random,
-/area/station/hydroponics/bay)
 "pwy" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -22317,7 +22340,7 @@
 /obj/railing/orange/reinforced{
 	dir = 1
 	},
-/obj/disposalpipe/segment/horizontal,
+/obj/disposalpipe/segment/bent/east,
 /obj/machinery/navbeacon/mule/ranch_north/south,
 /turf/simulated/floor/grasstodirt{
 	dir = 1
@@ -22346,6 +22369,16 @@
 	dir = 4
 	},
 /area/station/security/processing)
+"pIU" = (
+/obj/reagent_dispensers/compostbin,
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/hydroponics/bay)
 "pJo" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/radiostation/studio)
@@ -22652,15 +22685,8 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"pQG" = (
-/obj/disposalpipe/segment/vertical,
-/obj/item/device/radio/beacon,
-/turf/simulated/floor/green,
-/area/station/hydroponics/bay)
 "pQJ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "pQL" = (
@@ -22971,6 +22997,11 @@
 	dir = 8
 	},
 /area/research_outpost)
+"qbC" = (
+/obj/disposalpipe/segment/horizontal,
+/obj/machinery/navbeacon/mule/hydroponics_north,
+/turf/simulated/floor/grass/random,
+/area/station/hydroponics/bay)
 "qcr" = (
 /obj/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -23010,7 +23041,6 @@
 /turf/simulated/floor/shuttlebay,
 /area/research_outpost/hangar)
 "qeb" = (
-/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/grasstodirt{
 	dir = 5
 	},
@@ -23375,9 +23405,8 @@
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "qry" = (
-/obj/disposalpipe/segment/produce{
-	icon_state = "pipe-c";
-	dir = 8
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
@@ -23439,11 +23468,10 @@
 /turf/simulated/floor/shuttlebay,
 /area/research_outpost/hangar)
 "quP" = (
-/obj/disposalpipe/segment/vertical,
-/obj/landmark/gps_waypoint,
-/mob/living/carbon/human/npc/monkey/krimpus,
-/obj/submachine/cargopad/hydroponic,
-/turf/simulated/floor/green,
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "qvc" = (
 /obj/rack,
@@ -24218,6 +24246,21 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"qYB" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4;
+	req_access = null
+	},
+/obj/mapping_helper/access/hydro,
+/obj/mapping_helper/firedoor_spawn,
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
 "qZi" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/blue/corner,
@@ -24916,34 +24959,6 @@
 	dir = 1
 	},
 /area/station/security/checkpoint/sec_foyer/no_teleblock)
-"rBc" = (
-/obj/disposalpipe/segment/vertical,
-/obj/table/auto,
-/obj/item/paper_bin,
-/obj/item/device/reagentscanner{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/device/reagentscanner{
-	pixel_x = -6;
-	pixel_y = -3
-	},
-/obj/item/pen/pencil{
-	pixel_x = -6
-	},
-/obj/item/plantanalyzer{
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/plantanalyzer{
-	pixel_x = 6
-	},
-/obj/item/plantanalyzer{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/turf/simulated/floor/green/side,
-/area/station/hydroponics/bay)
 "rBf" = (
 /turf/simulated/floor/carpet{
 	dir = 5;
@@ -25364,10 +25379,10 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/gas)
 "rSO" = (
-/obj/machinery/light/incandescent,
-/obj/disposalpipe/trunk/produce,
-/obj/machinery/disposal/botany,
-/turf/simulated/floor,
+/obj/machinery/hydro_growlamp,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
 /area/station/hydroponics/bay)
 "rSQ" = (
 /obj/machinery/firealarm/directional/east,
@@ -25720,6 +25735,11 @@
 /obj/machinery/manufacturer/medical,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
+"scU" = (
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/hydroponics/bay)
 "scZ" = (
 /obj/rack,
 /obj/item/tank/jetpack/micro{
@@ -25924,11 +25944,6 @@
 	dir = 8
 	},
 /area/tech_outpost)
-"skJ" = (
-/obj/railing/orange/reinforced,
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "skW" = (
 /obj/machinery/light/incandescent/cool/very,
 /obj/random_item_spawner/gross/one_or_zero,
@@ -26118,6 +26133,14 @@
 /obj/machinery/light_switch/east,
 /turf/simulated/floor,
 /area/radiostation/podbay)
+"sqE" = (
+/obj/submachine/cargopad/hydroponic,
+/mob/living/carbon/human/npc/monkey/krimpus,
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/hydroponics/bay)
 "sqH" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4;
@@ -26226,6 +26249,13 @@
 /obj/landmark/halloween,
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
+"swf" = (
+/obj/machinery/door/airlock/pyro/glass/botany,
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/hydro,
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/green,
+/area/station/hydroponics/bay)
 "swx" = (
 /obj/crevice{
 	pixel_x = -28
@@ -27504,13 +27534,6 @@
 "tpP" = (
 /turf/simulated/wall/auto/reinforced/old,
 /area/evilreaver/genetics)
-"tpT" = (
-/obj/machinery/door/airlock/pyro/glass/botany,
-/obj/mapping_helper/firedoor_spawn,
-/obj/disposalpipe/segment/vertical,
-/obj/mapping_helper/access/hydro,
-/turf/simulated/floor/grass/random,
-/area/station/hydroponics/bay)
 "tqx" = (
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/wood,
@@ -27751,6 +27774,13 @@
 	dir = 4
 	},
 /area/station/science/chemistry)
+"tBI" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/closed/left{
+	icon_state = "blinds_cog2-L-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "tBS" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/plating,
@@ -28010,10 +28040,6 @@
 	dir = 5
 	},
 /area/station/hallway/primary/south)
-"tJY" = (
-/obj/disposalpipe/chicken_disposal_pipe/horizontal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "tJZ" = (
 /obj/vehicle/segway,
 /obj/machinery/computer/riotgear{
@@ -28304,11 +28330,19 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/diner/dining)
+"tTM" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/closed/right{
+	icon_state = "blinds_cog2-R-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "tUd" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/clown)
 "tUC" = (
-/obj/disposalpipe/segment/bent/east,
+/obj/machinery/disposal/mail/small/autoname/hydroponics/north,
+/obj/disposalpipe/trunk/mail/west,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "tUJ" = (
@@ -29211,7 +29245,6 @@
 	icon_state = "1-2"
 	},
 /obj/landmark/gps_waypoint,
-/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "uxK" = (
@@ -29451,8 +29484,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "uHs" = (
-/obj/reagent_dispensers/watertank/big,
-/turf/simulated/floor,
+/obj/machinery/plantpot,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
 /area/station/hydroponics/bay)
 "uHE" = (
 /obj/cable{
@@ -29939,6 +29974,13 @@
 /obj/landmark/start/job/assistant,
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge)
+"veq" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/closed/middle{
+	icon_state = "blinds_cog2-M-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "veu" = (
 /obj/machinery/door/airlock/pyro/glass/sci{
 	dir = 4
@@ -31589,9 +31631,10 @@
 /turf/simulated/floor/black,
 /area/station/security/brig)
 "wdz" = (
-/obj/machinery/sink/slim{
-	pixel_y = 12
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "wdN" = (
@@ -31888,10 +31931,14 @@
 	},
 /area/station/hallway/primary/central)
 "woo" = (
-/obj/disposalpipe/segment/horizontal,
+/obj/stool/chair/couch{
+	dir = 8
+	},
+/obj/landmark/start/job/botanist,
 /obj/machinery/light/incandescent,
-/obj/machinery/hydro_mister,
-/turf/simulated/floor/grass/random,
+/turf/simulated/floor/green/side{
+	dir = 9
+	},
 /area/station/hydroponics/bay)
 "woH" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
@@ -32509,7 +32556,7 @@
 	dir = 4
 	},
 /obj/machinery/plantpot,
-/obj/machinery/light/incandescent,
+/obj/item/device/radio/intercom/catering,
 /turf/simulated/floor/grasstodirt{
 	dir = 4
 	},
@@ -32598,6 +32645,13 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
+"wLS" = (
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "wLX" = (
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -33382,6 +33436,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
+"xqj" = (
+/obj/submachine/seed_vendor,
+/turf/simulated/floor/green/side,
+/area/station/hydroponics/bay)
 "xqD" = (
 /obj/table/auto,
 /obj/item/instrument/bikehorn,
@@ -33659,8 +33717,34 @@
 	name = "Supply Lobby"
 	})
 "xBZ" = (
-/obj/machinery/chem_master,
-/turf/simulated/floor,
+/obj/table/auto,
+/obj/item/paper_bin,
+/obj/item/device/reagentscanner{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/device/reagentscanner{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/pen/pencil{
+	pixel_x = -6
+	},
+/obj/item/plantanalyzer{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/plantanalyzer{
+	pixel_x = 6
+	},
+/obj/item/plantanalyzer{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/blind_switch/area/north/on,
+/turf/simulated/floor/green/side{
+	dir = 5
+	},
 /area/station/hydroponics/bay)
 "xCm" = (
 /obj/machinery/disposal/small/north{
@@ -33715,18 +33799,6 @@
 	},
 /turf/simulated/floor/carpet/blue/decal/innercross,
 /area/station/bridge)
-"xER" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4;
-	req_access = null
-	},
-/obj/mapping_helper/access/hydro,
-/obj/mapping_helper/firedoor_spawn,
-/obj/disposalpipe/segment/produce{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
 "xFO" = (
 /obj/decal/mule/beacon,
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
@@ -34108,15 +34180,6 @@
 	dir = 5
 	},
 /area/station/science/teleporter)
-"xSr" = (
-/obj/stool/chair/couch,
-/obj/landmark/start/job/botanist,
-/obj/disposalpipe/segment/vertical,
-/obj/item/paper/book/from_file/hydroponicsguide,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/hydroponics/bay)
 "xSz" = (
 /obj/submachine/chem_extractor,
 /obj/item/device/radio/intercom/cargo,
@@ -34266,15 +34329,6 @@
 /obj/disposalpipe/segment/bent/west,
 /turf/space/fluid,
 /area/space)
-"xXb" = (
-/obj/railing/orange/reinforced{
-	dir = 8
-	},
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/grasstodirt{
-	dir = 8
-	},
-/area/station/ranch)
 "xXc" = (
 /obj/machinery/vending/medical,
 /obj/machinery/light/incandescent/cool,
@@ -34324,14 +34378,6 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/central)
-"xYc" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/plantpot,
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/grass/random,
-/area/station/hydroponics/bay)
 "xYk" = (
 /obj/lattice,
 /obj/decal/cleanable/machine_debris,
@@ -80063,7 +80109,7 @@ kTG
 kTG
 kTG
 eAu
-gwM
+mni
 jdY
 jdY
 jdY
@@ -80666,9 +80712,9 @@ kqr
 kqr
 kqr
 pSE
-dgD
+wLS
 pgY
-lvW
+jLI
 jLI
 jLI
 xlk
@@ -80964,13 +81010,13 @@ iTZ
 tHr
 tHr
 iFb
-skJ
+vLM
 fuH
 qXv
 qXv
 mni
+iGJ
 dgD
-tJY
 jPZ
 irV
 dgD
@@ -81271,13 +81317,13 @@ kUx
 icL
 qXv
 lit
-lit
-xER
-lit
+qYB
 lit
 lit
 lit
-lFs
+lit
+lit
+lit
 lit
 lit
 lit
@@ -81567,22 +81613,22 @@ bYv
 vZW
 nxU
 tHr
-icL
+fTD
 vLM
 iFb
 olE
 qXv
 iOs
-lqR
+bsF
 lbr
-lit
-xYc
-aJT
-aEY
-mtv
-mql
+pIU
 qUb
+ccs
+aEY
+hHL
+ccs
 tPg
+qUb
 jhx
 tCh
 gyJ
@@ -81871,16 +81917,16 @@ ulK
 tHr
 med
 pSr
-xXb
+pSr
 eRq
 qXv
 rSO
 okB
 qry
-lit
+cZJ
 add
 qeG
-dyf
+qeG
 qeG
 qeG
 qeG
@@ -82176,18 +82222,18 @@ aGk
 uxl
 dxg
 ncd
+scU
 lqR
-lqR
-lqR
-lit
+bWI
+iKa
 wdz
-img
-jel
-nZQ
-oLV
+vRk
+vRk
+vRk
+vRk
 pQJ
-pQJ
-bjZ
+ccs
+jhx
 fym
 gyJ
 qZI
@@ -82477,21 +82523,21 @@ wGm
 wfV
 qeb
 iqI
-qXv
+tBI
 uHs
 lqR
-lqR
-kCU
+iOT
+lit
 tUC
-xSr
-pQG
 quP
-rBc
-vRk
-kTs
-tpT
-jXT
-hHY
+quP
+quP
+mtv
+qbC
+qUb
+jhx
+tCh
+gyJ
 tiY
 jym
 kPG
@@ -82775,25 +82821,25 @@ wFB
 oee
 mFl
 alb
-olE
+ckM
 kVy
 pHX
 gqC
-qXv
+veq
 ikA
 lqR
-lqR
+oRY
 lit
 woo
-aDl
-fVf
-fVf
 ilz
-mtv
-ccs
-jhx
+nZw
+ilz
+ilz
+ida
+bki
+swf
 mUZ
-rat
+hHY
 sKi
 rJq
 vMj
@@ -83081,18 +83127,18 @@ aJe
 iFb
 tEU
 dUl
-qXv
+tTM
 aLf
-lqR
-lqR
+eff
+oRY
 lit
 lMH
-mtv
-mtv
-mtv
-mtv
-mtv
-qUb
+lqR
+lqR
+lqR
+lqR
+gSz
+xqj
 jhx
 bSR
 fSB
@@ -83380,20 +83426,20 @@ oee
 eoZ
 alb
 icL
-jvb
+iFb
 tEU
 pMd
-qXv
+lit
 xBZ
-lqR
-lqR
+mri
+eNm
 lit
 hcS
 nIK
 jTK
-pwn
-qUb
-ccs
+fVf
+sqE
+dOc
 jhx
 jhx
 ndM
@@ -83676,7 +83722,7 @@ lVW
 dXO
 alb
 qYm
-qYm
+nZI
 maL
 shz
 alb
@@ -83685,7 +83731,7 @@ rdL
 wJA
 seb
 tEl
-qXv
+lit
 lit
 lit
 lit

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -1932,6 +1932,11 @@
 /area/station/crew_quarters/market{
 	name = "Supply Lobby"
 	})
+"bxN" = (
+/obj/submachine/cargopad/hydroponic,
+/mob/living/carbon/human/npc/monkey/krimpus,
+/turf/simulated/floor/grass/random,
+/area/station/hydroponics/bay)
 "bxT" = (
 /obj/submachine/slot_machine,
 /turf/simulated/floor/specialroom/bar,
@@ -5285,15 +5290,7 @@
 	},
 /area/station/security/processing)
 "dOc" = (
-/obj/table/reinforced/auto,
-/obj/item/wrench{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/bee_egg_carton{
-	pixel_y = 8;
-	pixel_x = -7
-	},
+/obj/submachine/seed_vendor,
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
@@ -26113,8 +26110,6 @@
 /turf/simulated/floor,
 /area/radiostation/podbay)
 "sqE" = (
-/obj/submachine/cargopad/hydroponic,
-/mob/living/carbon/human/npc/monkey/krimpus,
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/green/side{
 	dir = 4
@@ -33399,7 +33394,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "xqj" = (
-/obj/submachine/seed_vendor,
+/obj/table/reinforced/auto,
+/obj/item/wrench{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/bee_egg_carton{
+	pixel_y = 8;
+	pixel_x = -7
+	},
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
 "xqD" = (
@@ -82493,7 +82496,7 @@ tUC
 quP
 quP
 mtv
-mtv
+bxN
 mtv
 qUb
 jhx

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -5284,9 +5284,13 @@
 /area/station/security/processing)
 "dOc" = (
 /obj/table/reinforced/auto,
+/obj/item/wrench{
+	pixel_x = 3;
+	pixel_y = 2
+	},
 /obj/item/bee_egg_carton{
-	pixel_y = 5;
-	pixel_x = -1
+	pixel_y = 8;
+	pixel_x = -7
 	},
 /turf/simulated/floor/green/side{
 	dir = 4
@@ -81627,9 +81631,9 @@ lbr
 pIU
 qUb
 ccs
-aEY
-hHL
 ccs
+hHL
+aEY
 tPg
 qUb
 jhx

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -4062,6 +4062,8 @@
 /area/station/medical/medbay/pharmacy)
 "cZJ" = (
 /obj/machinery/door/airlock/pyro/alt,
+/obj/mapping_helper/access/hydro,
+/obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "cZT" = (

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -1349,6 +1349,13 @@
 	dir = 4
 	},
 /area/station/engine/elect)
+"aVV" = (
+/obj/machinery/sink/slim{
+	dir = 1
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/green/side,
+/area/station/hydroponics/bay)
 "aWp" = (
 /obj/machinery/light/flock{
 	dir = 8
@@ -15947,11 +15954,7 @@
 /turf/simulated/floor/grime,
 /area/iss)
 "lbr" = (
-/obj/machinery/sink/slim{
-	dir = 4;
-	pixel_x = -8
-	},
-/obj/machinery/drainage,
+/obj/machinery/hydro_growlamp,
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
@@ -25379,7 +25382,7 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/gas)
 "rSO" = (
-/obj/machinery/hydro_growlamp,
+/obj/submachine/seed_vendor,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -82828,7 +82831,7 @@ gqC
 veq
 ikA
 lqR
-oRY
+aVV
 lit
 woo
 ilz

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -13145,6 +13145,13 @@
 	},
 /turf/space/fluid,
 /area/space)
+"jkL" = (
+/obj/disposalpipe/segment/vertical,
+/obj/machinery/navbeacon/mule/hydroponics_north/west,
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/hydroponics/bay)
 "jkO" = (
 /obj/item/shipcomponent/sensor/ecto,
 /turf/simulated/floor/plating/airless/asteroid,
@@ -18294,6 +18301,10 @@
 	},
 /turf/simulated/floor/plating/damaged1,
 /area/evilreaver/atmospherics)
+"mHH" = (
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/green/side,
+/area/station/hydroponics/bay)
 "mIV" = (
 /obj/table/reinforced/auto{
 	icon_state = "3"
@@ -22976,10 +22987,6 @@
 	dir = 8
 	},
 /area/research_outpost)
-"qbC" = (
-/obj/machinery/navbeacon/mule/hydroponics_north,
-/turf/simulated/floor/grass/random,
-/area/station/hydroponics/bay)
 "qcr" = (
 /obj/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -82480,14 +82487,14 @@ iqI
 qXv
 eVa
 lqR
-aVV
+mHH
 lit
 tUC
 quP
 quP
-quP
 mtv
-qbC
+mtv
+mtv
 qUb
 jhx
 tCh
@@ -82782,14 +82789,14 @@ gqC
 qXv
 uHs
 lqR
-oRY
+aVV
 lit
 woo
 ida
 nZw
 ida
 ida
-ida
+jkL
 bki
 swf
 mUZ

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -1074,6 +1074,7 @@
 /area/diner/kitchen)
 "aLf" = (
 /obj/submachine/seed_manipulator,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -1793,12 +1794,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
 "bsF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment/produce{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -2519,10 +2520,6 @@
 /obj/bubble_vent/oxygen,
 /turf/space/fluid,
 /area/space)
-"bWI" = (
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/green/corner,
-/area/station/hydroponics/bay)
 "bWL" = (
 /obj/decal/cleanable/oil,
 /obj/disposalpipe/segment{
@@ -3747,6 +3744,11 @@
 /obj/railing,
 /turf/simulated/floor/yellow/side,
 /area/shuttle/sea_elevator_room)
+"cPe" = (
+/obj/machinery/plantpot,
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/grass/random,
+/area/station/hydroponics/bay)
 "cPj" = (
 /obj/submachine/laundry_machine,
 /obj/machinery/light_switch/west,
@@ -4059,10 +4061,8 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/pharmacy)
 "cZJ" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/green/side,
+/obj/machinery/door/airlock/pyro/alt,
+/turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "cZT" = (
 /obj/disposalpipe/segment/morgue,
@@ -6852,7 +6852,6 @@
 /obj/machinery/chem_master{
 	dir = 8
 	},
-/obj/machinery/light/incandescent,
 /turf/simulated/floor/green/side{
 	dir = 6
 	},
@@ -7051,6 +7050,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
+"eVa" = (
+/obj/machinery/plantpot,
+/obj/machinery/firealarm/directional/north,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/hydroponics/bay)
 "eVt" = (
 /obj/machinery/computer/ordercomp,
 /obj/machinery/ai_status_display{
@@ -11009,8 +11015,8 @@
 /turf/space/fluid,
 /area/evilreaver)
 "hKo" = (
-/obj/reagent_dispensers/watertank/big,
 /obj/disposalpipe/segment/mail,
+/obj/reagent_dispensers/compostbin,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "hKL" = (
@@ -11536,7 +11542,7 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "ida" = (
-/obj/disposalpipe/segment/bent/south,
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
@@ -11765,13 +11771,6 @@
 /obj/item/clothing/under/swimsuit/donkini,
 /turf/simulated/floor/grime,
 /area/iss)
-"ikA" = (
-/obj/machinery/plantpot,
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/hydroponics/bay)
 "ikC" = (
 /obj/storage/secure/closet/command/medical_director,
 /obj/item/device/radio/intercom/medical,
@@ -11790,11 +11789,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
-"ilz" = (
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/hydroponics/bay)
 "ilF" = (
 /turf/simulated/floor/redblack{
 	dir = 1
@@ -12461,12 +12455,6 @@
 "iJU" = (
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
 /area/iss)
-"iKa" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/green/side{
-	dir = 6
-	},
-/area/station/hydroponics/bay)
 "iKd" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor,
@@ -12597,11 +12585,6 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
-"iOT" = (
-/obj/machinery/disposal/mail/small/autoname/hydroponics/south,
-/obj/disposalpipe/trunk/west,
-/turf/simulated/floor/green/side,
-/area/station/hydroponics/bay)
 "iOX" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -15959,8 +15942,10 @@
 /area/iss)
 "lbr" = (
 /obj/machinery/hydro_growlamp,
+/obj/machinery/power/apc/autoname_west,
+/obj/cable,
 /turf/simulated/floor/green/side{
-	dir = 8
+	dir = 10
 	},
 /area/station/hydroponics/bay)
 "lbB" = (
@@ -16989,7 +16974,6 @@
 	dir = 4
 	},
 /obj/landmark/start/job/botanist,
-/obj/machinery/light_switch/north,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -20013,6 +19997,7 @@
 /area/station/maintenance/northeast)
 "nZw" = (
 /obj/machinery/light/small/floor,
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
@@ -20428,12 +20413,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
 /area/station/security/evidence)
-"okB" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
 "olE" = (
 /obj/submachine/chicken_incubator,
 /obj/item/reagent_containers/food/snacks/ingredient/egg{
@@ -21044,6 +21023,11 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"oLx" = (
+/obj/machinery/light/incandescent,
+/obj/reagent_dispensers/watertank/big,
+/turf/simulated/floor/grass/random,
+/area/station/hydroponics/bay)
 "oLG" = (
 /obj/machinery/door/airlock/pyro/engineering/alt{
 	dir = 8
@@ -22376,16 +22360,6 @@
 	dir = 4
 	},
 /area/station/security/processing)
-"pIU" = (
-/obj/reagent_dispensers/compostbin,
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/hydroponics/bay)
 "pJo" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/radiostation/studio)
@@ -22692,10 +22666,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"pQJ" = (
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor/grass/random,
-/area/station/hydroponics/bay)
 "pQL" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -23005,7 +22975,6 @@
 	},
 /area/research_outpost)
 "qbC" = (
-/obj/disposalpipe/segment/horizontal,
 /obj/machinery/navbeacon/mule/hydroponics_north,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
@@ -23411,12 +23380,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/black,
 /area/station/science/lab)
-"qry" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
 "qsc" = (
 /turf/simulated/wall/auto/reinforced/old,
 /area/evilreaver/atmospherics)
@@ -27781,13 +27744,6 @@
 	dir = 4
 	},
 /area/station/science/chemistry)
-"tBI" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/window_blinds/cog2/closed/left{
-	icon_state = "blinds_cog2-L-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/hydroponics/bay)
 "tBS" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/plating,
@@ -28337,19 +28293,17 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/diner/dining)
-"tTM" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/window_blinds/cog2/closed/right{
-	icon_state = "blinds_cog2-R-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/hydroponics/bay)
 "tUd" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/clown)
 "tUC" = (
-/obj/machinery/disposal/mail/small/autoname/hydroponics/north,
-/obj/disposalpipe/trunk/mail/west,
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/disposalpipe/trunk/east,
+/obj/machinery/disposal/small/north{
+	pixel_y = 32
+	},
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "tUJ" = (
@@ -29981,13 +29935,6 @@
 /obj/landmark/start/job/assistant,
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge)
-"veq" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/window_blinds/cog2/closed/middle{
-	icon_state = "blinds_cog2-M-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/hydroponics/bay)
 "veu" = (
 /obj/machinery/door/airlock/pyro/glass/sci{
 	dir = 4
@@ -31177,10 +31124,6 @@
 "vQZ" = (
 /turf/simulated/floor/plating,
 /area/derelict_diner)
-"vRk" = (
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/grass/random,
-/area/station/hydroponics/bay)
 "vRl" = (
 /obj/lattice,
 /turf/simulated/floor/martian,
@@ -31638,10 +31581,8 @@
 /turf/simulated/floor/black,
 /area/station/security/brig)
 "wdz" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/disposalpipe/segment/vertical,
+/obj/disposalpipe/trunk/mail/west,
+/obj/machinery/disposal/mail/small/autoname/hydroponics/north,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "wdN" = (
@@ -31947,6 +31888,7 @@
 	pixel_y = 5;
 	pixel_x = 14
 	},
+/obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/green/side{
 	dir = 9
 	},
@@ -33752,7 +33694,6 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
-/obj/blind_switch/area/north/on,
 /turf/simulated/floor/green/side{
 	dir = 5
 	},
@@ -81632,14 +81573,14 @@ qXv
 iOs
 bsF
 lbr
-pIU
+lit
 qUb
 ccs
-ccs
-hHL
 aEY
+hHL
+cPe
 tPg
-qUb
+oLx
 jhx
 tCh
 gyJ
@@ -81932,8 +81873,8 @@ pSr
 eRq
 qXv
 rSO
-okB
-qry
+lqR
+oRY
 cZJ
 add
 qeG
@@ -82235,14 +82176,14 @@ dxg
 ncd
 scU
 lqR
-bWI
-iKa
+oRY
+lit
 wdz
-vRk
-vRk
-vRk
-vRk
-pQJ
+mtv
+mtv
+mtv
+mtv
+mtv
 ccs
 jhx
 fym
@@ -82534,10 +82475,10 @@ wGm
 wfV
 qeb
 iqI
-tBI
-uHs
+qXv
+eVa
 lqR
-iOT
+aVV
 lit
 tUC
 quP
@@ -82836,16 +82777,16 @@ ckM
 kVy
 pHX
 gqC
-veq
-ikA
+qXv
+uHs
 lqR
-aVV
+oRY
 lit
 woo
-ilz
+ida
 nZw
-ilz
-ilz
+ida
+ida
 ida
 bki
 swf
@@ -83138,7 +83079,7 @@ aJe
 iFb
 tEU
 dUl
-tTM
+qXv
 aLf
 eff
 oRY
@@ -83440,7 +83381,7 @@ icL
 iFb
 tEU
 pMd
-lit
+qXv
 xBZ
 mri
 eNm


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[REWORK][MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Reworks Neon's hydroponics department, with some small incidental changes in the vicinity.

<img width="442" height="632" alt="image" src="https://github.com/user-attachments/assets/c68f53a3-b7d1-435f-ae4f-0d141eb76a01" />

- Overall layout has been restructured into a "swirl", with the door to the back room moved a ways left, and equipment regrouped such that there's a contiguous 2-wide strip of walkable space in the work areas.
- Mainly stemming from more utilization of the back room, there's a little bit of extra equipment compared to before; the front room now has its own PlantMaster by the couch, and the back room has its own seed fabricator.
- The Ranch's wall equipment has been repositioned a bit to work with the Hydroponics changes; along with some rearrangements to wall furnishings, the status display that used to be in the bar and on the south wall against the Ranch is now on one of the east windows in the bar.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Provides the department with a more open and reconfigurable space within the same footprint.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Built map and checked out the department ingame. Wires and chutes appear contiguous, and north blinds are closed at roundstart as intended.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Neon's hydroponics bay has been reworked to improve workflow and space utilization.
```