### PR TITLE
Fixes always booting from fixed disk first.

### DIFF
--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -817,6 +817,19 @@
 				src.active_program.initialize()
 
 		else
+			if(!src.host_program)
+				for(var/obj/item/disk/data/D in src)
+					if(D == src.hd)
+						continue
+
+					var/datum/computer/file/terminal_program/os/newos = locate() in D.root.contents
+
+					if(newos && istype(newos))
+						if(findtext(lowertext(D.title), "disk"))src.temp_add += "Booting from "+D.title+"...<br>"
+						else src.temp_add += "Booting from "+D.title+" diskette...<br>"
+						src.run_program(newos)
+						break
+
 			if(!src.host_program && src.hd && src.hd.root)
 				var/datum/computer/file/terminal_program/os/newos = locate(/datum/computer/file/terminal_program/os) in src.hd.root.contents
 
@@ -827,23 +840,7 @@
 					src.temp_add += "<font color=red>Unable to boot from fixed disk.</font><br>"
 
 			if(!src.host_program)
-				var/success = 0
-				for(var/obj/item/disk/data/D in src)
-					if(D == src.hd)
-						continue
-
-					var/datum/computer/file/terminal_program/os/newos = locate() in D.root.contents
-
-					if(newos && istype(newos))
-						src.temp_add += "Booting from diskette...<br>"
-						success = 1
-						src.run_program(newos)
-						break
-					else
-						src.temp_add += "<font color=red>Non-system disk or disk error.</font><br>"
-
-				if(!success)
-					src.temp_add += "<font color=red>ERR - BOOT FAILURE</font><br>"
+				src.temp_add += "<font color=red>ERR - BOOT FAILURE</font><br>"
 
 		src.updateUsrDialog()
 		return

--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -825,8 +825,10 @@
 					var/datum/computer/file/terminal_program/os/newos = locate() in D.root.contents
 
 					if(newos && istype(newos))
-						if(findtext(lowertext(D.title), "disk"))src.temp_add += "Booting from "+D.title+"...<br>"
-						else src.temp_add += "Booting from "+D.title+" diskette...<br>"
+						if(findtext(lowertext(D.title), "disk"))
+							src.temp_add += "Booting from "+D.title+"...<br>"
+						else
+							src.temp_add += "Booting from "+D.title+" diskette...<br>"
 						src.run_program(newos)
 						break
 


### PR DESCRIPTION
## About the PR
Fixes/Restores previous behaviour with bootorder.
Non-fixed disks are always booted from first.

## Why's this needed?
I broke this, because I thought booting from fixed disk first was the original behaviour, apparently not D:
(Edit: fixes https://github.com/goonstation/goonstation/issues/26415)

## Testing
<img width="541" height="368" alt="image" src="https://github.com/user-attachments/assets/9dbb496e-f773-48f8-8de5-2bc55b9ede59" />

<img width="549" height="408" alt="image" src="https://github.com/user-attachments/assets/712127c4-5c93-43da-b365-f1656def77e7" />

<img width="622" height="442" alt="image" src="https://github.com/user-attachments/assets/dbbb1a88-aa39-4a43-9503-4e2c80a68e40" />