### PR TITLE
Adds floppy drive to the personal variation of luggable computers

### DIFF
--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -277,7 +277,7 @@
 			desc = "This fine piece of hardware sports an incredible 2 kilobytes of RAM, all for a price slightly higher than the whole economy of greece."
 			icon_state = "oldlap"
 			base_icon_state = "oldlap"
-			setup_starting_peripherals = list(/obj/item/peripheral/card_scanner,/obj/item/peripheral/network/omni,/obj/item/peripheral/sound_card)
+			setup_starting_peripherals = list(/obj/item/peripheral/card_scanner,/obj/item/peripheral/drive,/obj/item/peripheral/network/omni,/obj/item/peripheral/sound_card)
 
 
 /obj/machinery/computer3/New()


### PR DESCRIPTION
## About the PR
Restores floppy drive in the personal variation of laptops.

## Why's this needed?
I screwed up while removing floppies and forgot to give one to the personal variation of luggables.
Fixes https://github.com/goonstation/goonstation/issues/26414

## Testing
<img width="296" height="425" alt="image" src="https://github.com/user-attachments/assets/faef33ec-26c5-4f45-9332-4b7a6c3f88ce" />
