### PR TITLE
Adds itemInteract proc for peripherals

### DIFF
--- a/code/modules/networks/computer3/peripherals.dm
+++ b/code/modules/networks/computer3/peripherals.dm
@@ -113,6 +113,18 @@ TYPEINFO(/obj/item/peripheral)
 
 		return 0
 
+/obj/item/peripheral/attackby(obj/item/P, mob/user)
+	var result = src.itemInteract(P, user)
+	if(result)
+		if(istext(result))
+			boutput(user, SPAN_ALERT(result))
+		else ..()
+
+/obj/item/peripheral/proc/itemInteract(obj/item/P, mob/user)
+	//Returns falsey if success
+	//Returns 1 if silent failure because this periph would never interact with the item
+	//Returns string if there's a failure reason but this periph would normally accept the item
+	return 1
 
 /obj/item/peripheral/network
 	var/code = null //Signal encryption code
@@ -1001,6 +1013,18 @@ TYPEINFO(/obj/item/peripheral)
 
 		return
 
+	itemInteract(obj/item/P, mob/user)
+		if(istype(P, /obj/item/card/id))
+			if(!src.authid)
+				user.drop_item()
+				P.loc = src
+				src.authid = P
+				boutput(user, "You insert [P] into the card scanner.")
+				return 0
+			else
+				return "There's already a card in the scanner."
+		return 1
+
 	receive_command(obj/source,command, datum/signal/signal)
 		if(..())
 			return 1
@@ -1281,6 +1305,18 @@ TYPEINFO(/obj/item/peripheral/sound_card)
 
 		return
 
+	itemInteract(obj/item/P, mob/user)
+		if(istype(P, setup_disk_type))
+			if(!src.disk)
+				user.drop_item()
+				P.loc = src
+				src.disk = P
+				boutput(user, "You insert [P] into the drive.")
+				return 0
+			else
+				return "There's already a diskette in the drive."
+		return 1
+
 /obj/item/peripheral/drive/cart_reader
 	name = "ROM cart reader module"
 	desc = "A peripheral board for reading ROM carts."
@@ -1304,6 +1340,18 @@ TYPEINFO(/obj/item/peripheral/sound_card)
 
 		return
 
+	itemInteract(obj/item/P, mob/user)
+		if(istype(P, setup_disk_type))
+			if(!src.disk)
+				user.drop_item()
+				P.loc = src
+				src.disk = P
+				boutput(user, "You insert [P] into the reader.")
+				return 0
+			else
+				return "There's already a cart in the reader."
+		return 1
+
 /obj/item/peripheral/drive/tape_reader
 	name = "Tape drive module"
 	desc = "A peripheral board designed for reading magnetic data tape."
@@ -1326,6 +1374,18 @@ TYPEINFO(/obj/item/peripheral/sound_card)
 			src.eject_disk()
 
 		return
+
+	itemInteract(obj/item/P, mob/user)
+		if(istype(P, setup_disk_type))
+			if(!src.disk)
+				user.drop_item()
+				P.loc = src
+				src.disk = P
+				boutput(user, "You insert [P] into the reader.")
+				return 0
+			else
+				return "There's already a reel in the reader."
+		return 1
 
 /obj/item/peripheral/cell_monitor
 	name = "cell monitor module"


### PR DESCRIPTION
[[C-QoL]](https://github.com/goonstation/goonstation/issues?q=state%3Aopen%20label%3AC-QoL)
[[A-Station-Systems]](https://github.com/goonstation/goonstation/issues?q=state%3Aopen%20label%3AA-Station-Systems)

## About the PR
- Adds a function called `itemInteract` for peripherals
- You can now place items in peripherals while they are standalone, as if you were interacting with a computer3

## Why's this needed?
You can take cards/disks out of standalone peripherals, but you can't put them in, this adds some symmetry
However this is mostly atomisation for another change I want to make, where computer3s call each peripheral's `itemInteract` instead of having hard-coded `attackby` logic for each possible item (surprise surprise, it's never updated and currently outdated), hence why I'm using a separate function instead of `attackby`

## Testing
<img width="1199" height="561" alt="image" src="https://github.com/user-attachments/assets/bc5a1f8a-0ec3-44f7-a15f-4d4964445cfd" />
<img width="357" height="162" alt="image" src="https://github.com/user-attachments/assets/fc8f45a7-2243-4304-aeb5-bf1c79b414bc" />
<img width="937" height="690" alt="image" src="https://github.com/user-attachments/assets/791fe21a-357b-4079-b181-5b601d0735da" />
<img width="1037" height="697" alt="image" src="https://github.com/user-attachments/assets/0ff056c4-e1c8-4e66-98d1-1f764974b88c" />
<img width="432" height="218" alt="image" src="https://github.com/user-attachments/assets/7b35b5c2-6a55-4a8d-924e-43b66c10bba5" />
<img width="1463" height="599" alt="image" src="https://github.com/user-attachments/assets/03b4fd99-d80f-48f1-993b-df441f005874" />



## Changelog
```changelog
(u)Pirate-Rob
(+)You can now place items directly into peripherals that are not currently in a computer.
```
