### PR TITLE
Voice changer speech modifier

### DIFF
--- a/_std/defines/speech_defines/modules.dm
+++ b/_std/defines/speech_defines/modules.dm
@@ -150,7 +150,7 @@
 #define SPEECH_MODIFIER_TEST_DUMMY "test_dummy"
 #define SPEECH_MODIFIER_TRANSLATOR "translator"
 #define SPEECH_MODIFIER_VENDING_MACHINE "vending_machine"
-
+#define SPEECH_MODIFIER_VOICE_CHANGER "voice_changer"
 
 //------------ Speech Prefixes ------------//
 #define SPEECH_PREFIX_AI_RADIO_1 "ai_radio_1"

--- a/_std/defines/speech_defines/modules.dm
+++ b/_std/defines/speech_defines/modules.dm
@@ -152,6 +152,7 @@
 #define SPEECH_MODIFIER_VENDING_MACHINE "vending_machine"
 #define SPEECH_MODIFIER_VOICE_CHANGER "voice_changer"
 
+
 //------------ Speech Prefixes ------------//
 #define SPEECH_PREFIX_AI_RADIO_1 "ai_radio_1"
 #define SPEECH_PREFIX_AI_RADIO_2 "ai_radio_2"

--- a/code/modules/speech/modules/speech/modifiers/voice_changer.dm
+++ b/code/modules/speech/modules/speech/modifiers/voice_changer.dm
@@ -1,0 +1,9 @@
+/datum/speech_module/modifier/voice_changer
+	id = SPEECH_MODIFIER_VOICE_CHANGER
+
+/datum/speech_module/modifier/voice_changer/process(datum/say_message/message)
+	. = message
+	if (!isnull(message.card_ident))
+		message.speaker_to_display = message.card_ident
+	else
+		message.speaker_to_display = "Unknown"

--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -377,13 +377,6 @@
 
 	var/mob/M = src.speaker
 
-	// The speaker is using a voice changer.
-	if (M.wear_mask?.vchange)
-		if (!isnull(src.card_ident))
-			return src.card_ident
-
-		return "Unknown"
-
 	// The speaker is vocally disfigured.
 	if (M.vdisfigured)
 		return "Unknown"

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -29,14 +29,14 @@
 
 	equipped(mob/user, slot)
 		. = ..()
-		if (slot != SLOT_WEAR_MASK)
+		if ((slot != SLOT_WEAR_MASK) || !src.vchange)
 			return
-		for(var/modifier in src.vchange?.speech_modifiers)
+		for(var/modifier in src.vchange.speech_modifiers)
 			user.ensure_speech_tree().AddSpeechModifier(modifier)
 
 	unequipped(mob/user)
-		if (src.equipped_in_slot == SLOT_WEAR_MASK)
-			for(var/modifier in src.vchange?.speech_modifiers)
+		if ((src.equipped_in_slot == SLOT_WEAR_MASK) && src.vchange)
+			for(var/modifier in src.vchange.speech_modifiers)
 				user.ensure_speech_tree().RemoveSpeechModifier(modifier)
 		. = ..()
 

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -27,6 +27,19 @@
 		setProperty("heatprot", 5)
 		setProperty("meleeprot_head", 2)
 
+	equipped(mob/user, slot)
+		. = ..()
+		if (slot != SLOT_WEAR_MASK)
+			return
+		for(var/modifier in src.vchange?.speech_modifiers)
+			user.ensure_speech_tree().AddSpeechModifier(modifier)
+
+	unequipped(mob/user)
+		if (src.equipped_in_slot == SLOT_WEAR_MASK)
+			for(var/modifier in src.vchange?.speech_modifiers)
+				user.ensure_speech_tree().RemoveSpeechModifier(modifier)
+		. = ..()
+
 /obj/item/clothing/mask/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/voice_changer))
 		if (src.see_face)
@@ -277,6 +290,7 @@ TYPEINFO(/obj/item/voice_changer)
 	icon_state = "voicechanger"
 	is_syndicate = 1
 	var/permanent = FALSE
+	var/speech_modifiers = list(SPEECH_MODIFIER_VOICE_CHANGER)
 	HELP_MESSAGE_OVERRIDE({"Use the voice changer on a face-concealing mask to fit it inside. You will speak as and appear in chat as the name of your worn ID, or as "unknown" if you aren't wearing your ID. Use wirecutters on the mask to remove the voice changer."})
 
 /obj/item/voice_changer/permanent

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -2163,6 +2163,7 @@
 #include "code\modules\speech\modules\speech\modifiers\test_dummy.dm"
 #include "code\modules\speech\modules\speech\modifiers\translator.dm"
 #include "code\modules\speech\modules\speech\modifiers\vending_machine.dm"
+#include "code\modules\speech\modules\speech\modifiers\voice_changer.dm"
 #include "code\modules\speech\modules\speech\modifiers\mutantraces\_mutantrace_modifier_parent.dm"
 #include "code\modules\speech\modules\speech\modifiers\mutantraces\abomination.dm"
 #include "code\modules\speech\modules\speech\modifiers\mutantraces\amphibian.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Voice changers now have a list of speech modifiers that they apply to the wearer of the mask containing them.
Moved voice changer behaviour to a new speech modifier rather than the get_speaker_to_display proc

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows custom voice changers with any arbitrary list of modifiers to be coded or varedited by admins.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="366" height="124" alt="image" src="https://github.com/user-attachments/assets/ff76074f-e6c2-4898-9cbd-c1334a569370" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

