### PR TITLE
Allows you to wrench a stationary pipe dispenser to relocate it

### DIFF
--- a/code/obj/machinery/pipe/pipe_dispenser.dm
+++ b/code/obj/machinery/pipe/pipe_dispenser.dm
@@ -19,6 +19,8 @@ var/static/list/obj/machinery/disposal_pipedispenser/availdisposalpipes = list(
 	icon = 'icons/obj/manufacturer.dmi'
 	icon_state = "pipe-fab"
 	density = 1
+	p_class = 3
+	always_slow_pull = TRUE
 	anchored = ANCHORED
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS
 
@@ -91,6 +93,19 @@ var/static/list/obj/machinery/disposal_pipedispenser/availdisposalpipes = list(
 	qdel(dummy_pipe) // above is a hack to get this to work. if anyone has any better way of doing this, go ahead.
 	. = icon2base64(dummy_icon)
 
+/obj/machinery/disposal_pipedispenser/attackby(obj/item/W, mob/user)
+	if(iswrenchingtool(W) && !istype(src, /obj/machinery/disposal_pipedispenser/mobile))
+		if(src.anchored == ANCHORED)
+			src.anchored = UNANCHORED
+			boutput(user, SPAN_NOTICE("You unanchor [src.name] from the floor."))
+			playsound(src.loc, 'sound/items/Ratchet.ogg', 30, 1, -2)
+		else
+			src.anchored = ANCHORED
+			boutput(user, SPAN_NOTICE("You anchor [src.name] to the floor."))
+			playsound(src.loc, 'sound/items/Ratchet.ogg', 30, 1, -2)
+	else
+		. = ..()
+
 TYPEINFO(/obj/machinery/disposal_pipedispenser/mobile)
 	mats = 16
 
@@ -100,6 +115,8 @@ TYPEINFO(/obj/machinery/disposal_pipedispenser/mobile)
 	anchored = UNANCHORED
 	icon_state = "fab-mobile"
 	mobile = TRUE
+	p_class = 2.5
+	always_slow_pull = FALSE
 
 	var/laying_pipe = FALSE
 	var/removing_pipe = FALSE


### PR DESCRIPTION
[FEATURE] [STATION SYSTEMS]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
You can now use a wrench to unanchor and anchor stationary pipe dispensers (like the one found in Disposals) to be able to drag them around. They've also been made to be heavy, making use of `p_class` and `always_slow_pull`. While dragging them around is now possible, the mobile cart is still easier to work with.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Right now working with the stationary pipe dispensers is just too much of a hassle. You're often going to be working far away from them, and you'd need to drag each pipe one at a time all the way to wherever you're working. Now, you at least can move the thing closer to you. Still doesn't have the automatic pipe laying of the mobile version, and it's slow to drag (about as slow as dragging someone that's lying down), but those just mean the cart version is more convenient and fast rather than the only realistic option.

(Also yes, you could just disassemble then reassemble it, but deconstruction devices and soldering irons are largely locked to engineering... and at that point if you can get into engineering, you may as well just use the mobile cart, or at least mechscan it)

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="355" height="30" alt="image" src="https://github.com/user-attachments/assets/5eceb009-e37d-4071-a780-18c147cca3a6" />
Yep, it works. Mobile dispensers are unaffected, whereas stationary ones can be wrenched/unwrenched and (slowly) dragged around.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Nexusuxen
(+)You can now use a wrench to (un)anchor pipe dispensers and drag them around.
```
