### PR TITLE
Remove Pathology access

### DIFF
--- a/_std/defines/access.dm
+++ b/_std/defines/access.dm
@@ -115,8 +115,7 @@
 //rancher job
 #define access_ranch 83
 
-//pathologist job
-#define access_pathology 84
+// Access 84 Unused
 
 //extra research access
 #define access_researchfoyer 85

--- a/code/datums/jobs/special/jobs_special.dm
+++ b/code/datums/jobs/special/jobs_special.dm
@@ -775,7 +775,7 @@ ABSTRACT_TYPE(/datum/job/special/pod_wars)
 	name = "Pathologist"
 	limit = 0
 	wages = PAY_DOCTORATE
-	access_string = "Pathologist"
+	access_string = "Medical Doctor"
 	slot_belt = list(/obj/item/device/pda2/genetics)
 	slot_jump = list(/obj/item/clothing/under/rank/pathologist)
 	slot_foot = list(/obj/item/clothing/shoes/white)

--- a/code/modules/mapping/helpers/access_spawn.dm
+++ b/code/modules/mapping/helpers/access_spawn.dm
@@ -75,11 +75,6 @@
 	req_access = list(access_robotics)
 	color = MEDICAL
 
-/obj/mapping_helper/access/pathology
-	name = "pathology access spawn"
-	req_access = list(access_medical)
-	color = MEDICAL
-
 /obj/mapping_helper/access/pharmacy
 	name = "pharmacy access spawn"
 	req_access = list(access_pharmacy)

--- a/code/obj/item/device/accessgun.dm
+++ b/code/obj/item/device/accessgun.dm
@@ -24,7 +24,7 @@ TYPEINFO(/obj/item/device/accessgun)
 	var/list/engineering_access_list = list(access_engineering, access_engineering_storage, access_engineering_power, access_engineering_engine, access_engineering_mechanic, access_engineering_atmos, access_engineering_control)
 	var/list/supply_access_list = list(access_cargo, access_supply_console, access_mining, access_mining_outpost)
 	var/list/research_access_list = list(access_tox, access_tox_storage, access_research, access_chemistry, access_researchfoyer, access_artlab, access_telesci, access_robotdepot)
-	var/list/medical_access_list = list(access_medical, access_medical_lockers, access_medlab, access_robotics, access_pathology)
+	var/list/medical_access_list = list(access_medical, access_medical_lockers, access_medlab, access_robotics)
 	var/list/security_access_list = list(access_security, access_brig, access_forensics_lockers, access_securitylockers, access_carrypermit, access_contrabandpermit, access_ticket)
 	var/list/command_access_list = list(access_research_director, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_heads, access_captain, access_engineering_chief, access_medical_director, access_head_of_personnel, access_dwaine_superuser, access_money)
 	var/list/allowed_access_list

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -17,7 +17,7 @@
 	var/list/engineering_access_list = list(access_engineering, access_engineering_storage, access_engineering_power, access_engineering_engine, access_engineering_mechanic, access_engineering_atmos, access_engineering_control)
 	var/list/supply_access_list = list(access_cargo, access_supply_console, access_mining, access_mining_outpost)
 	var/list/research_access_list = list(access_tox, access_tox_storage, access_research, access_chemistry, access_researchfoyer, access_artlab, access_telesci, access_robotdepot)
-	var/list/medical_access_list = list(access_medical, access_medical_lockers, access_medlab, access_robotics, access_pathology, access_pharmacy)
+	var/list/medical_access_list = list(access_medical, access_medical_lockers, access_medlab, access_robotics, access_pharmacy)
 	var/list/security_access_list = list(access_security, access_brig, access_forensics_lockers, access_securitylockers, access_carrypermit, access_contrabandpermit, access_ticket, access_fine_small, access_fine_large)
 	var/list/command_access_list = list(access_research_director, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_heads, access_captain, access_engineering_chief, access_medical_director, access_head_of_personnel, access_dwaine_superuser, access_money)
 	var/list/allowed_access_list

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -181,7 +181,7 @@
 						access_change_ids, access_eva, access_heads, access_head_of_personnel, access_medical_lockers, access_pharmacy,
 						access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
 						access_kitchen, access_robotics, access_cargo, access_supply_console,
-						access_research, access_hydro, access_ranch, access_ai_upload, access_pathology, access_researchfoyer,
+						access_research, access_hydro, access_ranch, access_ai_upload, access_researchfoyer,
 						access_telesci, access_teleporter, access_money)
 		if("Head of Security")
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_maxsec, access_brig, access_securitylockers,
@@ -191,7 +191,7 @@
 						access_research, access_dwaine_superuser, access_hydro, access_ranch, access_ai_upload,
 						access_tech_storage, access_maint_tunnels, access_bar, access_janitor, access_fine_small, access_fine_large,
 						access_engineering, access_teleporter, access_engineering_engine, access_engineering_control,
-						access_mining, access_pathology, access_researchfoyer, access_chapel_office, access_telesci,
+						access_mining, access_researchfoyer, access_chapel_office, access_telesci,
 						access_engineering_storage, access_engineering_mechanic)
 		if("Research Director")
 			return list(access_research, access_research_director, access_dwaine_superuser,
@@ -220,7 +220,7 @@
 		if("Security Officer")
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig,  access_ticket,
 			access_maint_tunnels, access_medical, access_morgue, access_research, access_cargo, access_engineering, access_engineering_control,
-			access_fine_small, access_chemistry, access_bar, access_kitchen, access_hydro, access_pathology, access_researchfoyer, access_mining
+			access_fine_small, access_chemistry, access_bar, access_kitchen, access_hydro, access_researchfoyer, access_mining
 			)
 		if("Vice Officer")
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_brig, access_ticket, access_maint_tunnels,
@@ -238,8 +238,6 @@
 			return list(access_medical, access_medical_lockers, access_morgue, access_maint_tunnels)
 		if("Geneticist")
 			return list(access_medical, access_medical_lockers, access_morgue, access_medlab, access_maint_tunnels)
-		if("Pathologist")
-			return list(access_medical, access_medical_lockers, access_morgue, access_pathology, access_maint_tunnels)
 		if("Roboticist")
 			return list(access_robotics, access_tech_storage, access_medical, access_medical_lockers, access_morgue, access_maint_tunnels)
 		if("Pharmacist")
@@ -310,7 +308,7 @@
 		if("Inspector", "Communications Officer")
 			return list(access_security, access_ticket, access_tox, access_tox_storage, access_chemistry, access_medical, access_medlab,
 						access_eva, access_heads, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
-						access_kitchen, access_robotics, access_cargo, access_research, access_hydro, access_ranch, access_pathology,
+						access_kitchen, access_robotics, access_cargo, access_research, access_hydro, access_ranch,
 						access_researchfoyer, access_artlab, access_telesci, access_robotdepot, access_fine_small)
 		if("Hall Monitor")
 			return list(access_ticket)
@@ -330,7 +328,7 @@
 				access_tox, access_tox_storage, access_chemistry, access_carrypermit, access_contrabandpermit,
 				access_change_ids, access_ai_upload,
 				access_teleporter, access_eva, access_heads, access_captain, access_head_of_personnel,
-				access_chapel_office, access_kitchen, access_medical_lockers, access_pathology,
+				access_chapel_office, access_kitchen, access_medical_lockers,
 				access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_supply_console, access_hydro, access_ranch,
 				access_engineering, access_maint_tunnels,
 				access_tech_storage, access_engineering_storage,
@@ -383,8 +381,6 @@ var/list/access_all_actually = null
 			return "Medical Equipment"
 		if(access_medlab)
 			return "Genetics"
-		if(access_pathology)
-			return "Pathology"
 		if(access_morgue)
 			return "Morgue"
 		if(access_tox)

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -6703,7 +6703,7 @@
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/pathology,
+/obj/mapping_helper/access/medical,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "bZT" = (
@@ -46626,7 +46626,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/mapping_helper/access/pathology,
+/obj/mapping_helper/access/medical,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "ozp" = (
@@ -74049,7 +74049,7 @@
 	},
 /obj/decal/stripe_delivery,
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/pathology,
+/obj/mapping_helper/access/medical,
 /turf/simulated/floor,
 /area/station/medical/cdc)
 "wOm" = (

--- a/tools/UpdatePaths/Scripts/26453_remove_pathology_access.txt
+++ b/tools/UpdatePaths/Scripts/26453_remove_pathology_access.txt
@@ -1,0 +1,1 @@
+/obj/mapping_helper/access/pathology : /obj/mapping_helper/access/medical{@OLD}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes pathology access
The unused "Pathologist" role receives the same access as medical doctors.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This access is not required for anything, the pathology access spawner places medical access and is only present on Donut 3.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="415" height="62" alt="image" src="https://github.com/user-attachments/assets/787ae107-8a6e-4e39-ba82-d56c5abbfbe4" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
