### PR TITLE
Pin node version to 24.14.1

### DIFF
--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.14.1
           cache: "yarn"
           cache-dependency-path: |
             ./tgui/yarn.lock


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Pins node version to `24.14.1`.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Node `24.15.0` is causing build failures
* https://github.com/yarnpkg/berry/issues/7065
