### PR TITLE
Mechcomp basketball hoops

### DIFF
--- a/code/obj/item/basketball.dm
+++ b/code/obj/item/basketball.dm
@@ -196,7 +196,18 @@
 
 	New()
 		..()
+		AddComponent(/datum/component/mechanics_holder)
 		BLOCK_SETUP(BLOCK_ALL)
+
+	pickup(mob/user)
+		if (!src.mounted)
+			SEND_SIGNAL(src, COMSIG_MECHCOMP_RM_ALL_CONNECTIONS)
+		return ..()
+
+	dropped(mob/user)
+		if (!src.mounted)
+			SEND_SIGNAL(src, COMSIG_MECHCOMP_RM_ALL_CONNECTIONS)
+		return ..()
 
 	attackby(obj/item/W, mob/user)
 		if (iswrenchingtool(W) && mounted)
@@ -205,6 +216,7 @@
 			src.pixel_x = 0
 			src.anchored = UNANCHORED
 			src.mounted = 0
+			SEND_SIGNAL(src, COMSIG_MECHCOMP_RM_ALL_CONNECTIONS)
 		else if (src.mounted && !istype(W, /obj/item/bballbasket))
 			if (W.cant_drop) return
 			src.visible_message(SPAN_NOTICE("<b>[user]</b> jumps up and tries to dunk [W] into [src]!"))
@@ -303,6 +315,7 @@
 		SPAWN(2.3 SECONDS)
 			A.invisibility = INVIS_NONE
 			src.active = 0
+		SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "scored_with=[A]")
 
 /obj/item/bballbasket/mounted
 	anchored = ANCHORED

--- a/code/obj/item/basketball.dm
+++ b/code/obj/item/basketball.dm
@@ -315,7 +315,7 @@
 		SPAWN(2.3 SECONDS)
 			A.invisibility = INVIS_NONE
 			src.active = 0
-		SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "scored_with=[A]")
+		SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "scored_with=[A.name]")
 
 /obj/item/bballbasket/mounted
 	anchored = ANCHORED


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds mech comp output to basketball hoops. The hoop outputs what item was used to score. Failing to score will not send a signal. Ball harder next time. 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Engineers can ball too. 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="615" height="524" alt="Screenshot 2026-04-23 152550" src="https://github.com/user-attachments/assets/dbed418d-3302-47be-8098-1169bf5fe16c" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bamlord
(+)Basketball hoops now send an mechcomp output and are thus even more illegal. 
```
