### PR TITLE
Changes gravity tethers to use Environment instead of Equipment on APCs

### DIFF
--- a/code/modules/gravity/tether/tether.dm
+++ b/code/modules/gravity/tether/tether.dm
@@ -13,6 +13,7 @@ ABSTRACT_TYPE(/obj/machinery/gravity_tether)
 	layer = EFFECTS_LAYER_BASE - 1 // covers people who walk behind it but not over other effects
 	status = REQ_PHYSICAL_ACCESS
 	object_flags = CAN_REPROGRAM_ACCESS | NO_GHOSTCRITTER
+	power_channel = ENVIRON
 
 	speech_verb_say = "drones"
 	voice_sound_override = 'sound/misc/talk/bottalk_3.ogg'
@@ -230,7 +231,7 @@ ABSTRACT_TYPE(/obj/machinery/gravity_tether)
 	if (src.cell)
 		charge_avail += src.cell.charge
 	var/area/A = get_area(src)
-	if (A.powered(ENVIRON))
+	if (A.powered(src.power_channel))
 		var/obj/machinery/power/apc/area_apc = A.area_apc
 		if (istype(area_apc) && area_apc.cell)
 			charge_avail += area_apc.cell.charge
@@ -239,7 +240,7 @@ ABSTRACT_TYPE(/obj/machinery/gravity_tether)
 		if(src.calculate_fault_chance(0))
 			src.random_fault()
 
-		src.use_power(cost, ENVIRON)
+		src.use_power(cost, src.power_channel)
 		src.begin_gravity_change(new_intensity)
 	else
 		src.say("Not enough power to complete change.")

--- a/code/modules/gravity/tether/tether.dm
+++ b/code/modules/gravity/tether/tether.dm
@@ -230,7 +230,7 @@ ABSTRACT_TYPE(/obj/machinery/gravity_tether)
 	if (src.cell)
 		charge_avail += src.cell.charge
 	var/area/A = get_area(src)
-	if (A.powered(EQUIP))
+	if (A.powered(ENVIRON))
 		var/obj/machinery/power/apc/area_apc = A.area_apc
 		if (istype(area_apc) && area_apc.cell)
 			charge_avail += area_apc.cell.charge
@@ -239,7 +239,7 @@ ABSTRACT_TYPE(/obj/machinery/gravity_tether)
 		if(src.calculate_fault_chance(0))
 			src.random_fault()
 
-		src.use_power(cost, EQUIP)
+		src.use_power(cost, ENVIRON)
 		src.begin_gravity_change(new_intensity)
 	else
 		src.say("Not enough power to complete change.")

--- a/code/modules/gravity/tether/tether_machinery.dm
+++ b/code/modules/gravity/tether/tether_machinery.dm
@@ -42,7 +42,7 @@
 
 	src.handle_power_cycle()
 
-	if (!src.powered())
+	if (src.has_no_power())
 		if (src.processing_state == TETHER_PROCESSING_PENDING)
 			src.finish_gravity_change()
 		if (src.gforce_intensity > GFORCE_GRAVITY_MINIMUM)

--- a/code/modules/gravity/tether/tether_machinery.dm
+++ b/code/modules/gravity/tether/tether_machinery.dm
@@ -82,8 +82,7 @@
 		playsound(src.loc, pick(global.ambience_gravity), 50, 1, pitch=(0.5 + (src.gforce_intensity/200)))
 
 /// The gravity tether prioritizes its own internal capacitor
-/obj/machinery/gravity_tether/use_power(amount, chan)
-	chan = ENVIRON
+/obj/machinery/gravity_tether/use_power(amount, chan = src.power_channel)
 	// convert powernet wattage to cell usage
 	var/battery_usage = CELLRATE * amount
 
@@ -92,15 +91,14 @@
 		src.use_cell_wrapper(src.cell.charge)
 		amount -= src.cell.charge / CELLRATE
 		var/area/A = get_area(src)
-		if (A.powered(ENVIRON))
+		if (A.powered(src.power_channel))
 			..(amount)
 		else
 			src.power_change()
 	else
 		src.use_cell_wrapper(battery_usage)
 
-/obj/machinery/gravity_tether/powered(chan)
-	chan = ENVIRON
+/obj/machinery/gravity_tether/powered(chan = src.power_channel)
 	. = FALSE
 	if (istype(src.loc, /obj/item/electronics/frame))
 		return FALSE
@@ -137,17 +135,17 @@
 					passive_wattage_needed = 0
 
 	if (src.uses_area_power && (passive_wattage_needed || recharge_wattage_needed))
-		if (A.powered(ENVIRON))
+		if (A.powered(src.power_channel))
 			var/obj/machinery/power/apc/area_apc = A?.area_apc
 			if (istype(area_apc) && area_apc.cell?.charge)
 				var/available_area_watts = area_apc.cell?.charge / CELLRATE
 				if (passive_wattage_needed && available_area_watts > passive_wattage_needed)
-					area_apc.use_power(passive_wattage_needed, ENVIRON)
+					area_apc.use_power(passive_wattage_needed, src.power_channel)
 					available_area_watts -= passive_wattage_needed
 					passive_wattage_needed = 0
 				if (!passive_wattage_needed && recharge_wattage_needed && available_area_watts > recharge_wattage_needed && area_apc.cell?.percent() > 40 )
 					if(src.give_cell_wrapper(recharge_wattage_needed * CELLRATE))
-						area_apc.use_power(recharge_wattage_needed, ENVIRON)
+						area_apc.use_power(recharge_wattage_needed, src.power_channel)
 						recharge_wattage_needed = 0
 
 	if (passive_wattage_needed) // no power, keel over

--- a/code/modules/gravity/tether/tether_machinery.dm
+++ b/code/modules/gravity/tether/tether_machinery.dm
@@ -83,6 +83,7 @@
 
 /// The gravity tether prioritizes its own internal capacitor
 /obj/machinery/gravity_tether/use_power(amount, chan)
+	chan = ENVIRON
 	// convert powernet wattage to cell usage
 	var/battery_usage = CELLRATE * amount
 
@@ -91,7 +92,7 @@
 		src.use_cell_wrapper(src.cell.charge)
 		amount -= src.cell.charge / CELLRATE
 		var/area/A = get_area(src)
-		if (A.powered(EQUIP))
+		if (A.powered(ENVIRON))
 			..(amount)
 		else
 			src.power_change()
@@ -99,6 +100,7 @@
 		src.use_cell_wrapper(battery_usage)
 
 /obj/machinery/gravity_tether/powered(chan)
+	chan = ENVIRON
 	. = FALSE
 	if (istype(src.loc, /obj/item/electronics/frame))
 		return FALSE
@@ -135,17 +137,17 @@
 					passive_wattage_needed = 0
 
 	if (src.uses_area_power && (passive_wattage_needed || recharge_wattage_needed))
-		if (A.powered(EQUIP))
+		if (A.powered(ENVIRON))
 			var/obj/machinery/power/apc/area_apc = A?.area_apc
 			if (istype(area_apc) && area_apc.cell?.charge)
 				var/available_area_watts = area_apc.cell?.charge / CELLRATE
 				if (passive_wattage_needed && available_area_watts > passive_wattage_needed)
-					area_apc.use_power(passive_wattage_needed, EQUIP)
+					area_apc.use_power(passive_wattage_needed, ENVIRON)
 					available_area_watts -= passive_wattage_needed
 					passive_wattage_needed = 0
 				if (!passive_wattage_needed && recharge_wattage_needed && available_area_watts > recharge_wattage_needed && area_apc.cell?.percent() > 40 )
 					if(src.give_cell_wrapper(recharge_wattage_needed * CELLRATE))
-						area_apc.use_power(recharge_wattage_needed, EQUIP)
+						area_apc.use_power(recharge_wattage_needed, ENVIRON)
 						recharge_wattage_needed = 0
 
 	if (passive_wattage_needed) // no power, keel over


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes Gravity Tethers to use the Environment on APCs instead of Equipment. This will allow for gravity tethers to last slightly longer at the cost of using more of the APC power
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gravity Tethers can be argued as a critical station system, one that is arguably more important then doors, and roughly as important as fire locks, as well as directly effects the station environment
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Gravity tether consuminng enviromental power

<img width="1180" height="921" alt="{38BEA5B2-0617-4A90-9C7E-AB0CF17FC897}" src="https://github.com/user-attachments/assets/6b47011d-a8b4-4d4e-9613-33df75b349c0" />

Gravity tether automatically shutting down when battery is removed and enviromental power is toggled off

<img width="844" height="884" alt="{815C9928-A18F-4E53-A41E-85C5DD34A4B0}" src="https://github.com/user-attachments/assets/e5f41f3b-5e16-414e-8e17-257f9e9f21b1" />



<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->