### PR TITLE
Removes maintenance access from a few more jobs

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -267,7 +267,7 @@
 						access_engineering_storage, access_engineering_atmos, access_engineering_engine, access_engineering_power,
 						access_tech_storage, access_engineering_mechanic)
 		if("Miner")
-			return list(access_mining, access_mining_outpost)
+			return list(access_maint_tunnels, access_mining, access_mining_outpost)
 		if("Quartermaster")
 			return list(access_maint_tunnels, access_cargo, access_supply_console)
 		if("Construction Worker")
@@ -280,7 +280,7 @@
 		if("Janitor")
 			return list(access_janitor, access_maint_tunnels, access_medical, access_morgue, access_crematorium)
 		if("Botanist", "Apiculturist")
-			return list(access_hydro)
+			return list(access_maint_tunnels, access_hydro)
 		if("Rancher")
 			return list(access_hydro, access_ranch)
 		if("Chef", "Sous-Chef")

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -237,14 +237,14 @@
 		if("Medical Doctor", "Medical Trainee")
 			return list(access_medical, access_medical_lockers, access_morgue, access_maint_tunnels)
 		if("Geneticist")
-			return list(access_medical, access_medical_lockers, access_morgue, access_medlab, access_maint_tunnels)
+			return list(access_medical, access_medical_lockers, access_morgue, access_medlab)
 		if("Roboticist")
-			return list(access_robotics, access_tech_storage, access_medical, access_medical_lockers, access_morgue, access_maint_tunnels)
+			return list(access_robotics, access_tech_storage, access_medical, access_medical_lockers, access_morgue)
 		if("Pharmacist")
-			return list(access_maint_tunnels, access_pharmacy,
+			return list(access_pharmacy,
 						access_medical_lockers, access_medical, access_morgue)
 		if("Psychiatrist")
-			return list(access_medical, access_maint_tunnels)
+			return list(access_medical)
 		if("Medical Specialist")
 			return list(access_robotics, access_medical, access_morgue,
 						access_maint_tunnels, access_tech_storage, access_medical_lockers,
@@ -267,7 +267,7 @@
 						access_engineering_storage, access_engineering_atmos, access_engineering_engine, access_engineering_power,
 						access_tech_storage, access_engineering_mechanic)
 		if("Miner")
-			return list(access_maint_tunnels, access_mining, access_mining_outpost)
+			return list(access_mining, access_mining_outpost)
 		if("Quartermaster")
 			return list(access_maint_tunnels, access_cargo, access_supply_console)
 		if("Construction Worker")
@@ -280,9 +280,9 @@
 		if("Janitor")
 			return list(access_janitor, access_maint_tunnels, access_medical, access_morgue, access_crematorium)
 		if("Botanist", "Apiculturist")
-			return list(access_maint_tunnels, access_hydro)
+			return list(access_hydro)
 		if("Rancher")
-			return list(access_maint_tunnels, access_hydro, access_ranch)
+			return list(access_hydro, access_ranch)
 		if("Chef", "Sous-Chef")
 			return list(access_kitchen)
 		if("Bartender")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes maint tunnels access from Geneticists, Roboticists, Pharmacists, Psychiatrists, and Ranchers.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Less jobs with maint access is good, means less people can investigate spooky noises in maint. It also makes maint a bit more dangerous as not as many people can get into maint to rescue you. Not every job needs maintenance access. Scientists, catering staff, and the chaplain already don't have maint access, this just adds a few more jobs that don't really need maint access to that list. These jobs can still access maint through their department backdoors if they have backdoors into maint.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
maint door no worky for these jobs
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sord
(*)Geneticists, Roboticists, Pharmacists, Psychiatrists, and Ranchers lost their maint tunnel access
```
