### PR TITLE
Delete req_access_txt

### DIFF
--- a/code/obj.dm
+++ b/code/obj.dm
@@ -29,7 +29,6 @@
 		if (HAS_FLAG(object_flags, HAS_DIRECTIONAL_BLOCKING))
 			var/turf/T = get_turf(src)
 			T?.UpdateDirBlocks()
-		src.update_access_from_txt()
 #ifdef CHECK_MORE_RUNTIMES
 		if (src.req_access && !islist(src.req_access))
 			stack_trace("[src] ([src.type]) initialized at \[[src.x], [src.y], [src.z]\] with non-list req_access >:(")

--- a/code/obj/item/rcd/rcd_construction.dm
+++ b/code/obj/item/rcd/rcd_construction.dm
@@ -136,10 +136,8 @@ TYPEINFO(/obj/item/rcd/construction)
 	T.name = door_name
 	if (door_access)
 		T.req_access = list(door_access)
-		T.req_access_txt = "[door_access]"
 	else
 		T.req_access = null
-		T.req_access_txt = null
 
 	for (var/obj/window/auto/O in orange(1,T))
 		O.UpdateIcon()

--- a/code/obj/machinery/door/door_control.dm
+++ b/code/obj/machinery/door/door_control.dm
@@ -590,7 +590,6 @@ TYPEINFO(/obj/machinery/door_control)
 		for (var/obj/machinery/door/airlock/M in by_type[/obj/machinery/door])
 			if (M.id == src.id)
 				M.req_access = null
-				M.req_access_txt = null
 
 	for (var/obj/machinery/conveyor/M as anything in machine_registry[MACHINES_CONVEYORS]) // Workaround for the stacked conveyor belt issue (Convair880).
 		if (M.id == src.id)

--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -130,7 +130,7 @@
 			continue
 		if (!(get_area(C) == A))
 			continue
-		if ((src.req_access || src.req_access_txt) && src.allowed(C))
+		if (src.req_access && src.allowed(C))
 			continue //optional access whitelist
 		. += C
 

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -6,56 +6,9 @@
  */
 /obj/var/list/req_access = null
 /*
- * Text version of req_access, converted on instantiation (useful for applying vars to specific instances in a map)
- * Syntax is "x|y;z", where "|" delimit access groups, and ";" delimit access within each group.
- * To set to no access requirements, set this to an empty string.
- * To not affect requirements, this should be null.
- */
-/obj/var/req_access_txt = null
-/*
  * Override all access requirements if user is an administrator
  */
 /obj/var/admin_access_override = FALSE
-
-/*
- * Overrides the object's req_access var based on what's in req_access_txt (if set).
- */
-/obj/proc/update_access_from_txt()
-	// null req_access_txt means no change
-	if (!isnull(src.req_access_txt))
-		// empty string (or "0") req_access_txt means set to no access required
-		if (src.req_access_txt && src.req_access_txt != "0")
-			// reset src.req_access to build it up
-			src.req_access = list()
-			var/list/access_group_txts = splittext(src.req_access_txt, "|")
-			// loop through the access groups, adding them to src.req_access as they are resolved
-			for (var/access_group_txt in access_group_txts)
-				// sanity check for an empty access group (e.g. src.req_access_txt is "1|"), giving an empty string as the last access group
-				if (access_group_txt)
-					var/list/access_group = list()
-					var/list/access_group_strings = splittext(access_group_txt, ";")
-					// loop through the access group, adding them to the list for this group
-					for (var/access_string in access_group_strings)
-						// sanity check for an empty access string (e.g. src.req_access_txt is "1;", giving an empty string as the last access string
-						if (access_string)
-							// parse the access string
-							var/access_code = text2num(access_string)
-							if (!isnull(access_code))
-								// numerical code
-								access_group += access_code
-							// else
-								// string code
-								// TODO: some sensible lookup, possibly using access_name_lookup (but they're VERY wordy)
-					// add to the src.req_access list (assuming non-empty)
-					if (length(access_group) > 1)
-						// add the whole access group
-						// odd syntax is because += with a list on the right appends the items of the list, not the list itself, so we wrap in a list so it only unpacks once
-						src.req_access += list(access_group)
-					else if (length(access_group) == 1)
-						// add the single element
-						src.req_access += access_group[1]
-		else
-			src.req_access = null
 
 /**
  * Determines if a mob is allowed to use an object (or pass through
@@ -663,7 +616,6 @@ proc/fetchAirlock(access,variant)
 
 /obj/proc/set_access_list(var/list/L)
 	src.req_access = L.Copy()
-	src.req_access_txt = null
 
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the req_access_txt variable from all objects.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This variable is as of the latest commit unused in all available maps, only set by the CE's RCD and that also sets req_access, the actual variable used in checking an access. This variable was originally for varediting access onto things but mapping helpers and subtypes have taken over this role and thus this variable only ever really makes mappers accidentally add an access they didn't mean to.

It also limits additional work that could be put into accesses to make their code cleaner by making changes to them require checking all varedits for access. Access varedits still exist in the form of req_access=list(x), but those are only present in 3 used files and can easily be converted to access on the objects themselves.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Access still works
<img width="153" height="362" alt="image" src="https://github.com/user-attachments/assets/1ba9624b-0ebe-4a93-a32a-687e0e0a7ece" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

