### PR TITLE
AI stun turret sound effect respects LOS

### DIFF
--- a/code/modules/projectiles/_projectile_object.dm
+++ b/code/modules/projectiles/_projectile_object.dm
@@ -247,7 +247,8 @@
 				die()
 		else if (ismob(A))
 			if (proj_data?.hit_mob_sound)
-				playsound(A.loc, proj_data.hit_mob_sound, 60, 0.5)
+				var/flags = proj_data.sound_los ? SOUND_DO_LOS : 0
+				playsound(A.loc, proj_data.hit_mob_sound, 60, 0.5, flags = flags)
 			SEND_SIGNAL(A, COMSIG_MOB_CLOAKING_DEVICE_DEACTIVATE)
 			SEND_SIGNAL(A, COMSIG_MOB_DISGUISER_DEACTIVATE)
 			if (ishuman(A))
@@ -274,7 +275,8 @@
 			if ((sigreturn & PROJ_ATOM_CANNOT_PASS) || (!goes_through_walls && !(sigreturn & PROJ_PASSOBJ) && !(sigreturn & PROJ_ATOM_PASSTHROUGH)))
 				if (iscritter(A))
 					if (proj_data?.hit_mob_sound)
-						playsound(A.loc, proj_data.hit_mob_sound, 60, 0.5)
+						var/flags = proj_data.sound_los ? SOUND_DO_LOS : 0
+						playsound(A.loc, proj_data.hit_mob_sound, 60, 0.5, flags = flags)
 				else
 					if (proj_data?.hit_object_sound)
 						playsound(A.loc, proj_data.hit_object_sound, 60, 0.5)

--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -38,6 +38,7 @@
 	if(istype(TP))
 		TP.turret_list += src
 	START_TRACKING
+	src.stun.sound_los = TRUE
 
 	#ifdef LOW_SECURITY
 	START_TRACKING_CAT(TR_CAT_DELETE_ME)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
AI (and armory, compcore, etc) turrets on the stun setting respect line of sight for their firing sound and hit effect.
If a projectile fire sound should respect LoS, LoS is also applied to the mob hit sound effect.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being able to tell if someone's in the upload chamber just by walking by should not be as simple as hearing the very loud very noticable turrets. If the turrets are however set to lethal this is _bad_ and thus the lethal setting remains audible through walls.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spawned a bunch of mice in upload on atlas, stood outside messing with the settings, couldn't hear them on stun, heard them on lethal.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)AI turrets (and Computer Core/Armory(If not using a NARCS)) on the stun setting can no longer be heard through walls
```
