### PR TITLE
Listening post must be unlocked with a stolen auth disk

### DIFF
--- a/code/obj/machinery/door/door_control.dm
+++ b/code/obj/machinery/door/door_control.dm
@@ -661,21 +661,31 @@ TYPEINFO(/obj/machinery/door_control)
 /obj/machinery/door_control/ex_act(severity)
 	return
 
+/obj/machinery/door_control/antagscanner/attackby(obj/item/W, mob/user)
+	if (istrainedsyndie(user) && istype(W, /obj/item/disk/data/floppy/read_only/authentication))
+		var/datum/listening_post/listening_post = get_singleton(/datum/listening_post)
+		if (!listening_post.unlocked)
+			listening_post.first_unlock(user)
+			src.say("Nanotrasen access hash verified. Full facility access granted.")
+		src.toggle(user)
+	else
+		. = ..()
+
 /obj/machinery/door_control/antagscanner/attack_hand(mob/user)
 	if (ON_COOLDOWN(src, "scan", 2 SECONDS))
 		return
 	playsound(src.loc, 'sound/effects/handscan.ogg', 50, 1)
-	if (istrainedsyndie(user))
-		var/datum/listening_post/listening_post = get_singleton(/datum/listening_post)
-		var/first_unlock_text
-		if (!listening_post.unlocked)
-			listening_post.first_unlock(user)
-			first_unlock_text = " Facility lockdown lifted."
-		src.toggle(user)
-		if (src.entrance_scanner)
-			src.say("Biometric profile accepted. Welcome, Agent.[first_unlock_text]")
-	else
+	if (!istrainedsyndie(user))
 		src.say("Invalid biometric profile. Access denied.")
+		return
+	var/datum/listening_post/listening_post = get_singleton(/datum/listening_post)
+	if (!listening_post.unlocked)
+		src.say("Facility access contingent on retrieval of Nanotrasen access codes.")
+		return
+
+	src.toggle(user)
+	if (src.entrance_scanner)
+		src.say("Biometric profile accepted. Welcome, Agent.")
 
 ////////////////////////////////////////////////////////
 //////////// Machine activation buttons	///////////////


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The listening post now starts locked and must be unlocked by presenting a stolen auth disk. A non-syndie presenting the auth disk will not work.
I haven't included fixes to the known ways to bypass the doors but that may end up being necessary if this is merged.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There has been a trend of a lot of syndie-aligned antags heading straight to the listening post and dressing up in full obvious syndicate gear before they do anything on station. While this can lead to some neat cooperation between traitors it has also contributed quite a bit to the issue of security over-escalating against antags.
When someone walks on station wearing the "Hello I am a member of the evil terrorist organisation" outfit there aren't a lot of options other than awkwardly ignoring them or escalating to swiftly throwing them off the station again, shooting them in the face, etc.
This game was designed (and importantly balanced) around the idea of traitors sneaking around, doing crime, murdering people, and denying everything when caught, not turning up at the front door in a redsuit and an ID saying "Agent Something something"

This change allows for full out redsuit syndies to still exist, but later in the round after they have already done some crime (stealing the disk), and hopefully makes syndicate announcements more impactful and worrying rather than something that happens every round and gets ignored.
It also potentially opens the door to the listening post having more powerful gear on offer as a reward for unlocking it (another reason for captains to protect the diske)
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested opening the door without the disk, trying to open with the disk but not a traitor, opening the door without the disk after it has already been opened.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)The listening post must now be unlocked by presenting a stolen authentication disk.
```
