### PR TITLE
Adjustable fart volume.

### DIFF
--- a/_std/defines/sound.dm
+++ b/_std/defines/sound.dm
@@ -24,6 +24,7 @@ var/global/admin_sound_channel = SOUNDCHANNEL_ADMIN_LOW // current admin channel
 #define VOLUME_CHANNEL_EMOTE 5
 #define VOLUME_CHANNEL_MENTORPM 6
 #define VOLUME_CHANNEL_INSTRUMENTS 7
+#define VOLUME_CHANNEL_FARTS 8
 
 var/global/list/audio_channel_name_to_id = list(
 	"master" = VOLUME_CHANNEL_MASTER,
@@ -33,7 +34,8 @@ var/global/list/audio_channel_name_to_id = list(
 	"admin" = VOLUME_CHANNEL_ADMIN,
 	"emote" = VOLUME_CHANNEL_EMOTE,
 	"mentorpm" = VOLUME_CHANNEL_MENTORPM,
-	"instruments" = VOLUME_CHANNEL_INSTRUMENTS
+	"instruments" = VOLUME_CHANNEL_INSTRUMENTS,
+	"farts" = VOLUME_CHANNEL_FARTS,
 )
 
 //Area Ambience

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1661,7 +1661,7 @@ TYPEINFO_NEW(/datum/mutantrace/monkey)
 			if ("scream")
 				if (src.mob.emote_check(voluntary, 5 SECONDS))
 					. = "<B>[src.mob]</B> screams!"
-					playsound(src.mob, src.sound_monkeyscream, 80, 0, 0, src.mob.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
+					playsound(src.mob, src.sound_monkeyscream, 80, 0, 0, src.mob.get_age_pitch(), channel=VOLUME_CHANNEL_FARTS)
 			if ("fart")
 				if(farting_allowed && (!src.mob.reagents || !src.mob.reagents.has_reagent("anti_fart")))
 					if (!src.mob.emote_check(voluntary, 1 SECOND))
@@ -1702,7 +1702,7 @@ TYPEINFO_NEW(/datum/mutantrace/monkey)
 							if(25) . = "<B>[src.mob]</B> makes a big goofy grin and farts loudly."
 							if(26) . = "<B>[src.mob]</B> hovers off the ground for a moment using a powerful fart."
 							if(27) . = "<B>[src.mob]</B> plays drums on its ass while farting."
-					playsound(src.mob.loc, 'sound/voice/farts/poo2.ogg', 80, 0, 0, src.mob.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
+					playsound(src.mob.loc, 'sound/voice/farts/poo2.ogg', 80, 0, 0, src.mob.get_age_pitch(), channel=VOLUME_CHANNEL_FARTS)
 
 					src.mob.remove_stamina(STAMINA_DEFAULT_FART_COST)
 					src.mob.stamina_stun()
@@ -2027,7 +2027,7 @@ TYPEINFO(/datum/mutantrace/amphibian)
 			if("burp","fart","gasp")
 				if (src.mob.emote_check(voluntary, 1 SECOND))
 					message = "<B>[src.mob]</B> croaks."
-					playsound(src.mob, 'sound/voice/farts/frogfart.ogg', 60, 1, channel=VOLUME_CHANNEL_EMOTE)
+					playsound(src.mob, 'sound/voice/farts/frogfart.ogg', 60, 1, channel=VOLUME_CHANNEL_FARTS)
 					return message
 
 			if ("clothes")

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -141,15 +141,15 @@
 
 
 						if (iscluwne(src))
-							playsound(src, 'sound/voice/farts/poo.ogg', 50, TRUE, channel=VOLUME_CHANNEL_EMOTE)
+							playsound(src, 'sound/voice/farts/poo.ogg', 50, TRUE, channel=VOLUME_CHANNEL_FARTS)
 						else if (src.organ_istype("butt", /obj/item/clothing/head/butt/cyberbutt))
-							playsound(src, 'sound/voice/farts/poo2_robot.ogg', 50, TRUE, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
+							playsound(src, 'sound/voice/farts/poo2_robot.ogg', 50, TRUE, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_FARTS)
 						else if (src.reagents && src.reagents.has_reagent("honk_fart"))
-							playsound(src.loc, 'sound/musical_instruments/Bikehorn_1.ogg', 50, 1, -1, channel=VOLUME_CHANNEL_EMOTE)
+							playsound(src.loc, 'sound/musical_instruments/Bikehorn_1.ogg', 50, 1, -1, channel=VOLUME_CHANNEL_FARTS)
 						else if (src.getStatusDuration("food_deep_fart"))
-							playsound(src, src.sound_fart, 50, 0, 0, src.get_age_pitch() - 0.3, channel=VOLUME_CHANNEL_EMOTE)
+							playsound(src, src.sound_fart, 50, 0, 0, src.get_age_pitch() - 0.3, channel=VOLUME_CHANNEL_FARTS)
 						else
-							playsound(src, src.sound_fart, 50, 0, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
+							playsound(src, src.sound_fart, 50, 0, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_FARTS)
 
 						var/fart_on_other = 0
 						for (var/atom/A as anything in src.loc)
@@ -181,7 +181,7 @@
 									var/mob/M = V.cursed_dude
 									if (!M || !M.lying)
 										continue
-									playsound(M, src.sound_fart, 20, 0, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
+									playsound(M, src.sound_fart, 20, 0, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_FARTS)
 									switch(rand(1, 7))
 										if (1) M.visible_message(SPAN_EMOTE("<b>[M]</b> suddenly radiates an unwelcoming odor."))
 										if (2) M.visible_message(SPAN_EMOTE("<b>[M]</b> is visited by ethereal incontinence."))

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -665,7 +665,7 @@ TYPEINFO(/mob/living/silicon/robot)
 							if (38) message = "<B>[src]</B> exterminates the air supply."
 							if (39) message = "<B>[src]</B> farts so hard the AI feels it."
 							if (40) message = "<B>[src] <span style='color:red'>f</span><span style='color:blue'>a</span>r<span style='color:red'>t</span><span style='color:blue'>s</span>!</B>"
-					playsound(src.loc, src.sound_fart, 50, 1, channel=VOLUME_CHANNEL_EMOTE)
+					playsound(src.loc, src.sound_fart, 50, 1, channel=VOLUME_CHANNEL_FARTS)
 	#ifdef DATALOGGER
 					game_stats.Increment("farts")
 	#endif

--- a/code/modules/sound/sound.dm
+++ b/code/modules/sound/sound.dm
@@ -61,7 +61,7 @@ var/global/ECHO_CLOSE = list(0,0,0,0,0,0,0,0.25,1.5,1.0,0,1.0,0,0,0,0,1.0,7)
 var/global/list/falloff_cache = list()
 
 //default volumes
-var/global/list/default_channel_volumes = list(1, 1, 1, 0.5, 0.5, 1, 1, 1)
+var/global/list/default_channel_volumes = list(1, 1, 1, 0.5, 0.5, 1, 1, 1, 1)
 
 //volumous hair with l'orial paris
 /client/var/list/volumes
@@ -69,7 +69,7 @@ var/global/list/default_channel_volumes = list(1, 1, 1, 0.5, 0.5, 1, 1, 1)
 
 /// Returns a list of friendly names for available sound channels
 /client/proc/getVolumeNames()
-	return list("Game", "Ambient", "Radio", "Admin", "Emote", "Mentor PM", "Instruments")
+	return list("Game", "Ambient", "Radio", "Admin", "Emote", "Mentor PM", "Instruments", "Farts")
 
 /// Returns the default volume for a channel, unattenuated for the master channel (0-1)
 /client/proc/getDefaultVolume(channel)
@@ -77,7 +77,7 @@ var/global/list/default_channel_volumes = list(1, 1, 1, 0.5, 0.5, 1, 1, 1)
 
 /// Returns a list of friendly descriptions for available sound channels
 /client/proc/getVolumeDescriptions()
-	return list("This will affect all sounds.", "Most in-game audio will use this channel.", "Ambient background music in various areas will use this channel.", "Any music played from the radio station", "Any music or sounds played by admins.", "Screams and farts.", "Mentor PM notification sound.", "Music from in-game instruments.")
+	return list("This will affect all sounds.", "Most in-game audio will use this channel.", "Ambient background music in various areas will use this channel.", "Any music played from the radio station", "Any music or sounds played by admins.", "Screams.", "Mentor PM notification sound.", "Music from in-game instruments.", "Farts. Only farts.")
 
 /// Get the friendly description for a specific sound channel.
 /client/proc/getVolumeChannelDescription(channel)

--- a/code/modules/sound/sound.dm
+++ b/code/modules/sound/sound.dm
@@ -77,7 +77,7 @@ var/global/list/default_channel_volumes = list(1, 1, 1, 0.5, 0.5, 1, 1, 1, 1)
 
 /// Returns a list of friendly descriptions for available sound channels
 /client/proc/getVolumeDescriptions()
-	return list("This will affect all sounds.", "Most in-game audio will use this channel.", "Ambient background music in various areas will use this channel.", "Any music played from the radio station", "Any music or sounds played by admins.", "Screams.", "Mentor PM notification sound.", "Music from in-game instruments.", "Farts. Only farts.")
+	return list("This will affect all sounds.", "Most in-game audio will use this channel.", "Ambient background music in various areas will use this channel.", "Any music played from the radio station", "Any music or sounds played by admins.", "Screams and other emotes.", "Mentor PM notification sound.", "Music from in-game instruments.", "Farts. Only farts.")
 
 /// Get the friendly description for a specific sound channel.
 /client/proc/getVolumeChannelDescription(channel)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -470,6 +470,11 @@ menu "menu"
 		category = "&Audio"
 		saved-params = "is-checked"
 	elem
+		name = "&Adjust Fart Volume"
+		command ="change-volume farts"
+		category = "&Audio"
+		saved-params = "is-checked"
+	elem
 		name = ""
 		command = ""
 		category = "&Audio"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fart volume can now be adjusted from 0 to 200% clientside.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Peoples' fart-related misophonia.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="260" height="221" alt="image" src="https://github.com/user-attachments/assets/933c283b-1b3c-498c-8cc6-3a325132d4a6" />

Compiled, working as of ebb2a59.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)DisturbHerb
(+)Fart volume may now be adjusted in your audio settings.
```
