### PR TITLE
Sugar overdose threshold tweaks

### DIFF
--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -617,7 +617,7 @@
 				boutput(M, SPAN_ALERT("You pass out from hyperglycemic shock!"))
 				M.emote("collapse")
 				//M.changeStatus("unconscious", ((2 * severity)*15) * mult)
-				M.changeStatus("knockdown", ((4 * severity)*1.5 SECONDS) * mult)
+				M.changeStatus("knockdown", ((6 SECONDS) * mult)
 
 			if (prob(8))
 				M.take_toxin_damage(severity * mult)

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -617,7 +617,7 @@
 				boutput(M, SPAN_ALERT("You pass out from hyperglycemic shock!"))
 				M.emote("collapse")
 				//M.changeStatus("unconscious", ((2 * severity)*15) * mult)
-				M.changeStatus("knockdown", ((6 SECONDS) * mult)
+				M.changeStatus("knockdown", ((6 SECONDS) * mult))
 
 			if (prob(8))
 				M.take_toxin_damage(severity * mult)

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -557,7 +557,7 @@
 	fluid_g = 255
 	fluid_b = 255
 	transparency = 255
-	overdose = 200
+	overdose = 80
 	hunger_value = 0.098
 	thirst_value = -0.098
 	taste = "sweet"
@@ -612,7 +612,7 @@
 
 				responseBee.visible_message("<b>[responseBee]</b> [ pick("looks confused.", "appears to undergo a metaphysical crisis.  What is human?  What is space bee?<br>Or it might just have gas.", "looks perplexed.", "bumbles in a confused way.", "holds out its forelegs, staring into its little bee-palms and wondering what is real.") ]")
 
-		else
+		else if (severity == 2)
 			if (!M.getStatusDuration("unconscious"))
 				boutput(M, SPAN_ALERT("You pass out from hyperglycemic shock!"))
 				M.emote("collapse")

--- a/code/obj/item/organs/pancreas.dm
+++ b/code/obj/item/organs/pancreas.dm
@@ -8,18 +8,25 @@
 	failure_disease = /datum/ailment/disease/pancreatitis
 	surgery_flags = SURGERY_SNIPPING | SURGERY_CUTTING
 	region = SUBCOSTAL
+	var/sugar_dose
 
 	on_life(var/mult = 1)
 		if (!..())
 			return 0
+		if (donor.reagents)
+			sugar_dose = donor.reagents.get_reagent_amount("sugar") //variable to check for whether and how much the donor is overdosing on sugar, with respect for chemical weakness defect and chemical resistant trait.
+			if(donor.traitHolder.hasTrait("chemresist"))
+				sugar_dose *= 0.65
+			if(HAS_ATOM_PROPERTY(donor, PROP_MOB_OVERDOSE_WEAKNESS))
+				sugar_dose *= 2
 		if(!emagged) //emagged pancreas doesn't regulate sugar for you anymore.
-			if (donor.reagents && donor.reagents.get_reagent_amount("sugar") > 80)
+			if (donor.reagents && sugar_dose > 80)
 				if (prob(50))
 					donor.reagents.add_reagent("insulin", 1 * mult)
 					if(!robotic) //don't kill a cyberpancreas
 						src.take_damage(0, 0, 10)
 				else if (prob(50))
-					if (donor.reagents.get_reagent_amount("sugar") > 160)
+					if (sugar_dose > 160)
 						donor.reagents.add_reagent("insulin", 2 * mult)
 						if(!robotic)
 							src.take_damage(0, 0, 40)

--- a/code/obj/item/organs/pancreas.dm
+++ b/code/obj/item/organs/pancreas.dm
@@ -8,31 +8,30 @@
 	failure_disease = /datum/ailment/disease/pancreatitis
 	surgery_flags = SURGERY_SNIPPING | SURGERY_CUTTING
 	region = SUBCOSTAL
-	var/sugar_dose
 
 	on_life(var/mult = 1)
 		if (!..())
 			return 0
 		if (donor.reagents)
-			sugar_dose = donor.reagents.get_reagent_amount("sugar") //variable to check for whether and how much the donor is overdosing on sugar, with respect for chemical weakness defect and chemical resistant trait.
+			var/sugar_dose = donor.reagents.get_reagent_amount("sugar") //variable to check for whether and how much the donor is overdosing on sugar, with respect for chemical weakness defect and chemical resistant trait.
 			if(donor.traitHolder.hasTrait("chemresist"))
 				sugar_dose *= 0.65
 			if(HAS_ATOM_PROPERTY(donor, PROP_MOB_OVERDOSE_WEAKNESS))
 				sugar_dose *= 2
-		if(!emagged) //emagged pancreas doesn't regulate sugar for you anymore.
-			if (donor.reagents && sugar_dose > 80)
-				if (prob(50))
-					donor.reagents.add_reagent("insulin", 1 * mult)
-					if(!robotic) //don't kill a cyberpancreas
-						src.take_damage(0, 0, 10)
-				else if (prob(50))
-					if (sugar_dose > 160)
-						donor.reagents.add_reagent("insulin", 2 * mult)
-						if(!robotic)
-							src.take_damage(0, 0, 40)
+			if(!emagged) //emagged pancreas doesn't regulate sugar for you anymore.
+				if (sugar_dose > 80)
+					if (prob(50))
+						donor.reagents.add_reagent("insulin", 1 * mult)
+						if(!robotic) //don't kill a cyberpancreas
+							src.take_damage(0, 0, 10)
+					else if (prob(50))
+						if (sugar_dose > 160)
+							donor.reagents.add_reagent("insulin", 2 * mult)
+							if(!robotic)
+								src.take_damage(0, 0, 40)
 
-			if (src.get_damage() >= 65 && prob(src.get_damage() * 0.2))
-				donor.contract_disease(failure_disease,null,null,1)
+		if (src.get_damage() >= 65 && prob(src.get_damage() * 0.2))
+			donor.contract_disease(failure_disease,null,null,1)
 		return 1
 
 	disposing()

--- a/code/obj/item/organs/pancreas.dm
+++ b/code/obj/item/organs/pancreas.dm
@@ -19,7 +19,7 @@
 					if(!robotic) //don't kill a cyberpancreas
 						src.take_damage(0, 0, 10)
 				else if (prob(50))
-					if (donor.reagents.get_reagent_amount("sugar") > 200)
+					if (donor.reagents.get_reagent_amount("sugar") > 160)
 						donor.reagents.add_reagent("insulin", 2 * mult)
 						if(!robotic)
 							src.take_damage(0, 0, 40)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[BALANCE] [CHEMISTRY] [MEDICAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lowers sugar's overdose threshold to 80 to better indicate at which dose patients start taking damage. To compensate, patients now only enter hyperglycemic shock at overdose severity 2 (i.e. 160 units- technically a buff to hyperglycemic shock but also under normal circumstances you aren't gonna have that much sugar in you anyways). Noteably, since apidae metabolism functions based off of overdose threshold, this PR also acts as an indirect buff to apidae metabolism.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, sugar overdose is set at 200 while sugar actually starts having negative effects on the body at 80 units, making the current overdose threshold somewhat misleading. Apidae metabolism also sucks pretty bad right now since you have to seriously fuck up your pancreas to get any use out of it.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="474" height="337" alt="Screenshot (623)" src="https://github.com/user-attachments/assets/2abfef22-71e1-4da1-bd3e-5e320f1ebe8e" />
<img width="527" height="358" alt="Screenshot (624)" src="https://github.com/user-attachments/assets/8ac64fe5-b10f-467c-93b0-eaae02518177" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(unova2053
(+)Medical scanners now indicate sugar overdose at 80 units rather than 200 units, better indicating at which point sugar overdose becomes dangerous.
(+)Sugar will now cause hyperglycemic shock at 160 units instead of 200 units.
```
