### PR TITLE
Namespaces (Atomised)

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -11,6 +11,7 @@
 #include "__build.dm"				// this controls how a lot of our defines and macros and code is compiled, so it absolutely needs to be the first
 #include "macros\_metamacros.dm"	// this has some structural helpers that a lot of other macros/defines use, so it needs to be near the start
 #include "_spaceman_dmm.dm"			// linter stuff is used in other macros
+#include "namespaces\_namespace.dm"
 #include "mapDefines.dm"			// knowing if we're underwater is important for some later macros
 #include "setup.dm"					// initializes important stuff for later macros
 #include "defines\_units.dm"		// this has some unit defines that a lot of other macros/defines use, so it needs to go near the start too

--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -11,9 +11,9 @@
 #include "__build.dm"				// this controls how a lot of our defines and macros and code is compiled, so it absolutely needs to be the first
 #include "macros\_metamacros.dm"	// this has some structural helpers that a lot of other macros/defines use, so it needs to be near the start
 #include "_spaceman_dmm.dm"			// linter stuff is used in other macros
-#include "namespaces\_namespace.dm"
 #include "mapDefines.dm"			// knowing if we're underwater is important for some later macros
 #include "setup.dm"					// initializes important stuff for later macros
+#include "namespaces\_namespace.dm"
 #include "defines\_units.dm"		// this has some unit defines that a lot of other macros/defines use, so it needs to go near the start too
 #include "macros\_unit_conversions.dm"
 #include "defines\lag.dm"			// the all important LAGCHECK()

--- a/_std/namespaces/_namespace.dm
+++ b/_std/namespaces/_namespace.dm
@@ -1,0 +1,105 @@
+/**
+ *	Declare a new namespace. If one argument is passed, a global namespace is created. If more than one argument is passed, a nested namespace is created. \
+ *	E.g.
+ *	- `CREATE_NAMESPACE(ANIMATE)`			: creates a global `ANIMATE` namespace.
+ *	- `CREATE_NAMESPACE(ANIMATE, MOB)`		: creates a nested `MOB` namespace inside of `ANIMATE`.
+ *	- `CREATE_NAMESPACE(ANIMATE, MOB, BEE)`	: creates a nested `BEE` namespace inside of `ANIMATE.MOB`.
+ */
+#define CREATE_NAMESPACE(_NAMES...) _NS_DEFINE(##_NAMES, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+
+#define _NS_DEFINE(a, b, c, d, e, f, g, h, i, j, ...) _NS_DEFINE_##j(a, b, c, d, e, f, g, h, i)
+#define _NS_DEFINE_0(a, b, c, d, e, f, g, h, i)
+#define _NS_DEFINE_1(a, b, c, d, e, f, g, h, i) var/datum/namespace/##a/##a = /datum/namespace/##a
+#define _NS_DEFINE_2(a, b, c, d, e, f, g, h, i) ADD_TO_NAMESPACE(a)(var/##ADD_TO_NAMESPACE(a, b)(##b = _NS_PATH(a, b)))
+#define _NS_DEFINE_3(a, b, c, d, e, f, g, h, i) ADD_TO_NAMESPACE(a, b)(var/##ADD_TO_NAMESPACE(a, b, c)(##c = _NS_PATH(a, b, c)))
+#define _NS_DEFINE_4(a, b, c, d, e, f, g, h, i) ADD_TO_NAMESPACE(a, b, c)(var/##ADD_TO_NAMESPACE(a, b, c, d)(##d = _NS_PATH(a, b, c, d)))
+#define _NS_DEFINE_5(a, b, c, d, e, f, g, h, i) ADD_TO_NAMESPACE(a, b, c, d)(var/##ADD_TO_NAMESPACE(a, b, c, d, e)(##e = _NS_PATH(a, b, c, d, e)))
+#define _NS_DEFINE_6(a, b, c, d, e, f, g, h, i) ADD_TO_NAMESPACE(a, b, c, d, e)(var/##ADD_TO_NAMESPACE(a, b, c, d, e, f)(##f = _NS_PATH(a, b, c, d, e, f)))
+#define _NS_DEFINE_7(a, b, c, d, e, f, g, h, i) ADD_TO_NAMESPACE(a, b, c, d, e, f)(var/##ADD_TO_NAMESPACE(a, b, c, d, e, f, g)(##g = _NS_PATH(a, b, c, d, e, f, g)))
+#define _NS_DEFINE_8(a, b, c, d, e, f, g, h, i) ADD_TO_NAMESPACE(a, b, c, d, e, f, g)(var/##ADD_TO_NAMESPACE(a, b, c, d, e, f, g, h)(##h = _NS_PATH(a, b, c, d, e, f, g, h)))
+#define _NS_DEFINE_9(a, b, c, d, e, f, g, h, i) ADD_TO_NAMESPACE(a, b, c, d, e, f, g, h)(var/##ADD_TO_NAMESPACE(a, b, c, d, e, f, g, h, i)(##i = _NS_PATH(a, b, c, d, e, f, g, h, i)))
+
+
+/**
+ *	Add a statement to the end of a namespace. \
+ *	E.g.
+ *	- `ADD_TO_NAMESPACE(ANIMATE)(var/example_var = null)`		: adds an `example_var` variable to `ANIMATE` and initialises it to `null`.
+ *	- `ADD_TO_NAMESPACE(ANIMATE, MOB)(var/example_var = null)`	: adds an `example_var` variable to `ANIMATE.MOB` and initialises it to `null`.
+ *	- `ADD_TO_NAMESPACE(ANIMATE)(proc/example_proc())`			: adds an `example_proc` proc to `ANIMATE`. Indented code following the macro will be treated as the body of the proc.
+ *	- `ADD_TO_NAMESPACE(ANIMATE, MOB)(proc/example_proc())`		: adds an `example_proc` proc to `ANIMATE.MOB`. Indented code following the macro will be treated as the body of the proc.
+ */
+#define ADD_TO_NAMESPACE(_NAMES...) _NS_PATH_I(##_NAMES)
+
+// The namespace path for a concatenated namespace name.
+#define _NS_PATH(_ARGS...) _NS_PATH_CONCAT(__NS_PATH, ##_ARGS, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define __NS_PATH(_NAME) /datum/namespace/##_NAME
+
+// The namespace path for a concatenated namespace name, with a capturing identity macro appended to the terminating forward slash.
+#define _NS_PATH_I(_ARGS...) _NS_PATH_CONCAT(__NS_PATH_I, ##_ARGS, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define __NS_PATH_I(_NAME) /datum/namespace/##_NAME/##IDENTITY
+
+#define _NS_PATH_CONCAT(X, a, b, c, d, e, f, g, h, i, j, ...) _NS_PATH_CONCAT_##j(X, a, b, c, d, e, f, g, h, i)
+#define _NS_PATH_CONCAT_0(X, a, b, c, d, e, f, g, h, i)
+#define _NS_PATH_CONCAT_1(X, a, b, c, d, e, f, g, h, i) X(a)
+#define _NS_PATH_CONCAT_2(X, a, b, c, d, e, f, g, h, i) X(a##__##b)
+#define _NS_PATH_CONCAT_3(X, a, b, c, d, e, f, g, h, i) X(a##__##b##__##c)
+#define _NS_PATH_CONCAT_4(X, a, b, c, d, e, f, g, h, i) X(a##__##b##__##c##__##d)
+#define _NS_PATH_CONCAT_5(X, a, b, c, d, e, f, g, h, i) X(a##__##b##__##c##__##d##__##e)
+#define _NS_PATH_CONCAT_6(X, a, b, c, d, e, f, g, h, i) X(a##__##b##__##c##__##d##__##e##__##f)
+#define _NS_PATH_CONCAT_7(X, a, b, c, d, e, f, g, h, i) X(a##__##b##__##c##__##d##__##e##__##f##__##g)
+#define _NS_PATH_CONCAT_8(X, a, b, c, d, e, f, g, h, i) X(a##__##b##__##c##__##d##__##e##__##f##__##g##__##h)
+#define _NS_PATH_CONCAT_9(X, a, b, c, d, e, f, g, h, i) X(a##__##b##__##c##__##d##__##e##__##f##__##g##__##h##__##i)
+
+
+/// Initialise all global namespaces by looping through global variables, determining which are namespaces, then instantiating them.
+/proc/initialise_namespaces()
+	for (var/variable_name as anything in global.vars)
+		var/namespace_path = global.vars[variable_name]
+		if (!ispath(namespace_path, /datum/namespace))
+			continue
+
+		global.vars[variable_name] = new namespace_path(variable_name)
+
+
+/datum/namespace
+	/// The name of this namespace, that is, the name of the variable that references this namespace.
+	var/_namespace_name = null
+	/// An associative list of proc references to procs defined on this namespace and its nested namespaces, indexed by proc name.
+	var/list/_namespace_procs = null
+
+/datum/namespace/New(_namespace_name)
+	src._namespace_name = _namespace_name
+
+	// Initialise any nested namespaces.
+	for (var/variable_name as anything in src.vars)
+		if ((variable_name == "type") || (variable_name == "parent_type"))
+			continue
+
+		var/namespace_path = src.vars[variable_name]
+		if (!ispath(namespace_path, /datum/namespace))
+			continue
+
+		src.vars[variable_name] = new namespace_path(variable_name)
+
+	. = ..()
+
+/// Returns an associative list of proc references to procs defined on this namespace and its nested namespaces, indexed by proc name.
+/datum/namespace/proc/_get_namespace_procs()
+	RETURN_TYPE(/list)
+
+	if (length(src._namespace_procs))
+		return src._namespace_procs
+
+	src._namespace_procs = global.get_singleton(/datum/proc_ownership_cache).procs_by_type[src.type] || list()
+	src._namespace_procs -= list("(init)", "New", "_get_namespace_procs")
+
+	for (var/variable_name as anything in src.vars)
+		var/datum/namespace/nested_namespace = src.vars[variable_name]
+		if (!istype(nested_namespace))
+			continue
+
+		var/list/nested_namespace_procs = nested_namespace._get_namespace_procs()
+		for (var/proc_name as anything in nested_namespace_procs)
+			src._namespace_procs["[nested_namespace._namespace_name]: [proc_name]"] = nested_namespace_procs[proc_name]
+
+	return src._namespace_procs

--- a/_std/namespaces/_namespace.dm
+++ b/_std/namespaces/_namespace.dm
@@ -51,14 +51,27 @@
 #define _NS_PATH_CONCAT_9(X, a, b, c, d, e, f, g, h, i) X(a##__##b##__##c##__##d##__##e##__##f##__##g##__##h##__##i)
 
 
+/// A list of all global namespaces.
+var/list/datum/namespace/global_namespaces = null
+
 /// Initialise all global namespaces by looping through global variables, determining which are namespaces, then instantiating them.
 /proc/initialise_namespaces()
+	global.global_namespaces = list()
+
 	for (var/variable_name as anything in global.vars)
 		var/namespace_path = global.vars[variable_name]
 		if (!ispath(namespace_path, /datum/namespace))
 			continue
 
-		global.vars[variable_name] = new namespace_path(variable_name)
+		var/datum/namespace/global_namespace = new namespace_path(variable_name)
+		global.vars[variable_name] = global_namespace
+		global.global_namespaces += global_namespace
+
+	global.sortList(global.global_namespaces, GLOBAL_PROC_REF(cmp_namespaces))
+
+/// Compare the names of two namespaces.
+/proc/cmp_namespaces(datum/namespace/a, datum/namespace/b)
+	return sorttext(b._namespace_name, a._namespace_name)
 
 
 /datum/namespace
@@ -66,9 +79,12 @@
 	var/_namespace_name = null
 	/// An associative list of proc references to procs defined on this namespace and its nested namespaces, indexed by proc name.
 	var/list/_namespace_procs = null
+	/// A list of this namespace's nested namespaces.
+	var/list/datum/namespace/_nested_namespaces = null
 
 /datum/namespace/New(_namespace_name)
 	src._namespace_name = _namespace_name
+	src._nested_namespaces = list()
 
 	// Initialise any nested namespaces.
 	for (var/variable_name as anything in src.vars)
@@ -79,27 +95,31 @@
 		if (!ispath(namespace_path, /datum/namespace))
 			continue
 
-		src.vars[variable_name] = new namespace_path(variable_name)
+		var/datum/namespace/nested_namespace = new namespace_path(variable_name)
+		src.vars[variable_name] = nested_namespace
+		src._nested_namespaces += nested_namespace
+
+	global.sortList(src._nested_namespaces, GLOBAL_PROC_REF(cmp_namespaces))
 
 	. = ..()
 
 /// Returns an associative list of proc references to procs defined on this namespace and its nested namespaces, indexed by proc name.
-/datum/namespace/proc/_get_namespace_procs()
+/datum/namespace/proc/_get_namespace_procs(prefix_name = FALSE)
 	RETURN_TYPE(/list)
 
-	if (length(src._namespace_procs))
-		return src._namespace_procs
+	if (!length(src._namespace_procs))
+		src._namespace_procs = global.get_singleton(/datum/proc_ownership_cache).procs_by_type[src.type] || list()
+		src._namespace_procs -= list("(init)", "New", "_get_namespace_procs")
+		global.sortList(src._namespace_procs, GLOBAL_PROC_REF(cmp_text_asc))
 
-	src._namespace_procs = global.get_singleton(/datum/proc_ownership_cache).procs_by_type[src.type] || list()
-	src._namespace_procs -= list("(init)", "New", "_get_namespace_procs")
+		for (var/datum/namespace/nested_namespace as anything in src._nested_namespaces)
+			src._namespace_procs += nested_namespace._get_namespace_procs(TRUE)
 
-	for (var/variable_name as anything in src.vars)
-		var/datum/namespace/nested_namespace = src.vars[variable_name]
-		if (!istype(nested_namespace))
-			continue
+	if (prefix_name)
+		var/list/procs = list()
+		for (var/proc_name as anything in src._namespace_procs)
+			procs["[src._namespace_name].[proc_name]"] = src._namespace_procs[proc_name]
 
-		var/list/nested_namespace_procs = nested_namespace._get_namespace_procs()
-		for (var/proc_name as anything in nested_namespace_procs)
-			src._namespace_procs["[nested_namespace._namespace_name]: [proc_name]"] = nested_namespace_procs[proc_name]
+		return procs
 
 	return src._namespace_procs

--- a/_std/namespaces/_namespace.dm
+++ b/_std/namespaces/_namespace.dm
@@ -1,3 +1,26 @@
+//------------ How To Use Namespaces ------------//
+/*
+
+CREATE_NAMESPACE(TEST)
+
+// Non-constant variable example.
+ADD_TO_NAMESPACE(TEST)(var/example_var = new /atom/movable)
+// Constant variable example. Can be statically accessed with `::`. See `test_var` below for a usecase.
+ADD_TO_NAMESPACE(TEST)(var/const/example_constant = (1 << 3))
+// Proc example.
+ADD_TO_NAMESPACE(TEST)(proc/example_proc())
+	return "example value"
+
+/datum/test_datum
+	var/test_var = TEST::example_constant
+
+/datum/test_datum/proc/test_proc()
+	message_admins(TEST.example_var)
+	message_admins(TEST.example_proc())
+
+*/
+
+
 /**
  *	Declare a new namespace. If one argument is passed, a global namespace is created. If more than one argument is passed, a nested namespace is created. \
  *	E.g.

--- a/code/modules/admin/viewvariables/call_proc_menu.dm
+++ b/code/modules/admin/viewvariables/call_proc_menu.dm
@@ -15,6 +15,9 @@ proc/list_procs(datum/target) // null for global
 
 	if (isnull(target))
 		.[null] = proc_ownership_cache.procs_by_type[null]
+		for (var/datum/namespace/namespace as anything in global.global_namespaces)
+			.[null] += namespace._get_namespace_procs(TRUE)
+
 		return
 
 	var/type = target.type

--- a/code/world/initialization/1_preMapLoad.dm
+++ b/code/world/initialization/1_preMapLoad.dm
@@ -55,6 +55,9 @@
 	world.log << ""
 #endif
 	enable_auxtools_debugger()
+
+	global.initialise_namespaces()
+
 	Z_LOG_DEBUG("Preload", "  radio")
 	radio_controller = new /datum/controller/radio()
 


### PR DESCRIPTION
## About The PR:
Implements namespaces; these are datums with the explicit purpose of holding globally accessible variables and procs. Namespaces are implemented through the use of macros, so developers need never consider the underlying type structure of namespaces.

Creating a global or nested namespace:
```
CREATE_NAMESPACE(ANIMATE)			: creates a global `ANIMATE` namespace.
CREATE_NAMESPACE(ANIMATE, MOB)		: creates a nested `MOB` namespace inside of `ANIMATE`.
CREATE_NAMESPACE(ANIMATE, MOB, BEE)	: creates a nested `BEE` namespace inside of `ANIMATE.MOB`.
```

Adding variables of procs to a namespace:
```
ADD_TO_NAMESPACE(ANIMATE)(var/example_var = null)		: adds an `example_var` variable to `ANIMATE` and initialises it to `null`.
ADD_TO_NAMESPACE(ANIMATE, MOB)(var/example_var = null)	: adds an `example_var` variable to `ANIMATE.MOB` and initialises it to `null`.
ADD_TO_NAMESPACE(ANIMATE)(proc/example_proc())			: adds an `example_proc` proc to `ANIMATE`. Indented code following the macro will be treated as the body of the proc.
ADD_TO_NAMESPACE(ANIMATE, MOB)(proc/example_proc())		: adds an `example_proc` proc to `ANIMATE.MOB`. Indented code following the macro will be treated as the body of the proc.
```


## Why Is This Needed?
Implementing a standard method of collecting variables and procs into globally accessible datums should help reduce global namespace pollution.

In addition to this, namespace datums are set up so to avoid the initialisation availability problem, wherein a global variable initialised through `... = new()` at the top of an arbitrary file will not be available during world initialisation due to BYOND not executing that particular `new()` call until the completion of the Genesis procedure.
Namespaces avoid this by being initialised by the `initialise_namespaces()` proc, called during `preMapLoad`.


## Testing:
See #25336