### PR TITLE
Pod remote door control setup adjustment for helpers

### DIFF
--- a/code/modules/mapping/helpers/button_helpers.dm
+++ b/code/modules/mapping/helpers/button_helpers.dm
@@ -29,6 +29,9 @@ This ID is then placed on buttons in your active tile, and doors one tile away i
 					O:id = pair_id
 				else
 					O:id = src.id
+			if(istype(O,/obj/machinery/r_door_control)) //refresh identifier
+				O:id_setup()
+
 		if(do_pair)
 			var/turf/looking_at = get_step(our_spot,src.dir)
 			for(var/obj/O in looking_at)

--- a/code/obj/machinery/door/door_control.dm
+++ b/code/obj/machinery/door/door_control.dm
@@ -1183,14 +1183,18 @@ ABSTRACT_TYPE(/obj/machinery/activation_button)
 		MAKE_DEFAULT_RADIO_PACKET_COMPONENT(null, null, frequency)
 
 		if(id)
-			pass = "[id]-[rand(1,50)]"
-			name = "Access Code: [pass]"
+			src.id_setup()
+
 		light = new /datum/light/point //They were kinda dark okay
 		light.attach(src)
 		light.set_brightness(0.6)
 		light.set_height(1.25)
 		light.set_color(0.9, 0.5, 0.5)
 		light.enable()
+
+	proc/id_setup()
+		src.pass = "[src.id]_[rand(0,9)][rand(0,9)][rand(0,9)][rand(0,9)]"
+		src.name = "Access Code: [src.pass]"
 
 	Click(var/location,var/control,var/params)
 		if(GET_DIST(usr, src) > 16)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[INTERNAL][FIX][MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Splits off pod remote door controls' ID-to-password setup into a separate proc which New() calls, creating a 4-digit PIN instead of a single random number from 1 to 50; door button mapping helpers will now call this proc after they set the control's ID, as a more structurally appropriate alternative to directly setting the password from the mapping helper.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes door button helpers work properly with the remote door controls.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Verified that both helper-configured and "regular" (type-defined ID) remote door controllers operate doors as intended.