### PR TITLE
Removes base whisper ability, do it on-click instead

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -30,9 +30,9 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //------------ OPTIONS TO GO FAST ------------//
 
-//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
+#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
 
-//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
+#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
 
 //#define SKIP_FEA_SETUP // Skip setting up atmospheric system
 //#define SKIP_Z5_SETUP // Skip generation of mining level

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -30,9 +30,9 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //------------ OPTIONS TO GO FAST ------------//
 
-#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
+//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
 
-#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
+//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
 
 //#define SKIP_FEA_SETUP // Skip setting up atmospheric system
 //#define SKIP_Z5_SETUP // Skip generation of mining level

--- a/code/mob/living/intangible/wraith.dm
+++ b/code/mob/living/intangible/wraith.dm
@@ -42,6 +42,7 @@ TYPEINFO(/mob/living/intangible/wraith)
 	/// flag set if we were manifested involuntarily, e.g. salt. Blocks wraith powers is true
 	var/forced_manifest = FALSE
 
+	var/whisper_toggled = TRUE // verb turning on-click whispers on and off
 	var/last_life_update = 0
 	var/const/life_tick_spacing = LIFE_PROCESS_TICK_SPACING
 	/// standard duration of an involuntary haunt action
@@ -449,7 +450,6 @@ TYPEINFO(/mob/living/intangible/wraith)
 		src.addAbility(/datum/targetable/wraithAbility/command)
 		src.addAbility(/datum/targetable/wraithAbility/animateObject)
 		src.addAbility(/datum/targetable/wraithAbility/spook)
-		src.addAbility(/datum/targetable/wraithAbility/whisper)
 		src.addAbility(/datum/targetable/wraithAbility/mass_whisper)
 		src.addAbility(/datum/targetable/wraithAbility/blood_writing)
 		src.addAbility(/datum/targetable/wraithAbility/haunt)
@@ -508,6 +508,12 @@ TYPEINFO(/mob/living/intangible/wraith)
 
 	proc/whisper(var/mob/target)
 		var/mob/living/carbon/human/H = target
+
+		if (!src.whisper_toggled)
+			return
+		if (src.hasStatus("corporeal"))
+			boutput(usr, SPAN_ALERT("You have no tongue to speak with when corporeal!"))
+			return
 		if (isdead(H))
 			boutput(usr, SPAN_ALERT("They can hear you just fine without the use of your abilities."))
 			return
@@ -617,6 +623,14 @@ TYPEINFO(/mob/living/intangible/wraith)
 //////////////
 // Related procs and verbs
 //////////////
+
+/mob/living/intangible/wraith/verb/toggle_click_to_whisper()
+	if (src.whisper_toggled)
+		src.whisper_toggled = FALSE
+		boutput(src, SPAN_ALERT("Clicking on humans will no longer whisper to them."))
+	else
+		src.whisper_toggled = TRUE
+		boutput(src, SPAN_ALERT("Clicking on humans will now whisper to them."))
 
 /proc/visibleBodies(var/mob/M)
 	var/list/ret = new

--- a/code/mob/living/intangible/wraith.dm
+++ b/code/mob/living/intangible/wraith.dm
@@ -397,6 +397,8 @@ TYPEINFO(/mob/living/intangible/wraith)
 			return ..()
 		if (!density)
 			src.examine_verb(target)
+		if (ishuman(target))
+			src.whisper(target)
 
 	examine_verb(atom/A as mob|obj|turf in view())
 		..()
@@ -503,6 +505,26 @@ TYPEINFO(/mob/living/intangible/wraith)
 			R.wraithPossess(src)
 			return 0
 		return 1
+
+	proc/whisper(var/mob/target)
+		var/mob/living/carbon/human/H = target
+		if (isdead(H))
+			boutput(usr, SPAN_ALERT("They can hear you just fine without the use of your abilities."))
+			return
+
+		var/message = html_encode(tgui_input_text(usr, "What would you like to whisper to [target]?", "Whisper"))
+		if (!message)
+			return
+
+		logTheThing(LOG_SAY, usr, "WRAITH WHISPER TO [constructTarget(target,"say")]: [message]")
+		message = trimtext(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
+
+		DISPLAY_MAPTEXT(target, list(target), MAPTEXT_MOB_RECIPIENTS_WITH_OBSERVERS, /image/maptext/wraith_whisper, message, src)
+
+		boutput(usr, "<b>You whisper to [target]:</b> [message]")
+		boutput(target, "<b>A netherworldly voice whispers into your ears... </b> [message]")
+		usr.playsound_local(usr.loc, "sound/voice/wraith/wraithwhisper[rand(1, 4)].ogg", 65, 0)
+		H.playsound_local(H.loc, "sound/voice/wraith/wraithwhisper[rand(1, 4)].ogg", 65, 0)
 
 //////////////
 // Subtypes


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR removes the base wraith whisper ability and moves its code to a proc on wraiths that triggers on clicking a human. There's also a command verb to turn this off if you want to, I wouldn't but maybe people would want to turn it off until they want to use it. 

Base whisper is also cooldown and point cost-less, enjoy!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Facilitating communication between wraith and crew is always good. I figured less buttons was also a good thing but I could put the button back and move the toggle verb onto that instead if wanted.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested multiple times including while manifested and de-manifested, can't find anything wrong with it. 

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CalliopeSoups
(+)Wraith's regular whisper ability is now instead used by clicking on a human
```
