### PR TITLE
Kondaru door helper upgrade pass (primarily button/autocycler)

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -71,10 +71,9 @@
 /area/space)
 "aaq" = (
 /obj/machinery/door/airlock/pyro/external{
-	dir = 4;
-	icon_state = "airlock_locked";
-	locked = 1
+	dir = 4
 	},
+/obj/mapping_helper/airlock/bolter,
 /turf/simulated/floor/airless,
 /area/space)
 "aar" = (
@@ -257,10 +256,6 @@
 	dir = 4;
 	name = "Owl Zone Access"
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "owlrey";
-	name = "Owlrey"
-	},
 /turf/simulated/floor/grey,
 /area/spacehabitat/owlery)
 "abt" = (
@@ -283,9 +278,8 @@
 /obj/machinery/door/airlock/pyro/external{
 	name = "Owl Zone Access"
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "owlrey";
-	name = "Owlrey"
+/obj/mapping_helper/airlock/cycler/auto/queen{
+	dir = 9
 	},
 /turf/simulated/floor/caution/north,
 /area/spacehabitat/owlery)
@@ -847,9 +841,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "routing2";
-	name = "Routing Cabinet"
+/obj/mapping_helper/airlock/cycler/auto/queen{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/eva{
@@ -938,10 +931,6 @@
 	},
 /obj/disposalpipe/segment/transport{
 	dir = 4
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "routing2";
-	name = "Routing Cabinet"
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/eva{
@@ -1181,20 +1170,6 @@
 /area/station/maintenance/north)
 "aeS" = (
 /obj/landmark/random_room/size3x5,
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
-"aeU" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/obj/disposalpipe/segment/horizontal,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "northmaint2";
-	name = "North Maintenance"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "aeZ" = (
@@ -1584,9 +1559,8 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "northmaint2";
-	name = "North Maintenance"
+/obj/mapping_helper/airlock/cycler/auto/queen{
+	dir = 8
 	},
 /turf/simulated/floor/grey,
 /area/station/maintenance/north)
@@ -2456,12 +2430,6 @@
 /obj/machinery/computer3/generic/personal,
 /obj/cable,
 /obj/machinery/power/data_terminal,
-/obj/machinery/door_control/bolter/new_walls/south{
-	id = "business2";
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = -21
-	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA)
 "ajJ" = (
@@ -3570,12 +3538,6 @@
 /obj/machinery/computer3/generic/personal,
 /obj/cable,
 /obj/machinery/power/data_terminal,
-/obj/machinery/door_control/bolter/new_walls/south{
-	id = "business1";
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = -21
-	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersB)
 "anD" = (
@@ -3954,8 +3916,7 @@
 /area/station/crew_quarters/radio/news_office)
 "apv" = (
 /obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "n_bathroom2"
+	dir = 4
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom{
@@ -6670,12 +6631,12 @@
 /area/station/maintenance/west)
 "aBF" = (
 /obj/machinery/door_control{
-	id = "det_entry";
 	pixel_x = -23;
 	dir = 8;
 	pixel_y = 1
 	},
 /obj/decal/cleanable/dirt,
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aBG" = (
@@ -7189,10 +7150,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	req_access = null;
-	id = "quarters_hos"
+	dir = 4
 	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
@@ -7597,9 +7557,9 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/fitness)
 "aFJ" = (
+/obj/machinery/door/airlock/pyro,
 /obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "n_bathroom1"
+	dir = 4
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom{
@@ -7623,9 +7583,8 @@
 /area/station/maintenance/east)
 "aFO" = (
 /obj/machinery/door/airlock/pyro/external,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "eastmaint";
-	name = "East Maintenance"
+/obj/mapping_helper/airlock/cycler/auto/knight{
+	dir = 5
 	},
 /turf/simulated/floor/grey,
 /area/station/maintenance/east)
@@ -8480,16 +8439,15 @@
 /obj/storage/secure/closet/command/medical_director,
 /obj/item/storage/box/beakerbox,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	pixel_y = 4
+	},
 /obj/item/clipboard,
 /obj/item/pen,
-/obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_mdir";
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = -21
-	},
 /obj/item/mdlicense,
+/obj/machinery/light_switch/east{
+	pixel_y = -7
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/md)
 "aJI" = (
@@ -9608,11 +9566,6 @@
 /area/station/crew_quarters/quarters_north)
 "aQe" = (
 /obj/stool/chair,
-/obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room7";
-	pixel_x = 23;
-	pixel_y = 1
-	},
 /turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/station/crew_quarters/quarters_north)
 "aQf" = (
@@ -12679,8 +12632,7 @@
 /area/station/crew_quarters/quarters_north)
 "beK" = (
 /obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "cc_room12"
+	dir = 4
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_south)
@@ -13171,8 +13123,7 @@
 "bhz" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Medbay Lobby"
+	dir = 4
 	},
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/lobby)
@@ -13613,10 +13564,6 @@
 "bjz" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "eastmaint";
-	name = "East Maintenance"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -14513,8 +14460,7 @@
 /area/station/crew_quarters/quarters_north)
 "bnu" = (
 /obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "cc_room11"
+	dir = 4
 	},
 /obj/mapping_helper/airlock/bolter,
 /turf/simulated/floor/grey,
@@ -15150,21 +15096,14 @@
 /area/station/medical/medbay/lobby)
 "bqm" = (
 /obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Head of Personnel's Quarters";
-	req_access = null;
-	id = "quarters_hop"
+	dir = 4
 	},
 /obj/mapping_helper/access/head_of_personnel,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "hopdesk";
-	enter_id = "hop";
-	name = "HOP Desk"
-	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hop)
 "bqn" = (
@@ -15862,9 +15801,8 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "westmaint";
-	name = "West Maintenance"
+/obj/mapping_helper/airlock/cycler/auto/queen{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -18509,9 +18447,6 @@
 "bGj" = (
 /turf/unsimulated/floor/sanitary,
 /area/station/crewquarters/cryotron)
-"bGk" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/science/chemistry)
 "bGl" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -18914,19 +18849,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
-"bIb" = (
-/obj/machinery/door_control{
-	id = "restitution_cell1";
-	name = "Exit Control";
-	pixel_y = 28
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/station/security/checkpoint/sec_foyer{
-	name = "Secure Release Foyer"
-	})
 "bIg" = (
 /obj/stool/chair/office/red{
 	dir = 8
@@ -20368,14 +20290,16 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bNg" = (
-/obj/machinery/door_control{
-	id = "restitution_genpop";
-	name = "Exit Control";
-	pixel_y = 28
+/obj/machinery/door_control/north{
+	dir = 2;
+	name = "Exit Control"
 	},
 /obj/disposalpipe/segment/brig{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/mapping_helper/button/pair{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer{
@@ -21132,6 +21056,9 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/mapping_helper/airlock/cycler/auto/pawn{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hangar/escape)
 "bQl" = (
@@ -21569,12 +21496,6 @@
 /obj/machinery/computer/card/department/security{
 	dir = 4
 	},
-/obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_hos";
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = -21
-	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bSc" = (
@@ -21594,6 +21515,12 @@
 	pixel_y = -3;
 	rand_pos = 0
 	},
+/obj/machinery/door_control/bolter/new_walls/south{
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -17
+	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bSd" = (
@@ -22555,21 +22482,12 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "westinnermaint";
-	name = "West Inner Maintenance"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "bXA" = (
-/obj/mesh/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 9
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/refinery)
 "bXG" = (
 /obj/machinery/recharge_station,
@@ -22838,9 +22756,7 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Business Accomodations";
-	id = "business1"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersB)
@@ -24366,10 +24282,7 @@
 /area/station/crew_quarters/market)
 "cfS" = (
 /obj/machinery/door/airlock/pyro/external,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "merchanta";
-	name = "Merchant Shuttle Dock"
-	},
+/obj/mapping_helper/airlock/cycler/auto/queen,
 /turf/simulated/floor/neutral,
 /area/station/crew_quarters/market)
 "cfU" = (
@@ -25190,16 +25103,14 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/indigo_rye)
 "cjs" = (
-/obj/machinery/door/airlock/pyro/medical/alt{
-	icon_state = "research2_locked";
-	locked = 1
-	},
+/obj/machinery/door/airlock/pyro/medical/alt,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple{
 	level = 2
 	},
+/obj/mapping_helper/airlock/bolter,
 /turf/simulated/floor/engine{
 	icon_state = "engine_caution_ns"
 	},
@@ -26236,11 +26147,6 @@
 /area/station/mining/staff_room)
 "coL" = (
 /obj/stool/chair,
-/obj/machinery/door_control/bolter/new_walls/west{
-	id = "cc_room2";
-	pixel_x = -23;
-	pixel_y = 0
-	},
 /turf/simulated/floor/carpet/purple/fancy/edge/west,
 /area/station/crew_quarters/quarters_north)
 "coM" = (
@@ -26251,8 +26157,7 @@
 /area/station/crew_quarters/quarters_north)
 "coO" = (
 /obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "cc_room2"
+	dir = 4
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_north)
@@ -27131,14 +27036,15 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
 /area/station/crew_quarters/diplomat)
 "cHs" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
 	icon_state = "1-8"
 	},
 /obj/landmark/gps_waypoint,
+/obj/mapping_helper/airlock/cycler/auto/pawn{
+	dir = 4
+	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "cHQ" = (
@@ -27154,15 +27060,6 @@
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"cId" = (
-/obj/mesh/catwalk{
-	dir = 9
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
-/area/station/mining/magnet)
 "cIR" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -27290,16 +27187,12 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "cMU" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/space)
 "cNh" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -27337,9 +27230,8 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "northmaint";
-	name = "North Maintenance"
+/obj/mapping_helper/airlock/cycler/auto/queen{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
@@ -27444,13 +27336,6 @@
 "cRL" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/inner/west)
-"cSg" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "cc_room7"
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_north)
 "cSO" = (
 /obj/storage/crate,
 /obj/item/clothing/under/gimmick/princess,
@@ -27582,10 +27467,7 @@
 /area/station/hangar/qm)
 "cVX" = (
 /obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Head of Personnel's Quarters";
-	req_access = null;
-	id = "quarters_hop"
+	dir = 4
 	},
 /obj/mapping_helper/access/head_of_personnel,
 /obj/cable{
@@ -27598,6 +27480,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hop)
 "cVY" = (
@@ -27768,6 +27651,12 @@
 /area/station/crew_quarters/radio/bathroom{
 	name = "News Office Bathroom"
 	})
+"dcu" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/mapping_helper/access/cargo,
+/obj/mapping_helper/airlock/cycler/auto/queen,
+/turf/simulated/floor/caution/northsouth,
+/area/station/hangar/qm)
 "ddx" = (
 /obj/machinery/conveyor/WE{
 	name = "cargo belt - east";
@@ -27999,13 +27888,6 @@
 	dir = 8
 	},
 /area/station/hangar/sec)
-"dmh" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "cc_room1"
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_south)
 "dmz" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable/orange{
@@ -28115,15 +27997,6 @@
 	dir = 8
 	},
 /area/station/security/main)
-"doT" = (
-/obj/mesh/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
-/area/space)
 "dpn" = (
 /obj/machinery/chem_heater/chemistry,
 /obj/item/storage/wall{
@@ -29195,9 +29068,7 @@
 	},
 /area/station/mining/magnet)
 "dXS" = (
-/obj/mesh/catwalk{
-	dir = 9
-	},
+/obj/mesh/catwalk,
 /obj/cable/yellow,
 /obj/cable/yellow{
 	icon_state = "0-2"
@@ -29205,10 +29076,7 @@
 /obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/east)
 "dXU" = (
 /obj/machinery/disposal,
@@ -29300,11 +29168,6 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "miningshuttle";
-	enter_id = "outer";
-	name = "Mining Shuttle"
 	},
 /turf/simulated/floor/grey/side,
 /area/station/maintenance/northwest)
@@ -29593,10 +29456,8 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "miningshuttle";
-	enter_id = "inner";
-	name = "Mining Shuttle"
+/obj/mapping_helper/airlock/cycler/auto/rook{
+	dir = 8
 	},
 /turf/simulated/floor/grey/side{
 	dir = 1
@@ -30143,12 +30004,8 @@
 /obj/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/mesh/catwalk{
-	dir = 4
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/west)
 "eBx" = (
 /obj/cable{
@@ -30294,9 +30151,7 @@
 /area/station/engine/monitoring)
 "eGE" = (
 /obj/machinery/door/airlock/pyro/glass/security/alt{
-	dir = 4;
-	id = "restitution_genpop";
-	name = "Genpop Restitution"
+	dir = 4
 	},
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -30324,16 +30179,12 @@
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
 "eHV" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/status_display{
 	pixel_y = -30
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/magnet)
 "eIo" = (
 /obj/random_item_spawner/armory_armor_supplies,
@@ -30384,11 +30235,6 @@
 /obj/item/sticker/heart{
 	pixel_x = -3;
 	pixel_y = -3
-	},
-/obj/machinery/door_control/bolter/new_walls/west{
-	id = "cc_room1";
-	pixel_x = -23;
-	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/crew_quarters/quarters_south)
@@ -30530,9 +30376,8 @@
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/access/engineering_power,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "westsolars";
-	name = "West Solars"
+/obj/mapping_helper/airlock/cycler/auto/queen{
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
@@ -30568,11 +30413,6 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "escapebay";
-	enter_id = "outer";
-	name = "Escape Pod Bay"
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/hangar/escape)
@@ -30611,7 +30451,6 @@
 /area/ghostdrone_factory)
 "eRv" = (
 /obj/machinery/door_control{
-	id = "kondaru_medexit";
 	name = "Medbay Door Control";
 	pixel_x = 23;
 	pixel_y = -8;
@@ -30622,6 +30461,7 @@
 	},
 /obj/machinery/disposal/mail/autoname/medbay,
 /obj/disposalpipe/trunk/mail/south,
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -30663,13 +30503,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "eSn" = (
-/obj/mesh/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 9
-	},
+/obj/mesh/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/hangar/main)
 "eTY" = (
 /obj/storage/closet/biohazard,
@@ -30750,24 +30585,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
-"eYk" = (
-/obj/mesh/catwalk{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
-/area/space)
 "eZq" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/medicine,
-/obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room10";
-	pixel_x = 23;
-	pixel_y = 0
-	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
 "eZD" = (
@@ -30863,15 +30683,6 @@
 "fdF" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hangar/qm)
-"fdH" = (
-/obj/stool/chair,
-/obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room5";
-	pixel_x = 23;
-	pixel_y = 1
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/station/crew_quarters/quarters_north)
 "fdN" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
@@ -31244,6 +31055,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/airlock/cycler/auto/pawn{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/sw)
 "fpw" = (
@@ -31356,10 +31170,7 @@
 /turf/simulated/floor/sanitary,
 /area/station/security/hos)
 "ftp" = (
-/obj/mesh/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/landmark/magnet_shield,
 /obj/securearea{
 	desc = "A warning that demarcates where the magnetic area begins.";
@@ -31383,9 +31194,7 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/mining/magnet)
 "ftt" = (
 /obj/machinery/firealarm/directional/north{
@@ -31467,12 +31276,6 @@
 /obj/fakeobject/microscope,
 /turf/simulated/floor/airless,
 /area/space)
-"fyR" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
-/turf/simulated/floor/airless/plating,
-/area/station/maintenance/west)
 "fzb" = (
 /obj/stool/chair{
 	dir = 8
@@ -31665,11 +31468,6 @@
 	pixel_x = 1;
 	pixel_y = 10
 	},
-/obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room11";
-	pixel_x = 23;
-	pixel_y = 0
-	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
 "fFt" = (
@@ -31833,15 +31631,6 @@
 	},
 /turf/simulated/floor/green,
 /area/station/crew_quarters/quarters_south)
-"fLO" = (
-/obj/mesh/catwalk{
-	dir = 6
-	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/airless/plating/catwalk{
-	icon_state = "catwalk_cross"
-	},
-/area/station/mining/magnet)
 "fLU" = (
 /obj/machinery/door_control/podbay/research/new_walls/west{
 	pixel_x = -23;
@@ -32310,15 +32099,6 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
-"geL" = (
-/obj/mesh/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
-/area/station/maintenance/southeast)
 "geT" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -32372,14 +32152,6 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"gfC" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "merchantb";
-	name = "Merchant Shuttle Dock"
-	},
-/turf/simulated/floor/neutral,
-/area/station/crew_quarters/market)
 "gfE" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -32886,10 +32658,6 @@
 /obj/machinery/light/traffic_light/trader_left/delay4,
 /turf/space,
 /area/space)
-"gvQ" = (
-/obj/mesh/catwalk,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/station/maintenance/southeast)
 "gvX" = (
 /obj/pool/perspective{
 	dir = 4;
@@ -33138,10 +32906,7 @@
 /area/station/engine/core)
 "gDM" = (
 /obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Research Director's Quarters";
-	req_access = null;
-	id = "quarters_rd"
+	dir = 4
 	},
 /obj/mapping_helper/access/research_director,
 /obj/cable{
@@ -33154,6 +32919,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/black,
 /area/station/science/research_director)
 "gDN" = (
@@ -33250,7 +33016,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/refinery)
 "gGT" = (
 /turf/simulated/floor/yellow/side{
@@ -33299,7 +33065,7 @@
 "gHX" = (
 /obj/mesh/catwalk,
 /obj/machinery/oreaccumulator,
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/refinery)
 "gIf" = (
 /obj/machinery/door/airlock/pyro/medical{
@@ -33520,13 +33286,6 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
-"gPn" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "cc_room8"
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_south)
 "gPC" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -33667,7 +33426,7 @@
 	icon_state = "1-2"
 	},
 /obj/mesh/catwalk,
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/east)
 "gTZ" = (
 /obj/disposalpipe/segment/brig{
@@ -33750,16 +33509,11 @@
 /turf/simulated/floor,
 /area/station/security/secwing)
 "gWP" = (
-/obj/mesh/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/east)
 "gWW" = (
 /obj/cable{
@@ -34069,10 +33823,6 @@
 "hed" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/cargo,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "cargobay";
-	name = "Cargo Bay"
-	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hangar/qm)
 "heQ" = (
@@ -34172,15 +33922,6 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
-"hjv" = (
-/obj/mesh/catwalk{
-	dir = 6
-	},
-/obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/airless/plating/catwalk{
-	icon_state = "catwalk_cross"
-	},
-/area/space)
 "hjz" = (
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/orangeblack/side{
@@ -34190,9 +33931,7 @@
 "hjC" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	id = "kondaru_medexit";
-	name = "Medbay"
+	dir = 4
 	},
 /obj/mapping_helper/access/medical,
 /obj/cable{
@@ -34209,6 +33948,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay)
 "hkn" = (
@@ -34234,15 +33974,14 @@
 /area/station/hallway/primary/west)
 "hkF" = (
 /obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Diplomatic Quarters";
-	id = "cc_diplo"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/heads,
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/diplomat)
 "hlM" = (
@@ -34279,10 +34018,7 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/maintenance/south)
 "hmZ" = (
-/obj/mesh/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/transport{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -34322,9 +34058,7 @@
 /turf/simulated/floor,
 /area/station/bridge)
 "hoL" = (
-/obj/mesh/catwalk{
-	dir = 6
-	},
+/obj/mesh/catwalk,
 /obj/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -34332,9 +34066,7 @@
 	icon_state = "0-8"
 	},
 /obj/cable/yellow,
-/turf/simulated/floor/airless/plating/catwalk{
-	icon_state = "catwalk_cross"
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/west)
 "hpg" = (
 /obj/disposalpipe/segment/vertical,
@@ -34459,6 +34191,16 @@
 /obj/disposalpipe/segment/mail/bent/south,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"htL" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
 "huD" = (
 /obj/decal/tile_edge/floorguide/evac{
 	dir = 1
@@ -34621,10 +34363,9 @@
 /obj/mapping_helper/access/hos,
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	req_access = null;
-	id = "quarters_hos"
+	dir = 4
 	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/red,
 /area/station/security/hos)
 "hzW" = (
@@ -34695,12 +34436,6 @@
 /obj/table/wood/auto,
 /obj/machinery/phone,
 /obj/item/pen/crayon/golden,
-/obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_hop";
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = -21
-	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hop)
 "hCO" = (
@@ -34881,15 +34616,6 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/hallway/primary/south)
-"hKQ" = (
-/obj/stool/chair,
-/obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room6";
-	pixel_x = 23;
-	pixel_y = 1
-	},
-/turf/simulated/floor/carpet/red/fancy/edge/east,
-/area/station/crew_quarters/quarters_north)
 "hLr" = (
 /obj/stool/chair/couch{
 	dir = 4
@@ -34941,11 +34667,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "eva";
-	enter_id = "outer";
-	name = "EVA Storage"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "hPa" = (
@@ -34974,6 +34695,10 @@
 /area/station/turret_protected/Zeta)
 "hRE" = (
 /obj/storage/secure/closet/medical/chemical,
+/obj/machinery/door_control/bolter/new_walls/east,
+/obj/mapping_helper/button/pair{
+	dir = 10
+	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
 "hRI" = (
@@ -35199,10 +34924,7 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen/freezer)
 "ibm" = (
-/obj/mesh/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/landmark/magnet_shield,
 /obj/securearea{
 	desc = "A warning that demarcates where the magnetic area begins.";
@@ -35226,9 +34948,7 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/mining/magnet)
 "ibs" = (
 /obj/machinery/conveyor/WE{
@@ -35281,9 +35001,7 @@
 /area/station/hallway/primary/south)
 "idb" = (
 /obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Business Accomodations";
-	id = "business2"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -35340,7 +35058,7 @@
 "ieW" = (
 /obj/mesh/catwalk,
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/space)
 "ifs" = (
 /obj/machinery/door/airlock/pyro/glass,
@@ -35509,14 +35227,6 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
-"ilC" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
-/area/station/maintenance/southeast)
 "imB" = (
 /turf/simulated/floor/stairs/wood2/wide{
 	dir = 5
@@ -35759,6 +35469,12 @@
 	pixel_x = 11
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/door_control/bolter/new_walls/west{
+	pixel_y = 11
+	},
+/obj/mapping_helper/button/pair{
+	dir = 10
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersB)
 "ivC" = (
@@ -35799,6 +35515,12 @@
 	},
 /turf/simulated/floor/red,
 /area/station/science/lab)
+"iwL" = (
+/obj/mapping_helper/airlock/cycler/auto/rook{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/east)
 "iwQ" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple{
@@ -35823,12 +35545,6 @@
 /obj/storage/secure/closet/command/research_director,
 /obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake{
 	pixel_x = -2
-	},
-/obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_rd";
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = -21
 	},
 /turf/simulated/floor/black,
 /area/station/science/research_director)
@@ -36039,17 +35755,15 @@
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/access/engineering_power,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "eastsolars";
-	name = "East Solars"
+/obj/mapping_helper/airlock/cycler/auto/queen{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
 "iEB" = (
 /obj/machinery/door/airlock/pyro/external,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "southmaint";
-	name = "South Maintenance"
+/obj/mapping_helper/airlock/cycler/auto/knight{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
@@ -36233,6 +35947,12 @@
 	pixel_x = -28
 	},
 /obj/landmark/start/job/assistant,
+/obj/machinery/door_control/bolter/new_walls/north{
+	dir = 2
+	},
+/obj/mapping_helper/button/pair{
+	dir = 10
+	},
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/crew_quarters/quarters_south)
 "iJY" = (
@@ -36349,10 +36069,8 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "podbay";
-	enter_id = "inner";
-	name = "Pod Bay"
+/obj/mapping_helper/airlock/cycler/auto/pawn{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
@@ -36447,13 +36165,9 @@
 	},
 /area/station/hallway/secondary/exit)
 "iQU" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/space)
 "iQW" = (
 /obj/cable{
@@ -36525,6 +36239,12 @@
 /area/station/medical/medbay/psychiatrist)
 "iTE" = (
 /obj/item/extinguisher,
+/obj/machinery/door_control/bolter/new_walls/north{
+	dir = 2
+	},
+/obj/mapping_helper/button/pair{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/crew_quarters/quarters_south)
 "iTP" = (
@@ -36593,11 +36313,6 @@
 	},
 /area/station/security/brig/solitary)
 "iVD" = (
-/obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room12";
-	pixel_x = 23;
-	pixel_y = 0
-	},
 /turf/simulated/floor/damaged5,
 /area/station/crew_quarters/quarters_south)
 "iVR" = (
@@ -36824,12 +36539,6 @@
 /obj/storage/secure/closet/command/chief_engineer,
 /obj/item/clipboard,
 /obj/item/pen,
-/obj/machinery/door_control/bolter/new_walls/south{
-	id = "quarters_ce";
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = -21
-	},
 /turf/simulated/floor/yellowblack,
 /area/station/crew_quarters/ce)
 "jfL" = (
@@ -37493,17 +37202,12 @@
 /turf/simulated/floor/plating/airless/asteroid/dark,
 /area/space)
 "jCF" = (
-/obj/mesh/catwalk{
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/tracker/west,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/west)
 "jCP" = (
 /obj/stool/chair/yellow{
@@ -37582,8 +37286,10 @@
 	pixel_x = 12
 	},
 /obj/machinery/door_control/bolter/new_walls/north{
-	id = "n_bathroom2";
 	dir = 2
+	},
+/obj/mapping_helper/button/pair{
+	dir = 8
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/radio/bathroom{
@@ -37703,40 +37409,28 @@
 	},
 /area/station/medical/medbay)
 "jKj" = (
-/obj/mesh/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/bent/west,
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/refinery)
 "jKT" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/west)
 "jKV" = (
 /obj/machinery/door/airlock/pyro/glass{
-	autoclose = 0;
-	dir = 4;
-	frequency = 1449;
-	icon_state = "glass_locked";
-	id_tag = "tox_airlock_exterior";
-	locked = 1;
-	name = "Toxins Research Access"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/access/tox,
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/airlock/bolter,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -37776,14 +37470,6 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/utility)
-"jMI" = (
-/obj/mesh/catwalk{
-	dir = 6
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	icon_state = "catwalk_cross"
-	},
-/area/space)
 "jNl" = (
 /obj/table/reinforced/auto,
 /obj/item/hand_labeler{
@@ -37911,21 +37597,9 @@
 /obj/item/storage/belt/utility,
 /turf/simulated/floor/black,
 /area/station/engine/gravity)
-"jPi" = (
-/obj/mesh/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
-/area/station/mining/magnet)
 "jPs" = (
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	id = "clone_begone";
-	name = "Cloning Foyer"
+	dir = 4
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/mapping_helper/access/medical,
@@ -38086,11 +37760,6 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "miningshuttle";
-	enter_id = "outer";
-	name = "Mining Shuttle"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 1
@@ -38259,11 +37928,8 @@
 	rand_pos = 1
 	},
 /obj/item/pen/fancy,
-/obj/machinery/door_control/bolter/new_walls/west{
-	id = "cc_diplo";
-	pixel_x = -23;
-	pixel_y = 0
-	},
+/obj/machinery/door_control/bolter/new_walls/west,
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/crew_quarters/diplomat)
 "kdy" = (
@@ -38388,7 +38054,7 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/mining/magnet)
 "khr" = (
 /obj/lattice{
@@ -38496,9 +38162,8 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "westinnermaint";
-	name = "West Inner Maintenance"
+/obj/mapping_helper/airlock/cycler/auto/queen{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
@@ -38900,11 +38565,6 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "southwestinnermaint";
-	enter_id = "inner";
-	name = "Southwest Inner Maintenance"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/sw)
 "kBF" = (
@@ -38953,10 +38613,6 @@
 /obj/mesh/catwalk,
 /obj/disposalpipe/segment/transport{
 	dir = 4
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "westmaint";
-	name = "West Maintenance"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -39008,6 +38664,10 @@
 	pixel_y = 21
 	},
 /obj/item/deconstructor,
+/obj/machinery/door_control/bolter/new_walls/north{
+	dir = 2
+	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -39143,10 +38803,6 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "westsolars";
-	name = "West Solars"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
@@ -39297,10 +38953,9 @@
 	powerlevel = 1
 	},
 /obj/machinery/door/airlock/pyro{
-	dir = 4;
-	icon_state = "door_locked";
-	locked = 1
+	dir = 4
 	},
+/obj/mapping_helper/airlock/bolter,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "kNC" = (
@@ -39332,6 +38987,12 @@
 	icon_state = "bedsheet-green"
 	},
 /obj/landmark/start/job/assistant,
+/obj/machinery/door_control/bolter/new_walls/north{
+	dir = 2
+	},
+/obj/mapping_helper/button/pair{
+	dir = 10
+	},
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/crew_quarters/quarters_south)
 "kNR" = (
@@ -39366,11 +39027,6 @@
 /obj/machinery/door/airlock/pyro/security{
 	name = "Courtroom"
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "hopdesk";
-	enter_id = "sec";
-	name = "HOP Desk"
-	},
 /obj/mapping_helper/access/security,
 /turf/simulated/floor,
 /area/station/security/secwing)
@@ -39381,11 +39037,6 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "engineering";
-	enter_id = "inner";
-	name = "Engineering Bay"
 	},
 /turf/simulated/floor/grey,
 /area/station/hangar/engine)
@@ -39472,9 +39123,7 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/west)
 "kSI" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/landmark/magnet_shield,
 /obj/securearea{
 	desc = "A warning that demarcates where the magnetic area begins.";
@@ -39482,9 +39131,7 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/mining/magnet)
 "kSO" = (
 /obj/vehicle/tug,
@@ -39495,20 +39142,6 @@
 	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/office)
-"kSW" = (
-/obj/machinery/door/airlock/pyro/glass/security/alt{
-	dir = 4;
-	id = "restitution_cell1";
-	name = "Cell One Restitution"
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/mapping_helper/access/security,
-/turf/simulated/floor/black,
-/area/station/security/checkpoint/sec_foyer{
-	name = "Secure Release Foyer"
-	})
 "kSZ" = (
 /obj/table/reinforced/auto,
 /obj/machinery/networked/printer{
@@ -39682,7 +39315,7 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/mining/magnet)
 "kXr" = (
 /obj/item/device/radio/beacon,
@@ -39722,26 +39355,6 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating,
 /area/station/security/secwing)
-"kYw" = (
-/obj/mesh/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
-	},
-/obj/cable/yellow,
-/obj/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
-/area/station/solar/east)
 "kZl" = (
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/darkblue/checker,
@@ -39923,10 +39536,6 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "merchanta";
-	name = "Merchant Shuttle Dock"
-	},
 /turf/simulated/floor/neutral,
 /area/station/crew_quarters/market)
 "lhD" = (
@@ -40037,13 +39646,8 @@
 /turf/simulated/floor/plating,
 /area/station/storage/northeast)
 "lmm" = (
-/obj/mesh/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
+/obj/mesh/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/maintenance/southeast)
 "lmR" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -40236,25 +39840,6 @@
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
-"lsZ" = (
-/obj/mesh/catwalk{
-	dir = 10
-	},
-/obj/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/cable/yellow,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
-	},
-/area/station/solar/west)
 "ltn" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/wood/seven,
@@ -40270,10 +39855,7 @@
 /area/station/ai_monitored/armory)
 "ltC" = (
 /obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Captain's Quarters";
-	req_access = null;
-	id = "quarters_cap"
+	dir = 4
 	},
 /obj/mapping_helper/access/captain,
 /obj/cable{
@@ -40283,6 +39865,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/grey,
 /area/station/bridge/captain)
 "lui" = (
@@ -40638,14 +40221,6 @@
 /obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/crew_quarters/quarters_north)
-"lEC" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
-/area/space)
 "lEU" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 1
@@ -40663,24 +40238,15 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "engineairbridge2";
-	enter_id = "outer";
-	name = "Engineering Airbridge 2"
-	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
 /area/station/engine/monitoring)
 "lFD" = (
-/obj/machinery/door/airlock/pyro/medical{
-	autoclose = 0;
-	icon_state = "research_locked";
-	name = "Toxin Chamber";
-	req_access = null
-	},
+/obj/machinery/door/airlock/pyro/medical,
 /obj/mapping_helper/access/tox,
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/airlock/bolter,
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
 	},
@@ -40846,7 +40412,6 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/machinery/light_switch/north,
 /obj/machinery/phone,
 /obj/item/stamp/md{
 	pixel_x = -14;
@@ -40858,6 +40423,10 @@
 /obj/item/clothing/glasses/healthgoggles,
 /obj/item/remote/porter/port_a_nanomed,
 /obj/item/reagent_containers/hypospray,
+/obj/machinery/door_control/bolter/new_walls/north{
+	dir = 2
+	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/crew_quarters/md)
 "lJO" = (
@@ -41025,26 +40594,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/secwing)
-"lPV" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "merchantb";
-	name = "Merchant Shuttle Dock"
-	},
-/turf/simulated/floor/neutral,
-/area/station/crew_quarters/market)
-"lQv" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "cc_room9"
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_south)
 "lQz" = (
 /obj/machinery/light{
 	dir = 1;
@@ -41247,9 +40796,7 @@
 /turf/simulated/floor/plating,
 /area/station/security/secwing)
 "lYj" = (
-/obj/mesh/catwalk{
-	dir = 5
-	},
+/obj/mesh/catwalk,
 /obj/cable/yellow,
 /obj/cable/yellow{
 	icon_state = "0-2"
@@ -41257,10 +40804,7 @@
 /obj/cable/yellow{
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross"
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/east)
 "lYl" = (
 /obj/machinery/drainage,
@@ -41342,16 +40886,6 @@
 	},
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
-"mbe" = (
-/obj/mesh/catwalk{
-	dir = 9
-	},
-/obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
-/area/space)
 "mcl" = (
 /obj/stool/bed/moveable,
 /obj/machinery/camera/directional/east{
@@ -41390,14 +40924,8 @@
 /obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/mesh/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/west)
 "mdn" = (
 /obj/lattice{
@@ -41438,9 +40966,11 @@
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
 /obj/mapping_helper/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/mapping_helper/access/security,
 /obj/disposalpipe/segment/vertical,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 1
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "mgm" = (
@@ -41504,16 +41034,11 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/escape)
 "mjM" = (
-/obj/mesh/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/west)
 "mkA" = (
 /obj/disposalpipe/segment/mail/horizontal,
@@ -41712,13 +41237,9 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "mpv" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/refinery)
 "mpA" = (
 /obj/table/auto,
@@ -41742,11 +41263,6 @@
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
 	icon_state = "4-8"
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "southwestinnermaint";
-	enter_id = "outer";
-	name = "Southwest Inner Maintenance"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/sw)
@@ -41800,13 +41316,6 @@
 	dir = 8
 	},
 /area/station/medical/medbay)
-"mqi" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "cc_room6"
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_north)
 "mqC" = (
 /obj/noticeboard/persistent/brig/directional/east,
 /obj/machinery/vending/snack{
@@ -42035,19 +41544,8 @@
 /obj/submachine/cargopad/magnet,
 /turf/simulated/floor/grey,
 /area/station/mining/magnet)
-"mym" = (
-/obj/mesh/catwalk{
-	dir = 9
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
-/area/station/maintenance/southeast)
 "mys" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/southwest)
 "mzu" = (
@@ -42076,10 +41574,6 @@
 "mAq" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "eastinnermaint";
-	name = "East Inner Maintenance"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
@@ -42194,11 +41688,7 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "eva";
-	enter_id = "inner";
-	name = "EVA Storage"
-	},
+/obj/mapping_helper/airlock/cycler/auto/pawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "mGJ" = (
@@ -42257,7 +41747,7 @@
 	icon_state = "0-8"
 	},
 /obj/cable/yellow,
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/west)
 "mJy" = (
 /obj/cable{
@@ -42278,10 +41768,10 @@
 	pixel_y = 10
 	},
 /obj/machinery/door_control/bolter/new_walls/north{
-	id = "quarters_cap";
 	dir = 2
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "mJR" = (
@@ -42347,21 +41837,11 @@
 	dir = 8
 	},
 /obj/mapping_helper/access/tox_storage,
-/obj/mapping_helper/airlock/cycler/manual{
-	enter_id = "inner";
-	cycle_id = "tox";
-	name = "Toxins"
+/obj/mapping_helper/airlock/cycler/auto/queen{
+	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
-"mMz" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
-/area/station/hangar/main)
 "mMB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42400,17 +41880,12 @@
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
 "mNU" = (
-/obj/mesh/catwalk{
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/tracker/east,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/east)
 "mOh" = (
 /obj/disposalpipe/segment/mail/horizontal,
@@ -42701,16 +42176,11 @@
 /turf/simulated/floor/engine,
 /area/research_outpost/indigo_rye)
 "naK" = (
-/obj/mesh/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 9
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/east)
 "nbc" = (
 /obj/cable{
@@ -43012,16 +42482,10 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "mining";
-	name = "Mining"
-	},
 /turf/simulated/floor/grey,
 /area/station/mining/magnet)
 "nkj" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/cable/yellow,
 /obj/cable/yellow{
 	icon_state = "0-2"
@@ -43032,9 +42496,7 @@
 /obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/east)
 "nkD" = (
 /obj/machinery/light,
@@ -43244,15 +42706,6 @@
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/gravity)
-"nvT" = (
-/obj/mesh/catwalk{
-	dir = 9
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
-/area/space)
 "nwI" = (
 /obj/stool/chair/office/red,
 /obj/disposalpipe/segment/brig{
@@ -43771,9 +43224,7 @@
 /area/station/crew_quarters/ce)
 "nPp" = (
 /obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	name = "Detective's Office";
-	req_access = null
+	dir = 4
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -44061,11 +43512,6 @@
 	dir = 4
 	},
 /obj/mapping_helper/access/engineering_storage,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "engineering";
-	enter_id = "outer";
-	name = "Engineering Bay"
-	},
 /turf/simulated/floor/grey,
 /area/station/hangar/engine)
 "obp" = (
@@ -44284,9 +43730,7 @@
 /turf/simulated/floor/purpleblack,
 /area/research_outpost/indigo_rye)
 "oip" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/landmark/magnet_shield,
 /obj/securearea{
 	desc = "A warning that demarcates where the magnetic area begins.";
@@ -44294,9 +43738,7 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/mining/magnet)
 "oiw" = (
 /turf/simulated/floor/circuit/purple,
@@ -44370,15 +43812,12 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/bridge)
-"okL" = (
-/obj/mesh/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
+"old" = (
+/obj/mapping_helper/airlock/cycler/auto/rook{
+	dir = 1
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 9
-	},
-/area/space)
+/turf/simulated/floor,
+/area/station/crew_quarters/courtroom)
 "oma" = (
 /obj/stool/bench/red,
 /obj/landmark/start/job/security_officer,
@@ -44433,11 +43872,6 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "escapebay";
-	enter_id = "inner";
-	name = "Escape Pod Bay"
 	},
 /turf/simulated/floor,
 /area/station/hangar/escape)
@@ -44497,23 +43931,20 @@
 /area/station/ranch)
 "ooN" = (
 /obj/machinery/door_control{
-	id = "clone_begone";
 	name = "Exit Door Control";
 	pixel_x = 23;
 	dir = 4;
 	pixel_y = 1
 	},
 /obj/spawner/clone_rack,
+/obj/mapping_helper/button/pair{
+	dir = 6
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "oph" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "miningshuttle";
-	enter_id = "inner";
-	name = "Mining Shuttle"
 	},
 /turf/simulated/floor/grey/side,
 /area/station/maintenance/northwest)
@@ -44828,16 +44259,12 @@
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "oCx" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/camera/directional/south{
 	pixel_x = -10
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/magnet)
 "oCG" = (
 /obj/cable{
@@ -45083,20 +44510,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
-"oKR" = (
-/obj/machinery/door/airlock/pyro/glass/security/alt{
-	dir = 4;
-	id = "restitution_cell2";
-	name = "Cell Two Restitution"
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/mapping_helper/access/security,
-/turf/simulated/floor/black,
-/area/station/security/checkpoint/sec_foyer{
-	name = "Secure Release Foyer"
-	})
 "oLe" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -45361,12 +44774,6 @@
 	pixel_y = 11
 	},
 /obj/item/pen,
-/obj/machinery/door_control/bolter/new_walls/south{
-	pixel_x = 6;
-	id = "treatment1";
-	dir = 1;
-	pixel_y = -21
-	},
 /obj/machinery/camera/directional/south,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
@@ -45428,11 +44835,6 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/horizontal,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "routing";
-	enter_id = "outer";
-	name = "Routing Depot"
-	},
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
 "pdl" = (
@@ -45574,9 +44976,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	id = "kondaru_medexit";
-	name = "Medbay"
+	dir = 4
 	},
 /obj/mapping_helper/access/medical,
 /obj/mapping_helper/firedoor_spawn,
@@ -45587,6 +44987,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay)
 "pjC" = (
@@ -46045,7 +45446,7 @@
 	icon_state = "1-2"
 	},
 /obj/mesh/catwalk,
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/west)
 "pyS" = (
 /obj/machinery/light/small,
@@ -46112,7 +45513,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
 	},
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/space)
 "pCp" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -46330,11 +45731,6 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "engineairbridge1";
-	enter_id = "inner";
-	name = "Engineering Airbridge 1"
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/engine/hotloop)
@@ -46821,22 +46217,6 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/bridge)
-"pXz" = (
-/obj/mesh/catwalk{
-	dir = 10
-	},
-/obj/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/cable/yellow,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/station/solar/west)
 "pXJ" = (
 /obj/machinery/computer/card,
 /obj/cable{
@@ -46858,13 +46238,6 @@
 /obj/item/shipcomponent/secondary_system/tractor_beam,
 /turf/simulated/floor,
 /area/station/hangar/sec)
-"pYH" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "cc_room4"
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_north)
 "pZc" = (
 /obj/machinery/vending/air_vendor/plasma,
 /turf/simulated/floor/grey/side{
@@ -46906,14 +46279,6 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
-"qaY" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
-/area/station/mining/magnet)
 "qbc" = (
 /obj/shrub,
 /obj/machinery/light/small{
@@ -46928,16 +46293,13 @@
 	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/mining,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "mining";
-	name = "Mining"
+/obj/mapping_helper/airlock/cycler/auto/queen{
+	dir = 1
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/mining/magnet)
 "qcn" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
@@ -47119,6 +46481,12 @@
 	dir = 8
 	},
 /area/station/science/lab)
+"qjL" = (
+/obj/mapping_helper/airlock/cycler/auto/pawn{
+	dir = 8
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/routing/depot)
 "qjT" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/mapping_helper/access/maint,
@@ -47272,19 +46640,12 @@
 /obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/mesh/catwalk{
-	dir = 9
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/west)
 "qqe" = (
 /obj/machinery/drainage,
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /turf/simulated/floor/white,
 /area/research_outpost/indigo_rye)
 "qqj" = (
@@ -47464,11 +46825,6 @@
 	dir = 4;
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "eva";
-	enter_id = "inner";
-	name = "EVA Storage"
 	},
 /turf/simulated/floor,
 /area/station/storage/eva)
@@ -47785,9 +47141,7 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "qGY" = (
-/obj/mesh/catwalk{
-	dir = 6
-	},
+/obj/mesh/catwalk,
 /obj/cable/yellow,
 /obj/cable/yellow{
 	icon_state = "0-8"
@@ -47795,9 +47149,7 @@
 /obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	icon_state = "catwalk_cross"
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/west)
 "qHE" = (
 /obj/cable{
@@ -47981,11 +47333,6 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "engineairbridge2";
-	enter_id = "inner";
-	name = "Engineering Airbridge 2"
-	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
 "qMf" = (
@@ -48020,15 +47367,6 @@
 /obj/mapping_helper/access/maint,
 /turf/simulated/floor/red/checker,
 /area/station/maintenance/central)
-"qNU" = (
-/obj/mesh/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5
-	},
-/area/space)
 "qOw" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -48045,11 +47383,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "escapebay";
-	enter_id = "inner";
-	name = "Escape Pod Bay"
-	},
 /turf/simulated/floor,
 /area/station/hangar/escape)
 "qQJ" = (
@@ -48089,7 +47422,7 @@
 /area/station/turret_protected/ai)
 "qRa" = (
 /obj/mesh/catwalk,
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/magnet)
 "qRd" = (
 /obj/stool/chair/yellow{
@@ -48112,10 +47445,6 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "eastsolars";
-	name = "East Solars"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
@@ -48181,9 +47510,6 @@
 "qTX" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -48654,13 +47980,15 @@
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "rim" = (
-/obj/machinery/door_control{
-	id = "restitution_cell2";
-	name = "Exit Control";
-	pixel_y = 28
+/obj/machinery/door_control/north{
+	dir = 2;
+	name = "Exit Control"
 	},
 /obj/disposalpipe/segment/brig{
 	dir = 8
+	},
+/obj/mapping_helper/button/pair{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer{
@@ -49022,9 +48350,7 @@
 /turf/space,
 /area/space)
 "rxZ" = (
-/obj/mesh/catwalk{
-	dir = 9
-	},
+/obj/mesh/catwalk,
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
 	name = "Research Sector";
@@ -49036,11 +48362,6 @@
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "research";
-	enter_id = "inner";
-	name = "Research"
-	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "ryq" = (
@@ -49078,14 +48399,9 @@
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/power)
 "rzZ" = (
-/obj/mesh/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/bent/west,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/space)
 "rAa" = (
 /obj/table/reinforced/auto,
@@ -49349,15 +48665,6 @@
 /area/station/maintenance/storage{
 	name = "Secure Atmospherics"
 	})
-"rKa" = (
-/obj/mesh/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
-/area/space)
 "rKr" = (
 /obj/machinery/atmospherics/pipe/simple/junction,
 /turf/space,
@@ -49381,12 +48688,8 @@
 /obj/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/mesh/catwalk{
-	dir = 4
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/east)
 "rKU" = (
 /obj/stool/chair{
@@ -49419,6 +48722,10 @@
 /obj/item/toy/plush/small/possum{
 	pixel_x = 4;
 	pixel_y = -1
+	},
+/obj/machinery/door_control/bolter/new_walls/east,
+/obj/mapping_helper/button/pair{
+	dir = 5
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/crew_quarters/quarters_south)
@@ -49701,18 +49008,13 @@
 /area/station/hallway/primary/east)
 "rWQ" = (
 /obj/disposalpipe/segment/bent/west,
-/obj/mesh/catwalk{
-	dir = 5
-	},
+/obj/mesh/catwalk,
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross"
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/refinery)
 "rWY" = (
 /obj/machinery/power/apc/autoname_north,
@@ -49776,15 +49078,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/west)
-"rZE" = (
-/obj/mesh/catwalk{
-	dir = 5
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross"
-	},
-/area/station/mining/magnet)
 "rZZ" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/info_map,
@@ -49881,7 +49174,10 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/machinery/light_switch/north,
+/obj/machinery/door_control/bolter/new_walls/north{
+	dir = 2
+	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/carpet/purple/fancy/edge/north,
 /area/station/science/research_director)
 "sdD" = (
@@ -49946,9 +49242,7 @@
 /area/station/maintenance/disposal)
 "shc" = (
 /obj/machinery/drainage,
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
@@ -49999,13 +49293,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"sjA" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "cc_room3"
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_north)
 "sjM" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
@@ -50015,15 +49302,6 @@
 /obj/mapping_helper/access/maint,
 /turf/simulated/floor/greenblack,
 /area/station/garden/aviary)
-"sjX" = (
-/obj/stool/chair,
-/obj/machinery/door_control/bolter/new_walls/west{
-	id = "cc_room4";
-	pixel_x = -23;
-	pixel_y = 0
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/west,
-/area/station/crew_quarters/quarters_north)
 "skp" = (
 /obj/table/reinforced/auto,
 /turf/simulated/floor/white,
@@ -50119,10 +49397,8 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "engineering";
-	enter_id = "inner";
-	name = "Engineering Bay"
+/obj/mapping_helper/airlock/cycler/auto/pawn{
+	dir = 8
 	},
 /turf/simulated/floor/grey,
 /area/station/engine/storage)
@@ -50302,11 +49578,6 @@
 	},
 /obj/item/reagent_containers/food/drinks/cola{
 	pixel_x = 8
-	},
-/obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room9";
-	pixel_x = 23;
-	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
@@ -50600,10 +49871,6 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "eastinnermaint";
-	name = "East Inner Maintenance"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "sFU" = (
@@ -50615,10 +49882,7 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "engine";
-	name = "Inner Engineering"
-	},
+/obj/mapping_helper/airlock/cycler/auto/queen,
 /turf/simulated/floor/engine/caution/north,
 /area/station/engine/core)
 "sGt" = (
@@ -50779,13 +50043,8 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/station/bridge)
 "sNi" = (
-/obj/mesh/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5
-	},
+/obj/mesh/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/hangar/escape)
 "sNv" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -50871,16 +50130,11 @@
 	},
 /area/station/science/testchamber)
 "sPq" = (
-/obj/mesh/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/machinery/computer/telescope{
 	dir = 8
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/magnet)
 "sPt" = (
 /obj/machinery/light/small{
@@ -51092,7 +50346,7 @@
 /area/station/hallway/primary/east)
 "sVw" = (
 /obj/mesh/catwalk,
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/space)
 "sVX" = (
 /obj/table/reinforced/auto,
@@ -51172,21 +50426,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"sXh" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "cc_room10"
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_south)
 "sXN" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/machinery/light/small,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/hangar/main)
 "sXS" = (
 /obj/lattice{
@@ -51870,11 +51113,6 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 8
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	enter_id = "outer";
-	cycle_id = "tox";
-	name = "Toxins"
-	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "txs" = (
@@ -51887,12 +51125,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
-"txV" = (
-/obj/mesh/catwalk,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5
-	},
-/area/space)
 "tya" = (
 /obj/storage/secure/closet/command{
 	name = "Vessel Commissioning Supply"
@@ -52220,10 +51452,7 @@
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
 "tKg" = (
-/obj/mesh/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/transport{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -52307,10 +51536,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "tOo" = (
-/obj/machinery/door/airlock/pyro/security{
-	name = "Detective's Room";
-	req_access = null
-	},
+/obj/machinery/door/airlock/pyro/security,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -52731,9 +51957,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
 "udo" = (
-/obj/mesh/catwalk{
-	dir = 9
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/junction/left/north,
 /obj/cable{
 	icon_state = "1-2"
@@ -52741,10 +51965,7 @@
 /obj/machinery/camera/directional/west{
 	pixel_y = 10
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/refinery)
 "udD" = (
 /obj/machinery/plantpot,
@@ -52812,8 +52033,9 @@
 	},
 /area/station/security/evidence)
 "ufJ" = (
-/obj/machinery/door_control/bolter/new_walls/east{
-	id = "pool_bathroom"
+/obj/machinery/door_control/bolter/new_walls/east,
+/obj/mapping_helper/button/pair{
+	dir = 8
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -52955,9 +52177,7 @@
 	},
 /area/station/medical/medbay/psychiatrist)
 "uhR" = (
-/obj/mesh/catwalk{
-	dir = 5
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/door/airlock/pyro/medical{
 	dir = 4;
@@ -52965,11 +52185,6 @@
 	req_access = null
 	},
 /obj/mapping_helper/access/research_foyer,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "research";
-	enter_id = "outer";
-	name = "Research"
-	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "uiE" = (
@@ -53025,10 +52240,7 @@
 	},
 /area/station/science/lab)
 "ujV" = (
-/obj/mesh/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/landmark/magnet_shield,
 /obj/securearea{
 	desc = "A warning that demarcates where the magnetic area begins.";
@@ -53053,9 +52265,7 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/mining/magnet)
 "ujW" = (
 /obj/machinery/door/airlock/pyro/external,
@@ -53370,13 +52580,6 @@
 /obj/lattice,
 /turf/space,
 /area/station/engine/gas)
-"uwB" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	id = "cc_room5"
-	},
-/turf/simulated/floor/grey,
-/area/station/crew_quarters/quarters_north)
 "uwM" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/right{
@@ -53588,10 +52791,6 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "southmaint";
-	name = "South Maintenance"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "uDK" = (
@@ -53659,23 +52858,14 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/mapping_helper/access/engineering_engine,
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "engine";
-	name = "Inner Engineering"
-	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "uFe" = (
-/obj/mesh/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/machinery/computer/magnet{
 	dir = 4
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/magnet)
 "uGb" = (
 /obj/table/wood/auto,
@@ -53739,13 +52929,9 @@
 /turf/simulated/floor/grey,
 /area/station/quartermaster/cargobay)
 "uHT" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/magnet)
 "uIb" = (
 /obj/disposalpipe/segment/vertical,
@@ -53826,9 +53012,7 @@
 /turf/simulated/floor/engine,
 /area/station/hangar/qm)
 "uLX" = (
-/obj/mesh/catwalk{
-	dir = 10
-	},
+/obj/mesh/catwalk,
 /obj/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -53838,10 +53022,7 @@
 /obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/solar/east)
 "uMr" = (
 /obj/table/reinforced/auto,
@@ -53895,6 +53076,12 @@
 	pixel_x = 11
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/door_control/bolter/new_walls/west{
+	pixel_y = 11
+	},
+/obj/mapping_helper/button/pair{
+	dir = 10
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA)
 "uNh" = (
@@ -53980,6 +53167,7 @@
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "uQl" = (
+/obj/mapping_helper/airlock/cycler/auto/rook,
 /turf/simulated/floor/caution/westeast,
 /area/station/hallway/secondary/exit)
 "uQv" = (
@@ -53999,9 +53187,7 @@
 /area/station/hydroponics/bay)
 "uQI" = (
 /obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Toilet";
-	id = "pool_bathroom"
+	dir = 4
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -54128,8 +53314,13 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	pixel_y = 4
+	},
 /obj/cable,
+/obj/machinery/light_switch/east{
+	pixel_y = -7
+	},
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/science/research_director)
 "uUh" = (
@@ -54230,11 +53421,6 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "routing";
-	enter_id = "inner";
-	name = "Routing Depot"
-	},
 /turf/simulated/floor,
 /area/station/routing/depot)
 "uZQ" = (
@@ -54291,12 +53477,10 @@
 	},
 /obj/cable,
 /obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	id = "det_entry";
-	name = "Detective's Office";
-	req_access = null
+	dir = 4
 	},
 /obj/mapping_helper/access/forensics,
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "vcg" = (
@@ -54499,11 +53683,6 @@
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/pipe/simple,
 /obj/mapping_helper/access/security,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "sec";
-	enter_id = "inner";
-	name = "Security"
-	},
 /turf/simulated/floor/red/side,
 /area/station/security/equipment)
 "viE" = (
@@ -54570,11 +53749,11 @@
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/customs)
 "vkt" = (
-/obj/stool/chair/comfy/red{
-	dir = 4
-	},
 /obj/disposalpipe/segment/brig{
 	dir = 8
+	},
+/obj/stool/chair/comfy/red{
+	dir = 4
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -54956,11 +54135,6 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "escape";
-	enter_id = "outer";
-	name = "Escape"
-	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hallway/secondary/exit)
 "vwR" = (
@@ -55025,11 +54199,6 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "podbay";
-	enter_id = "outer";
-	name = "Pod Bay"
-	},
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "vzq" = (
@@ -55070,15 +54239,6 @@
 	},
 /turf/simulated/floor/caution/corner/nw,
 /area/station/engine/gas)
-"vAN" = (
-/obj/stool/chair,
-/obj/machinery/door_control/bolter/new_walls/west{
-	id = "cc_room3";
-	pixel_x = -23;
-	pixel_y = 0
-	},
-/turf/simulated/floor/carpet/purple/fancy/edge/west,
-/area/station/crew_quarters/quarters_north)
 "vAY" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
@@ -55152,10 +54312,7 @@
 	},
 /area/station/security/checkpoint/podbay)
 "vCz" = (
-/obj/machinery/door/airlock/pyro/medical{
-	name = "Treatment Room One";
-	id = "treatment1"
-	},
+/obj/machinery/door/airlock/pyro/medical,
 /obj/mapping_helper/access/medical,
 /obj/cable{
 	icon_state = "1-2"
@@ -55185,8 +54342,7 @@
 "vDH" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Cloning Foyer"
+	dir = 4
 	},
 /obj/mapping_helper/access/medical,
 /obj/cable{
@@ -55312,17 +54468,12 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "vIi" = (
-/obj/mesh/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 12
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 9
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/maintenance/inner/east)
 "vIN" = (
 /obj/decal/tile_edge/floorguide/arrow_n{
@@ -55527,11 +54678,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "sec";
-	enter_id = "outer";
-	name = "Security"
-	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "vSE" = (
@@ -55728,11 +54874,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "southwestinnermaint";
-	enter_id = "inner";
-	name = "Southwest Inner Maintenance"
-	},
 /turf/simulated/floor/orangeblack,
 /area/station/mining/refinery)
 "wbB" = (
@@ -55819,13 +54960,8 @@
 	icon_state = "magwarning";
 	name = "Magnet Area Boundary"
 	},
-/obj/mesh/catwalk{
-	dir = 9
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/mining/magnet)
 "wgj" = (
 /obj/machinery/atmospherics/unary/furnace_connector,
@@ -55910,6 +55046,12 @@
 	pixel_x = 28
 	},
 /obj/landmark/start/job/assistant,
+/obj/mapping_helper/button/pair{
+	dir = 6
+	},
+/obj/machinery/door_control/bolter/new_walls/north{
+	dir = 2
+	},
 /turf/simulated/floor/carpet/purple/fancy/edge/ne,
 /area/station/crew_quarters/quarters_north)
 "wiT" = (
@@ -55941,8 +55083,10 @@
 "wkQ" = (
 /obj/table/reinforced/auto,
 /obj/mapping_helper/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/mapping_helper/access/security,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 1
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "wle" = (
@@ -55993,6 +55137,8 @@
 	pixel_x = 5
 	},
 /obj/item/device/radio/intercom/bridge,
+/obj/machinery/door_control/bolter/new_walls/west,
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/crew_quarters/hop)
 "wmg" = (
@@ -56005,11 +55151,6 @@
 "wmJ" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Auxiliary Docking Point"
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "escape";
-	enter_id = "inner";
-	name = "Escape"
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hallway/secondary/exit)
@@ -56081,10 +55222,7 @@
 	},
 /area/station/security/checkpoint/podbay)
 "woI" = (
-/obj/mesh/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/landmark/magnet_shield,
 /obj/securearea{
 	desc = "A warning that demarcates where the magnetic area begins.";
@@ -56109,9 +55247,7 @@
 	icon_state = "magwarning2";
 	name = "ACTIVE MAGNET AREA"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 9
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/mining/magnet)
 "woM" = (
 /obj/cable{
@@ -56296,11 +55432,6 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "engineairbridge1";
-	enter_id = "outer";
-	name = "Engineering Airbridge 1"
-	},
 /turf/simulated/floor/caution/westeast,
 /area/station/engine/gas)
 "wtj" = (
@@ -56433,9 +55564,7 @@
 /area/station/science/research_director)
 "wyD" = (
 /obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	name = "Detective's Office";
-	req_access = null
+	dir = 4
 	},
 /obj/disposalpipe/segment/horizontal,
 /obj/cable{
@@ -56535,6 +55664,9 @@
 /obj/airbridge_controller{
 	id = "vigilatorsud";
 	primary_controller = 1
+	},
+/obj/mapping_helper/airlock/cycler/auto/pawn{
+	dir = 4
 	},
 /turf/space,
 /area/space)
@@ -57005,7 +56137,7 @@
 "wRa" = (
 /obj/mesh/catwalk,
 /obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/space)
 "wRj" = (
 /obj/storage/secure/closet/fridge{
@@ -57098,11 +56230,6 @@
 	desc = "A door-linked force field that prevents gasses from passing through it.";
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
-	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "routing";
-	enter_id = "inner";
-	name = "Routing Depot"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
@@ -57270,10 +56397,7 @@
 /area/station/hallway/primary/east)
 "wXU" = (
 /obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Medical Director's Quarters";
-	req_access = null;
-	id = "quarters_mdir"
+	dir = 4
 	},
 /obj/mapping_helper/access/medical_director,
 /obj/cable{
@@ -57286,6 +56410,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/md)
 "wYp" = (
@@ -57338,19 +56463,6 @@
 /obj/disposalpipe/trunk/west,
 /turf/simulated/floor/grey,
 /area/station/quartermaster/cargobay)
-"xav" = (
-/obj/table/wood/auto,
-/obj/machinery/light/lamp/black{
-	pixel_x = 1;
-	pixel_y = 10
-	},
-/obj/machinery/door_control/bolter/new_walls/east{
-	id = "cc_room8";
-	pixel_x = 23;
-	pixel_y = 0
-	},
-/turf/simulated/floor/carpet/green/fancy/edge/ne,
-/area/station/crew_quarters/quarters_south)
 "xaw" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
@@ -57423,11 +56535,6 @@
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "hopdesk";
-	enter_id = "outer";
-	name = "HOP Desk"
-	},
 /obj/mapping_helper/access/security,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -57453,6 +56560,12 @@
 	pixel_x = -28
 	},
 /obj/landmark/start/job/assistant,
+/obj/mapping_helper/button/pair{
+	dir = 10
+	},
+/obj/machinery/door_control/bolter/new_walls/north{
+	dir = 2
+	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/crew_quarters/quarters_north)
 "xew" = (
@@ -57665,11 +56778,6 @@
 /area/station/maintenance/southeast)
 "xnK" = (
 /obj/machinery/door/airlock/pyro/external,
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "podbay";
-	enter_id = "inner";
-	name = "Pod Bay"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "xof" = (
@@ -57699,14 +56807,9 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "xoN" = (
-/obj/mesh/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
-	},
+/obj/mesh/catwalk,
 /obj/disposalpipe/segment/bent/east,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 9
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/space)
 "xpa" = (
 /obj/cable/blue{
@@ -57860,7 +56963,6 @@
 /obj/item/clothing/mask/gas/emergency,
 /obj/item/clothing/head/helmet/space/captain,
 /obj/item/tank/jetpack,
-/obj/machinery/light_switch/east,
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "xtW" = (
@@ -57882,6 +56984,7 @@
 	primary_controller = 1;
 	tunnel_width = 2
 	},
+/obj/mapping_helper/airlock/cycler/auto/pawn,
 /turf/space,
 /area/space)
 "xuo" = (
@@ -58019,7 +57122,7 @@
 	name = "Magnet Area Boundary"
 	},
 /obj/mesh/catwalk,
-/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/mining/magnet)
 "xBa" = (
 /obj/kitchenspike,
@@ -58157,8 +57260,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "xFV" = (
-/obj/submachine/poster_creator,
 /obj/noticeboard/persistent/customs/directional/north,
+/obj/submachine/poster_creator,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "xGt" = (
@@ -58227,10 +57330,7 @@
 /area/station/security/hos)
 "xHK" = (
 /obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Chief Engineer's Quarters";
-	req_access = null;
-	id = "quarters_ce"
+	dir = 4
 	},
 /obj/mapping_helper/access/engineering_chief,
 /obj/cable{
@@ -58243,26 +57343,9 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/mapping_helper/button/area,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/ce)
-"xIr" = (
-/obj/item/storage/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/machinery/door_control/bolter/new_walls/south{
-	id = "n_bathroom1";
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = -21
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/radio/bathroom{
-	name = "News Office Bathroom"
-	})
 "xII" = (
 /obj/machinery/conveyor/WE{
 	name = "cargo belt - east";
@@ -58784,18 +57867,14 @@
 	},
 /area/station/crew_quarters/quarters_north)
 "xWy" = (
-/obj/mesh/catwalk{
-	dir = 4
-	},
+/obj/mesh/catwalk,
 /obj/machinery/magnet_chassis{
 	dir = 1
 	},
 /obj/machinery/mining_magnet{
 	dir = 1
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
+/turf/simulated/floor/airless/plating/catwalk/auto,
 /area/station/mining/magnet)
 "xWE" = (
 /obj/machinery/door/airlock/pyro/glass,
@@ -87177,7 +86256,7 @@ aaa
 aaa
 aaa
 abW
-lsZ
+mIZ
 mIZ
 mIZ
 mIZ
@@ -90497,7 +89576,7 @@ aaa
 aaa
 aaa
 abW
-pXz
+mIZ
 mIZ
 mIZ
 mIZ
@@ -91136,7 +90215,7 @@ fFh
 ivd
 cob
 bsF
-fyR
+rgv
 acO
 aaa
 ach
@@ -96582,7 +95661,7 @@ ehG
 bDh
 bEk
 bFh
-bGk
+bAW
 bAU
 uhR
 bAU
@@ -98984,7 +98063,7 @@ blb
 rzs
 xcx
 qTX
-xgW
+blb
 brB
 brB
 brB
@@ -99223,7 +98302,7 @@ aaa
 acj
 xcP
 acj
-mMz
+eSn
 aeK
 vrz
 afI
@@ -99837,7 +98916,7 @@ ajt
 dYP
 gSB
 aqA
-xIr
+jEH
 aqA
 jEH
 aqD
@@ -100833,9 +99912,9 @@ ccw
 cdo
 ceh
 cfc
-gfC
+cfS
 cgF
-lPV
+lgW
 cqM
 cqM
 cqM
@@ -105059,7 +104138,7 @@ gGu
 nhu
 jCP
 fkP
-hed
+dcu
 uvf
 hed
 acO
@@ -105317,10 +104396,10 @@ aQJ
 aQJ
 aQJ
 oip
-cId
-jPi
 qRa
-fLO
+qRa
+qRa
+uHT
 xkQ
 svJ
 vfH
@@ -105904,7 +104983,7 @@ auL
 auL
 uvh
 azW
-doT
+sVw
 aaf
 kSI
 aQJ
@@ -105921,7 +105000,7 @@ aQJ
 aQJ
 aQJ
 oip
-qaY
+qRa
 mLb
 tOE
 oCx
@@ -106203,10 +105282,10 @@ syb
 sFU
 aIu
 uFb
-eYk
+ieW
 ieW
 pBx
-rKa
+sVw
 aaf
 kSI
 aQJ
@@ -106223,10 +105302,10 @@ aQJ
 aQJ
 aQJ
 oip
-rZE
-jPi
 qRa
-fLO
+qRa
+qRa
+uHT
 qSo
 quY
 eEO
@@ -106505,7 +105584,7 @@ auN
 auL
 auL
 auL
-lEC
+sVw
 aaf
 aMN
 aad
@@ -106807,7 +105886,7 @@ sHU
 idg
 aIv
 aJu
-lEC
+sVw
 acO
 wXw
 aaa
@@ -107076,7 +106155,7 @@ aaa
 aaO
 adp
 adp
-cNE
+htL
 adp
 agG
 ahI
@@ -107109,7 +106188,7 @@ aGu
 aHy
 aIw
 aCf
-lEC
+sVw
 acO
 aaa
 aaa
@@ -107411,7 +106490,7 @@ wSs
 hSf
 jbt
 aCf
-lEC
+sVw
 acO
 aaa
 aaa
@@ -107713,7 +106792,7 @@ aGw
 dmH
 gnh
 aCf
-lEC
+sVw
 acO
 aaa
 aaa
@@ -108015,7 +107094,7 @@ tVy
 aCf
 aCf
 aFn
-lEC
+sVw
 aaf
 aay
 aay
@@ -108317,8 +107396,6 @@ dlp
 aaa
 aaa
 ach
-qNU
-nvT
 sVw
 sVw
 sVw
@@ -108332,7 +107409,9 @@ sVw
 sVw
 sVw
 sVw
-mbe
+sVw
+sVw
+xoN
 wRa
 wRa
 wRa
@@ -108361,7 +107440,7 @@ bDA
 bxm
 bFG
 wlu
-bIb
+rim
 wlu
 rim
 wlu
@@ -108620,7 +107699,7 @@ aaa
 aaa
 aaO
 aaf
-lEC
+sVw
 aaf
 aad
 aad
@@ -108663,9 +107742,9 @@ bDA
 bxm
 bFH
 wlu
-kSW
+eGE
 wlu
-oKR
+eGE
 wlu
 eGE
 wlu
@@ -108922,7 +108001,7 @@ aaa
 aaa
 aaa
 ach
-lEC
+sVw
 acO
 aaa
 aaa
@@ -109224,7 +108303,7 @@ abZ
 abZ
 abZ
 aaf
-lEC
+sVw
 acO
 aaa
 aaa
@@ -109526,7 +108605,7 @@ aaa
 aaa
 aaa
 ach
-lEC
+sVw
 acO
 aaa
 aaa
@@ -109828,7 +108907,7 @@ aaa
 aaa
 aaa
 ach
-lEC
+sVw
 acO
 aaa
 aaa
@@ -110130,7 +109209,7 @@ aaa
 aaa
 aaa
 aci
-lEC
+sVw
 acO
 aaa
 aaa
@@ -110144,7 +109223,7 @@ acO
 aaa
 aaa
 vIi
-hjv
+iQU
 aaa
 aaa
 aaa
@@ -110432,7 +109511,7 @@ aaa
 aaa
 aaa
 aci
-lEC
+sVw
 aaf
 abZ
 abZ
@@ -110700,7 +109779,7 @@ aaa
 aaa
 adp
 adp
-aeU
+htL
 adp
 adp
 abZ
@@ -110724,7 +109803,6 @@ qYv
 iuX
 qhU
 rti
-okL
 sVw
 sVw
 sVw
@@ -110734,7 +109812,8 @@ sVw
 sVw
 sVw
 sVw
-jMI
+sVw
+sVw
 acO
 aaa
 aaa
@@ -111026,7 +110105,7 @@ qvN
 kWo
 jPe
 rti
-lEC
+sVw
 aCh
 aPM
 aGF
@@ -111036,7 +110115,7 @@ bwp
 aXM
 aCh
 aad
-lEC
+sVw
 awS
 aaa
 aaa
@@ -111050,7 +110129,7 @@ sdD
 xXd
 tIm
 bca
-bca
+qjL
 uZG
 bca
 sUo
@@ -111338,7 +110417,7 @@ skX
 wMw
 lgL
 aay
-lEC
+sVw
 afw
 aaa
 aaa
@@ -111640,7 +110719,7 @@ aIA
 tDq
 aCh
 aaf
-lEC
+sVw
 aaf
 abZ
 abZ
@@ -111942,7 +111021,7 @@ aKJ
 aKJ
 aCh
 aaf
-lEC
+sVw
 acO
 aaa
 aaa
@@ -112244,7 +111323,7 @@ bqC
 bEJ
 bNl
 abb
-lEC
+sVw
 acO
 aaa
 aaa
@@ -112546,7 +111625,7 @@ xEt
 xEt
 bNo
 aaa
-lEC
+sVw
 acO
 aaa
 aaa
@@ -112848,7 +111927,7 @@ xEt
 xEt
 bNo
 aaa
-lEC
+sVw
 acO
 aaa
 aaa
@@ -113150,7 +112229,7 @@ xEt
 xEt
 bNo
 aaa
-lEC
+sVw
 acO
 aaa
 aaa
@@ -113452,7 +112531,7 @@ xEt
 vwY
 aCh
 uez
-lEC
+sVw
 acO
 mEy
 mEy
@@ -114358,7 +113437,7 @@ aCh
 aCh
 aCh
 uEM
-xXd
+iwL
 mkV
 mEy
 dGG
@@ -119536,7 +118615,7 @@ bEL
 xde
 bHf
 bIC
-wrE
+old
 kOL
 mZB
 bNL
@@ -123475,9 +122554,9 @@ bfO
 bDX
 bnq
 bnq
-gvQ
-gvQ
-gvQ
+lmm
+lmm
+lmm
 lmm
 acO
 aaa
@@ -123780,7 +122859,7 @@ xnF
 dsx
 dsx
 dsx
-ilC
+lmm
 acO
 aaa
 aaa
@@ -124082,7 +123161,7 @@ dsx
 dsx
 dsx
 dsx
-ilC
+lmm
 acO
 aaa
 aaa
@@ -124384,7 +123463,7 @@ dsx
 dsx
 dsx
 dsx
-ilC
+lmm
 acO
 aaa
 aaa
@@ -124686,7 +123765,7 @@ xnF
 dsx
 dsx
 dsx
-ilC
+lmm
 acO
 aaa
 aaa
@@ -124931,7 +124010,7 @@ aIS
 aIS
 aIS
 lEw
-vAN
+coL
 gWE
 aIS
 eMP
@@ -124984,11 +124063,11 @@ eyk
 bfO
 tOk
 bnq
-mym
-gvQ
-gvQ
-gvQ
-geL
+lmm
+lmm
+lmm
+lmm
+lmm
 acO
 aaa
 aaa
@@ -125229,7 +124308,7 @@ aRT
 aTL
 aIS
 lfY
-sjX
+coL
 aUa
 aIS
 cSO
@@ -125551,7 +124630,7 @@ hkF
 qdY
 qdY
 qdY
-dmh
+beK
 aZa
 aZa
 vFi
@@ -125837,7 +124916,7 @@ coN
 aZf
 aIS
 aIS
-sjA
+coO
 aIS
 aIS
 aIS
@@ -126135,7 +125214,7 @@ aRT
 aTL
 aIS
 aIS
-pYH
+coO
 aIS
 aIS
 cVi
@@ -126755,13 +125834,13 @@ cXE
 bTr
 aZa
 aZa
-gPn
+beK
 aZa
 aZa
-lQv
+beK
 aZa
 aZa
-sXh
+beK
 aZa
 aZa
 beK
@@ -127041,15 +126120,15 @@ aHa
 brU
 aIS
 aIS
-uwB
+coO
 aIS
 aIS
 aIS
-mqi
+coO
 aIS
 aIS
 aIS
-cSg
+coO
 aIS
 aIS
 aVW
@@ -127336,7 +126415,7 @@ anX
 aoc
 anX
 aaf
-txV
+sVw
 bEC
 bmI
 aHa
@@ -127611,7 +126690,7 @@ gTN
 gTN
 gTN
 gTN
-kYw
+nkj
 gTN
 gTN
 gTN
@@ -127660,7 +126739,7 @@ bJK
 aWZ
 mkA
 aZa
-xav
+fFj
 cgR
 aZa
 swJ
@@ -127947,11 +127026,11 @@ gfq
 bty
 aIS
 wBc
-fdH
+aQe
 aMJ
 aIS
 pfc
-hKQ
+aQe
 aQE
 aIS
 ofa
@@ -129725,7 +128804,7 @@ aaa
 aaa
 aaa
 ext
-kYw
+nkj
 wNG
 aaa
 aaa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -33922,6 +33922,10 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
+"hiT" = (
+/obj/machinery/light_switch/north,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/arcade)
 "hjz" = (
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/orangeblack/side{
@@ -56963,6 +56967,7 @@
 /obj/item/clothing/mask/gas/emergency,
 /obj/item/clothing/head/helmet/space/captain,
 /obj/item/tank/jetpack,
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "xtW" = (
@@ -122519,7 +122524,7 @@ paR
 bfO
 qSI
 sKA
-sKA
+hiT
 sKA
 dgL
 sKA


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[INTERNAL][MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Replaces all airlock cyclers, all door bolter buttons and (that I could tell) all non-poddoor door opener buttons with versions set up by self-configuring mapping helpers. Also added some bolter helpers to replace manually-edited bolted doors, and made some small structural alterations to accommodate the changes where appropriate.

Functionality should be unchanged in most cases; an exception to this is Security, which has had the front-office cycler skipped and the Courtroom cycler changed to only apply to the north and south doors of that junction.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Reduces use of varedits for improved legibility and easier ongoing maintenance, and provides an additional reference for use of the helpers in a map.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Spun up the map on a local server and tested a sampling of buttons and airlocks to see if they work as intended, including but not limited to all north crew quarters rooms, the diplomatic quarters, all head offices, the Medbay exit button, the Detective guest button, inner-facing airlock cyclers, Research's entrance airlock cycler, and the courtroom-to-brig airlock cycler.