### PR TITLE
Fix Wraiths not being able to use keybinded abilities

### DIFF
--- a/code/mob/living/intangible.dm
+++ b/code/mob/living/intangible.dm
@@ -81,9 +81,6 @@ TYPEINFO(/mob/living/intangible)
 
 		return ..()
 
-	click(atom/target, params, location, control)
-		. = ..()
-
 /mob/living/intangible/change_eye_blurry(var/amount, var/cap = 0)
 	if (amount < 0)
 		return ..()

--- a/code/mob/living/intangible.dm
+++ b/code/mob/living/intangible.dm
@@ -81,6 +81,9 @@ TYPEINFO(/mob/living/intangible)
 
 		return ..()
 
+	click(atom/target, params, location, control)
+		. = ..()
+
 /mob/living/intangible/change_eye_blurry(var/amount, var/cap = 0)
 	if (amount < 0)
 		return ..()

--- a/code/mob/living/intangible/wraith.dm
+++ b/code/mob/living/intangible/wraith.dm
@@ -392,12 +392,6 @@ TYPEINFO(/mob/living/intangible/wraith)
 	equipped()
 		return 0
 
-	click(atom/target)
-		if (src.targeting_ability)
-			return ..()
-		if (!density)
-			src.examine_verb(target)
-
 	examine_verb(atom/A as mob|obj|turf in view())
 		..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #24242, I don't think anything in the old wraith click() was needed so I just axed it and made intangible mobs actually call the click logic.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug bad. Clicking on anything doing examine bad too, alt click still exists.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Clicked around a bit and used some abilities, seems to work. I don't THINK the src.targeting_ability check is needed but feel free to slap me if it was.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

