### PR TITLE
New starting equpment for Computer Operator job

### DIFF
--- a/code/datums/jobs/special/jobs_random.dm
+++ b/code/datums/jobs/special/jobs_random.dm
@@ -487,7 +487,7 @@ ABSTRACT_TYPE(/datum/job/special/random)
 	slot_eyes = list(/obj/item/clothing/glasses/packetvision)
 	slot_poc1 = list(/obj/item/paper/packets)
 	items_in_backpack = list(/obj/item/luggable_computer/techpersonal,
-							/obj/item/storage/box/opdiskbox)
+							/obj/item/storage/box/diskbox/programs)
 	alt_names = list("Cybersecurity Expert", \
 					"IT Specialist", \
 					"Network Technician")

--- a/code/datums/jobs/special/jobs_random.dm
+++ b/code/datums/jobs/special/jobs_random.dm
@@ -488,7 +488,8 @@ ABSTRACT_TYPE(/datum/job/special/random)
 	slot_poc1 = list(/obj/item/paper/packets)
 	slot_poc2 = list(/obj/item/device/pda2/computeroperator)
 	items_in_backpack = list(/obj/item/luggable_computer/techpersonal,
-							/obj/item/storage/box/diskbox/programs)
+							/obj/item/storage/box/diskbox/programs,
+							/obj/item/cable_coil)
 	alt_names = list("Cybersecurity Expert", \
 					"IT Specialist", \
 					"Network Technician")

--- a/code/datums/jobs/special/jobs_random.dm
+++ b/code/datums/jobs/special/jobs_random.dm
@@ -485,6 +485,7 @@ ABSTRACT_TYPE(/datum/job/special/random)
 	slot_belt = list(/obj/item/device/pda2/computeroperator)
 	slot_ears = list(/obj/item/device/radio/headset/civilian)
 	slot_eyes = list(/obj/item/clothing/glasses/packetvision)
+	slot_poc1 = list(/obj/item/disk/data/floppy/read_only/network_progs)
 	items_in_backpack = list(/obj/item/luggable_computer/techpersonal)
 	alt_names = list("Cybersecurity Expert", \
 					"IT Specialist", \

--- a/code/datums/jobs/special/jobs_random.dm
+++ b/code/datums/jobs/special/jobs_random.dm
@@ -485,8 +485,9 @@ ABSTRACT_TYPE(/datum/job/special/random)
 	slot_belt = list(/obj/item/device/pda2/computeroperator)
 	slot_ears = list(/obj/item/device/radio/headset/civilian)
 	slot_eyes = list(/obj/item/clothing/glasses/packetvision)
-	slot_poc1 = list(/obj/item/disk/data/floppy/read_only/network_progs)
-	items_in_backpack = list(/obj/item/luggable_computer/techpersonal)
+	slot_poc1 = list(/obj/item/paper/packets)
+	items_in_backpack = list(/obj/item/luggable_computer/techpersonal,
+							/obj/item/storage/box/opdiskbox)
 	alt_names = list("Cybersecurity Expert", \
 					"IT Specialist", \
 					"Network Technician")

--- a/code/datums/jobs/special/jobs_random.dm
+++ b/code/datums/jobs/special/jobs_random.dm
@@ -482,10 +482,11 @@ ABSTRACT_TYPE(/datum/job/special/random)
 					/obj/item/clothing/under/misc/casualjeansblue = 1, \
 					/obj/item/clothing/under/misc/casualjeanskhaki = 1)
 	slot_suit = list(/obj/item/clothing/suit/hoodie/random)
-	slot_belt = list(/obj/item/device/pda2/computeroperator)
+	slot_belt = list(/obj/item/storage/belt/utility/it)
 	slot_ears = list(/obj/item/device/radio/headset/civilian)
 	slot_eyes = list(/obj/item/clothing/glasses/packetvision)
 	slot_poc1 = list(/obj/item/paper/packets)
+	slot_poc2 = list(/obj/item/device/pda2/computeroperator)
 	items_in_backpack = list(/obj/item/luggable_computer/techpersonal,
 							/obj/item/storage/box/diskbox/programs)
 	alt_names = list("Cybersecurity Expert", \

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -930,13 +930,13 @@
 /obj/item/storage/belt/utility/it
 	name = "IT utility belt"
 	desc = "Tools for fixing computers and other electronics."
-	spawn_contents = list(/obj/item/crowbar/vr,
-	/obj/item/weldingtool,
+	spawn_contents = list(/obj/item/weldingtool,
 	/obj/item/wirecutters,
 	/obj/item/screwdriver,
 	/obj/item/wrench,
 	/obj/item/crowbar,
-	/obj/item/device/multitool)
+	/obj/item/device/multitool,
+	/obj/item/electronics/soldering)
 
 /obj/item/storage/belt/utility/superhero
 	name = "superhero utility belt"

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -927,6 +927,17 @@
 	/obj/item/device/multitool,
 	/obj/item/deconstructor)
 
+/obj/item/storage/belt/utility/it
+	name = "IT utility belt"
+	desc = "Tools for fixing computers and other electronics."
+	spawn_contents = list(/obj/item/crowbar/vr,
+	/obj/item/weldingtool,
+	/obj/item/wirecutters,
+	/obj/item/screwdriver,
+	/obj/item/wrench,
+	/obj/item/crowbar,
+	/obj/item/device/multitool)
+
 /obj/item/storage/belt/utility/superhero
 	name = "superhero utility belt"
 	spawn_contents = list(/obj/item/clothing/mask/breath,/obj/item/tank/pocket/oxygen)

--- a/code/obj/item/storage/electronics.dm
+++ b/code/obj/item/storage/electronics.dm
@@ -38,9 +38,7 @@
 	icon_state = "disk_kit"
 	spawn_contents = list(/obj/item/disk/data/floppy = 7)
 
-/obj/item/storage/box/opdiskbox
-	name = "diskette box"
-	icon_state = "disk_kit"
+/obj/item/storage/box/diskbox/programs
 	spawn_contents = list(/obj/item/disk/data/floppy/computer3boot,
 	/obj/item/disk/data/floppy/read_only/terminal_os,
 	/obj/item/disk/data/floppy/read_only/network_progs,

--- a/code/obj/item/storage/electronics.dm
+++ b/code/obj/item/storage/electronics.dm
@@ -38,6 +38,18 @@
 	icon_state = "disk_kit"
 	spawn_contents = list(/obj/item/disk/data/floppy = 7)
 
+/obj/item/storage/box/opdiskbox
+	name = "diskette box"
+	icon_state = "disk_kit"
+	spawn_contents = list(/obj/item/disk/data/floppy/computer3boot,
+	/obj/item/disk/data/floppy/read_only/terminal_os,
+	/obj/item/disk/data/floppy/read_only/network_progs,
+	/obj/item/disk/data/floppy/read_only/medical_progs,
+	/obj/item/disk/data/floppy/read_only/ext_research_progs,
+	/obj/item/disk/data/floppy/read_only/communications,
+	/obj/item/disk/data/floppy/read_only/engine_prog)
+
+
 /obj/item/storage/box/tapebox
 	name = "\improper ThinkTape box"
 	desc = "A box of magnetic data tapes."

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -266,7 +266,7 @@
 		if("Hall Monitor")
 			return list(access_ticket)
 		if("Computer Operator")
-			return list(access_maint_tunnels, access_tech_storage, access_dwaine_superuser, access_heads, access_research, access_researchfoyer, access_robotdepot)
+			return list(access_maint_tunnels, access_tech_storage, access_dwaine_superuser, access_research, access_researchfoyer, access_robotdepot)
 		if("Admin")
 			return access_all_actually
 		else

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -266,7 +266,7 @@
 		if("Hall Monitor")
 			return list(access_ticket)
 		if("Computer Operator")
-			return list(access_maint_tunnels, access_tech_storage, access_dwaine_superuser, access_research, access_researchfoyer, access_robotdepot)
+			return list(access_maint_tunnels, access_tech_storage, access_dwaine_superuser, access_heads, access_research, access_researchfoyer, access_robotdepot)
 		if("Admin")
 			return access_all_actually
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Computer Operators now spawn a box of useful floppy disks, an IT toolbelt, a cable coil, and the frequency reference sheet.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The toolbelt lets them easily build, repair, and upgrade computers form the start.
The box of disks lets them easily install software onto computers.
The frequency reference sheet helps with packet hacking.
The cable coil lets them connect computers together.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
The code compiled and ran fine. I spawned as a computer operator and had all the new starting equipment in the right places.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bonnedav
(+)Computer Operators now spawn a box of useful floppy disks, an IT toolbelt, a cable coil, and the frequency reference sheet.
```
