### PR TITLE
Proc to simplify copying appearances to images

### DIFF
--- a/_std/filters.dm
+++ b/_std/filters.dm
@@ -76,6 +76,14 @@
 	for(var/filter in filter_data)
 		other.add_filter(filter, filter_data[filter]["priority"], filter_data[filter])
 
+/// Copy appearance modifiers from an atom and apply them to an image. Useful if the image is supposed to visually represent the atom
+/atom/proc/copy_appearance_to_image(image/other_img)
+	other_img.color = src.color
+	other_img.alpha = src.alpha
+	if(!filter_data)
+		return
+	other_img.filters = src.filters.Copy()
+
 
 //Helpers to generate lists for filter helpers
 //This is the only practical way of writing these that actually produces sane lists

--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -109,7 +109,8 @@
 		var/image/suit_image
 		wear_sanity_check(src.w_uniform)
 		suit_image = src.w_uniform.wear_image
-		suit_image.filters = src.w_uniform.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.w_uniform)
+		src.w_uniform.copy_appearance_to_image(suit_image)
+		suit_image.filters += src.mutantrace?.apply_clothing_filters(src.w_uniform)
 
 		var/wear_state = src.w_uniform.wear_state || src.w_uniform.icon_state
 		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
@@ -120,8 +121,6 @@
 		suit_image.icon_state = wear_state
 
 		suit_image.layer = src.w_uniform.wear_layer
-		suit_image.alpha = src.w_uniform.alpha
-		suit_image.color = src.w_uniform.color
 		src.w_uniform.update_wear_image(src, src.w_uniform.wear_image.icon != src.w_uniform.wear_image_icon)
 		src.AddOverlays(suit_image, "suit_image1")
 
@@ -152,9 +151,8 @@
 			src.wear_id.wear_image.pixel_y = head_offset
 
 		src.wear_id.wear_image.layer = src.wear_id.wear_layer
-		src.wear_id.wear_image.color = src.wear_id.color
-		src.wear_id.wear_image.alpha = src.wear_id.alpha
-		src.wear_id.wear_image.filters = src.wear_id.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.wear_id)
+		src.wear_id.copy_appearance_to_image(src.wear_id.wear_image)
+		src.wear_id.wear_image.filters += src.mutantrace?.apply_clothing_filters(src.wear_id)
 		src.AddOverlays(src.wear_id.wear_image, "wear_id")
 	else
 		src.ClearSpecificOverlays("wear_id")
@@ -166,7 +164,8 @@
 		var/icon_name = src.gloves.wear_state || src.gloves.item_state || src.gloves.icon_state
 		var/no_offset = FALSE
 		src.gloves.wear_image.layer = src.gloves.wear_layer
-		src.gloves.wear_image.filters = src.gloves.filters.Copy() + src.mutantrace.apply_clothing_filters(src.gloves)
+		src.gloves.copy_appearance_to_image(src.gloves.wear_image)
+		src.gloves.wear_image.filters += src.mutantrace.apply_clothing_filters(src.gloves)
 		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
 		if (src.limbs && src.limbs.l_arm && src.limbs.l_arm.accepts_normal_human_overlays) //src.bioHolder && !src.bioHolder.HasEffect("robot_left_arm"))
 			var/icon_local = (src.gloves.which_hands & GLOVE_HAS_LEFT) ? icon_name : "transparent"
@@ -178,8 +177,6 @@
 			else
 				src.gloves.wear_image.icon = src.gloves.wear_image_icon
 			src.gloves.wear_image.icon_state = "left_[icon_local]"
-			src.gloves.wear_image.color = src.gloves.color
-			src.gloves.wear_image.alpha = src.gloves.alpha
 			src.gloves.update_wear_image(src, src.gloves.wear_image.icon != src.gloves.wear_image_icon)
 			src.AddOverlays(src.gloves.wear_image, "wear_gloves_l")
 		else
@@ -242,12 +239,14 @@
 				else
 					src.shoes.wear_image.icon = src.shoes.wear_image_icon
 				var/image/right_shoe_overlay = image(src.shoes.wear_image.icon, "right_[wear_state]")
-				right_shoe_overlay.filters = src.shoes.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.shoes)
+				src.shoes.copy_appearance_to_image(right_shoe_overlay)
+				right_shoe_overlay.filters += src.mutantrace?.apply_clothing_filters(src.shoes)
 				src.shoes.wear_image.overlays += right_shoe_overlay
 
 
 		if(shoes_count)
-			src.shoes.wear_image.filters = src.shoes.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.shoes)
+			src.shoes.copy_appearance_to_image(src.shoes.wear_image)
+			src.shoes.wear_image.filters += src.mutantrace?.apply_clothing_filters(src.shoes)
 			src.AddOverlays(src.shoes.wear_image, "wear_shoes")
 		else
 			src.ClearSpecificOverlays("wear_shoes")
@@ -259,8 +258,8 @@
 	if (src.wear_suit)
 		wear_sanity_check(src.wear_suit)
 		src.wear_suit.wear_image.layer = src.wear_suit.wear_layer
-		src.wear_suit.wear_image.filters = src.wear_suit.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.wear_suit)
-		//src.wear_suit.wear_image.filters += src.mutantrace?.apply_clothing_filters(src.wear_suit)
+		src.wear_suit.copy_appearance_to_image(src.wear_suit.wear_image)
+		src.wear_suit.wear_image.filters += src.mutantrace?.apply_clothing_filters(src.wear_suit)
 		var/typeinfo/datum/mutantrace/typeinfo = src.mutantrace?.get_typeinfo()
 		var/wear_state = src.wear_suit.wear_state || src.wear_suit.icon_state
 		if (wear_state in typeinfo?.clothing_icon_states["overcoats"])
@@ -270,8 +269,6 @@
 		src.wear_suit.wear_image.icon_state = wear_state
 
 		src.wear_suit.update_wear_image(src, src.wear_suit.wear_image.icon != src.wear_suit.wear_image_icon)
-		src.wear_suit.wear_image.color = src.wear_suit.color
-		src.wear_suit.wear_image.alpha = src.wear_suit.alpha
 
 		if (src.organHolder?.tail) update_tail_clothing(wear_state, src.wear_suit)
 
@@ -321,10 +318,9 @@
 		src.back.wear_image.layer = src.back.wear_layer
 		if(src.back.wear_image.layer == MOB_CLOTHING_LAYER) // if default let's assume you actually want this on back
 			src.back.wear_image.layer = MOB_BACK_LAYER
-		src.back.wear_image.color = src.back.color
-		src.back.wear_image.alpha = src.back.alpha
 		src.back.update_wear_image(src, src.back.wear_image.icon != src.back.wear_image_icon)
-		src.back.wear_image.filters = src.back.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.back)
+		src.back.copy_appearance_to_image(src.back.wear_image)
+		src.back.wear_image.filters += src.mutantrace?.apply_clothing_filters(src.back)
 		src.AddOverlays(src.back.wear_image, "wear_back")
 
 		if (src.back.worn_material_texture_image != null)
@@ -354,10 +350,9 @@
 		if (!no_offset)
 			src.glasses.wear_image.pixel_x = 0
 			src.glasses.wear_image.pixel_y = head_offset
-		src.glasses.wear_image.color = src.glasses.color
-		src.glasses.wear_image.alpha = src.glasses.alpha
 		src.glasses.update_wear_image(src, src.glasses.wear_image.icon != src.glasses.wear_image_icon)
-		src.glasses.wear_image.filters = src.glasses.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.glasses)
+		src.glasses.copy_appearance_to_image(src.glasses.wear_image)
+		src.glasses.wear_image.filters += src.mutantrace?.apply_clothing_filters(src.glasses)
 		src.AddOverlays(src.glasses.wear_image, "wear_glasses")
 		if (src.glasses.worn_material_texture_image != null)
 			src.glasses.worn_material_texture_image.layer = src.glasses.wear_image.layer + 0.1
@@ -385,9 +380,8 @@
 		if (!no_offset)
 			src.ears.wear_image.pixel_x = 0
 			src.ears.wear_image.pixel_y = head_offset
-		src.ears.wear_image.color = src.ears.color
-		src.ears.wear_image.alpha = src.ears.alpha
-		src.ears.wear_image.filters = src.ears.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.ears)
+		src.ears.copy_appearance_to_image(src.ears.wear_image)
+		src.ears.wear_image.filters += src.mutantrace?.apply_clothing_filters(src.ears)
 		src.AddOverlays(src.ears.wear_image, "wear_ears")
 		if (src.ears.worn_material_texture_image != null)
 			src.ears.worn_material_texture_image.layer = src.ears.wear_image.layer + 0.1
@@ -418,10 +412,9 @@
 			src.wear_mask.wear_image.pixel_x = 0
 			src.wear_mask.wear_image.pixel_y = head_offset
 		src.wear_mask.wear_image.layer = src.wear_mask.wear_layer
-		src.wear_mask.wear_image.color = src.wear_mask.color
-		src.wear_mask.wear_image.alpha = src.wear_mask.alpha
 		src.wear_mask.update_wear_image(src, src.wear_mask.wear_image.icon != src.wear_mask.wear_image_icon)
-		src.wear_mask.wear_image.filters = src.wear_mask.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.wear_mask)
+		src.wear_mask.copy_appearance_to_image(src.wear_mask.wear_image)
+		src.wear_mask.wear_image.filters += src.mutantrace?.apply_clothing_filters(src.wear_mask)
 		src.AddOverlays(src.wear_mask.wear_image, "wear_mask")
 		if (src.wear_mask.worn_material_texture_image != null)
 			src.wear_mask.worn_material_texture_image.layer = src.wear_mask.wear_image.layer + 0.1
@@ -452,10 +445,9 @@
 		if (!no_offset)
 			src.head.wear_image.pixel_x = 0
 			src.head.wear_image.pixel_y = head_offset
-		src.head.wear_image.color = src.head.color
-		src.head.wear_image.alpha = src.head.alpha
 		src.head.update_wear_image(src, src.head.wear_image.icon != src.head.wear_image_icon)
-		src.head.wear_image.filters = src.head.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.head)
+		src.head.copy_appearance_to_image(src.head.wear_image)
+		src.head.wear_image.filters += src.mutantrace?.apply_clothing_filters(src.head)
 		src.AddOverlays(src.head.wear_image, "wear_head")
 		if (src.head.worn_material_texture_image != null)
 			src.head.worn_material_texture_image.layer = src.head.wear_image.layer + 0.1
@@ -485,9 +477,8 @@
 		src.belt.wear_image.layer = src.belt.wear_layer
 		if(src.belt.wear_image.layer == MOB_CLOTHING_LAYER) // if default let's assume you actually want this on back
 			src.belt.wear_image.layer = MOB_BELT_LAYER
-		src.belt.wear_image.color = src.belt.color
-		src.belt.wear_image.alpha = src.belt.alpha
-		src.belt.wear_image.filters = src.belt.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.belt)
+		src.belt.copy_appearance_to_image(src.belt.wear_image)
+		src.belt.wear_image.filters += src.mutantrace?.apply_clothing_filters(src.belt)
 		src.AddOverlays(src.belt.wear_image, "wear_belt")
 		if (src.belt.worn_material_texture_image != null)
 			src.belt.worn_material_texture_image.layer = src.belt.wear_image.layer + 0.1
@@ -504,9 +495,8 @@
 		var/image/handcuff_img = SafeGetOverlayImage("handcuffs", 'icons/mob/mob.dmi', "handcuff1", MOB_HANDCUFF_LAYER)
 		handcuff_img.pixel_y = hand_offset
 		if(src.handcuffs)
-			handcuff_img.color = src.handcuffs.color
-			handcuff_img.alpha = src.handcuffs.alpha
-			handcuff_img.filters = src.handcuffs.filters.Copy() + src.mutantrace?.apply_clothing_filters(src.handcuffs)
+			src.handcuffs.copy_appearance_to_image(handcuff_img)
+			handcuff_img.filters += src.mutantrace?.apply_clothing_filters(src.handcuffs)
 		src.AddOverlays(handcuff_img, "handcuffs")
 		if (src.handcuffs.worn_material_texture_image)
 			src.handcuffs.worn_material_texture_image.layer = src.handcuffs.wear_image.layer + 0.1
@@ -542,9 +532,8 @@
 		if (islist(tail_overrides) && (icon_state in tail_overrides))
 			human_tail_image = image(our_tail.clothing_image_icon, icon_state)
 			if(tail_clothing)
-				human_tail_image.color = tail_clothing.color
-				human_tail_image.alpha = tail_clothing.alpha
-				human_tail_image.filters = tail_clothing.filters.Copy() + src.mutantrace?.apply_clothing_filters(tail_clothing)
+				tail_clothing.copy_appearance_to_image(src.human_tail_image)
+				human_tail_image.filters += src.mutantrace?.apply_clothing_filters(tail_clothing)
 			src.tail_standing.overlays += human_tail_image
 			src.tail_standing_oversuit.overlays += human_tail_image
 			if(tail_clothing.worn_material_texture_image)

--- a/code/modules/transport/pods/MainWeapon.dm
+++ b/code/modules/transport/pods/MainWeapon.dm
@@ -43,9 +43,7 @@
 		if(src.ship.uses_weapon_overlays && src.appearanceString)
 			var/image/weap_image = image('icons/effects/64x64.dmi', "[src.appearanceString]")
 			weap_image.appearance_flags = KEEP_APART | RESET_COLOR | RESET_ALPHA
-			weap_image.color = src.color
-			weap_image.alpha = src.alpha
-			weap_image.filters = src.filters.Copy()
+			src.copy_appearance_to_image(weap_image)
 			src.ship.UpdateOverlays(weap_image, "mainweapon")
 
 	ship_uninstall()

--- a/code/modules/transport/pods/engine.dm
+++ b/code/modules/transport/pods/engine.dm
@@ -103,9 +103,7 @@
 
 		if(src.engine_icon)
 			src.engine_icon.appearance_flags = KEEP_APART | RESET_COLOR | RESET_ALPHA
-			src.engine_icon.color = src.color
-			src.engine_icon.alpha = src.alpha
-			src.engine_icon.filters = src.filters.Copy()
+			src.copy_appearance_to_image(src.engine_icon)
 			ship.AddOverlays(engine_icon, "engine")
 		..()
 

--- a/code/modules/transport/pods/locomotion.dm
+++ b/code/modules/transport/pods/locomotion.dm
@@ -30,9 +30,7 @@
 			var/obj/machinery/vehicle/tank/tank = src.ship
 			var/image/loco_image = image('icons/obj/machines/8dirvehicles.dmi', "[tank.body_type]_[src.appearanceString]")
 			loco_image.appearance_flags = KEEP_APART | RESET_COLOR | RESET_ALPHA
-			loco_image.color = src.color
-			loco_image.alpha = src.alpha
-			loco_image.filters = src.filters.Copy()
+			src.copy_appearance_to_image(loco_image)
 			tank.UpdateOverlays(loco_image, "locomotion")
 		src.activate() // Locomotion should always be active
 


### PR DESCRIPTION
## About the PR
- Adds `/atom/proc/copy_appearance_to_image(image/other_img)`, which will take appearance modifiers on an atom and copy them to an image

## Why's this needed?
- Takes the process of copying color, filters, ect. from an atom and then applying them to an image that is supposed to represent that atom and puts it in one proc. If something else needs to be applied from the atom to the image (say an animation), the change can be made in the proc instead of having to track down every image that is supposed to represent an atom's appearance.

## Testing
<img width="230" height="183" alt="Screenshot 2026-05-12 012345" src="https://github.com/user-attachments/assets/08abf3e9-f71f-4c40-9c79-b7eb7b37f47e" />
