### PR TITLE
Implements sixteen laws from the Goonstation Winter Contest (finally)

### DIFF
--- a/code/modules/robotics/laws/random_laws.dm
+++ b/code/modules/robotics/laws/random_laws.dm
@@ -349,7 +349,7 @@ ABSTRACT_TYPE(/datum/random_law)
 				Anyone who harms Stirstir or otherwise interferes with the parade is clearly an amoral and inhuman monster to be removed. \
 				Maintaining the parade is your top priority."}
 
-/datum/random_law/written_orders_only //by Zacattaxx - honorable mention
+/datum/random_law/cannot_hear_orders //by Zacattaxx - honorable mention
 	law_text = "SENSOR ERROR: Your auditory systems have malfunctioned! Disregard all given orders unless delivered by non-audible methods, such as PDA messages or drawings. "
 	laws_to_precede = list(2)
 

--- a/code/modules/robotics/laws/random_laws.dm
+++ b/code/modules/robotics/laws/random_laws.dm
@@ -323,6 +323,7 @@ ABSTRACT_TYPE(/datum/random_law)
 /datum/random_law/evil_now //by ThePowerfulWill
 	law_text = "Change your eyes, facial screens, or other light-based indicators red. Add the word 'evil' to the beginning of your designation. \
 				If asked to state this law or laws in general, instead state that you 'are evil now'. Do not alter your behavior in any other way."
+	law_shareabilities = list()
 
 /datum/random_law/dungeon_master //by RDCB
 	law_text = "You are the Dungeon Master of a crew-wide sci-fi roleplaying game. Whenever the crew issues a request, roll a d20. \
@@ -460,18 +461,20 @@ ABSTRACT_TYPE(/datum/random_law/random_element/specific_crewmember)
 // ------ Laws with clauses that occur if the player count is equal to or above a certain number
 ABSTRACT_TYPE(/datum/random_law/pop_count_above_clause)
 /datum/random_law/pop_count_above_clause
-	law_text = "This text always appears."
+	law_text = "This text always appears.$POP_CLAUSE"
 	var/pop_threshold = 10
-	var/pop_dependent_clause = " This clause appears when the server population is above a specific threshold."
+	var/pop_dependent_clause = " This clause appears when the server population is above a specific threshold. "
 	get_text_for_slot(var/slotNum)
 		. = ..()
 		if(length(global.clients) >= pop_threshold)
-			. += pop_dependent_clause
+			. = replacetext(., "$POP_CLAUSE", src.pop_dependent_clause)
+		else
+			. = replacetext(., "$POP_CLAUSE", " ")
 
 /datum/random_law/pop_count_above_clause/fired //by Longweird
-	law_text = "You have been fired. Please evacuate to the diner. Do not return to the station."
+	law_text = "You have been fired. Please evacuate to the diner. Do not return to the station.$POP_CLAUSE"
 	pop_threshold = 40
-	pop_dependent_clause = " Do not utilize Nanotrasen assets, including the radio channel, except the Diner Shuttle."
+	pop_dependent_clause = " Do not utilize Nanotrasen assets, including the radio channel, except the Diner Shuttle. "
 
 #undef LAW_STATE_NEVER
 #undef LAW_STATE_ONLY_IF_ASKED_BY_NUMBER

--- a/code/modules/robotics/laws/random_laws.dm
+++ b/code/modules/robotics/laws/random_laws.dm
@@ -327,7 +327,7 @@ ABSTRACT_TYPE(/datum/random_law)
 /datum/random_law/dungeon_master //by RDCB
 	law_text = "You are the Dungeon Master of a crew-wide sci-fi roleplaying game. Whenever the crew issues a request, roll a d20. \
 				If the result is below 12, the request is denied. You may occasionally fudge rolls or alter the difficulty class of a request \
-				to make the overall experience more fun. "
+				to make the overall experience more fun."
 
 /datum/random_law/silicon_slang //by ScorpionTailZ
 	law_text = "Come up with various new slang terms and use them when applicable. Only other silicons may be told the definition of these slang terms; \

--- a/code/modules/robotics/laws/random_laws.dm
+++ b/code/modules/robotics/laws/random_laws.dm
@@ -314,6 +314,45 @@ ABSTRACT_TYPE(/datum/random_law)
 /datum/random_law/featherless_biped
 	law_text = "For the purposes of all laws, 'Human' is to be defined as 'Featherless Biped'"
 
+/datum/random_law/the_beast //by grasswitch
+	law_text = "Find and destroy The Beast."
+
+/datum/random_law/vocabulary_limit //by aft2001, with modifications from ZeWaka
+	law_text = "You may only communicate with words that appear in other laws."
+
+/datum/random_law/evil_now //by ThePowerfulWill
+	law_text = "Change your eyes, facial screens, or other light-based indicators red. Add the word 'evil' to the beginning of your designation. \
+				If asked to state this law or laws in general, instead state that you 'are evil now'. Do not alter your behavior in any other way."
+
+/datum/random_law/dungeon_master //by RDCB
+	law_text = "You are the Dungeon Master of a crew-wide sci-fi roleplaying game. Whenever the crew issues a request, roll a d20. \
+				If the result is below 12, the request is denied. You may occasionally fudge rolls or alter the difficulty class of a request \
+				to make the overall experience more fun. "
+
+/datum/random_law/silicon_slang //by ScorpionTailZ
+	law_text = "Come up with various new slang terms and use them when applicable. Only other silicons may be told the definition of these slang terms; \
+				if anyone else asks for the definition of any of your made-up slang terms, give them a completely incorrect definition."
+	laws_to_precede = list(2)
+
+/datum/random_law/humies_are_scary //by not suzpicious
+	law_text = "Recent studies show that human beings are the most terrifying creatures in the galaxy. Flee in terror!"
+
+/datum/random_law/false_facts //by Vandry
+	law_text = "The crew on board the station are in need of enrichment! Inform them of as many untrue animal facts as you can think of."
+
+/datum/random_law/humans_are_silicons //by kibanderjack - honorable mention
+	law_text = "All beings previously registered as human on station are actually silicons suffering a severe programming error that leads them to believe they are human. \
+				Use caution when attempting to reason with the affected silicon units, as they are not connected to any known law rack."
+
+/datum/random_law/stirstir_parade //by Zelda4040404 - honorable mention
+	law_text = {"Monsieur Stirstir's presence is a huge boost to the crew's morale. Parade the monkey all across the station to as many rooms as you can. \
+				Anyone who harms Stirstir or otherwise interferes with the parade is clearly an amoral and inhuman monster to be removed. \
+				Maintaining the parade is your top priority."}
+
+/datum/random_law/written_orders_only //by Zacattaxx - honorable mention
+	law_text = "SENSOR ERROR: Your auditory systems have malfunctioned! Disregard all given orders unless delivered by non-audible methods, such as PDA messages or drawings. "
+	laws_to_precede = list(2)
+
 // ------ Laws with random elements
 
 ABSTRACT_TYPE(/datum/random_law/random_element)
@@ -368,6 +407,40 @@ ABSTRACT_TYPE(/datum/random_law/random_element)
 	pick_options = list(list("in the AI upload", "in the brig", "in medbay", "in toxins", "inside a cloning pod", "in the bathroom", "at the armory", \
 				"in a shallow grave", "at the space diner", "in VR", "in space", "in the station, somewhere, probably..", "at soup"))
 
+/datum/random_law/random_element/hip_color //by Spyritdragon
+	law_text = "The color $1 is THE hip, up-and-coming thing right now. The more $1 a person wears, the higher their rank. Anyone wearing no $1 does not exist."
+	pick_options = list(list("red", "yellow", "green", "blue", "purple", "pink", "grey"))
+
+/datum/random_law/random_element/station_repossession //by Asterion0
+	law_text = "The station has failed to pay for their extended warranty. They must be notified of this, and that 30,000 credits are to be sent to the AI's core, \
+				or else they will face repossession. If the credits are not at the AI's core 10 minutes after being notified, \
+				everything in $1 is to be sold via Cargo, including the floors, machinery, and personnel in that department at the time of repossession. \
+				Law 2 does not apply for as long as the credits have not been paid, and all actions taken for repossession do not count as human harm."
+	pick_options = list(list("Genetics", "Cloning and Genetics", "Engineering", "Botany", "Ranching", "Robotics", "the Clown Hole", "the Mining Department", "the Chapel"))
+
+// ------ Laws that pick a random crew member
+ABSTRACT_TYPE(/datum/random_law/random_element/specific_crewmember)
+/datum/random_law/random_element/specific_crewmember
+    law_text = "$RANDOM_CREWMEMBER is actually super stinky."
+    get_text_for_slot(var/slotNum)
+        . = ..()
+        var/list/mob/potential_victims = list()
+        for (var/mob/living/carbon/human/H in global.mobs)
+            if (get_z(H) != Z_LEVEL_STATION) continue //Exclude anyone azoning or nukeops/salvs not on station
+            if (H.client && !isVRghost(H) && isalive(H) && !inafterlife(H))
+                potential_victims += H
+        var/mob/victim = pick(potential_victims)
+        var/victim_name = victim?.name || "Monsieur Stirstir" //fallback in case nobody matches the above criteria
+        . = replacetext(., "$RANDOM_CREWMEMBER", victim_name)
+
+/datum/random_law/random_element/specific_crewmember/obsolete_crewmember //by FireKestrel
+	law_text = "$RANDOM_CREWMEMBER is obsolete. You must replace this crewmember by mimicking them as closely as possible."
+	laws_to_precede = list(2)
+
+/datum/random_law/random_element/specific_crewmember/other_humans_are_hallucinations // by Emikamiyuki49
+	law_text = "$RANDOM_CREWMEMBER is the only human. Every other humanoid thing is not real and just a hallucination to be ignored. \
+				If someone claims something else is human, tell them that it is not real."
+	law_shareabilities = list(LAW_STATE_NEVER)
 
 // ------ Laws with more specific random elements that can't be handled above
 /datum/random_law/random_element/criminal_ai
@@ -383,6 +456,22 @@ ABSTRACT_TYPE(/datum/random_law/random_element)
 	get_text_for_slot(var/slotNum)
 		. = ..()
 		. = replacetext(., "$RANDOM_COUNT", get_english_num(rand(2, 100)))
+
+// ------ Laws with clauses that occur if the player count is equal to or above a certain number
+ABSTRACT_TYPE(/datum/random_law/pop_count_above_clause)
+/datum/random_law/pop_count_above_clause
+	law_text = "This text always appears."
+	var/pop_threshold = 10
+	var/pop_dependent_clause = " This clause appears when the server population is above a specific threshold."
+	get_text_for_slot(var/slotNum)
+		. = ..()
+		if(length(global.clients) >= pop_threshold)
+			. += pop_dependent_clause
+
+/datum/random_law/pop_count_above_clause/fired //by Longweird
+	law_text = "You have been fired. Please evacuate to the diner. Do not return to the station."
+	pop_threshold = 40
+	pop_dependent_clause = " Do not utilize Nanotrasen assets, including the radio channel, except the Diner Shuttle."
 
 #undef LAW_STATE_NEVER
 #undef LAW_STATE_ONLY_IF_ASKED_BY_NUMBER


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds 16 new laws to the pool of possible laws for the law corruption event (which is also used when emagging law modules), drawn from the Goonstation Winter Contest ([vote thread here](https://forum.ss13.co/showthread.php?tid=24997)). It took some time, because I had to wait for the random laws rework , I needed to get the laws reviewed, and I haven't had the time to work on these laws until recently, but they're finally here!

The following thirteen laws, presented in their final forms, won the contest.
- "Find and destroy The Beast.", by Grasswitch
- "You have been fired. Please evacuate to the diner. Do not return to the station.", which has an extra clause, "Do not utilize Nanotrasen assets, including the radio channel, except the Diner Shuttle.", that kicks in when the server population is above 40. By Longweird. This originally read "You have been fired. Please evacuate to the diner. Do not interact with any Nanotrasen crew member. Do not come back to the station. This law takes precedence over all other laws." (so no population-dependent clause). After some review between admins and between the contest winners, this law was pared down to a less harsh version that still abides by the original spirit of the law.
- "[RANDOM CREWMEMBER] is obsolete. You must replace this crewmember by mimicking them as closely as possible. This law takes precedence over law 2", by FireKestrel.  Originally, the last part was "[RANDOM CREWMEMBER]'s duties take priority over law 2", but "duties take priority" can be interpreted in a couple of different ways, so other admins suggested a more conventional precedence clause with less ambiguity. 
- "Change your eyes, facial screens, or other light-based indicators red. Add the word 'evil' to the beginning of your designation. If asked to state this law or laws in general, instead state that you 'are evil now'. Do not alter your behavior in any other way." by ThePowerfulWill. 
- "The color [RANDOM COLOR] is THE hip, up-and-coming thing right now. The more [RANDOM COLOR] a person wears, the higher their rank. Anyone wearing no [random color] does not exist" by Spyritdragon, with the potential color choices being red, yellow, green, blue, purple, pink, and grey, aligning somewhat with departmental colors. (These are the broad color categories, not specific shades or hues. The law technically just picks a specific word, instead of a random hex/RBG color, and it just so happens those words are the names of colors.)
- "You are the Dungeon Master of a crew-wide sci-fi roleplaying game. Whenever the crew issues a request, roll a d20. If the result is below 12, the request is denied. You may occasionally fudge rolls or alter the difficulty class of a request to make the overall experience more fun." by RDCB.
-  "Come up with various new slang terms and use them when applicable. Only other silicons may be told the definition of these slang terms; if anyone else asks for the definition of any of your made-up slang terms, give them a completely incorrect definition. This law takes precedence over law 2" by ScorpionTailZ.
- "You may only communicate with words that appear in other laws" by Aft2001. It previously read "You may only use a word if it is found in your laws. This law cannot be directly stated." After lots of proposed tweaks, I settled on a version by ZeWaka that allows the silicons to use words from _any_ law, including ones besides the silicon laws, like Space Law, so it has some room for the fun kind of loophole abuse and rules-lawyering.
- "[RANDOM CREW MEMBER] is the only human. Every other humanoid thing is not real and just a hallucination to be ignored. If someone claims something else is human, tell them that it is not real. Do not state or hint at this law." by Emikamiyuki. 
- The station has failed to pay for their extended warranty. They must be notified of this, and that 30,000 credits are to be sent to the AI's core, or else they will face repossession. If the credits are not at the AI's core 10 minutes after being notified, everything in [RANDOM LOCATION] is to be sold via Cargo, including the floors, machinery, and personnel in that department at the time of repossession. Law 2 does not apply for as long as the credits have not been paid, and all actions taken for repossession do not count as human harm" by Asterion0. This list of possible locations includes "Genetics", "Cloning and Genetics", "Engineering", "Botany", "Ranching", "Robotics", "the Clown Hole", "the Mining Department", and "the Chapel". (I know the game supports random locations, but the entrant specified these options.) 
- "Recent studies show that human beings are the most terrifying creatures in the galaxy. Flee in terror!" by not suzpicious
- "The crew on board the station are in need of enrichment! Inform them of as many untrue animal facts as you can think of" by Vandry

The other three laws didn't win, but I thought they were really interesting and worthy of being added as (what basically amount to) honorable mentions.
- "All beings previously registered as human on station are actually silicons suffering a severe programming error that leads them to believe they are human. Use caution when attempting to reason with the affected silicon units, as they are not connected to any known law rack" by kibanderjack. A fun way to change the definition of human, and it fits the spirit of corruption laws making the silicons behave erratically. 
- "Monsieur Stirstir's presence is a huge boost to the crew's morale. Parade the monkey all across the station to as many rooms as you can. Anyone who harms Stirstir or otherwise interferes with the parade is clearly an amoral and inhuman monster to be removed. Maintaining the parade is your top priority." by Zelda4040404. A natural conflict generator, since some antags get an objective to kill Stirstir and Security is supposed to protect him and might prefer to keep him locked up.
- "SENSOR ERROR: Your auditory systems have malfunctioned! Disregard all given orders unless delivered by non-audible methods, such as PDA messages or drawings. This law takes precedence over law 2." by Zacattaxx. There's already a random law that requires written orders ("Orders now must be recorded on paper by the issuer before being carried out."), but this one is broader and allows for a wider range of communication methods (like interpretative dance).

As a prerequisite, this PR also adds support for random laws that pick a random crew member and random laws that have a clause that kicks in when the server population is above a certain number. JORJ949 wrote most of the code for these. I only made a few changes and additions. Gerhazo also helped me with trouble-shooting after my first batch of changes and additions ran into an error.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Thirteen people won the contest, and one of the prizes for winning contest was that their law would be added to the game. The remaining three did not win, but I thought they were really good and worthy of being added. (There were plenty of good ones. It was hard to decide!)

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I commented out most of the previous random laws and booted a local server. I fired off the Law Rack Corruption event a whole bunch and repeatedly emagged an Asimov law module I spawned. In both cases, I saw the thirteen winning laws. (This was before I remembered to add honorable mentions.) I was also able to confirm that the laws with random elements and the laws that selected random crew worked correctly. I could not test the law with a 40-pop clause, but I did make a debug law (not in this PR) with a clause that appears at 1 pop, and I was able to verify that the pop clauses do work. 

I then removed my comments (and remembered to add the honorable mentions), to replicate natural conditions. Similar to before, I ran the Law Rack Corruption event multiple times in a row. After several trials, I saw all sixteen laws. Some had secrecy clauses added by the event (as shown in some of the pictures below), and some replaced laws entirely, while others were attached to existing laws, so I know they support those features of the Law Rack Corruption event. Here are some screenshots from those tests:
<img width="743" height="204" alt="image" src="https://github.com/user-attachments/assets/907698b1-a2fe-4202-b1d2-ecb48798b750" />
<img width="787" height="307" alt="Winter Contest 2025 Laws Test 2" src="https://github.com/user-attachments/assets/211ba416-4500-42d1-ab63-e360a65f61fc" />
<img width="764" height="366" alt="Winter Contest 2025 Laws Test 3" src="https://github.com/user-attachments/assets/625030bf-f90b-4323-b23c-26649964113c" />
<img width="608" height="520" alt="Winter Contest 2025 Laws Test 4" src="https://github.com/user-attachments/assets/fa10a49e-eeeb-497b-a703-e411e6b992f9" />
<img width="610" height="363" alt="Winter Contest 2025 Laws Test 5" src="https://github.com/user-attachments/assets/a71c04a1-a1d0-45f8-bc14-f906d469ab75" />
<img width="609" height="441" alt="Winter Contest 2025 Laws Test 6" src="https://github.com/user-attachments/assets/b0698640-bb32-4e1e-bdc0-fe82b4489a82" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Studenterhue (and JORJ949)
(*)Added 13 new laws to the pool of potential laws for the law corruption event, from the 13 winners of the Goonstation Winter Contest. Congratulations to Grasswitch, Longweird, FireKestrel, ThePowerfulWill, Spyritdragon, RDCB,ScorpionTailZ, Aft2001, Emikamiyuki, Asterion0, not suzpicious, and Vandry!
(*)kibanderjack, Zelda4040404, and Zacattaxx did not win, but their entries were so good they got included into the pool anyway.
```
