### PR TITLE
Updated ballistic gun profiles to new forensics

### DIFF
--- a/_std/defines/forensics.dm
+++ b/_std/defines/forensics.dm
@@ -30,6 +30,8 @@
 #define FORENSIC_HEADER_FINGERPRINTS "Fingerprints"
 #define FORENSIC_HEADER_DNA "DNA Samples"
 
+var/static/datum/forensic_display/gun_profile_display = new("Gun Profile: @F")
+
 #define FORENSIC_VALUE_IGNORE 1 // How basic data evidence value is affected when duplicate evidence is added
 #define FORENSIC_VALUE_SUM 2
 #define FORENSIC_VALUE_MULT 3

--- a/_std/defines/forensics.dm
+++ b/_std/defines/forensics.dm
@@ -41,6 +41,7 @@ var/static/datum/forensic_display/gun_profile_display = new("Gun Profile: @F")
 // Chose 16 letters that look distinct and sort of fingerprinty with curves and such
 #define FORENSIC_CHARS_FINGERPRINTS list("a","b","c","d","e","g","n","o","p","q","s","u","v","x","y","z")
 #define FORENSIC_CHARS_HEX list("0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F")
+#define FORENSIC_CHARS_BALLISTICS list("=","=","+","-","#","H","8")
 
 #define FORENSIC_GLOVE_MASK_FINGERLESS "0123-4567-89AB-CDEF"
 #define FORENSIC_GLOVE_MASK_NONE "...???..."

--- a/code/WorkInProgress/MarqStuff.dm
+++ b/code/WorkInProgress/MarqStuff.dm
@@ -450,6 +450,7 @@
 				var/obj/item/implant/projectile/body_visible/arrow/A = new
 				A.material = fusedmaterial
 				A.setMaterial(fusedmaterial, appearance = 0, setname = 0)
+				src.forensic_holder.copy_to(A.forensic_holder)
 				A.arrow = src
 				A.name = name
 				set_loc(A)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3422,7 +3422,7 @@ mob/living/carbon/human/has_genetics()
 			if (istype(I, /obj/item/implant/projectile))
 				wound_count++
 		if(wound_count)
-			scan.add_text("Gunshot wounds: [wound_count] fragments detected")
+			scan.add_text("Gunshot wounds: [wound_count] fragments detected") // Seems to double-count for some reason?
 
 /mob/living/carbon/human/proc/get_fingerprint(var/ignore_gloves = FALSE, force_hand = -1)
 	RETURN_TYPE(/datum/forensic_data/fingerprint)

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -39,12 +39,10 @@
 						implanted.set_loc(src)
 						if (istype(implanted))
 							implanted.owner = src
-							if (P.forensic_ID)
-								implanted.forensic_ID = P.forensic_ID
 							src.implant += implanted
-							implanted.forensic_holder = P.forensic_holder // Give projectile forensics to the implanted bullet
 							if (P.proj_data.material)
 								implanted.setMaterial(P.proj_data.material)
+							implanted.forensic_holder = P.forensic_holder
 							implanted.implanted(src, null, 60)
 							//extra damage from silver for werewolves
 							if (istype(implanted, /datum/material/metal/silver) && iswerewolf(src))
@@ -73,8 +71,6 @@
 					if (istype(implanted))
 						implanted.owner = src
 						src.implant += implanted
-						if (P.forensic_ID)
-							implanted.forensic_ID = P.forensic_ID
 						implanted.forensic_holder = P.forensic_holder
 						if (P.proj_data.material)
 							implanted.setMaterial(P.proj_data.material)
@@ -127,8 +123,6 @@
 						implanted.set_loc(src)
 						if (istype(implanted))
 							implanted.owner = src
-							if (P.forensic_ID)
-								implanted.forensic_ID = P.forensic_ID
 							implanted.forensic_holder = P.forensic_holder
 							implanted.setMaterial(P.proj_data.material)
 							implanted.implanted(src, null, 0)

--- a/code/modules/forensics/forensic_scan.dm
+++ b/code/modules/forensics/forensic_scan.dm
@@ -92,7 +92,7 @@
 		var/report_title = SPAN_SUCCESS(src.title)
 		if(print_hyperlink)
 			report_title += ": [print_hyperlink]"
-		report = "[report_title]<br>" + report
+		report = "[report_title]<br>[report]"
 		return report
 
 	proc/compile_report_header(var/header, var/compress)
@@ -107,7 +107,7 @@
 		else if(compress && header == FORENSIC_HEADER_FINGERPRINTS && !src.scan.has_effect("effect_silver_nitrate"))
 			return compile_report_compress(header, 2)
 		else
-			var/header_text = "<ul style='margin-top:0px;padding-left:20px'>"
+			var/header_text = "<ul style='margin-top:0px;margin-bottom:0px;padding-left:20px'>"
 			for(var/line in src.report_lines[header])
 				header_text += "<li style='padding-left:0px'>[line]</li>" // Indent line and add a bullet point
 			return "[header_text]</ul>"

--- a/code/modules/projectiles/_projectile_datum.dm
+++ b/code/modules/projectiles/_projectile_datum.dm
@@ -57,7 +57,6 @@ ABSTRACT_TYPE(/datum/projectile)
 
 	var/casing = null
 	var/reagent_payload = null
-	var/forensic_ID = null
 	var/precalculated = 1
 
 	var/hit_object_sound = 0

--- a/code/modules/projectiles/_projectile_utils.dm
+++ b/code/modules/projectiles/_projectile_utils.dm
@@ -127,6 +127,9 @@
 
 	if (DATA.implanted)
 		P.implanted = DATA.implanted
+	if(isatom(P.implanted))
+		var/atom/A = P.implanted
+		A.forensic_holder = P.forensic_holder
 
 	P.called_target = called_target
 	P.called_target_turf = get_turf(called_target)

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1963,6 +1963,7 @@ datum/projectile/bullet/autocannon
 				else
 					var/obj/item/implant/projectile/shrapnel/implanted = new /obj/item/implant/projectile/shrapnel
 					implanted.implanted(M, null, 2)
+					hit.forensic_holder.copy_to(implanted.forensic_holder)
 					boutput(M, SPAN_ALERT("You are struck by shrapnel!"))
 
 			T.hotspot_expose(700,125)
@@ -2077,6 +2078,7 @@ ABSTRACT_TYPE(/datum/projectile/bullet/homing/rocket)
 				else
 					var/obj/item/implant/projectile/shrapnel/implanted = new /obj/item/implant/projectile/shrapnel
 					implanted.implanted(M, null, 2)
+					hit.forensic_holder.copy_to(implanted.forensic_holder)
 					boutput(M, SPAN_ALERT("You are struck by shrapnel!"))
 
 			T.hotspot_expose(700,125)

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -586,17 +586,18 @@ toxic - poisons
 	on_hit(atom/hit, direction, obj/projectile/P)
 		..()
 		var/turf/T = istype(hit, /mob) ? get_turf(hit) : get_turf(P) // drop on same tile if mob, drop 1 tile away otherwise
-		drop_as_ammo(get_turf(T))
+		drop_as_ammo(get_turf(T), P)
 		qdel(P) // we dropped, don't keep going
 
 	on_max_range_die(obj/projectile/P)
 		..()
-		drop_as_ammo(get_turf(P))
+		drop_as_ammo(get_turf(P), P)
 
-	proc/drop_as_ammo(turf/T)
+	proc/drop_as_ammo(turf/T, obj/projectile/P)
 		if(T)
-			var/obj/item/ammo/bullets/foamdarts/ammo_dropped = new /obj/item/ammo/bullets/foamdarts (T)
+			var/obj/item/ammo/bullets/foamdarts/ammo_dropped = new /obj/item/ammo/bullets/foamdarts(T)
 			ammo_dropped.amount_left = 1
+			ammo_dropped.forensic_holder = P.forensic_holder
 			ammo_dropped.UpdateIcon()
 			ammo_dropped.pixel_x += rand(-12,12)
 			ammo_dropped.pixel_y += rand(-12,12)

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -21,9 +21,6 @@
 	var/_health = 100
 	var/_max_health = 100
 
-	/// if gun/bullet related, forensic profile of it
-	var/forensic_ID = null
-
 	New()
 		. = ..()
 		if (HAS_FLAG(object_flags, HAS_DIRECTIONAL_BLOCKING))
@@ -128,11 +125,6 @@
 		if (isnull(src.real_name) && !isnull(src.name))
 			src.real_name = src.name
 		src.name = "[name_prefix(null, 1)][src.real_name || initial(src.name)][name_suffix(null, 1)]"
-
-	on_forensic_scan(datum/forensic_scan/scan)
-		. = ..()
-		if(src.forensic_ID)
-			scan.add_text("Forensic profile: [src.forensic_ID]")
 
 	proc/can_access_remotely(mob/user)
 		. = FALSE
@@ -414,15 +406,6 @@
 		return TRUE
 
 /obj/proc/after_abcu_spawn()
-
-/// creates an id profile for any forenics purpose. override as needed
-/obj/proc/CreateID()
-	. = ""
-
-	do
-		for(var/i = 1 to 10) // 20 characters are way too fuckin' long for anyone to care about
-			. += "[pick(numbersAndLetters)]"
-	while(. in forensic_IDs)
 
 /obj/proc/become_frame(mob/user, flatpack = FALSE)
 	// Prevent glue based frame exploits

--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -18,15 +18,11 @@ ABSTRACT_TYPE(/obj/item/turret_deployer)
 	var/associated_turret = null //what kind of turret should this spawn?
 	var/turret_health = 100
 
-	New(newLoc, forensics_id)
+	var/datum/forensic_id/forensic_profile = null // Forensic profile of the gun
+
+	New(newLoc)
 		..()
 		icon_state = "[src.icon_tag]_deployer"
-		if (!src.forensic_ID)
-			if (forensics_id)
-				src.forensic_ID = forensics_id
-			else
-				src.forensic_ID = src.CreateID()
-				forensic_IDs.Add(src.forensic_ID)
 
 	get_desc()
 		. = "<br>[SPAN_NOTICE("It looks [damage_words]")]"
@@ -143,17 +139,18 @@ ADMIN_INTERACT_PROCS(/obj/deployable_turret, proc/admincmd_shoot, proc/admincmd_
 	var/can_toggle_activation = TRUE // whether you can enable or disable the turret with a screwdriver, used for map setpiece turrets
 	var/emagged = FALSE
 
-	New(loc, direction, forensics_id)
+	var/datum/forensic_id/forensic_profile = null // Forensic profile of the gun
+
+	New(loc, direction, var/datum/forensic_id/gun_id)
 		..()
 		src.set_dir(direction || src.dir) // don't set the dir if we weren't passed one
 		src.set_initial_angle()
 
-		if (!src.forensic_ID)
-			if (forensics_id)
-				src.forensic_ID = forensics_id
-			else
-				src.forensic_ID = src.CreateID()
-				forensic_IDs.Add(src.forensic_ID)
+		if (gun_id)
+			src.forensic_profile = gun_id
+		else
+			var/char_list_gun = list("=","=","+","-","#","H","8")
+			src.forensic_profile = register_id("=[build_id(char_list_gun, 9)]=")
 
 		src.icon_state = "[src.icon_tag]_base"
 		src.appearance_flags |= RESET_TRANSFORM
@@ -187,6 +184,11 @@ ADMIN_INTERACT_PROCS(/obj/deployable_turret, proc/admincmd_shoot, proc/admincmd_
 
 	get_desc(dist)
 		. = "<br>[SPAN_NOTICE("It looks [src.damage_words]. It is [src.anchored ? "secured to" : "unsecured from"] the floor and powered [src.active ? "on" : "off"].")]"
+
+	on_forensic_scan(datum/forensic_scan/scan)
+		. = ..()
+		var/datum/forensic_data/basic/gun_profile_data = new(src.forensic_profile, gun_profile_display)
+		scan.add_data(gun_profile_data)
 
 	proc/set_initial_angle()
 		switch(src.dir)
@@ -230,6 +232,8 @@ ADMIN_INTERACT_PROCS(/obj/deployable_turret, proc/admincmd_shoot, proc/admincmd_
 				if (src.current_projectile.casing)
 					picked_turf = pick(casing_turfs)
 					var/obj/item/casing/turret_casing = new src.current_projectile.casing(picked_turf, src)
+					var/datum/forensic_data/basic/gun_profile_data = new(src.forensic_profile, gun_profile_display)
+					turret_casing.add_evidence(gun_profile_data, FORENSIC_GROUP_NOTES)
 					// prevent infinite casing stacks
 					if (length(picked_turf.contents) > 10)
 						SPAWN(30 SECONDS)
@@ -396,11 +400,12 @@ ADMIN_INTERACT_PROCS(/obj/deployable_turret, proc/admincmd_shoot, proc/admincmd_
 		qdel(src)
 
 	proc/spawn_deployer()
-		var/obj/item/turret_deployer/deployer = new src.associated_deployer(src.loc, src.forensic_ID)
+		var/obj/item/turret_deployer/deployer = new src.associated_deployer(src.loc)
 		deployer.turret_health = src.health // NO FREE REPAIRS, ASSHOLES
 		deployer.damage_words = src.damage_words
 		deployer.quick_deploy_fuel = src.quick_deploy_fuel
 		deployer.tooltip_rebuild = TRUE
+		deployer.forensic_profile = src.forensic_profile
 		qdel(src)
 		return deployer
 

--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -149,8 +149,7 @@ ADMIN_INTERACT_PROCS(/obj/deployable_turret, proc/admincmd_shoot, proc/admincmd_
 		if (gun_id)
 			src.forensic_profile = gun_id
 		else
-			var/char_list_gun = list("=","=","+","-","#","H","8")
-			src.forensic_profile = register_id("=[build_id(char_list_gun, 9)]=")
+			src.forensic_profile = register_id("=[build_id(FORENSIC_CHARS_BALLISTICS, 9)]=")
 
 		src.icon_state = "[src.icon_tag]_base"
 		src.appearance_flags |= RESET_TRANSFORM

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -1,4 +1,3 @@
-var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder uID stuff
 
 /obj/item/gun
 	name = "gun"
@@ -92,6 +91,8 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	var/camera_recoil_sway_min = 0 //! Minimum recoil variance
 	var/camera_recoil_sway_max = 20 //! Maximum recoil variance
 
+	var/datum/forensic_id/forensic_profile = null
+
 
 	buildTooltipContent()
 		. = ..() + src.current_projectile?.get_tooltip_content()
@@ -99,9 +100,8 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 
 	New()
 		src.AddComponent(/datum/component/log_item_pickup, first_time_only=FALSE, authorized_job=null, message_admins_too=FALSE)
-		SPAWN(2 SECONDS)
-			src.forensic_ID = src.CreateID()
-			forensic_IDs.Add(src.forensic_ID)
+		var/char_list_gun = list("=","=","+","-","#","H","8")
+		src.forensic_profile = register_id("=[build_id(char_list_gun, 9)]=")
 		return ..()
 
 	// equip handling for weapons that fit on your back
@@ -118,6 +118,11 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 		if (user.back.storage.check_can_hold(src) == STORAGE_CAN_HOLD)
 			user.back.Attackby(src, user)
 			return TRUE
+
+	on_forensic_scan(datum/forensic_scan/scan)
+		. = ..()
+		var/datum/forensic_data/basic/gun_profile_data = new(src.forensic_profile, gun_profile_display)
+		scan.add_data(gun_profile_data)
 
 ///CHECK_LOCK
 ///Call to run a weaponlock check vs the users implant
@@ -343,10 +348,11 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 			P.shooter = null
 			P.mob_shooter = user
 
-		P.forensic_ID = src.forensic_ID // Was missing (Convair880).
+		var/datum/forensic_data/basic/gun_profile_data = new(src.forensic_profile, gun_profile_display)
+		P.add_evidence(gun_profile_data, FORENSIC_GROUP_NOTES)
 		if(isobj(P.implanted))
 			var/obj/O = P.implanted
-			O.forensic_holder = P.forensic_holder
+			O.forensic_holder = P.forensic_holder // Any evidence applied to the projectile will also be applied to the bullet
 		if(BOUNDS_DIST(user, target) == 0)
 			P.was_pointblank = 1
 			hit_with_existing_projectile(P, target) // Includes log entry.
@@ -429,7 +435,8 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 
 	var/obj/projectile/P = shoot_projectile_ST_pixel_spread(user, current_projectile, target, POX, POY, spread, alter_proj = new/datum/callback(src, PROC_REF(alter_projectile)), called_target = called_target)
 	if (P)
-		P.forensic_ID = src.forensic_ID
+		var/datum/forensic_data/basic/gun_profile_data = new(src.forensic_profile, gun_profile_display)
+		P.add_evidence(gun_profile_data, FORENSIC_GROUP_NOTES)
 		if(isobj(P.implanted))
 			var/obj/O = P.implanted
 			O.forensic_holder = P.forensic_holder

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -100,8 +100,7 @@
 
 	New()
 		src.AddComponent(/datum/component/log_item_pickup, first_time_only=FALSE, authorized_job=null, message_admins_too=FALSE)
-		var/char_list_gun = list("=","=","+","-","#","H","8")
-		src.forensic_profile = register_id("=[build_id(char_list_gun, 9)]=")
+		src.forensic_profile = register_id("=[build_id(FORENSIC_CHARS_BALLISTICS, 9)]=")
 		return ..()
 
 	// equip handling for weapons that fit on your back

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -120,8 +120,9 @@
 
 	on_forensic_scan(datum/forensic_scan/scan)
 		. = ..()
-		var/datum/forensic_data/basic/gun_profile_data = new(src.forensic_profile, gun_profile_display)
-		scan.add_data(gun_profile_data)
+		if(src.forensic_profile)
+			var/datum/forensic_data/basic/gun_profile_data = new(src.forensic_profile, gun_profile_display)
+			scan.add_data(gun_profile_data)
 
 ///CHECK_LOCK
 ///Call to run a weaponlock check vs the users implant
@@ -347,8 +348,6 @@
 			P.shooter = null
 			P.mob_shooter = user
 
-		var/datum/forensic_data/basic/gun_profile_data = new(src.forensic_profile, gun_profile_display)
-		P.add_evidence(gun_profile_data, FORENSIC_GROUP_NOTES)
 		if(isobj(P.implanted))
 			var/obj/O = P.implanted
 			O.forensic_holder = P.forensic_holder // Any evidence applied to the projectile will also be applied to the bullet
@@ -372,6 +371,9 @@
 		return
 
 /obj/item/gun/proc/alter_projectile(var/obj/projectile/P)
+	if(P && src.forensic_profile)
+		var/datum/forensic_data/basic/gun_profile_data = new(src.forensic_profile, gun_profile_display)
+		P.add_evidence(gun_profile_data, FORENSIC_GROUP_NOTES)
 	return
 
 /obj/item/gun/proc/Shoot(turf/target, turf/start, mob/user, POX, POY, is_dual_wield, atom/called_target = null)
@@ -434,8 +436,6 @@
 
 	var/obj/projectile/P = shoot_projectile_ST_pixel_spread(user, current_projectile, target, POX, POY, spread, alter_proj = new/datum/callback(src, PROC_REF(alter_projectile)), called_target = called_target)
 	if (P)
-		var/datum/forensic_data/basic/gun_profile_data = new(src.forensic_profile, gun_profile_display)
-		P.add_evidence(gun_profile_data, FORENSIC_GROUP_NOTES)
 		if(isobj(P.implanted))
 			var/obj/O = P.implanted
 			O.forensic_holder = P.forensic_holder

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -188,7 +188,9 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 						var/number_of_casings = max(1, src.current_projectile.shot_number)
 						//DEBUG_MESSAGE("Ejected [number_of_casings] casings from [src].")
 						for (var/i in 1 to number_of_casings)
-							new src.current_projectile.casing(T, src)
+							var/atom/casing = new src.current_projectile.casing(T, src)
+							var/datum/forensic_data/basic/gun_profile_data = new(src.forensic_profile, gun_profile_display)
+							casing.add_evidence(gun_profile_data, FORENSIC_GROUP_NOTES)
 			else
 				if (src.casings_to_eject < 0)
 					src.casings_to_eject = 0
@@ -204,7 +206,9 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 						var/number_of_casings = max(1, src.current_projectile.shot_number)
 						//DEBUG_MESSAGE("Ejected [number_of_casings] casings from [src].")
 						for (var/i in 1 to number_of_casings)
-							new src.current_projectile.casing(T, src)
+							var/atom/casing = new src.current_projectile.casing(T, src)
+							var/datum/forensic_data/basic/gun_profile_data = new(src.forensic_profile, gun_profile_display)
+							casing.add_evidence(gun_profile_data, FORENSIC_GROUP_NOTES)
 			else
 				if (src.casings_to_eject < 0)
 					src.casings_to_eject = 0
@@ -269,7 +273,9 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 			if(T)
 				//DEBUG_MESSAGE("Ejected [src.casings_to_eject] [src.current_projectile.casing] from [src].")
 				while (src.casings_to_eject > 0)
-					new src.current_projectile.casing(T, src)
+					var/atom/casing = new src.current_projectile.casing(T, src)
+					var/datum/forensic_data/basic/gun_profile_data = new(src.forensic_profile, gun_profile_display)
+					casing.add_evidence(gun_profile_data, FORENSIC_GROUP_NOTES)
 					src.casings_to_eject--
 		return
 
@@ -483,7 +489,6 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	src.pixel_x += rand(-12,12)
 	src.set_dir(pick(alldirs))
 	if(firearm)
-		src.forensic_ID = firearm.forensic_ID
 		//Only include the default name of the gun, some special names set randomly in new are confusing and labels shouldnt be readable
 		src.fired_by = initial(firearm.name)
 

--- a/code/obj/torpedoes.dm
+++ b/code/obj/torpedoes.dm
@@ -16,6 +16,7 @@
 				else
 					M.TakeDamage("chest", 15, 0)
 					var/obj/item/implant/projectile/shrapnel/implanted = new /obj/item/implant/projectile/shrapnel
+					src.forensic_holder.copy_to(implanted.forensic_holder)
 					implanted.implanted(M, null, 2)
 					boutput(M, SPAN_ALERT("You are struck by shrapnel!"))
 					if (!M.stat)


### PR DESCRIPTION
## About the PR
- Moves ballistic forensics over to the new forensic system.
- Gun profiles have different IDs (meant to mimic a gun barrel) and are now applied to bullet casings.
- Projectiles and their implants now share the same forensic_holder, so forensic evidence applied to the projectile will also be applied the the implanted bullet.

## Why's this needed?
- Ballistic forensics should now be more reliable and easier to edit.

## Testing
<img width="1183" height="607" alt="Screenshot 2026-05-13 033957" src="https://github.com/user-attachments/assets/74f103ea-0d14-4eab-ae7d-9850c25112bc" />

## Changelog
```changelog
(u)LorrMaster
(*)More reliable ballistic forensics
```
