### PR TITLE
Portable Reclaimer outputs leftover material as sheets

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -676,6 +676,8 @@
 	icon = 'icons/obj/items/materials/scrap.dmi'
 	icon_state = "scrapA_1"
 	stack_type = /obj/item/raw_material/scrap_metal
+	amount = 10
+	material_amt = 0.1
 	burn_possible = FALSE
 	mat_changename = TRUE
 	material_name = "Steel"
@@ -919,24 +921,21 @@
 			if (istype(M, /obj/item/wizard_crystal))
 				var/obj/item/wizard_crystal/wc = M
 				wc.setMaterial(getMaterial(wc.assoc_material),0,0,1,0)
-
 			if (!istype(M.material))
 				M.set_loc(src.loc)
 				src.reject = 1
 				continue
-
 			else if (istype(M, /obj/item/cable_coil))
 				var/obj/item/cable_coil/C = M
 				reclaim_materials(C.material, C.material_amt * C.amount)
 				reclaim_materials(C.conductor, C.material_amt * C.amount)
 				qdel(C)
-
 			else
 				reclaim_materials(M.material, M.material_amt * M.amount)
 				qdel(M)
-
 			sleep(smelt_interval)
 
+		output_scrap()
 		if (reject)
 			src.reject = 0
 			src.visible_message("<b>[src]</b> emits an angry buzz and rejects some unsuitable materials!")
@@ -956,11 +955,9 @@
 		leftovers[material_id] = material_amount - num_of_bars
 		output_bar(material_reclaim, num_of_bars)
 
-	proc/output_bar(material, amount)
-
+	proc/output_bar(var/datum/material/material, var/amount)
 		if(amount <= 0)
 			return
-
 		var/datum/material/MAT = material
 		if (!istype(MAT))
 			MAT = getMaterial(material)
@@ -985,8 +982,36 @@
 				if (BAR.material.isSameMaterial(other_bar.material))
 					if (other_bar.stack_item(BAR))
 						break
-
 		playsound(src.loc, sound_process, 40, 1)
+
+	proc/output_scrap()
+		// Dump leftover materials as scrap when finished
+		var/atom/output_location = src.get_output_location()
+		if (istype(output_location, /obj/machinery/manufacturer))
+			output_location = get_turf(src)
+
+		var/obj/item/raw_material/scrap_metal/dummy = new() // Just here to get the material_amt for scrap metal
+		for(var/leftover_id in leftovers)
+			if(leftovers[leftover_id] < dummy.material_amt)
+				continue
+			var/datum/material/material_reclaim = getMaterial(leftover_id)
+			if(!material_reclaim)
+				continue
+			var/material_amount = leftovers[leftover_id]
+			var/num_of_scrap = floor(material_amount * 10)
+			leftovers[leftover_id] = material_amount - (num_of_scrap * 0.1)
+
+			var/obj/item/raw_material/scrap_metal/scrap = new()
+			scrap.setMaterial(material_reclaim)
+			scrap.set_stack_amount(num_of_scrap)
+			scrap.set_loc(output_location)
+			for (var/obj/item/raw_material/scrap_metal/other_scrap in output_location.contents)
+				if (other_scrap == scrap)
+					continue
+				if (scrap.material.isSameMaterial(other_scrap.material))
+					if (other_scrap.stack_item(scrap))
+						break
+			playsound(src.loc, sound_process, 40, 1)
 
 	proc/load_reclaim(obj/item/W as obj, mob/user as mob)
 		. = FALSE

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -676,8 +676,6 @@
 	icon = 'icons/obj/items/materials/scrap.dmi'
 	icon_state = "scrapA_1"
 	stack_type = /obj/item/raw_material/scrap_metal
-	amount = 10
-	material_amt = 0.1
 	burn_possible = FALSE
 	mat_changename = TRUE
 	material_name = "Steel"
@@ -935,7 +933,7 @@
 				qdel(M)
 			sleep(smelt_interval)
 
-		output_scrap()
+		output_sheets()
 		if (reject)
 			src.reject = 0
 			src.visible_message("<b>[src]</b> emits an angry buzz and rejects some unsuitable materials!")
@@ -984,13 +982,13 @@
 						break
 		playsound(src.loc, sound_process, 40, 1)
 
-	proc/output_scrap()
+	proc/output_sheets()
 		// Dump leftover materials as scrap when finished
 		var/atom/output_location = src.get_output_location()
 		if (istype(output_location, /obj/machinery/manufacturer))
 			output_location = get_turf(src)
 
-		var/obj/item/raw_material/scrap_metal/dummy = new() // Just here to get the material_amt for scrap metal
+		var/obj/item/sheet/dummy = new() // Just here to get the material_amt for scrap metal
 		for(var/leftover_id in leftovers)
 			if(leftovers[leftover_id] < dummy.material_amt)
 				continue
@@ -998,18 +996,18 @@
 			if(!material_reclaim)
 				continue
 			var/material_amount = leftovers[leftover_id]
-			var/num_of_scrap = floor(material_amount * 10)
-			leftovers[leftover_id] = material_amount - (num_of_scrap * 0.1)
+			var/num_of_sheet = floor(material_amount * 10)
+			leftovers[leftover_id] = material_amount - (num_of_sheet * 0.1)
 
-			var/obj/item/raw_material/scrap_metal/scrap = new()
-			scrap.setMaterial(material_reclaim)
-			scrap.set_stack_amount(num_of_scrap)
-			scrap.set_loc(output_location)
-			for (var/obj/item/raw_material/scrap_metal/other_scrap in output_location.contents)
-				if (other_scrap == scrap)
+			var/obj/item/sheet/sheet = new()
+			sheet.setMaterial(material_reclaim)
+			sheet.set_stack_amount(num_of_sheet)
+			sheet.set_loc(output_location)
+			for (var/obj/item/sheet/other_sheet in output_location.contents)
+				if (other_sheet == sheet)
 					continue
-				if (scrap.material.isSameMaterial(other_scrap.material))
-					if (other_scrap.stack_item(scrap))
+				if (sheet.material.isSameMaterial(other_sheet.material))
+					if (other_sheet.stack_item(sheet))
 						break
 			playsound(src.loc, sound_process, 40, 1)
 


### PR DESCRIPTION
## About the PR
- When finished, the portable reclaimer will output leftover materials as sheets.
- Sheets themselves are unaffected in this PR. As-is sheets of any material can be obtained this way (such as char sheets). They do not seem to be able to be used to build anything though. 

## Why's this needed?
- Makes the portable reclaimer less confusing when reclaiming less than a full bar of material.
- Fixes #22182 
- Fixes #14724

## Testing
<img width="292" height="227" alt="Screenshot 2026-06-15 054716" src="https://github.com/user-attachments/assets/6f3ec73c-cfdd-4b39-b700-4244521ff0cf" />

## Changelog
```changelog
(u)LorrMaster
(*)Portable reclaimer now outputs leftover material as sheets.
```
