### PR TITLE
increases water bottle initial volume from 25 to 75

### DIFF
--- a/code/modules/cooking/food_and_drink/drinks.dm
+++ b/code/modules/cooking/food_and_drink/drinks.dm
@@ -179,7 +179,7 @@
 	desc = "I wonder if this is still fresh?"
 	icon_state = "water"
 	item_state = "water"
-	initial_volume = 25
+	initial_volume = 75
 	initial_reagents = "water"
 
 /obj/item/reagent_containers/food/drinks/mate


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

increases reagent capacity of water bottle

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

lil babby mugs get 50u but BIG BOY water bottle gets 25? no thanks

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="1381" height="885" alt="image" src="https://github.com/user-attachments/assets/d5672287-5f94-4ae3-bfe1-d9b77b0f633c" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bork
(+)water bottles hold 75u instead of 25u now.
```
