### PR TITLE
Manufacturing pattern forensic IDs

### DIFF
--- a/_std/defines/forensics.dm
+++ b/_std/defines/forensics.dm
@@ -39,6 +39,10 @@
 // Chose 16 letters that look distinct and sort of fingerprinty with curves and such
 #define FORENSIC_CHARS_FINGERPRINTS list("a","b","c","d","e","g","n","o","p","q","s","u","v","x","y","z")
 #define FORENSIC_CHARS_HEX list("0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F")
+// Letters that do not look like numbers (such as 'D', 'O', 'I', etc)
+#define FORENSIC_CHARS_UPPER_LIMITED list("A","B","C","E","F","H","K","L","M","N","P","R","T","U","V","W","X","Y","Z")
+#define FORENSIC_CHARS_LOWER_LIMITED list("a","b","c","d","e","f","g","h","k","m","n","p","q","r","s","t","u","v","w","x","y","z")
+#define FORENSIC_CHARS_NUMBERS list("0","1","2","3","4","5","6","7","8","9")
 
 #define FORENSIC_GLOVE_MASK_FINGERLESS "0123-4567-89AB-CDEF"
 #define FORENSIC_GLOVE_MASK_NONE "...???..."

--- a/code/modules/forensics/forensic_id.dm
+++ b/code/modules/forensics/forensic_id.dm
@@ -54,6 +54,21 @@ var/global/list/datum/forensic_id/registered_id_list = new()
 
 /proc/build_id_fingerprint(var/list/char_list)
 	return build_id_separate(build_id_norepeat(char_list, 16), 4)
+/proc/build_id_pattern(var/str_pattern)
+	// L = Uppercase Letter | l = Lowercase Letter | # = Number
+	var/result = ""
+	for(var/i in 1 to length(str_pattern))
+		var/char = copytext(str_pattern, i, i + 1)
+		switch(char)
+			if("L") // Uppercase letters
+				result += pick(FORENSIC_CHARS_UPPER_LIMITED)
+			if("l")
+				result += pick(FORENSIC_CHARS_LOWER_LIMITED)
+			if("#") // Uppercase letters
+				result += pick(FORENSIC_CHARS_NUMBERS)
+			else
+				result += char
+	return result
 
 // -----| Forensic Display |-----
 

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1720,6 +1720,10 @@ TYPEINFO(/obj/machinery/networked/printer)
 	var/blinking = 0 //Is our indicator light blinking?
 	var/sheets_remaining = 15 //How many blank sheets of paper do we have left?
 
+	var/static/datum/forensic_display/forensic_pattern_disp = new("Recently Printed: @F")
+	var/forensic_pattern_prefix = "PRINTER"
+	var/datum/forensic_id/forensic_pattern
+
 #define MAX_SHEETS 20
 #define SETUP_JAM_IGNITION 6 //How jammed do we have to be before we break down?
 #define MAX_PRINTBUFFER_SIZE 10
@@ -1730,6 +1734,7 @@ TYPEINFO(/obj/machinery/networked/printer)
 		src.AddComponent(/datum/component/obj_projectile_damage)
 		if(!print_id)
 			src.print_id = "GENERIC"
+		src.forensic_pattern = register_id("[src.forensic_pattern_prefix]-[build_id_pattern("L###")]")
 
 		SPAWN(0.5 SECONDS)
 			src.net_id = generate_net_id(src)
@@ -2034,6 +2039,10 @@ TYPEINFO(/obj/machinery/networked/printer)
 
 		return
 
+	on_forensic_scan(datum/forensic_scan/scan)
+		. = ..()
+		scan.add_text("Printing Pattern: [src.forensic_pattern.id]")
+
 	proc
 		print()
 			if(status & (NOPOWER|BROKEN))
@@ -2074,15 +2083,14 @@ TYPEINFO(/obj/machinery/networked/printer)
 
 				if (istype(print_text, /datum/computer/file/image)) // trying to print a photo! :I
 					var/datum/computer/file/image/IMG = print_text
-					/*var/obj/item/photo/P = */new/obj/item/photo(src.loc, IMG.ourImage, IMG.ourIcon, IMG.img_name, IMG.img_desc)
-					/*P.fullImage = IMG.ourImage ? IMG.ourImage : image(IMG.ourIcon)
-					P.fullIcon = IMG.ourIcon
-					P.name = IMG.img_name
-					P.desc = IMG.img_desc*/
+					var/obj/item/photo/P = new(src.loc, IMG.ourImage, IMG.ourIcon, IMG.img_name, IMG.img_desc)
+					var/datum/forensic_data/basic/pattern_data = new(src.forensic_pattern, src.forensic_pattern_disp)
+					P.add_evidence(pattern_data)
 				else
 					var/obj/item/paper/P = new /obj/item/paper
 					P.set_loc(src.loc)
-
+					var/datum/forensic_data/basic/pattern_data = new(src.forensic_pattern, src.forensic_pattern_disp)
+					P.add_evidence(pattern_data)
 
 					var/titlepoint = findtext(print_text, "&title;",1 , 72)
 					if (titlepoint)

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -405,10 +405,14 @@
 	var/boot_time = null
 	var/data_initialized = FALSE
 
+	var/static/datum/forensic_display/forensic_pattern_disp = new("Recently Printed: @F")
+	var/datum/forensic_id/forensic_pattern
+
 /obj/machinery/rkit/New()
 	. = ..()
 	known_rucks = new
 	ruck_controls = new
+	src.forensic_pattern = register_id("RUCK-[build_id_pattern("L###")]")
 	MAKE_SENDER_RADIO_PACKET_COMPONENT(src.net_id, "pda", FREQ_PDA)
 
 	if(isnull(mechanic_controls)) mechanic_controls = ruck_controls //For objective tracking and admin
@@ -446,6 +450,10 @@
 		send_sync()
 	else
 		if (src.net_id == host_ruck) send_sync(1)
+
+/obj/machinery/rkit/on_forensic_scan(datum/forensic_scan/scan)
+		. = ..()
+		scan.add_text("Printing Pattern: [src.forensic_pattern.id]")
 
 /obj/machinery/rkit/proc/send_sync(var/dispose) //Request SYNCREPLY from other rucks
 	//If dispose is true we use "DROP" which won't be saved as the host
@@ -765,7 +773,9 @@
 				playsound(src.loc, 'sound/machines/printer_thermal.ogg', 25, 1)
 				SPAWN(2.5 SECONDS)
 					if (src)
-						new /obj/item/paper/manufacturer_blueprint(src.loc, M)
+						var/obj/item/paper/manufacturer_blueprint/blueprint = new(src.loc, M)
+						var/datum/forensic_data/basic/pattern_data = new(src.forensic_pattern, src.forensic_pattern_disp)
+						blueprint.add_evidence(pattern_data)
 				. = TRUE
 		if("lock")
 			if (!src.allowed(usr))

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -56,10 +56,13 @@ TYPEINFO(/obj/machinery/glass_recycler)
 	event_handler_flags = NO_MOUSEDROP_QOL
 
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS
+	var/static/datum/forensic_display/forensic_pattern_disp = new("Recently Fabricated: @F")
+	var/datum/forensic_id/forensic_pattern
 
 	New()
 		..()
 		src.get_products()
+		src.forensic_pattern = register_id("GLASS-[build_id_pattern("L###")]")
 		UnsubscribeProcess()
 
 	MouseDrop_T(atom/movable/O as obj, mob/user as mob)
@@ -142,6 +145,10 @@ TYPEINFO(/obj/machinery/glass_recycler)
 			boutput(user, SPAN_ALERT("You cannot put [W] into [src]!"))
 			return FALSE
 
+	on_forensic_scan(datum/forensic_scan/scan)
+		. = ..()
+		scan.add_text("Fabrication Pattern: [src.forensic_pattern.id]")
+
 	proc/get_products()
 		product_list += new /datum/glass_product("beaker", /obj/item/reagent_containers/glass/beaker, 1)
 		product_list += new /datum/glass_product("largebeaker", /obj/item/reagent_containers/glass/beaker/large, 2)
@@ -183,6 +190,9 @@ TYPEINFO(/obj/machinery/glass_recycler)
 
 		var/obj/item/G = new target_product.product_path(get_turf(src))
 		src.glass_amt -= target_product.product_cost
+
+		var/datum/forensic_data/basic/pattern_data = new(src.forensic_pattern, src.forensic_pattern_disp)
+		G.add_evidence(pattern_data)
 
 		src.visible_message(SPAN_NOTICE("[src] manufactures \a [G]!"))
 		playsound(src.loc, 'sound/machines/vending_dispense_small.ogg', 40, 0, 0.1)

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -128,6 +128,10 @@ TYPEINFO(/obj/machinery/manufacturer)
 	///!!very hacky and dumb!! All manufacturers with the same share_id have the same storage datum, ie share materials inherently
 	var/share_id = null
 
+	var/static/datum/forensic_display/forensic_pattern_disp = new("Recently Fabricated: @F")
+	var/forensic_pattern_prefix = "FAB"
+	var/datum/forensic_id/forensic_pattern
+
 	New()
 		START_TRACKING
 		if (src.share_id)
@@ -143,6 +147,7 @@ TYPEINFO(/obj/machinery/manufacturer)
 		..()
 		MAKE_SENDER_RADIO_PACKET_COMPONENT(src.net_id, null, src.frequency)
 		src.net_id = generate_net_id(src)
+		src.forensic_pattern = register_id("[src.forensic_pattern_prefix]-[build_id_pattern("L###")]")
 
 		if(!src.link)
 			var/turf/T = get_turf(src)
@@ -1515,6 +1520,10 @@ TYPEINFO(/obj/machinery/manufacturer)
 				src.speed = given_speed
 				post_signal(list("address_1" = sender, "sender" = src.net_id, "command" = "term_message", "data" = "ACK#SPEEDSET"))
 
+	on_forensic_scan(datum/forensic_scan/scan)
+		. = ..()
+		scan.add_text("Fabrication Pattern: [src.forensic_pattern.id]")
+
 	proc/post_signal(var/list/data)
 		var/datum/signal/new_signal = get_free_signal()
 		new_signal.source = src
@@ -1863,6 +1872,9 @@ TYPEINFO(/obj/machinery/manufacturer)
 		else if (isobj(product) || ismob(product))
 			A = product
 			A.set_loc(get_output_location())
+		if(A)
+			var/datum/forensic_data/basic/pattern_data = new(src.forensic_pattern, src.forensic_pattern_disp)
+			A.add_evidence(pattern_data)
 
 		return A
 

--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -4,6 +4,7 @@
 /obj/machinery/manufacturer/general
 	name = "general manufacturer"
 	supplemental_desc = "This one produces tools and other hardware, as well as general-purpose items like replacement lights."
+	forensic_pattern_prefix = "GEN"
 	free_resources = list(/obj/item/material_piece/steel = 5,
 		/obj/item/material_piece/copper = 5,
 		/obj/item/material_piece/glass = 5)
@@ -88,6 +89,7 @@
 	name = "grody manufacturer"
 	desc = "It's covered in more gunk than a truck stop ashtray. Is this thing even safe?"
 	supplemental_desc = "This one has seen better days. There are bits and pieces of the internal mechanisms poking out the side."
+	forensic_pattern_prefix = "GRODY"
 	free_resources = list()
 	malfunction = TRUE
 	wires = 15 & ~(1 << 3) // This cuts the malfunction wire, so the fab malfunctions immediately
@@ -98,6 +100,7 @@
 	supplemental_desc = "This one produces robot parts, cybernetic organs, and other robotics-related equipment."
 	icon_state = "fab-robotics"
 	icon_base = "robotics"
+	forensic_pattern_prefix = "ROBO"
 	free_resources = list(/obj/item/material_piece/steel = 5,
 		/obj/item/material_piece/copper = 5,
 		/obj/item/material_piece/glass = 5)
@@ -202,6 +205,7 @@
 	supplemental_desc = "This one produces medical equipment and sterile clothing."
 	icon_state = "fab-med"
 	icon_base = "med"
+	forensic_pattern_prefix = "MEDIC"
 	free_resources = list(/obj/item/material_piece/steel = 2,
 		/obj/item/material_piece/copper = 2,
 		/obj/item/material_piece/glass = 2,
@@ -272,6 +276,7 @@
 	supplemental_desc = "This one produces science equipment for experiments as well as expeditions."
 	icon_state = "fab-sci"
 	icon_base = "sci"
+	forensic_pattern_prefix = "SCI"
 	free_resources = list(/obj/item/material_piece/steel = 2,
 		/obj/item/material_piece/copper = 2,
 		/obj/item/material_piece/glass = 2,
@@ -329,6 +334,7 @@
 	supplemental_desc = "This one produces mining equipment like concussive charges and powered tools."
 	icon_state = "fab-mining"
 	icon_base = "mining"
+	forensic_pattern_prefix = "MINING"
 	free_resources = list(/obj/item/material_piece/steel = 2,
 		/obj/item/material_piece/copper = 2,
 		/obj/item/material_piece/glass = 2)
@@ -383,6 +389,7 @@
 	supplemental_desc = "This one produces modules for space pods or minisubs."
 	icon_state = "fab-hangar"
 	icon_base = "hangar"
+	forensic_pattern_prefix = "SHIP"
 	free_resources = list(/obj/item/material_piece/steel = 2,
 		/obj/item/material_piece/copper = 2,
 		/obj/item/material_piece/glass = 2)
@@ -429,6 +436,7 @@
 	supplemental_desc = "This one can create a wide variety of one-size-fits-all jumpsuits, as well as backpacks and radio headsets."
 	icon_state = "fab-jumpsuit"
 	icon_base = "jumpsuit"
+	forensic_pattern_prefix = "UNIFORM"
 	free_resources = list(/obj/item/material_piece/cloth/cottonfabric = 5,
 		/obj/item/material_piece/steel = 5,
 		/obj/item/material_piece/copper = 5)
@@ -499,6 +507,7 @@
 	icon_state = "fab-atmos"
 	icon_base = "atmos"
 	accept_blueprints = FALSE
+	forensic_pattern_prefix = "ATMOS"
 	available = list(
 		/datum/manufacture/atmos_can,
 		/datum/manufacture/air_can/large,
@@ -515,6 +524,7 @@
 	desc = "A specialized manufacturing unit designed to create new things (or copies of existing things) from blueprints."
 	icon_state = "fab-hangar"
 	icon_base = "hangar"
+	forensic_pattern_prefix = "REVERSE"
 	free_resources = list(/obj/item/material_piece/steel = 2,
 		/obj/item/material_piece/copper = 2,
 		/obj/item/material_piece/glass = 2)
@@ -524,6 +534,7 @@
 	supplemental_desc = "This one can produce blank ID cards and access implants."
 	icon_state = "fab-access"
 	icon_base = "access"
+	forensic_pattern_prefix = "ACCESS"
 	free_resources = list(/obj/item/material_piece/steel = 2,
 		/obj/item/material_piece/copper = 2,
 		/obj/item/material_piece/glass = 2)
@@ -544,6 +555,7 @@
 	supplemental_desc = "This one is a multi-purpose model, and is able to produce uniforms, headsets, and identification equipment."
 	icon_state = "fab-access"
 	icon_base = "access"
+	forensic_pattern_prefix = "UNIFORM"
 	free_resources = list(/obj/item/material_piece/steel = 5,
 		/obj/item/material_piece/copper = 5,
 		/obj/item/material_piece/glass = 5,
@@ -561,6 +573,7 @@
 	supplemental_desc = "This one produces crates, carts, that sort of thing. Y'know, box stuff."
 	icon_state = "fab-crates"
 	icon_base = "crates"
+	forensic_pattern_prefix = "CARGO"
 	free_resources = list(/obj/item/material_piece/steel = 1,
 		/obj/item/material_piece/organic/wood = 1)
 	accept_blueprints = FALSE
@@ -588,6 +601,7 @@
 	desc = "This manufacturing unit seems to have been loaded with a bunch of nonstandard blueprints, apparently to be useful in surviving \"extreme scenarios\"."
 	icon_state = "fab-crates"
 	icon_base = "crates"
+	forensic_pattern_prefix = "ZOMBIE"
 	free_resources = list(/obj/item/material_piece/steel = 50,
 		/obj/item/material_piece/copper = 50,
 		/obj/item/material_piece/glass = 50,
@@ -634,6 +648,7 @@
 	desc = "This one produces specialist engineering devices."
 	icon_state = "fab-engineering"
 	icon_base = "engineering"
+	forensic_pattern_prefix = "ENGI"
 	free_resources = list(/obj/item/material_piece/steel = 2,
 		/obj/item/material_piece/copper = 2,
 		/obj/item/material_piece/glass = 2)


### PR DESCRIPTION
## About the PR
- Fabricators, glass recyclers, network printers, and ruck kits now have a fabrication pattern ID. Items they print/make will be given a forensic note stating that they were recently printed/fabricated and an ID that can be used to trace back to where.

## Why's this needed?
- Adds another minor aspect to forensic work that could potentially be used to solve a crime. Maybe.

## Testing
<img width="531" height="724" alt="Screenshot 2026-05-13 233933" src="https://github.com/user-attachments/assets/c4ecd5ce-8e54-49e7-99a2-cbe4721afa26" />

## Changelog
```changelog
(u)LorrMaster
(*)Fabricators, glass recyclers, network printers, and ruck kits now apply a forensic ID to items they print/create.
```
