### PR TITLE
Assembled pods can be given a material by plating the pod armor

### DIFF
--- a/code/modules/transport/pods/preassembled_frame_kit.dm
+++ b/code/modules/transport/pods/preassembled_frame_kit.dm
@@ -11,6 +11,7 @@ ABSTRACT_TYPE(/obj/item/preassembled_frame_box)
 		var/obj/O = new frame_type( get_turf(user) )
 		logTheThing(LOG_STATION, user, "builds [O] in [get_area(user)] ([log_loc(user)])")
 		O.forensic_holder = src.forensic_holder
+		O.setMaterial(src.material)
 		qdel(src)
 
 /obj/item/preassembled_frame_box/putt
@@ -74,6 +75,7 @@ ABSTRACT_TYPE(/obj/structure/preassembeled_vehicleframe)
 	density = TRUE
 	HELP_MESSAGE_OVERRIDE("Use a <b>wrench</b> to secure the parts together.")
 	var/step_build_time = 10 SECONDS //per each 7 steps
+	var/datum/material/frame_material // The material of the frame in case of disassembly, stored after armor is applied
 
 /obj/structure/preassembeled_vehicleframe/puttframe
 	name = "Preassembled MiniPutt Frame"
@@ -220,15 +222,15 @@ ABSTRACT_TYPE(/obj/structure/preassembeled_vehicleframe)
 	src.help_message = "Use any kind of pod armor from a manufacturer."
 
 /obj/structure/preassembeled_vehicleframe/proc/step_armor(var/mob/user, var/obj/item/podarmor/armor)
-	user.u_equip(armor)
-	qdel(armor)
 	src.overlays += image(src.icon, armor.overlay_state)
 	src.stage = BUILD_STEP_ARMOR
 	src.help_message = "Use a <b>wrench</b> to secure the pod's thrusters and control system."
 	src.armor_type = armor.type
 	src.vehicle_type = armor.vehicle_types["[src.type]"]
-	if(istype(armor, /obj/item/podarmor/armor_custom))
-		src.setMaterial(armor.material)
+	src.frame_material = src.material
+	src.setMaterial(armor.material)
+	user.u_equip(armor)
+	qdel(armor)
 
 /obj/structure/preassembeled_vehicleframe/proc/step_wrench_2(var/mob/user)
 	src.overlays += image(src.icon, "thrust")
@@ -243,9 +245,8 @@ ABSTRACT_TYPE(/obj/structure/preassembeled_vehicleframe)
 
 /obj/structure/preassembeled_vehicleframe/proc/step_screw_2(var/mob/user)
 	var/obj/machinery/vehicle/V = new vehicle_type( src.loc )
-	if (src.armor_type == /obj/item/podarmor/armor_custom)
-		V.name = src.vehicle_name
-		V.setMaterial(src.material)
+	V.forensic_holder = src.forensic_holder
+	V.setMaterial(src.material)
 	logTheThing(LOG_STATION, user, "finishes building a [V] in [get_area(user)] ([log_loc(user)])")
 	qdel(src)
 
@@ -272,13 +273,15 @@ ABSTRACT_TYPE(/obj/structure/preassembeled_vehicleframe)
 	if (src.stage >= BUILD_STEP_ARMOR)
 		O = new src.armor_type( get_turf(src) )
 		O.forensic_holder = src.forensic_holder
-		if (istype(O,/obj/item/podarmor/armor_custom))
-			O.setMaterial(src.material)
-			src.removeMaterial()
+		O.setMaterial(src.material)
 
 	O = new src.box_type( get_turf(src) )
 	logTheThing(LOG_STATION, user, "deconstructs [src] in [get_area(user)] ([log_loc(user)])")
 	O.forensic_holder = src.forensic_holder
+	if (src.stage >= BUILD_STEP_ARMOR)
+		O.setMaterial(src.frame_material)
+	else
+		O.setMaterial(src.material)
 	qdel(src)
 
 

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -358,6 +358,7 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 /obj/structure/vehicleframe
 	var/stage = 0
 	var/obj/item/podarmor/armor_type = null
+	var/datum/material/frame_material = null // The material of the frame in case of disassembly, stored after armor is applied
 	var/engine_type = null
 	var/control_type = null
 	var/boards_type = null
@@ -381,6 +382,7 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 		var/obj/O = new /obj/structure/vehicleframe/puttframe( get_turf(user) )
 		logTheThing(LOG_STATION, user, "builds [O] in [get_area(user)] ([log_loc(user)])")
 		O.forensic_holder = src.forensic_holder
+		O.setMaterial(src.material)
 		qdel(src)
 
 /obj/item/sub/frame_box
@@ -394,6 +396,7 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 		var/obj/O = new /obj/structure/vehicleframe/subframe( get_turf(user) )
 		logTheThing(LOG_STATION, user, "builds [O] in [get_area(user)] ([log_loc(user)])")
 		O.forensic_holder = src.forensic_holder
+		O.setMaterial(src.material)
 		qdel(src)
 
 /obj/structure/vehicleframe/puttframe
@@ -465,39 +468,33 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 	var/obj/O
 	if (stage == 10)
 		O = new src.control_type( get_turf(src) )
-		O.forensic_holder = src.forensic_holder
 		stage -= 2
 	if (stage == 9)
 		stage-- // no parts involved here, this construction step is welding the exterior
 	if (stage == 8)
 		O = new src.armor_type( get_turf(src) )
-		O.forensic_holder = src.forensic_holder
-		if (istype(O,/obj/item/podarmor/armor_custom))
-			O.setMaterial(src.material)
-			src.removeMaterial()
+		O.setMaterial(src.material)
+		src.setMaterial(src.frame_material)
 		stage--
 	if (stage == 7)
 		O = new src.engine_type( get_turf(src) )
-		O.forensic_holder = src.forensic_holder
 		stage--
 	if (stage == 6)
 		var/obj/item/sheet/steel/M = new ( get_turf(src) )
 		M.amount = src.metal_amt
-		M.forensic_holder = src.forensic_holder
 		stage--
 	if (stage == 5)
 		O = new src.boards_type( get_turf(src) )
-		O.forensic_holder = src.forensic_holder
 		stage--
 	if (stage == 4)
 		var/obj/item/cable_coil/cut/C = new ( get_turf(src) )
 		C.amount = src.cable_amt
-		C.forensic_holder = src.forensic_holder
 		// all other steps were tool applications, no more parts to create
 
 	O = new src.box_type( get_turf(src) )
 	logTheThing(LOG_STATION, usr, "deconstructs [src] in [get_area(usr)] ([log_loc(usr)])")
 	O.forensic_holder = src.forensic_holder
+	O.setMaterial(src.material)
 	qdel(src)
 
 /*-----------------------------*/
@@ -631,9 +628,9 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 				src.overlays += image(src.icon, armor.overlay_state)
 				stage = 8
 				armor_type = armor.type
+				src.frame_material = src.material
+				src.setMaterial(armor.material)
 				src.vehicle_type = armor.vehicle_types["[src.type]"]
-				if(istype(W, /obj/item/podarmor/armor_custom))
-					src.setMaterial(W.material)
 			else
 				boutput(user, "You don't think you're going anywhere without a skin, do you? Get some armor!")
 
@@ -687,9 +684,7 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 
 				var/obj/machinery/vehicle/V = new vehicle_type( src.loc )
 				V.forensic_holder = src.forensic_holder
-				if (src.armor_type == /obj/item/podarmor/armor_custom)
-					V.name = src.vehicle_name
-					V.setMaterial(src.material)
+				V.setMaterial(src.material)
 				logTheThing(LOG_STATION, user, "finishes building a [V] in [get_area(user)] ([log_loc(user)])")
 				qdel(src)
 
@@ -1195,19 +1190,6 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 		"/obj/structure/preassembeled_vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/light,
 		"/obj/structure/preassembeled_vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/civilian)
 
-/obj/item/podarmor/armor_custom
-	name = "Pod Armor"
-	desc = "Plating for vehicle pods made from a custom compound."
-	icon = 'icons/obj/electronics.dmi'
-	icon_state = "dbox"
-	overlay_state = "skin1"
-	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt,
-		"/obj/structure/vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/light,
-		"/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/civilian,
-		"/obj/structure/preassembeled_vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt,
-		"/obj/structure/preassembeled_vehicleframe/podframe" = /obj/machinery/vehicle/pod_smooth/light,
-		"/obj/structure/preassembeled_vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/civilian)
-
 /obj/item/podarmor/armor_heavy
 	name = "Heavy Pod Armor"
 	desc = "Reinforced exterior plating for vehicle pods."
@@ -1353,6 +1335,7 @@ ABSTRACT_TYPE(/obj/item/podarmor)
 			var/obj/O = new /obj/structure/vehicleframe/podframe( get_turf(user) )
 			logTheThing(LOG_STATION, user, "builds [O] in [get_area(user)] ([log_loc(user)])")
 			O.forensic_holder = src.forensic_holder
+			O.setMaterial(src.material)
 			qdel(src)
 
 /obj/item/pod/paintjob


### PR DESCRIPTION
## About the PR
- Plating pod armor will now apply the material to the pod during assembly.
- The unarmored frame can also be plated, but the material will be overwritten when the armor is applied. Deconstructing the unfinished pod will recover the material of both the frame and the armor.
- Custom pod armor, which appears to have been intended for this role, has been removed since it seems to be completely unused anyways.
- Also fixed how forensic evidence is moved during construction because I noticed that it wasn't working as intended. Not directly related to pod materials, but the material and forensic data had to be applied at the same stages anyways.
- Changes have also been applied to `obj/structure/vehicleframe` just in case, but that seems to be an outdated system only used in wrestlemap anyways.

## Why's this needed?
- Allows pods to have a material, which they could not before.
- Some fixes and adjustments to pod assembly.

## Testing
<img width="359" height="717" alt="Screenshot 2026-05-14 030301" src="https://github.com/user-attachments/assets/199f7817-5501-4816-b10d-5a0adbc76db0" />
<img width="577" height="445" alt="Screenshot 2026-05-14 030314" src="https://github.com/user-attachments/assets/282a2a46-957d-4287-9b72-56cb0335be63" />
<img width="449" height="335" alt="Screenshot 2026-05-14 030335" src="https://github.com/user-attachments/assets/75119e93-473b-4f9a-87be-7e9459335bd2" />
<img width="362" height="377" alt="Screenshot 2026-05-14 030605" src="https://github.com/user-attachments/assets/4d056e1f-1261-443e-a0ee-20cc70cc5f81" />
<img width="446" height="362" alt="Screenshot 2026-05-14 022012" src="https://github.com/user-attachments/assets/74bf0845-2006-45c3-b219-8e799a7347db" />


## Changelog
```changelog
(u)LorrMaster
(*)Assembled pods can be given a material by plating the pod armor.
```
