### PR TITLE
A bunch more syndicate stealth descriptions

### DIFF
--- a/_std/macros/descriptions.dm
+++ b/_std/macros/descriptions.dm
@@ -1,4 +1,5 @@
 // Adds a syndicate only description to any type. syndie_desc is shown to syndies and spiefs, alt_desc is shown to everyone else, both are optional.
+// Do NOT forget to add REBUILD_USER to any items with a syndicate stealth description!
 #define SYNDICATE_STEALTH_DESCRIPTION(syndie_desc, alt_desc) \
 	get_desc(dist, mob/user) { \
 		. = ..(); \

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1635,6 +1635,7 @@ ADMIN_INTERACT_PROCS(/obj/item/reagent_containers/food/drinks/drinkingglass, pro
 	wedge_y_offset = -2
 
 /obj/item/reagent_containers/food/drinks/drinkingglass/shot/syndie
+	SYNDICATE_STEALTH_DESCRIPTION("The label mentions something about \"nearly bottomless mimosas\".", null)
 	amount_per_transfer_from_this = 50
 	gulp_size = 50
 	initial_volume = 50

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1636,6 +1636,7 @@ ADMIN_INTERACT_PROCS(/obj/item/reagent_containers/food/drinks/drinkingglass, pro
 
 /obj/item/reagent_containers/food/drinks/drinkingglass/shot/syndie
 	SYNDICATE_STEALTH_DESCRIPTION("The label mentions something about \"nearly bottomless mimosas\".", null)
+	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
 	amount_per_transfer_from_this = 50
 	gulp_size = 50
 	initial_volume = 50

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -448,6 +448,7 @@ TYPEINFO(/obj/item/chem_grenade/custom)
 /obj/item/chem_grenade/fcleaner
 	name = "cleaner grenade"
 	desc = "BLAM!-brand foaming space cleaner. In a special applicator for rapid cleaning of wide areas."
+	SYNDICATE_STEALTH_DESCRIPTION("You struggle to keep a good grip on it.", null)
 	icon = 'icons/obj/items/grenade.dmi'
 	icon_state = "cleaner"
 	icon_state_armed = "cleaner1"

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -449,6 +449,7 @@ TYPEINFO(/obj/item/chem_grenade/custom)
 	name = "cleaner grenade"
 	desc = "BLAM!-brand foaming space cleaner. In a special applicator for rapid cleaning of wide areas."
 	SYNDICATE_STEALTH_DESCRIPTION("You struggle to keep a good grip on it.", null)
+	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
 	icon = 'icons/obj/items/grenade.dmi'
 	icon_state = "cleaner"
 	icon_state_armed = "cleaner1"

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -449,7 +449,7 @@ TYPEINFO(/obj/item/chem_grenade/custom)
 	name = "cleaner grenade"
 	desc = "BLAM!-brand foaming space cleaner. In a special applicator for rapid cleaning of wide areas."
 	SYNDICATE_STEALTH_DESCRIPTION("You struggle to keep a good grip on it.", null)
-	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
+	tooltip_flags = REBUILD_USER
 	icon = 'icons/obj/items/grenade.dmi'
 	icon_state = "cleaner"
 	icon_state_armed = "cleaner1"

--- a/code/modules/cooking/kitchen_items.dm
+++ b/code/modules/cooking/kitchen_items.dm
@@ -435,6 +435,7 @@ TRAYS
 
 /obj/item/kitchen/utensil/knife/pizza_cutter/traitor
 	SYNDICATE_STEALTH_DESCRIPTION("The blade is illegally sharp.", null)
+	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
 	var/sharpener_mode = FALSE
 
 	attack_self(mob/user as mob)

--- a/code/modules/cooking/kitchen_items.dm
+++ b/code/modules/cooking/kitchen_items.dm
@@ -435,7 +435,7 @@ TRAYS
 
 /obj/item/kitchen/utensil/knife/pizza_cutter/traitor
 	SYNDICATE_STEALTH_DESCRIPTION("The blade is illegally sharp.", null)
-	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
+	tooltip_flags = REBUILD_USER
 	var/sharpener_mode = FALSE
 
 	attack_self(mob/user as mob)

--- a/code/modules/cooking/kitchen_items.dm
+++ b/code/modules/cooking/kitchen_items.dm
@@ -434,6 +434,7 @@ TRAYS
 		return 1
 
 /obj/item/kitchen/utensil/knife/pizza_cutter/traitor
+	SYNDICATE_STEALTH_DESCRIPTION("The blade is illegally sharp.", null)
 	var/sharpener_mode = FALSE
 
 	attack_self(mob/user as mob)

--- a/code/modules/medical/genetics/geneticsItems.dm
+++ b/code/modules/medical/genetics/geneticsItems.dm
@@ -153,6 +153,7 @@ ADMIN_INTERACT_PROCS(/obj/item/genetics_injector/dna_injector, proc/admin_comman
 	name = "screwdriver"
 	desc = "A hollow tool used to turn slotted screws and other slotted objects."
 	SYNDICATE_STEALTH_DESCRIPTION("There's a hole in the back that is the perfect size to hold DNA injectors.", null)
+	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
 	icon = 'icons/obj/items/tools/screwdriver.dmi'
 	inhand_image_icon = 'icons/mob/inhand/tools/screwdriver.dmi'
 	icon_state = "screwdriver"

--- a/code/modules/medical/genetics/geneticsItems.dm
+++ b/code/modules/medical/genetics/geneticsItems.dm
@@ -152,6 +152,7 @@ ADMIN_INTERACT_PROCS(/obj/item/genetics_injector/dna_injector, proc/admin_comman
 /obj/item/speed_injector
 	name = "screwdriver"
 	desc = "A hollow tool used to turn slotted screws and other slotted objects."
+	SYNDICATE_STEALTH_DESCRIPTION("There's a hole in the back that is the perfect size to hold DNA injectors.", null)
 	icon = 'icons/obj/items/tools/screwdriver.dmi'
 	inhand_image_icon = 'icons/mob/inhand/tools/screwdriver.dmi'
 	icon_state = "screwdriver"

--- a/code/modules/medical/genetics/geneticsItems.dm
+++ b/code/modules/medical/genetics/geneticsItems.dm
@@ -153,7 +153,7 @@ ADMIN_INTERACT_PROCS(/obj/item/genetics_injector/dna_injector, proc/admin_comman
 	name = "screwdriver"
 	desc = "A hollow tool used to turn slotted screws and other slotted objects."
 	SYNDICATE_STEALTH_DESCRIPTION("There's a hole in the back that is the perfect size to hold DNA injectors.", null)
-	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
+	tooltip_flags = REBUILD_USER
 	icon = 'icons/obj/items/tools/screwdriver.dmi'
 	inhand_image_icon = 'icons/mob/inhand/tools/screwdriver.dmi'
 	icon_state = "screwdriver"

--- a/code/modules/scanners/electronics.dm
+++ b/code/modules/scanners/electronics.dm
@@ -19,6 +19,7 @@
 	syndicate
 		is_syndicate = TRUE
 		SYNDICATE_STEALTH_DESCRIPTION("The internal circuitry has been jailbroken.", null)
+		tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
 
 	New()
 		. = ..()

--- a/code/modules/scanners/electronics.dm
+++ b/code/modules/scanners/electronics.dm
@@ -18,6 +18,7 @@
 
 	syndicate
 		is_syndicate = TRUE
+		SYNDICATE_STEALTH_DESCRIPTION("The internal circuitry has been jailbroken.", null)
 
 	New()
 		. = ..()

--- a/code/modules/scanners/electronics.dm
+++ b/code/modules/scanners/electronics.dm
@@ -19,7 +19,7 @@
 	syndicate
 		is_syndicate = TRUE
 		SYNDICATE_STEALTH_DESCRIPTION("The internal circuitry has been jailbroken.", null)
-		tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
+		tooltip_flags = REBUILD_USER
 
 	New()
 		. = ..()

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -509,8 +509,6 @@
 /obj/item/clothing/mask/cigarette/syndicate
 	//desc = "It looks a little funny." //fucka you
 	exploding = 1
-	SYNDICATE_STEALTH_DESCRIPTION("It smells faintly of gunpowder.", null)
-	tooltip_flags = REBUILD_USER
 
 // this was in the middle of plants_food_etc.dm
 // WHY
@@ -631,8 +629,6 @@
 /obj/item/cigpacket/syndicate // cogwerks: made them more sneaky, removed the glaringly obvious name
 // haine: these can just inherit the parent name and description vOv
 	cigtype = /obj/item/clothing/mask/cigarette/syndicate
-	SYNDICATE_STEALTH_DESCRIPTION("The ingredients list notably includes gunpowder.", null)
-	tooltip_flags = REBUILD_USER
 
 /obj/item/cigpacket/update_icon()
 	src.overlays = null

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -510,7 +510,7 @@
 	//desc = "It looks a little funny." //fucka you
 	exploding = 1
 	SYNDICATE_STEALTH_DESCRIPTION("It smells faintly of gunpowder.", null)
-	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
+	tooltip_flags = REBUILD_USER
 
 // this was in the middle of plants_food_etc.dm
 // WHY
@@ -632,7 +632,7 @@
 // haine: these can just inherit the parent name and description vOv
 	cigtype = /obj/item/clothing/mask/cigarette/syndicate
 	SYNDICATE_STEALTH_DESCRIPTION("The ingredients list notably includes gunpowder.", null)
-	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
+	tooltip_flags = REBUILD_USER
 
 /obj/item/cigpacket/update_icon()
 	src.overlays = null

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -509,6 +509,7 @@
 /obj/item/clothing/mask/cigarette/syndicate
 	//desc = "It looks a little funny." //fucka you
 	exploding = 1
+	SYNDICATE_STEALTH_DESCRIPTION("It smells faintly of gunpowder.", null)
 
 // this was in the middle of plants_food_etc.dm
 // WHY
@@ -629,6 +630,7 @@
 /obj/item/cigpacket/syndicate // cogwerks: made them more sneaky, removed the glaringly obvious name
 // haine: these can just inherit the parent name and description vOv
 	cigtype = /obj/item/clothing/mask/cigarette/syndicate
+	SYNDICATE_STEALTH_DESCRIPTION("The ingredients list notably includes gunpowder.", null)
 
 /obj/item/cigpacket/update_icon()
 	src.overlays = null

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -510,6 +510,7 @@
 	//desc = "It looks a little funny." //fucka you
 	exploding = 1
 	SYNDICATE_STEALTH_DESCRIPTION("It smells faintly of gunpowder.", null)
+	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
 
 // this was in the middle of plants_food_etc.dm
 // WHY
@@ -631,6 +632,7 @@
 // haine: these can just inherit the parent name and description vOv
 	cigtype = /obj/item/clothing/mask/cigarette/syndicate
 	SYNDICATE_STEALTH_DESCRIPTION("The ingredients list notably includes gunpowder.", null)
+	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
 
 /obj/item/cigpacket/update_icon()
 	src.overlays = null

--- a/code/obj/item/clothing/plants.dm
+++ b/code/obj/item/clothing/plants.dm
@@ -231,6 +231,7 @@
 	flags = 0
 	hide_attack = ATTACK_VISIBLE
 	SYNDICATE_STEALTH_DESCRIPTION("It smells faintly of death.", null)
+	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
 	attack(mob/M, mob/user, def_zone)
 		if (!..() || is_incapacitated(M) || src.trick)
 			return

--- a/code/obj/item/clothing/plants.dm
+++ b/code/obj/item/clothing/plants.dm
@@ -230,6 +230,7 @@
 	var/trick = FALSE
 	flags = 0
 	hide_attack = ATTACK_VISIBLE
+	SYNDICATE_STEALTH_DESCRIPTION("It smells faintly of death.", null)
 	attack(mob/M, mob/user, def_zone)
 		if (!..() || is_incapacitated(M) || src.trick)
 			return

--- a/code/obj/item/clothing/plants.dm
+++ b/code/obj/item/clothing/plants.dm
@@ -231,7 +231,7 @@
 	flags = 0
 	hide_attack = ATTACK_VISIBLE
 	SYNDICATE_STEALTH_DESCRIPTION("It smells faintly of death.", null)
-	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
+	tooltip_flags = REBUILD_USER
 	attack(mob/M, mob/user, def_zone)
 		if (!..() || is_incapacitated(M) || src.trick)
 			return

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -613,6 +613,7 @@ TRASH BAG
 	item_function_flags = IMMUNE_TO_ACID
 	var/obj/item/reagent_containers/payload
 	SYNDICATE_STEALTH_DESCRIPTION("A small nozzle can be seen poking out the top.", null)
+	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
 
 	New()
 		. = ..()

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -613,7 +613,7 @@ TRASH BAG
 	item_function_flags = IMMUNE_TO_ACID
 	var/obj/item/reagent_containers/payload
 	SYNDICATE_STEALTH_DESCRIPTION("A small nozzle can be seen poking out the top.", null)
-	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
+	tooltip_flags = REBUILD_USER
 
 	New()
 		. = ..()

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -612,6 +612,7 @@ TRASH BAG
 /obj/item/caution/traitor
 	item_function_flags = IMMUNE_TO_ACID
 	var/obj/item/reagent_containers/payload
+	SYNDICATE_STEALTH_DESCRIPTION("A small nozzle can be seen poking out the top.", null)
 
 	New()
 		. = ..()

--- a/code/obj/item/storage/food.dm
+++ b/code/obj/item/storage/food.dm
@@ -10,6 +10,7 @@
 	icon_state = "glassware"
 	desc = "A box with glass cups for drinking liquids from."
 	SYNDICATE_STEALTH_DESCRIPTION("The label mentions something about \"nearly bottomless mimosas\".", null)
+	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
 	spawn_contents = list(/obj/item/reagent_containers/food/drinks/drinkingglass/shot/syndie = 7)
 
 /obj/item/storage/box/cutlery

--- a/code/obj/item/storage/food.dm
+++ b/code/obj/item/storage/food.dm
@@ -10,7 +10,7 @@
 	icon_state = "glassware"
 	desc = "A box with glass cups for drinking liquids from."
 	SYNDICATE_STEALTH_DESCRIPTION("The label mentions something about \"nearly bottomless mimosas\".", null)
-	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
+	tooltip_flags = REBUILD_USER
 	spawn_contents = list(/obj/item/reagent_containers/food/drinks/drinkingglass/shot/syndie = 7)
 
 /obj/item/storage/box/cutlery

--- a/code/obj/item/storage/food.dm
+++ b/code/obj/item/storage/food.dm
@@ -9,6 +9,7 @@
 	name = "glassware box"
 	icon_state = "glassware"
 	desc = "A box with glass cups for drinking liquids from."
+	SYNDICATE_STEALTH_DESCRIPTION("The label mentions something about \"nearly bottomless mimosas\".", null)
 	spawn_contents = list(/obj/item/reagent_containers/food/drinks/drinkingglass/shot/syndie = 7)
 
 /obj/item/storage/box/cutlery

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -223,7 +223,7 @@
 	icon_state = "flashbang"
 	spawn_contents = list(/obj/item/chem_grenade/fcleaner = 5)
 	SYNDICATE_STEALTH_DESCRIPTION("You struggle to keep a good grip on it.", null)
-	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
+	tooltip_flags = REBUILD_USER
 
 /obj/item/storage/box/grenade_starter_kit
 	name = "grenade starter kit"

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -223,6 +223,7 @@
 	icon_state = "flashbang"
 	spawn_contents = list(/obj/item/chem_grenade/fcleaner = 5)
 	SYNDICATE_STEALTH_DESCRIPTION("You struggle to keep a good grip on it.", null)
+	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
 
 /obj/item/storage/box/grenade_starter_kit
 	name = "grenade starter kit"

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -222,6 +222,7 @@
 	name = "cleaner grenade box"
 	icon_state = "flashbang"
 	spawn_contents = list(/obj/item/chem_grenade/fcleaner = 5)
+	SYNDICATE_STEALTH_DESCRIPTION("You struggle to keep a good grip on it.", null)
 
 /obj/item/storage/box/grenade_starter_kit
 	name = "grenade starter kit"

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -2367,6 +2367,7 @@ TYPEINFO(/obj/item/cargotele)
 	icon_state = "cargotelegreen"
 
 /obj/item/cargotele/traitor
+	SYNDICATE_STEALTH_DESCRIPTION("The targeting system is fluctuating rapidly.", null)
 	cost = 15
 	///The account to credit for sales
 	var/datum/db_record/account = null

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -2368,7 +2368,7 @@ TYPEINFO(/obj/item/cargotele)
 
 /obj/item/cargotele/traitor
 	SYNDICATE_STEALTH_DESCRIPTION("The targeting system is fluctuating rapidly.", null)
-	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
+	tooltip_flags = REBUILD_USER
 	cost = 15
 	///The account to credit for sales
 	var/datum/db_record/account = null

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -2368,6 +2368,7 @@ TYPEINFO(/obj/item/cargotele)
 
 /obj/item/cargotele/traitor
 	SYNDICATE_STEALTH_DESCRIPTION("The targeting system is fluctuating rapidly.", null)
+	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
 	cost = 15
 	///The account to credit for sales
 	var/datum/db_record/account = null

--- a/code/obj/storage/carts.dm
+++ b/code/obj/storage/carts.dm
@@ -152,6 +152,7 @@
 
 /obj/storage/cart/trash/syndicate
 	crunches_contents = 1
+	SYNDICATE_STEALTH_DESCRIPTION("There appears to be a crushing mechanism installed inside.", null)
 
 /obj/storage/cart/hotdog
 	name = "hotdog stand"
@@ -164,3 +165,4 @@
 /obj/storage/cart/hotdog/syndicate
 	crunches_contents = 1
 	crunches_deliciously = 1
+	SYNDICATE_STEALTH_DESCRIPTION("There appears to be a crushing mechanism installed inside.", null)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds syndicate stealth descriptions to the following syndicate stealth items:
- Syndicate shot glasses (and box) > "The label mentions something about "nearly bottomless mimosas""
- Syndicate cleaner grenades (and box) > "You struggle to keep a good grip on it"
- Pizza sharpener > "The blade is illegally sharp"
- Speed injector > "There's a hole in the back that is the perfect size to hold DNA injectors."
- Syndicate device analyzer > "The internal circuitry has been jailbroken."
- Poison rose > "It smells faintly of death."
- Slip n Sign > "A small nozzle can be seen poking out the top."
- Syndicate cargo transporter > "The targeting system is fluctuating rapidly."
- Trash compactor and hotdog cart > "There appears to be a crushing mechanism installed inside."

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows syndies to identify contraband at a glance without having to try whatever the stealth function would be and not get their stealth items mixed up with any normal items they may have.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="540" height="683" alt="image" src="https://github.com/user-attachments/assets/4a9dacd1-d81c-4942-b7b0-15d6eb3f08fb" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Many stealthy syndicate items now have special syndicate-only (indicated by being bold and red) descriptive pieces to tell syndies that the item is in fact the sneaky crime version. See the PR for the full list of items.
```
