### PR TITLE
Fixes `<mutable>` Tags Showing Up Where They Shouldn't

### DIFF
--- a/_std/defines/speech_defines/speech.dm
+++ b/_std/defines/speech_defines/speech.dm
@@ -42,7 +42,7 @@ var/regex/mutable_tags_regex = regex(@"(\<\/?mutable\>)", "g")
 #define STRIP_MUTABLE_CONTENT_TAGS(CONTENT) global.mutable_tags_regex.Replace(CONTENT, "")
 /// Selects the immutable content from a string, alongside mutable tags.
 var/regex/immutable_content_regex = regex(@"<\/mutable>.*?<mutable>|<mutable>|<\/mutable>", "g")
-/// Strips immutable tags and content from a string.
+/// Strips mutable tags and immutable content from a string.
 #define STRIP_IMMUTABLE_CONTENT(CONTENT) global.immutable_content_regex.Replace(CONTENT, "")
 /// Selects all the HTML tags present in a string.
 var/regex/html_tags_regex = regex(@"(\<.*?\>)", "g")
@@ -55,7 +55,9 @@ var/regex/mutable_content_regex = regex(@"(?<=\<mutable\>).*?(?=\<\/mutable\>)",
 /// Ensures that the content of a string is immutable.
 #define MAKE_CONTENT_IMMUTABLE(CONTENT) "</mutable>[CONTENT]<mutable>"
 /// Applies a proc to the mutable content of a say message datum in the form of a callback.
-#define APPLY_CALLBACK_TO_MESSAGE_CONTENT(_MESSAGE, _CALLBACK) _MESSAGE.content = global.mutable_content_regex.ReplaceWithCallback(_MESSAGE.content, _CALLBACK)
+#define APPLY_CALLBACK_TO_MESSAGE_CONTENT(_MESSAGE, _CALLBACK) _MESSAGE.content = APPLY_CALLBACK_TO_CONTENT(_MESSAGE.content, _CALLBACK)
+/// Applies a proc to the mutable content of a string in the form of a callback.
+#define APPLY_CALLBACK_TO_CONTENT(_CONTENT, _CALLBACK) global.mutable_content_regex.ReplaceWithCallback(_CONTENT, _CALLBACK)
 
 //-------- Soundproofing --------//
 /// Spoken lines from contents will not be emitted

--- a/code/client.dm
+++ b/code/client.dm
@@ -1021,7 +1021,7 @@ var/global/curr_day = null
 	if (!forced_desussification)
 		return
 
-	if (!phrase_log.is_sussy(message.original_content))
+	if (!phrase_log.is_sussy(message.get_original_content_parsable()))
 		return
 
 	arcFlash(message.speaker, message.speaker, forced_desussification)

--- a/code/modules/events/law_corruption.dm
+++ b/code/modules/events/law_corruption.dm
@@ -45,7 +45,7 @@ TYPEINFO(/datum/random_event/major/law_rack_corruption)
 			if(!length(src.law_text))
 				src.law_text = ticker.ai_law_rack_manager.generate_random_law(src.replace ? src.law_number : src.law_number + 1)
 
-			src.law_text = random_accent_source.process_message(src.law_text).content
+			src.law_text = random_accent_source.process_message(src.law_text).get_content()
 
 		for_by_tcl(M, /mob/living/silicon/ai)
 			if (M.deployed_to_eyecam && M.eyecam)

--- a/code/modules/events/law_corruption.dm
+++ b/code/modules/events/law_corruption.dm
@@ -45,7 +45,7 @@ TYPEINFO(/datum/random_event/major/law_rack_corruption)
 			if(!length(src.law_text))
 				src.law_text = ticker.ai_law_rack_manager.generate_random_law(src.replace ? src.law_number : src.law_number + 1)
 
-			src.law_text = random_accent_source.process_message(src.law_text).get_content()
+			src.law_text = random_accent_source.process_message(src.law_text).get_content_parsable()
 
 		for_by_tcl(M, /mob/living/silicon/ai)
 			if (M.deployed_to_eyecam && M.eyecam)

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -3127,7 +3127,7 @@ TYPEINFO(/obj/item/mechanics/miccomp)
 			return
 
 		LIGHT_UP_HOUSING
-		SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "name=[message.speaker_to_display]&message=[message.content]")
+		SEND_SIGNAL(src, COMSIG_MECHCOMP_TRANSMIT_SIGNAL, "name=[message.speaker_to_display]&message=[message.get_content_parsable()]")
 		animate_flash_color_fill(src, "#00FF00", 2, 2)
 
 	copy_identical_mechcomp(obj/item/mechanics/copied_mechcomp, mob/attacker)

--- a/code/modules/rituals/chaplainRitualBase.dm
+++ b/code/modules/rituals/chaplainRitualBase.dm
@@ -230,7 +230,7 @@ var/list/globalRituals = list() //Global list of rituals.
 		return
 
 	proc/hear(datum/say_message/message)
-		if(istype(ownerAnchor) && findtext(lowertext(message.content), lowertext(name)) )// && BOUNDS_DIST(owner, M) == 0)
+		if(istype(ownerAnchor) && findtext(lowertext(message.get_content_parsable()), lowertext(name)) )// && BOUNDS_DIST(owner, M) == 0)
 			if(!active)
 				setActive(1)
 				ownerAnchor.tryFire(message.speaker)

--- a/code/modules/speech/modules/listen/effects/artifact_trigger.dm
+++ b/code/modules/speech/modules/listen/effects/artifact_trigger.dm
@@ -13,7 +13,7 @@
 	if (!trigger || ON_COOLDOWN(O, "speech_act_cd", 2 SECONDS))
 		return
 
-	var/result = trigger.speech_act(message.original_content)
+	var/result = trigger.speech_act(message.get_original_content_parsable())
 	switch (result)
 		if (null)
 			return

--- a/code/modules/speech/modules/listen/effects/audio_log.dm
+++ b/code/modules/speech/modules/listen/effects/audio_log.dm
@@ -14,7 +14,7 @@
 	if (istype(M) && (M.mind?.assigned_role == "Captain"))
 		M.unlock_medal("Captain's Log", TRUE)
 
-	if (!audio_log.tape.add_message(message.speaker_to_display, message.content, audio_log.continuous))
+	if (!audio_log.tape.add_message(message.speaker_to_display, message.get_content_parsable(), audio_log.continuous))
 		audio_log.say("Memory full. Have a nice day.", message_params = list("speaker_to_display" = ""))
 		audio_log.mode = MODE_OFF
 		audio_log.updateSelfDialog()

--- a/code/modules/speech/modules/listen/effects/bradbury.dm
+++ b/code/modules/speech/modules/listen/effects/bradbury.dm
@@ -7,5 +7,5 @@
 		return
 
 	SPAWN(0)
-		bradbury.say(message.content, message_params = list("can_relay" = FALSE))
+		bradbury.say(message.get_content_parsable(), message_params = list("can_relay" = FALSE))
 		playsound(bradbury, 'sound/machines/modem.ogg', 80, TRUE)

--- a/code/modules/speech/modules/listen/effects/buttbot.dm
+++ b/code/modules/speech/modules/listen/effects/buttbot.dm
@@ -6,4 +6,4 @@
 	if (!istype(bot) || !bot.on || !ismob(message.speaker))
 		return
 
-	bot.butt_memory |= message.content
+	bot.butt_memory |= message.get_content_parsable()

--- a/code/modules/speech/modules/listen/effects/detgadget.dm
+++ b/code/modules/speech/modules/listen/effects/detgadget.dm
@@ -6,12 +6,13 @@
 	if (!istype(hat) || !ismob(message.speaker))
 		return
 
-	var/phrase_location = findtext(message.content, hat.phrase)
+	var/searchable_content = message.get_content_parsable()
+	var/phrase_location = findtext(searchable_content, hat.phrase)
 	if (!phrase_location)
 		return
 
 	var/mob/M = message.speaker
-	var/gadget = copytext(message.content, phrase_location + length(hat.phrase))
+	var/gadget = copytext(searchable_content, phrase_location + length(hat.phrase))
 	gadget = replacetext(gadget, " ", "")
 
 	for (var/name in hat.items)

--- a/code/modules/speech/modules/listen/effects/lawbringer.dm
+++ b/code/modules/speech/modules/listen/effects/lawbringer.dm
@@ -29,13 +29,14 @@
 	if (lawbringer.loc != message.original_speaker)
 		return
 
+	var/searchable_content = message.get_content_parsable()
 	if (!ishuman(message.original_speaker))
-		lawbringer.are_you_the_law(message.original_speaker, message.content)
+		lawbringer.are_you_the_law(message.original_speaker, searchable_content)
 		return
 
 	var/mob/living/carbon/human/H = message.original_speaker
 	if (!lawbringer.fingerprints_can_shoot(H))
-		lawbringer.are_you_the_law(H, message.content)
+		lawbringer.are_you_the_law(H, searchable_content)
 		return
 
 	if (!length(lawbringer.projectiles))
@@ -46,7 +47,7 @@
 		lawbringer.UpdateIcon()
 		return
 
-	var/text = lawbringer.sanitize_talk(message.content)
+	var/text = lawbringer.sanitize_talk(searchable_content)
 
 	for(var/valid_mode in valid_modes)
 		if(!findtext(text, valid_mode))

--- a/code/modules/speech/modules/listen/effects/meat_head.dm
+++ b/code/modules/speech/modules/listen/effects/meat_head.dm
@@ -6,4 +6,4 @@
 	if (!istype(meat_head) || prob(80))
 		return
 
-	meat_head.update_meat_head_dialog(message.content)
+	meat_head.update_meat_head_dialog(message.get_content_parsable())

--- a/code/modules/speech/modules/listen/effects/memetic_toolbox.dm
+++ b/code/modules/speech/modules/listen/effects/memetic_toolbox.dm
@@ -11,4 +11,4 @@
 		if (!M || (M == message.speaker))
 			continue
 
-		boutput(M, "<i><b><font color=blue face=Tempus Sans ITC>[message.content]</font></b></i>")
+		boutput(M, "<i><b><font color=blue face=Tempus Sans ITC>[message.get_content()]</font></b></i>")

--- a/code/modules/speech/modules/listen/effects/microphone_component.dm
+++ b/code/modules/speech/modules/listen/effects/microphone_component.dm
@@ -11,14 +11,10 @@
 		if (isnull(message.speaker_to_display))
 			message.speaker_to_display = message.real_ident || message.face_ident
 
-		content = "name=[message.speaker_to_display]&message=[message.content]"
+		content = "name=[message.speaker_to_display]&message=[message.get_content_parsable()]"
 
 	else
-		content = message.content
-
-	//we're sending it to in-game components now, so strip our internal mutability handling tags
-	content = STRIP_MUTABLE_CONTENT_TAGS(content)
-	content = strip_html_tags(content)
+		content = message.get_content_parsable()
 
 	SPAWN(0)
 		microphone.light_up_housing()

--- a/code/modules/speech/modules/listen/effects/parrot.dm
+++ b/code/modules/speech/modules/listen/effects/parrot.dm
@@ -22,7 +22,7 @@
 		boost = parrot.signing_learn_boost
 
 	if (prob(parrot.learn_words_chance + boost))
-		parrot.learn_stuff(message.content)
+		parrot.learn_stuff(message.get_content_parsable())
 
 	if (prob(parrot.learn_phrase_chance + boost))
-		parrot.learn_stuff(message.content, TRUE)
+		parrot.learn_stuff(message.get_content_parsable(), TRUE)

--- a/code/modules/speech/modules/listen/effects/prototype_maptext.dm
+++ b/code/modules/speech/modules/listen/effects/prototype_maptext.dm
@@ -2,4 +2,4 @@
 	id = LISTEN_EFFECT_PROTOTYPE_MAPTEXT
 
 /datum/listen_module/effect/prototype_maptext/process(datum/say_message/message)
-	new /obj/maptext_junk/speech(message.speaker, msg = message.content)
+	new /obj/maptext_junk/speech(message.speaker, msg = message.get_content())

--- a/code/modules/speech/modules/listen/effects/skullbot.dm
+++ b/code/modules/speech/modules/listen/effects/skullbot.dm
@@ -7,4 +7,4 @@
 		return
 
 	SPAWN(0)
-		bot.say(message.content, message_params = list("can_relay" = FALSE))
+		bot.say(message.get_content_parsable(), message_params = list("can_relay" = FALSE))

--- a/code/modules/speech/modules/speech/modifiers/dectalk.dm
+++ b/code/modules/speech/modules/speech/modifiers/dectalk.dm
@@ -9,7 +9,7 @@
 		return
 
 	SPAWN(0)
-		var/audio = dectalk("\[:nk\][STRIP_IMMUTABLE_CONTENT(message.content)]", BOTTALK_VOLUME)
+		var/audio = dectalk("\[:nk\][message.get_content_parsable()]", BOTTALK_VOLUME)
 		if (!audio || !audio["audio"])
 			return
 

--- a/code/modules/speech/modules/speech/outputs/looc.dm
+++ b/code/modules/speech/modules/speech/outputs/looc.dm
@@ -24,7 +24,7 @@
 	if (!dooc_allowed && (mob_speaker.client.deadchat != 0))
 		boutput(mob_speaker, "LOOC for dead mobs has been turned off.")
 		return
-	if (findtext(message.original_content, "byond://"))
+	if (findtext(message.get_original_content_parsable(), "byond://"))
 		boutput(mob_speaker, "<B>Advertising other servers is not allowed.</B>")
 		logTheThing(LOG_ADMIN, mob_speaker, "has attempted to advertise in LOOC.")
 		logTheThing(LOG_DIARY, mob_speaker, "has attempted to advertise in LOOC.", "admin")

--- a/code/modules/speech/modules/speech/outputs/ooc.dm
+++ b/code/modules/speech/modules/speech/outputs/ooc.dm
@@ -26,7 +26,7 @@
 	if (!dooc_allowed && (mob_speaker.client.deadchat != 0))
 		boutput(mob_speaker, "OOC for dead mobs has been turned off.")
 		return
-	if (findtext(message.original_content, "byond://"))
+	if (findtext(message.get_original_content_parsable(), "byond://"))
 		boutput(mob_speaker, "<B>Advertising other servers is not allowed.</B>")
 		logTheThing(LOG_ADMIN, mob_speaker, "has attempted to advertise in OOC.")
 		logTheThing(LOG_DIARY, mob_speaker, "has attempted to advertise in OOC.", "admin")

--- a/code/modules/speech/modules/speech/outputs/spoken/_spoken.dm
+++ b/code/modules/speech/modules/speech/outputs/spoken/_spoken.dm
@@ -8,7 +8,7 @@
 
 	if (isliving(message.speaker))
 		var/mob/living/M = message.speaker
-		M.last_words = message.content
+		M.last_words = message.get_content()
 
 	if (!src.send_to_global)
 		message.flags |= SAYFLAG_DELIMITED_CHANNEL_ONLY

--- a/code/modules/speech/say_channels/_say_channel_parent.dm
+++ b/code/modules/speech/say_channels/_say_channel_parent.dm
@@ -91,8 +91,8 @@ ABSTRACT_TYPE(/datum/say_channel)
 
 /// If a message was spoken by a client, logs the message.
 /datum/say_channel/proc/log_message(datum/say_message/message)
-	logTheThing(LOG_SAY, message.speaker, "[uppertext(src.channel_id)]: [message.prefix] [message.content] [log_loc(message.speaker)]")
-	phrase_log.log_phrase("say", message.content)
+	logTheThing(LOG_SAY, message.speaker, "[uppertext(src.channel_id)]: [message.prefix] [message.get_original_content()] [log_loc(message.speaker)]")
+	phrase_log.log_phrase("say", message.get_content())
 
 /// Set up an output module for sending messages over this channel.
 /datum/say_channel/proc/RegisterOutput(datum/speech_module/output/registree)

--- a/code/modules/speech/say_channels/deadchat.dm
+++ b/code/modules/speech/say_channels/deadchat.dm
@@ -19,8 +19,8 @@
 		RELAY_MESSAGE_TO_SAY_CHANNEL(src.ghostly_whisper_channel, message.Copy())
 
 /datum/say_channel/dead/log_message(datum/say_message/message)
-	logTheThing(LOG_SAY, message.speaker, "[uppertext(src.channel_id)]: [message.prefix] [message.content] [log_loc(message.speaker)]")
-	phrase_log.log_phrase("deadsay", message.content)
+	logTheThing(LOG_SAY, message.speaker, "[uppertext(src.channel_id)]: [message.prefix] [message.get_original_content()] [log_loc(message.speaker)]")
+	phrase_log.log_phrase("deadsay", message.get_content())
 
 
 /datum/say_channel/delimited/local/ghostly_whisper

--- a/code/modules/speech/say_channels/looc.dm
+++ b/code/modules/speech/say_channels/looc.dm
@@ -35,8 +35,8 @@
 	src.PassToListeners(message, listen_modules_by_type)
 
 /datum/say_channel/delimited/local/looc/log_message(datum/say_message/message)
-	logTheThing(LOG_OOC, message.speaker, "[uppertext(src.channel_id)]: [message.content] [log_loc(message.speaker)]")
-	phrase_log.log_phrase("looc", message.content)
+	logTheThing(LOG_OOC, message.speaker, "[uppertext(src.channel_id)]: [message.get_original_content()] [log_loc(message.speaker)]")
+	phrase_log.log_phrase("looc", message.get_content())
 
 
 /datum/say_channel/global_channel/looc

--- a/code/modules/speech/say_channels/ooc.dm
+++ b/code/modules/speech/say_channels/ooc.dm
@@ -8,5 +8,5 @@
 	suppress_speech_bubble = TRUE
 
 /datum/say_channel/ooc/log_message(datum/say_message/message)
-	logTheThing(LOG_OOC, message.speaker, "[uppertext(src.channel_id)]: [message.content] [log_loc(message.speaker)]")
-	phrase_log.log_phrase("ooc", message.content)
+	logTheThing(LOG_OOC, message.speaker, "[uppertext(src.channel_id)]: [message.get_original_content()] [log_loc(message.speaker)]")
+	phrase_log.log_phrase("ooc", message.get_content())

--- a/code/modules/speech/say_channels/outloud.dm
+++ b/code/modules/speech/say_channels/outloud.dm
@@ -146,16 +146,16 @@
 /datum/say_channel/delimited/local/outloud/log_message(datum/say_message/message)
 	var/content = ""
 	if (message.flags & SAYFLAG_SINGING)
-		content = "SAY: [html_encode(message.original_content)] [log_loc(message.speaker)]"
-		phrase_log.log_phrase("sing", message.content, user = message.speaker, strip_html = TRUE)
+		content = "SAY: [message.get_original_content()] [log_loc(message.speaker)]"
+		phrase_log.log_phrase("sing", message.get_content(), user = message.speaker)
 
 	else if (message.flags & SAYFLAG_WHISPER)
-		content = "SAY: [html_encode(message.original_content)] (WHISPER) [log_loc(message.speaker)]"
-		phrase_log.log_phrase("whisper", message.content, user = message.speaker, strip_html = TRUE)
+		content = "SAY: [message.get_original_content()] (WHISPER) [log_loc(message.speaker)]"
+		phrase_log.log_phrase("whisper", message.get_content(), user = message.speaker)
 
 	else
-		content = "SAY: [html_encode(message.original_content)] [log_loc(message.speaker)]"
-		phrase_log.log_phrase("say", message.content, user = message.speaker, strip_html = TRUE)
+		content = "SAY: [message.get_original_content()] [log_loc(message.speaker)]"
+		phrase_log.log_phrase("say", message.get_content(), user = message.speaker)
 
 	logTheThing(LOG_SAY, message.speaker, content)
 

--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -8,7 +8,7 @@
 	var/speaker_to_display = null
 	/// The text indicating where this message was spoken from, if it was spoken from inside of an object.
 	var/speaker_location_text = null
-	/// The sanitised and processed content of this message.
+	/// The processed content of this message. Do not read from this directly, lest you permit HTML injection.
 	var/content = ""
 	/// The verb to display when this message is received, i.e: "Jeff [say_verb], [message]"
 	var/say_verb = null
@@ -48,7 +48,7 @@
 	var/id = ""
 	/// The datum that should act as a signal recipient for every copy of this message.
 	var/datum/signal_recipient = null
-	/// The original contents of this message, uneditied, unsanitised.
+	/// The original contents of this message, uneditied, unsanitised. Do not read from this directly, lest you permit HTML injection.
 	var/original_content = ""
 	/// Message flags. See `_std/defines/speech_defines/sayflags.dm`.
 	var/flags = SAYFLAG_HAS_QUOTATION_MARKS
@@ -316,8 +316,8 @@
 	// Apply any message modifier flags to the message.
 	global.SpeechManager.ApplyMessageModifierPostprocessing(src)
 
-	// Apply HTML escaping to mutable characters.
-	APPLY_CALLBACK_TO_MESSAGE_CONTENT(src, CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(strip_html)))
+	// Apply HTML escaping to mutable content and strip mutable tags.
+	src.content = src.get_content()
 
 	// Apply loudness effects.
 	if (!isnull(src.message_size_override))
@@ -369,6 +369,30 @@
 		[src.format_content_style_suffix]\
 		[src.format_content_suffix]\
 	"}
+
+/// Returns the message content with HTML escaping applied to the mutable content and the mutable tags removed.
+/// Use this if you want to output the message content *directly* to the browser.
+/datum/say_message/proc/get_content()
+	var/content = src.content
+	content = APPLY_CALLBACK_TO_CONTENT(content, CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(strip_html)))
+	content = STRIP_MUTABLE_CONTENT_TAGS(content)
+
+	return content
+
+/// Returns the message content with all mutable tags and immutable content stripped.
+/// Use this if you want to search the message content or retransmit it through `say()`.
+/datum/say_message/proc/get_content_parsable()
+	return STRIP_IMMUTABLE_CONTENT(src.content)
+
+/// Returns the original message content with HTML escaping applied.
+/// Use this if you want to output the original message content *directly* to the browser.
+/datum/say_message/proc/get_original_content()
+	return strip_html(src.original_content)
+
+/// Returns the original message content in parsable format.
+/// Use this if you want to search the original message content or retransmit it through `say()`.
+/datum/say_message/proc/get_original_content_parsable()
+	return src.original_content
 
 /// Returns the heard name of the speaker, taking into account masks, voice changers, and IDs.
 /datum/say_message/proc/get_speaker_name(heard_name_only = FALSE)

--- a/code/modules/speech/trees/speech_module_tree.dm
+++ b/code/modules/speech/trees/speech_module_tree.dm
@@ -126,7 +126,7 @@
 		return
 
 	// If the say channel permits, apply the effects of all modifiers, otherwise only those that override say channel preferences.
-	var/was_uncool = global.phrase_log.is_uncool(message.content)
+	var/was_uncool = global.phrase_log.is_uncool(message.get_content_parsable())
 	if (global.SpeechManager.GetSayChannelInstance(message.output_module_channel).affected_by_modifiers)
 		for (var/modifier_id in src.speech_modifiers_by_id)
 			message = src.speech_modifiers_by_id[modifier_id].process(message)
@@ -141,18 +141,18 @@
 				return
 
 	// If a combination of message modifiers caused the message's content to become uncool, log the modifier combination and garble the uncool words.
-	if (!was_uncool && global.phrase_log.is_uncool(message.content))
+	if (!was_uncool && global.phrase_log.is_uncool(message.get_content_parsable()))
 		var/list/modifier_ids
 		if (global.SpeechManager.GetSayChannelInstance(message.output_module_channel).affected_by_modifiers)
 			modifier_ids = src.speech_modifiers_by_id.Copy()
 		else
 			modifier_ids = src.persistent_speech_modifiers_by_id.Copy()
 
-		logTheThing(LOG_ADMIN, message.speaker, "[message.speaker] tried to say \"[message.original_content]\" but it was garbled into \"[message.content]\", which is uncool by the following effects: [jointext(modifier_ids, ", ")]. The uncool words were garbled.")
+		logTheThing(LOG_ADMIN, message.speaker, "[message.speaker] tried to say \"[message.get_original_content()]\" but it was garbled into \"[message.get_content()]\", which is uncool by the following effects: [jointext(modifier_ids, ", ")]. The uncool words were garbled.")
 		message.content = replacetext(message.content, global.phrase_log.uncool_words, pick("urr", "blargh", "der", "hurr", "pllt"))
 
 	// Check for URLs if we're an IC channel, let people paste wiki links at each other in LOOC if they want to.
-	if ((message.flags & SAYFLAG_SPOKEN_BY_PLAYER) && !global.SpeechManager.GetSayChannelInstance(message.output_module_channel).allows_urls && global.url_regex.Find(message.content))
+	if ((message.flags & SAYFLAG_SPOKEN_BY_PLAYER) && !global.SpeechManager.GetSayChannelInstance(message.output_module_channel).allows_urls && global.url_regex.Find(message.get_content_parsable()))
 		if (ismob(message.speaker))
 			boutput(message.speaker, SPAN_NOTICE("<b>Web/BYOND links are not allowed in ingame chat.</b>"))
 

--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -121,9 +121,7 @@
 		if(!message || length_char(message) > max_length || !unlocked || get_time(user) > 0)
 			return
 
-		message = user.say(message, flags = SAYFLAG_DO_NOT_OUTPUT)?.content
-		message = STRIP_MUTABLE_CONTENT_TAGS(message)
-		message = sanitize(adminscrub(message))
+		message = user.say(message, flags = SAYFLAG_DO_NOT_OUTPUT)?.get_content()
 		if (!message)
 			return
 


### PR DESCRIPTION
## About The PR:
Accessing a say message datum's content has been refactored. All instances now use `get_content()` or `get_content_parsable()` depending on the usecase.

`get_content()` is used when outputting content directly to a browser is desired, e.g. logging, phrase logging, announcements, last words, and `format_for_output()`.

`get_content_parsable()` is used when searching message content or retransmitting it through `say()` is desired, e.g. DetGadgets, Lawbringers, audio logs, microphones, skullbots, and uncool word checking.

Fixes #24547 (note that this does not remove already stored phrases from the phraselog).


## Testing:
The following were tested by first checking with no accents how `"example"` and `<i>example</i>` rendered, then repeating the check with the flock gradient accent, introducing a large number of mutable tags into the message content: audio logs, skullbots, microphone components, logging, and announcement computers. They work as expected, with the `<i>` tags being preserved and escaped, while the gradient either being correctly applied or discarded depending on the case. Any line of code that was not tested directly is identical to an already tested case.

The following were tested in a similar way, but with their activation phrases or searched words being used: the Lawbringer, speech channel link detection, and uncool word filters. Searched phrases were detected as expected. This is an improvement from the existing code, as prior to the changes, phrases with the flock gradient (or similar) would not be picked up by `findtext()` or regex.