### PR TITLE
Update cogmap1's engine room to avoid late-join death by the singularity

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -22444,6 +22444,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/camera/directional/south{
+	pixel_x = -10
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},
@@ -50654,6 +50657,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/camera/directional/west,
 /turf/simulated/floor/grey,
 /area/station/engine/inner)
 "ogM" = (
@@ -54437,6 +54441,19 @@
 	dir = 4
 	},
 /area/station/crew_quarters/bar)
+"qKD" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "pdoor0";
+	id = "engi";
+	layer = 4;
+	name = "Engine Room Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "qKH" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -56474,19 +56491,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/pharmacy)
-"shT" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "pdoor0";
-	id = "engi";
-	layer = 4;
-	name = "Engine Room Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/inner)
 "siu" = (
 /obj/landmark/start/job/miner,
 /turf/simulated/floor,
@@ -112840,7 +112844,7 @@ adC
 adC
 adC
 jKQ
-shT
+qKD
 nJe
 lWj
 oOe

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -792,6 +792,15 @@
 	icon_state = "0-8"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "pdoor0";
+	id = "engi";
+	layer = 4;
+	name = "Engine Room Shield";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/station/hangar/engine)
 "adJ" = (
@@ -21564,6 +21573,12 @@
 	},
 /obj/table/wood/auto,
 /obj/machinery/computer3/generic/personal,
+/obj/machinery/door_control{
+	id = "engi";
+	name = "Engine Room Shield Control";
+	pixel_x = 5;
+	pixel_y = 27
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},
@@ -37517,6 +37532,15 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "engi";
+	layer = 4;
+	name = "Engine Room Shield";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/coldloop)
 "eML" = (
@@ -38431,6 +38455,15 @@
 	icon_state = "0-2"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "engi";
+	layer = 4;
+	name = "Engine Room Shield";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/coldloop)
 "fre" = (
@@ -43037,6 +43070,15 @@
 	icon_state = "0-2"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "engi";
+	layer = 4;
+	name = "Engine Room Shield";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/hotloop)
 "iEM" = (
@@ -43126,6 +43168,15 @@
 	icon_state = "0-2"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "engi";
+	layer = 4;
+	name = "Engine Room Shield";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/hotloop)
 "iJw" = (
@@ -50548,6 +50599,15 @@
 	icon_state = "0-4"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "pdoor0";
+	id = "engi";
+	layer = 4;
+	name = "Engine Room Shield";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/station/hangar/engine)
 "ofw" = (
@@ -59302,6 +59362,15 @@
 	icon_state = "0-8"
 	},
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "engi";
+	layer = 4;
+	name = "Engine Room Shield";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/hotloop)
 "umE" = (
@@ -60912,6 +60981,15 @@
 	},
 /obj/cable,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "engi";
+	layer = 4;
+	name = "Engine Room Shield";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/coldloop)
 "vtV" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -39475,7 +39475,7 @@
 /obj/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/glass/engineering{
+/obj/machinery/door/airlock/pyro/engineering{
 	name = "Hangar Access"
 	},
 /obj/mapping_helper/firedoor_spawn,

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -47368,7 +47368,7 @@
 /turf/simulated/floor/plating/airless,
 /area/station/mining/magnet)
 "lUF" = (
-/obj/machinery/door/airlock/pyro/glass/engineering{
+/obj/machinery/door/airlock/pyro/engineering{
 	name = "Core Access"
 	},
 /obj/mapping_helper/firedoor_spawn,
@@ -54759,7 +54759,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/north)
 "qWU" = (
-/obj/machinery/door/airlock/pyro/glass/engineering{
+/obj/machinery/door/airlock/pyro/engineering{
 	name = "Core Access"
 	},
 /obj/mapping_helper/firedoor_spawn,

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -6513,9 +6513,7 @@
 	name = "Gas Mixer Control (Combustion Chamber)"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
+/obj/noticeboard/persistent/engineering/directional/north,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -44495,7 +44493,6 @@
 	name = "Catering Hangar"
 	})
 "jKQ" = (
-/obj/machinery/firealarm/directional/south,
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -49985,13 +49982,9 @@
 /turf/simulated/floor,
 /area/station/engine/monitoring)
 "nJe" = (
-/obj/noticeboard/persistent/engineering/directional/north,
 /obj/decal/stripe_delivery,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
-	},
-/obj/machinery/camera/directional/north{
-	pixel_x = -10
 	},
 /turf/simulated/floor,
 /area/station/engine/monitoring)
@@ -50660,6 +50653,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/grey,
 /area/station/engine/inner)
 "ogM" = (
@@ -51855,6 +51849,9 @@
 	},
 /obj/machinery/light{
 	dir = 8;
+	pixel_x = -10
+	},
+/obj/machinery/camera/directional/north{
 	pixel_x = -10
 	},
 /turf/simulated/floor/yellow/side{
@@ -56477,6 +56474,19 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/pharmacy)
+"shT" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "pdoor0";
+	id = "engi";
+	layer = 4;
+	name = "Engine Room Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/inner)
 "siu" = (
 /obj/landmark/start/job/miner,
 /turf/simulated/floor,
@@ -63338,6 +63348,12 @@
 "xbK" = (
 /obj/cable/orange{
 	icon_state = "1-2"
+	},
+/obj/machinery/door_control{
+	id = "engi";
+	name = "Engine Room Shield Control";
+	pixel_x = 24;
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
@@ -112824,7 +112840,7 @@ adC
 adC
 adC
 jKQ
-bsN
+shT
 nJe
 lWj
 oOe


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replace the glass doors into the engine in cogmap1 with regular ones.
Add shutters to the main engine roon in cogmap1

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Doors:
Often when you late join on singularity rounds what happen is that, since you have a line of sight to the mighty ORB, you get stunned and irradiated to a lethal amount before even finding where the round-start engineers moved the suits to. 

Shutters:
Often on singularity maps walking to the PTL/ gas storage, or being in the hangar ALSO irradiate you to death, hence the shutters


## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->



https://github.com/user-attachments/assets/220e15f1-9a8f-472f-a3ce-e154b47f5fa3


camera coverage (Taken 1 commit after but said commit only added 2 cameras)
<img width="1243" height="885" alt="image" src="https://github.com/user-attachments/assets/f4af8e8a-670f-4954-883a-d0c4aaea4306" />




<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ANNmagedon
(+)Cogmap 1's engine room has received more line of sight blockers to help with getting around a singularity.
```
