### PR TITLE
Mainframe APC management program.

### DIFF
--- a/code/modules/networks/computer3/mainframe2/os_drivers.dm
+++ b/code/modules/networks/computer3/mainframe2/os_drivers.dm
@@ -2220,6 +2220,87 @@
 
 		return
 
+//Interface program for APCs
+/datum/computer/file/mainframe_program/apc_interface
+	name = "pwrman"
+	size = 4
+
+	initialize(var/initparams)
+		if (..())
+			mainframe_prog_exit
+			return
+
+		. = read_user_field("group")
+		if ((. > src.metadata["group"]) && (. != 0)) //User isn't sysop.
+			message_user("Error: Access denied. System Operator status required.")
+			mainframe_prog_exit
+			return
+
+		var/list/initlist = splittext(initparams, " ")
+		if (!initparams || !length(initlist))
+			message_user("Invalid commmand argument.|nValid Arguments:|n \"list\" to list connected APCs.|n \"stat (APC Net ID)\" to view APC status. |n \"set (APC Net ID) (mode) (setting)\" to set APC mode.","multiline")
+			mainframe_prog_exit
+			return
+
+		var/list/driverlist = signal_program(1, list("command"=DWAINE_COMMAND_DLIST, "dtag"="pwr_cntrl"))
+		if (!istype(driverlist) || !length(driverlist))
+			message_user("Error: Could not detect APC driver(s).")
+			mainframe_prog_exit
+			return
+
+		var/command = lowertext(initlist[1])
+		switch(command)
+			if ("list")
+				var/listText = ""
+				for (var/x in driverlist)
+					if (isnull(driverlist[x]))
+						continue
+					listText += "[x] - [driverlist[x]]|n"
+				if (!listText)
+					listText = "NONE"
+				message_user("Connected APCs:|n[listText]", "multiline")
+
+			if ("stat")
+				if (length(initlist) < 2 || !(lowertext(initlist[2]) in driverlist))
+					message_user("Error: Disconnected or invalid APC Net ID")
+					mainframe_prog_exit
+					return
+
+				else
+					message_user(driverlist[initlist[2]])
+
+			if ("set")
+				if (length(initlist) < 2 || !(lowertext(initlist[2]) in driverlist))
+					message_user("Error: Disconnected or invalid APC Net ID")
+					mainframe_prog_exit
+					return
+				if (length(initlist) < 4)
+					message_user("Error: Insufficient arguments for set command.|nUsage: set (APC Net ID) (mode) (setting)|nValid modes: equip, light, environ, cover","multiline")
+					mainframe_prog_exit
+					return
+
+				var/mode = lowertext(initlist[3])
+				var/setting = lowertext(initlist[4])
+				switch (mode)
+					if ("equip")
+						signal_program(1, list("command"=DWAINE_COMMAND_DMSG,"target"=initlist[2],"dcommand"="setmode","equip"=setting))
+					if ("light")
+						signal_program(1, list("command"=DWAINE_COMMAND_DMSG,"target"=initlist[2],"dcommand"="setmode","light"=setting))
+					if ("environ")
+						signal_program(1, list("command"=DWAINE_COMMAND_DMSG,"target"=initlist[2],"dcommand"="setmode","environ"=setting))
+					if ("cover")
+						signal_program(1, list("command"=DWAINE_COMMAND_DMSG,"target"=initlist[2],"dcommand"="setmode","cover"=setting))
+					else
+						message_user("Valid mode arguments: equip, light, environ, cover.")
+						mainframe_prog_exit
+						return
+				message_user("Changing [mode] to [setting]...")
+
+			else
+				message_user("Unknown command argument.")
+
+		mainframe_prog_exit
+		return
 
 //HEPT emitter
 /datum/computer/file/mainframe_program/driver/hept_emitter

--- a/code/modules/networks/computer3/mainframe2/os_drivers.dm
+++ b/code/modules/networks/computer3/mainframe2/os_drivers.dm
@@ -2139,7 +2139,7 @@
 /datum/computer/file/mainframe_program/driver/apc
 	name = "pwr_cntrl"
 	setup_processes = 1
-	status = "0;0;0;0"
+	status = "none;0;0;0;0"
 	var/tmp/apcID = null
 
 	var/tmp/apcEquip = 0
@@ -2196,11 +2196,16 @@
 
 				return
 
+			if ("ack")
+				message_device("command=status")
+				return
+
 			if ("status")
 				var/newEquip = text2num_safe(datalist["equip"])
 				var/newLight = text2num_safe(datalist["light"])
 				var/newEnviron = text2num_safe(datalist["environ"])
 				var/newCover = text2num_safe(datalist["cover"])
+				apcID = ckey(datalist["area"])
 
 				if (!isnull(newEquip))
 					apcEquip = round(clamp(newEquip, 0, 3))
@@ -2216,13 +2221,13 @@
 				else
 					apcCover = 0
 
-				status = "[apcEquip];[apcLight];[apcEnviron];[apcCover]"
+				status = "[apcID];[apcEquip];[apcLight];[apcEnviron];[apcCover]"
 
 		return
 
 //Interface program for APCs
 /datum/computer/file/mainframe_program/apc_interface
-	name = "pwrman"
+	name = "apcman"
 	size = 4
 
 	initialize(var/initparams)
@@ -2238,7 +2243,7 @@
 
 		var/list/initlist = splittext(initparams, " ")
 		if (!initparams || !length(initlist))
-			message_user("Invalid commmand argument.|nValid Arguments:|n \"list\" to list connected APCs.|n \"stat (APC Net ID)\" to view APC status. |n \"set (APC Net ID) (mode) (setting)\" to set APC mode.","multiline")
+			message_user("Error: Invalid commmand argument.|nValid Arguments:|n \"list\" to list connected APCs.|n \"stat (APC Net ID)\" to view APC status. |n \"set (APC Net ID) (mode) (setting)\" to set APC mode.","multiline")
 			mainframe_prog_exit
 			return
 
@@ -2251,14 +2256,14 @@
 		var/command = lowertext(initlist[1])
 		switch(command)
 			if ("list")
-				var/listText = ""
+				message_user("Connected APCs:")
+				if (length(driverlist) == 0)
+					message_user("NONE")
 				for (var/x in driverlist)
 					if (isnull(driverlist[x]))
 						continue
-					listText += "[x] - [driverlist[x]]|n"
-				if (!listText)
-					listText = "NONE"
-				message_user("Connected APCs:|n[listText]", "multiline")
+					var/status = splittext(driverlist[x], ";")
+					message_user("[x] - [status[1]]")
 
 			if ("stat")
 				if (length(initlist) < 2 || !(lowertext(initlist[2]) in driverlist))
@@ -2267,7 +2272,8 @@
 					return
 
 				else
-					message_user(driverlist[initlist[2]])
+					var/status = splittext(driverlist[initlist[2]], ";")
+					message_user("Area: [status[1]]|nEquip: [status[2]]|nLight: [status[3]]|nEnviron: [status[4]]|nCover: [status[5]]", "multiline")
 
 			if ("set")
 				if (length(initlist) < 2 || !(lowertext(initlist[2]) in driverlist))
@@ -2280,24 +2286,32 @@
 					return
 
 				var/mode = lowertext(initlist[3])
-				var/setting = lowertext(initlist[4])
+				var/setting = text2num_safe(initlist[4])
+				if (isnull(setting))
+					message_user("Error: Invalid setting argument. Setting must be a number.")
+					mainframe_prog_exit
+					return
+
+				var/driver_id = signal_program(1, list("command"=DWAINE_COMMAND_DGET, "dnetid"=initlist[2]))
+				driver_id &= ~ESIG_DATABIT
+
 				switch (mode)
 					if ("equip")
-						signal_program(1, list("command"=DWAINE_COMMAND_DMSG,"target"=initlist[2],"dcommand"="setmode","equip"=setting))
+						signal_program(1, list("command"=DWAINE_COMMAND_DMSG,"target"=driver_id,"dcommand"="setmode","equip"=setting))
 					if ("light")
-						signal_program(1, list("command"=DWAINE_COMMAND_DMSG,"target"=initlist[2],"dcommand"="setmode","light"=setting))
+						signal_program(1, list("command"=DWAINE_COMMAND_DMSG,"target"=driver_id,"dcommand"="setmode","light"=setting))
 					if ("environ")
-						signal_program(1, list("command"=DWAINE_COMMAND_DMSG,"target"=initlist[2],"dcommand"="setmode","environ"=setting))
+						signal_program(1, list("command"=DWAINE_COMMAND_DMSG,"target"=driver_id,"dcommand"="setmode","environ"=setting))
 					if ("cover")
-						signal_program(1, list("command"=DWAINE_COMMAND_DMSG,"target"=initlist[2],"dcommand"="setmode","cover"=setting))
+						signal_program(1, list("command"=DWAINE_COMMAND_DMSG,"target"=driver_id,"dcommand"="setmode","cover"=setting))
 					else
-						message_user("Valid mode arguments: equip, light, environ, cover.")
+						message_user("Error: Invalid setting argument.|nValid mode arguments: equip, light, environ, cover.", "multiline")
 						mainframe_prog_exit
 						return
 				message_user("Changing [mode] to [setting]...")
 
 			else
-				message_user("Unknown command argument.")
+				message_user("Error: Invalid commmand argument.|nValid Arguments:|n \"list\" to list connected APCs.|n \"stat (APC Net ID)\" to view APC status. |n \"set (APC Net ID) (mode) (setting)\" to set APC mode.","multiline")
 
 		mainframe_prog_exit
 		return

--- a/code/modules/networks/computer3/mainframe2/tapes.dm
+++ b/code/modules/networks/computer3/mainframe2/tapes.dm
@@ -159,6 +159,7 @@
 		//Nuke interface, because sometimes the nuke is alround.
 		src.root.add_file( new /datum/computer/file/mainframe_program/nuke_interface(src) )
 		//src.root.add_file( new /datum/computer/file/mainframe_program/srv/telecontrol(src) )
+		src.root.add_file( new /datum/computer/file/mainframe_program/apc_interface(src) )
 
 		for (var/datum/computer/file/F in src.root.contents)
 			F.metadata["permission"] = COMP_ROWNER|COMP_RGROUP|COMP_ROTHER
@@ -191,7 +192,8 @@
 		src.root.add_file( new /datum/computer/file/mainframe_program/driver/mountable/user_terminal(src) )
 		src.root.add_file( new /datum/computer/file/mainframe_program/driver/telepad(src) )
 		src.root.add_file( new /datum/computer/file/mainframe_program/driver/mountable/comm_dish(src) )
-		//src.root.add_file( new /datum/computer/file/mainframe_program/driver/mountable/logreader(src) )
+		//src.root.add_file( new /datum/computer/file/mainframe_program/driver/mountable/logreader(src)
+		src.root.add_file( new /datum/computer/file/mainframe_program/driver/apc(src) )
 
 		src.root.add_file( new /datum/computer/file/mainframe_program/utility/cd(src) )
 		src.root.add_file( new /datum/computer/file/mainframe_program/utility/ls(src) )
@@ -228,6 +230,7 @@
 		src.root.add_file( new /datum/computer/file/record/c3help(src) )
 		src.root.add_file( new /datum/computer/file/mainframe_program/nuke_interface(src) )
 		src.root.add_file( new /datum/computer/file/mainframe_program/test_interface(src) )
+		src.root.add_file( new /datum/computer/file/mainframe_program/apc_interface(src) )
 
 /obj/item/disk/data/tape/guardbot_tools
 	name = "ThinkTape-'PR-6S Config'"

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1005,6 +1005,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/power/apc, proc/toggle_operating, proc/zapSt
 		src.area.power_equip = equip
 		src.area.power_environ = environ
 
+		if(src.host_id)
+			src.post_status(src.host_id,"command","term_message","data","command=status&area=[ckey("[src.area]")]&charge=[cell ? round(cell.percent()) : "00"]&equip=[equipment]&light=[lighting]&environ=[environ]&cover=[coverlocked]")
+
 		src.area.power_change() //Note: the power_change() for areas ALREADY deals with relatedArea. Don't put it in the loops here!!
 
 /obj/machinery/power/apc/proc/get_power_levels()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Creates a new APC management program on the mainframe. It lets you list APCs, view APC status, and change APC settings. Requires root access to run. Loaded onto the master and test tapes.
Updates the APC driver to respond to ack packets with a status request and store the area name in the device file. Also loads it onto the OS backup tape.
APCs now send out a status packet when they update.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This allows APCs to be managed from remotely via the mainframe. I believe this to be the intent behind having them connect to the mainframe and the mainframe having a driver for them.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I fully tested the APC management program and made sure all functions work correctly. I also made sure APCs send out their status packet when updated.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bonnedav
(+)Creates a new APC management program on the mainframe and updates the mainframe's APC driver.
(+)APCs now send out a status packet when they update.
```
