### PR TITLE
Properly pin CI to use node v24.14.1

### DIFF
--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -222,7 +222,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.14.1
           cache: "yarn"
           cache-dependency-path: |
             ./tgui/yarn.lock


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
#26456 missed the secret module node version definition
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
v24.15.0 Causes build failures, this is a stop gap until we update to v26 LTS
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
This PR's CI is the test!
