### PR TITLE
Sentences and Plural words can trigger Language Artifacts

### DIFF
--- a/code/obj/artifacts/triggers.dm
+++ b/code/obj/artifacts/triggers.dm
@@ -1,5 +1,8 @@
 // TRIGGERS
 
+// Maximum number of 5-letter words language artifacts will check in a sentence. Here to prevent abuse.
+#define ARTIFACT_LANGUAGE_SENTENCE_CHECK 3
+
 ABSTRACT_TYPE(/datum/artifact_trigger/)
 /datum/artifact_trigger
 	var/type_name = "bad artifact code"
@@ -132,9 +135,16 @@ ABSTRACT_TYPE(/datum/artifact_trigger/)
 	proc/speech_act(text)
 		if (!text)
 			return
-		text = ckey(text)
-		if (length(text) != 5)
-			return "hint"
+		var/text_cleaned = ckey(text)
+		if (length(text_cleaned) == 5)
+			return speech_act_word(text_cleaned)
+
+		var/list/ignore_characters = list(".",",","!","?","(",")","*","%","$","#","/",";",":","\"","'","_","+","=","&")
+		for(var/char in ignore_characters)
+			text = replacetext(text, char, " ")
+		return speech_act_sentence(text)
+
+	proc/speech_act_word(var/text)
 		if (!(text in src.word_dict))
 			return "error"
 		var/input_vowels = 0
@@ -160,3 +170,25 @@ ABSTRACT_TYPE(/datum/artifact_trigger/)
 		if (correct_vowels > 0)
 			return " emits [correct_vowel_msg]."
 		return " emits [misplaced_vowel_msg]."
+
+	proc/speech_act_sentence(var/text)
+		if (!text)
+			return
+		var/list/words = splittext(text, " ")
+
+		var/check_count = 0
+		for(var/word in words)
+			word = ckey(word)
+			if((length(word) == 6 && copytext(word, 6, 7) == "s") || (length(word) == 7 && copytext(word, 6, 8) == "es"))
+				word = copytext(word, 1, 6) // Assume that the word is plural
+			else if(length(word) != 5)
+				continue
+			check_count++;
+			var/result_word = speech_act_word(word)
+			if(result_word == "correct")
+				return "correct"
+			if(check_count == ARTIFACT_LANGUAGE_SENTENCE_CHECK)
+				return "hint"
+		return "hint"
+
+#undef ARTIFACT_LANGUAGE_SENTENCE_CHECK


### PR DESCRIPTION
## About the PR
- Five-letter words contained within sentences can now trigger language artifacts. Vowel hints are ignored in these cases (so partial matches within sentences do not respond with a high or low chime).
- Only the first 3 five-letter words are checked to prevent abuse.
- Words ending in "s" or "es" are assumed to be plural when checking for five-letter words, so "radios" will be turned into "radio".

## Why's this needed?
- Accidentally triggering a language artifact is currently very unlikely. Checking sentences for matching words and plural versions of five-letter words makes accidentally triggering an artifact much more likely. 
- Could also allow antags to "accidentally" trigger an artifact if they already know a trigger word to avoid suspicion.

## Testing
<img width="1320" height="414" alt="Screenshot 2026-05-18 020451" src="https://github.com/user-attachments/assets/a4567f0d-d731-4017-9122-6d984857798e" />

## Changelog
```changelog
(u)LorrMaster
(*)Language artifacts can be triggered by matching plural words and words within sentences.
```
