### PR TITLE
Eldritch and Wizard Artifacts no longer work inside the Chapel

### DIFF
--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -222,6 +222,7 @@ var/datum/artifact_controller/artifact_controls
 	var/fx_alpha_max = 255
 	var/nofx = 0 // If set to 1, does not apply an overlay but a flat icon_state change.
 	var/scramblechance = 10 //probability to have "fake" artifact with altered appearance
+	var/chapel_block = FALSE // Artifact does not work inside chapels
 	var/list/activation_sounds = list()
 	var/list/instrument_sounds = list()
 	var/list/lightswitch_sounds = list('sound/misc/lightswitch.ogg')
@@ -399,6 +400,7 @@ var/datum/artifact_controller/artifact_controls
 		/datum/artifact_fault/messager/what_dead_people_said = 5,
 		/datum/artifact_fault/messager/what_people_said = 5,
 		/datum/artifact_fault/messager/emoji = 5)
+	chapel_block = TRUE
 	activation_sounds = list('sound/machines/ArtifactWiz1.ogg')
 	instrument_sounds = list('sound/musical_instruments/artifact/Artifact_Wizard_1.ogg',
 		'sound/musical_instruments/artifact/Artifact_Wizard_2.ogg',
@@ -473,6 +475,7 @@ var/datum/artifact_controller/artifact_controls
 /datum/artifact_origin/eldritch
 	type_name = "Eldritch"
 	name = "eldritch"
+	chapel_block = TRUE
 	activation_sounds = list('sound/machines/ArtifactEld1.ogg','sound/machines/ArtifactEld2.ogg')
 	instrument_sounds = list('sound/musical_instruments/artifact/Artifact_Eldritch_1.ogg',
 		'sound/musical_instruments/artifact/Artifact_Eldritch_2.ogg',

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -125,6 +125,8 @@
 
 	ArtifactDevelopFault(10)
 
+	if(A.artitype.chapel_block)
+		src.RegisterSignal(src, XSIG_MOVABLE_AREA_CHANGED, PROC_REF(Artifact_chapel_block))
 	if (A.automatic_activation)
 		src.ArtifactActivated()
 
@@ -154,6 +156,13 @@
 		return 1 // can't activate these ones at all by design
 	if (!A.may_activate(src))
 		return 1
+	if(A.artitype.chapel_block)
+		var/is_chapel = istype(get_area(src), /area/station/chapel)
+		if(is_chapel)
+			playsound(src.loc, 'sound/effects/bamf.ogg', 50, 1, pitch = 1.25)
+			var/turf/T = get_turf(src)
+			T.visible_message(SPAB_ALERT("<b>[src] attempts to activate but fails!</b>"))
+			return 1
 	if (A.activ_sound)
 		playsound(src.loc, A.activ_sound, 100, 1)
 	if (A.activ_text)
@@ -381,6 +390,14 @@
 	src.ArtifactHitWith(W, user)
 	return 1
 
+/obj/proc/Artifact_chapel_block(var/thing, var/area/old_area, var/area/new_area)
+	var/is_chapel = istype(new_area, /area/station/chapel)
+	if(is_chapel && src.artifact.activated)
+		playsound(src.loc, 'sound/effects/bamf.ogg', 50, 1, pitch = 1.25)
+		src.ArtifactDeactivated()
+	if(!is_chapel && !src.artifact.activated && src.artifact.automatic_activation)
+		src.ArtifactActivated()
+
 #define FAULT_RESULT_INVALID 2 // artifact can't do faults
 #define FAULT_RESULT_STOP	1		 // we gotta stop, artifact was destroyed or deactivated
 #define FAULT_RESULT_SUCCESS 0 // everything's cool!
@@ -565,6 +582,8 @@
 	src.remove_artifact_forms()
 
 	src.ArtifactDeactivated()
+	if(src.artifact.artitype.chapel_block)
+		UnregisterSignal(src, XSIG_MOVABLE_AREA_CHANGED)
 
 	ArtifactLogs(usr, null, src, "destroyed", null, 0)
 

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -161,7 +161,7 @@
 		if(is_chapel)
 			playsound(src.loc, 'sound/effects/bamf.ogg', 50, 1, pitch = 1.25)
 			var/turf/T = get_turf(src)
-			T.visible_message(SPAB_ALERT("<b>[src] attempts to activate but fails!</b>"))
+			T.visible_message(SPAN_ALERT("<b>[src] attempts to activate but fails!</b>"))
 			return 1
 	if (A.activ_sound)
 		playsound(src.loc, A.activ_sound, 100, 1)


### PR DESCRIPTION
## About the PR
- Eldritch and Wizard artifacts will not activate inside the chapel (a message and sound effect will play instead). Artifacts that have already been activated will deactivate upon entering the chapel.
- Auto-activating artifacts will automatically reactivate upon exiting the chapel.

## Why's this needed?
- Wraiths, Vampires, and Wizards all have issues inside the chapel, why not associated artifacts too?
- Could be an interesting way to stop artifact bombs.
- Could be used to test for disguised artifacts.

## Testing
<img width="252" height="338" alt="Screenshot 2026-05-18 034412" src="https://github.com/user-attachments/assets/30201266-7767-4d5f-9b68-a2123f17802d" />

## Changelog
```changelog
(u)LorrMaster
(*)Eldritch and Wizard artifacts no longer work inside the chapel.
```
