### PR TITLE
Update monkey barrel descriptions to mention holoclothing feature

### DIFF
--- a/code/datums/syndicate_buylist/buylist_job.dm
+++ b/code/datums/syndicate_buylist/buylist_job.dm
@@ -479,7 +479,7 @@
 	items = list(/obj/monkey_barrel)
 	cost = 6
 	vr_allowed = FALSE
-	desc = "A barrel of bloodthirsty apes. Careful!"
+	desc = "A barrel of bloodthirsty apes. Careful! The ad mentions a holographic clothing feature..."
 	job = list("Staff Assistant","Test Subject","Geneticist","Pathologist")
 
 /datum/syndicate_buylist/traitor/mindhack_module

--- a/code/obj/item/device/monkey_barrel.dm
+++ b/code/obj/item/device/monkey_barrel.dm
@@ -4,8 +4,7 @@
 	name = "mysterious barrel"
 	desc = "Some curious looking barrel..?"
 	SYNDICATE_STEALTH_DESCRIPTION("More fun than a ValuChimp! Looks like there's a tray to put clothes inside.", null)
-	HELP_MESSAGE_OVERRIDE("Right click to access the holographic clothing menu, letting you set the clothes of the monkeys.")
-	tooltip_flags = REBUILD_USER
+	help_message = "Right click to access the holographic clothing menu, letting you set the clothes of the monkeys."
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "barrel"
 	throwforce = 50

--- a/code/obj/item/device/monkey_barrel.dm
+++ b/code/obj/item/device/monkey_barrel.dm
@@ -2,8 +2,7 @@
 
 /obj/monkey_barrel
 	name = "mysterious barrel"
-	desc = "Some curious looking barrel..?"
-	SYNDICATE_STEALTH_DESCRIPTION("More fun than a ValuChimp! Looks like there's a tray to put clothes inside.", null)
+	desc = "More fun than a ValuChimp! Looks like there's a tray to put clothes inside."
 	HELP_MESSAGE_OVERRIDE("Right click to access the holographic clothing menu, letting you set the clothes of the monkeys.")
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "barrel"

--- a/code/obj/item/device/monkey_barrel.dm
+++ b/code/obj/item/device/monkey_barrel.dm
@@ -4,7 +4,7 @@
 	name = "mysterious barrel"
 	desc = "Some curious looking barrel..?"
 	SYNDICATE_STEALTH_DESCRIPTION("More fun than a ValuChimp! Looks like there's a tray to put clothes inside.", null)
-	help_message = "Right click to access the holographic clothing menu, letting you set the clothes of the monkeys."
+	HELP_MESSAGE_OVERRIDE("Right click to access the holographic clothing menu, letting you set the clothes of the monkeys.")
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "barrel"
 	throwforce = 50

--- a/code/obj/item/device/monkey_barrel.dm
+++ b/code/obj/item/device/monkey_barrel.dm
@@ -2,7 +2,10 @@
 
 /obj/monkey_barrel
 	name = "mysterious barrel"
-	desc = "More fun than a ValuChimp!"
+	desc = "Some curious looking barrel..?"
+	SYNDICATE_STEALTH_DESCRIPTION("More fun than a ValuChimp! Looks like there's a tray to put clothes inside.", null)
+	HELP_MESSAGE_OVERRIDE("Right click to access the holographic clothing menu, letting you set the clothes of the monkeys.")
+	tooltip_flags = REBUILD_USER
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "barrel"
 	throwforce = 50


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a help text for the monkey barrel, a syndicate stealth description and a mention in the buylist description. This isn't a bugfix but I feel like it doesn't need a changelog entry.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Adds some way to know the holographic clothing feature exists in-game. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested quickly, small enough change everything's fine.

