### PR TITLE
Add new Computer Core to cogmap2 and donut3.

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -6018,6 +6018,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aug" = (
@@ -51826,6 +51829,10 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"dVE" = (
+/obj/machinery/light_switch/south,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "dVF" = (
 /obj/table/auto,
 /obj/item/sheet/steel{
@@ -128377,7 +128384,7 @@ rnj
 igt
 pkg
 lPo
-lPo
+dVE
 uXV
 aam
 cha

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -6014,10 +6014,10 @@
 	},
 /area/station/maintenance/northeast)
 "auf" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc/autoname_south,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aug" = (
@@ -24796,12 +24796,6 @@
 /area/station/bridge)
 "bBK" = (
 /obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = "Control";
-	locked = 0;
-	name = "Databank - Control";
-	setup_drive_type = /obj/item/disk/data/tape/master
-	},
 /obj/item/device/radio/intercom/catering,
 /obj/cable{
 	icon_state = "0-2"
@@ -26783,6 +26777,7 @@
 	dir = 8
 	},
 /obj/item/storage/box/trackimp_kit,
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -26916,7 +26911,6 @@
 	},
 /area/station/crew_quarters/ce)
 "bIx" = (
-/obj/machinery/networked/radio,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -27355,9 +27349,6 @@
 /area/station/bridge)
 "bJA" = (
 /obj/machinery/power/data_terminal,
-/obj/machinery/networked/mainframe/zeta{
-	tag = "ZETA_MAINFRAME"
-	},
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -29451,7 +29442,6 @@
 /area/station/bridge)
 "bPV" = (
 /obj/table/auto,
-/obj/item/circuitboard/robotics,
 /obj/item/disk/data/floppy/read_only/network_progs,
 /obj/item/storage/toolbox/electrical,
 /obj/item/disk/data/floppy/read_only/communications,
@@ -51552,6 +51542,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"dEb" = (
+/obj/machinery/firealarm/directional/south,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "dEt" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -52558,6 +52552,18 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/maintenance/central)
+"eGj" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "eGJ" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/mail/vertical,
@@ -53250,6 +53256,15 @@
 	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/com_dish/auxdish)
+"fnk" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "fnA" = (
 /obj/table/auto,
 /obj/machinery/computer/television/small{
@@ -53453,6 +53468,23 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/mining/magnet)
+"fwC" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/mainframe/zeta{
+	tag = "ZETA_MAINFRAME"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/camera/directional/west,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "fxZ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -54143,6 +54175,17 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/com_dish/auxdish)
+"giF" = (
+/obj/table/auto,
+/obj/item/paper/book/from_file/guardbot_guide,
+/obj/item/paper/book/from_file/dwainedummies,
+/obj/item/device/multitool,
+/obj/item/screwdriver,
+/obj/machinery/light/incandescent/cool{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "gjf" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/disposalpipe/segment/transport,
@@ -54757,6 +54800,20 @@
 /obj/item/spraybottle/cleaner,
 /turf/simulated/floor/sanitary/blue,
 /area/station/medical/morgue)
+"gFT" = (
+/obj/table/auto,
+/obj/item/disk/data/floppy/read_only/bank_progs,
+/obj/item/disk/data/floppy/read_only/communications,
+/obj/item/disk/data/floppy/read_only/engine_prog,
+/obj/item/disk/data/floppy/read_only/ext_research_progs,
+/obj/item/disk/data/floppy/read_only/medical_progs,
+/obj/item/disk/data/floppy/read_only/network_progs,
+/obj/item/disk/data/floppy/read_only/security_progs,
+/obj/item/disk/data/floppy/read_only/terminal_os,
+/obj/item/disk/data/floppy/computer3boot,
+/obj/item/circuitboard/robotics,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "gGV" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
@@ -56671,6 +56728,15 @@
 	},
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
+"igt" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "igu" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
@@ -56724,6 +56790,17 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/catwalk/north)
+"ijZ" = (
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer3/generic/radio,
+/obj/machinery/light/incandescent/cool{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "ika" = (
 /obj/decal/poster/wallsign/stencil/left/a{
 	pixel_x = -8
@@ -56758,6 +56835,14 @@
 /obj/tree,
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
+"imu" = (
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Backup"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "imD" = (
 /obj/machinery/conveyor/NS{
 	name = "cargo belt - south";
@@ -57665,6 +57750,13 @@
 	},
 /turf/simulated/floor/red,
 /area/station/science/lab)
+"jaW" = (
+/obj/machinery/vending/computer3,
+/obj/machinery/light/incandescent/cool{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "jba" = (
 /obj/decal/poster/wallsign/stencil/right/p{
 	pixel_x = 16
@@ -59102,6 +59194,15 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/science)
+"kcs" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/incandescent/cool{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/maintenance/northeast)
 "kcH" = (
 /obj/item/device/radio/intercom/mining{
 	dir = 1
@@ -59899,18 +60000,16 @@
 /turf/space,
 /area/shuttle/research/outpost)
 "kOD" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
+/obj/machinery/door/airlock/pyro/command{
+	name = "Computer Core"
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "ne_maint";
-	name = "North East Maintenance"
+/obj/mapping_helper/access/computer_core,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/caution/northsouth,
-/area/station/maintenance/northeast)
+/obj/mapping_helper/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "kPs" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/maintenance)
@@ -60418,6 +60517,20 @@
 	},
 /turf/simulated/floor/airless/plating/damaged3,
 /area/station/mining/magnet)
+"lfP" = (
+/obj/machinery/power/data_terminal,
+/obj/table/auto,
+/obj/machinery/networked/printer{
+	print_id = "Mainframe"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "lgq" = (
 /obj/cable/orange{
 	icon_state = "0-8"
@@ -61169,6 +61282,9 @@
 "lOo" = (
 /turf/space,
 /area/station/turret_protected/AIbaseoutside)
+"lPo" = (
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "lPr" = (
 /obj/disposalpipe/segment,
 /obj/decal/tile_edge/stripe/big,
@@ -61736,6 +61852,12 @@
 	icon_state = "fgreen2"
 	},
 /area/station/hydroponics/bay)
+"mqt" = (
+/obj/machinery/light/incandescent/cool{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "mrr" = (
 /obj/cable/orange{
 	icon_state = "1-8"
@@ -62699,6 +62821,15 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit)
+"ndi" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "nej" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -63748,6 +63879,17 @@
 	dir = 4
 	},
 /area/station/hallway/primary/northwest)
+"ocg" = (
+/obj/table/auto,
+/obj/item/storage/box/tapebox,
+/obj/item/storage/box/diskbox,
+/obj/item/storage/box/diskbox,
+/obj/item/storage/box/tapebox,
+/obj/machinery/light/incandescent/cool{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "ocj" = (
 /obj/machinery/atmospherics/binary/valve{
 	desc = "Connects to a cooling radiator loop outside of the hull.";
@@ -64006,6 +64148,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"okV" = (
+/obj/machinery/networked/radio,
+/obj/machinery/power/data_terminal,
+/obj/machinery/light/incandescent/cool{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "olE" = (
 /obj/decal/tile_edge/stripe{
 	dir = 6;
@@ -64389,6 +64542,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
+"oIs" = (
+/obj/machinery/light/incandescent/cool,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "oIB" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -65007,6 +65167,15 @@
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plating,
 /area/research_outpost)
+"pkg" = (
+/obj/table/auto,
+/obj/item/disk/data/tape/master/readonly,
+/obj/item/disk/data/tape/test,
+/obj/item/disk/data/tape/boot2,
+/obj/item/disk/data/tape/guardbot_tools,
+/obj/item/disk/data/tape/artifact_research,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "pkw" = (
 /obj/machinery/computer/camera_viewer,
 /obj/cable{
@@ -65610,6 +65779,13 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/solar/small_backup1)
+"pKF" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "pLe" = (
 /obj/rack,
 /obj/item/storage/belt/utility,
@@ -65715,6 +65891,15 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /turf/space,
 /area/space)
+"pPi" = (
+/obj/machinery/light/incandescent/cool{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "pPN" = (
 /obj/machinery/sink{
 	desc = "A common utility sink.";
@@ -66537,6 +66722,13 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/routing/depot)
+"qyA" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/alarm/directional/north,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "qzf" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -67033,6 +67225,12 @@
 	dir = 9
 	},
 /area/mining/magnet)
+"qOI" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northeast)
 "qOJ" = (
 /obj/mesh/catwalk{
 	dir = 4
@@ -67601,6 +67799,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/mapping_helper/access/computer_core,
 /turf/simulated/floor/grime,
 /area/station/engine/gas)
 "rlM" = (
@@ -67646,6 +67845,14 @@
 	icon_state = "blue1"
 	},
 /area/station/hallway/primary/east)
+"rnj" = (
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer3/terminal/zeta/os_loaded,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "rno" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/external,
@@ -68537,6 +68744,10 @@
 	dir = 10
 	},
 /area/station/com_dish/auxdish)
+"sgG" = (
+/obj/machinery/camera/directional/east,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "shp" = (
 /obj/decal/cleanable/cobweb,
 /obj/landmark/halloween,
@@ -71013,6 +71224,10 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/hangar/catering)
+"uuf" = (
+/obj/machinery/light/incandescent/cool,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "uuC" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -71650,6 +71865,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/catering)
+"uXV" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/turret_protected/Zeta)
 "uYm" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/mail/vertical,
@@ -71755,12 +71973,18 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "veT" = (
-/obj/machinery/networked/storage/tape_drive,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/noticeboard/persistent/engineering/directional/north,
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "CE";
+	locked = 0;
+	read_only = 1;
+	setup_drive_type = null;
+	setup_spawn_with_tape = 0
+	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/power{
 	name = "Engineering Control Room"
@@ -71950,6 +72174,14 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
+"vrz" = (
+/obj/machinery/power/data_terminal,
+/obj/item/device/net_sniffer,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "vrK" = (
 /obj/cable/orange{
 	icon_state = "1-4"
@@ -72545,6 +72777,17 @@
 	dir = 10
 	},
 /area/station/quartermaster/office)
+"vSV" = (
+/obj/machinery/power/data_terminal,
+/obj/table/auto,
+/obj/machinery/networked/storage/scanner{
+	bank_id = "Mainframe"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "vTP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/kitchen)
@@ -72598,6 +72841,16 @@
 /obj/mesh/grille/steel,
 /turf/simulated/floor/grime,
 /area/station/routing/engine)
+"vWy" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "vWN" = (
 /obj/mesh/grille/steel,
 /obj/cable{
@@ -73187,6 +73440,20 @@
 	dir = 1
 	},
 /area/station/hallway/primary/west)
+"wBo" = (
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Control";
+	locked = 0;
+	name = "Databank - Control";
+	setup_drive_type = /obj/item/disk/data/tape/master
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/light/incandescent/cool{
+	dir = 8
+	},
+/obj/cable,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "wBK" = (
 /obj/disposalpipe/segment/mineral{
 	dir = 4
@@ -73876,6 +74143,12 @@
 	},
 /turf/simulated/floor/grey/blackgrime,
 /area/station/hangar/catering)
+"xhZ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "xia" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/morgue{
@@ -73911,15 +74184,12 @@
 /area/station/engine/elect)
 "xmC" = (
 /obj/mapping_helper/firedoor_spawn,
-/obj/machinery/door/airlock/pyro/external,
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
+/obj/machinery/door/airlock/pyro/command{
+	name = "Computer Core"
 	},
-/obj/mapping_helper/airlock/cycler/manual{
-	cycle_id = "ne_maint";
-	name = "North East Maintenance"
+/obj/mapping_helper/access/computer_core,
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/maintenance/northeast)
@@ -74083,6 +74353,12 @@
 	oxygen = 21.8249
 	},
 /area/station/hangar/science)
+"xqw" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "xss" = (
 /obj/machinery/atmospherics/unary/vent{
 	dir = 4
@@ -127190,13 +127466,13 @@ aaa
 aaa
 aaa
 aaa
-cha
-cha
-cha
-cha
-cha
-cha
-cha
+uXV
+uXV
+uXV
+uXV
+uXV
+uXV
+uXV
 cha
 cha
 atn
@@ -127492,13 +127768,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uXV
+okV
+fwC
+wBo
+lPo
+jaW
+uXV
 aam
 cha
 ckp
@@ -127794,15 +128070,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uXV
+vrz
+eGj
+imu
+lPo
+dEb
+uXV
 aam
-chb
+cha
 ckp
 chV
 chb
@@ -128096,15 +128372,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uXV
+rnj
+igt
+pkg
+lPo
+lPo
+uXV
 aam
-chb
+cha
 ckp
 chV
 cha
@@ -128398,14 +128674,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cXb
-chU
+uXV
+mqt
+xqw
+lPo
+lPo
+uuf
+uXV
+cha
 cha
 atP
 chV
@@ -128700,17 +128976,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uXV
+qyA
+fnk
+xhZ
+xhZ
+ndi
 kOD
-cVQ
+kcs
 xmC
-ckp
-chV
+pKF
+qOI
 avS
 cha
 aaa
@@ -129002,17 +129278,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cXb
-chU
+uXV
+pPi
+lPo
+lPo
+lPo
+oIs
+uXV
+cha
 cha
 atQ
-chV
+cnG
 avT
 cha
 aaa
@@ -129304,17 +129580,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uXV
+vWy
+lPo
+lPo
+lPo
+lfP
+uXV
 aam
-chb
+cha
 ckp
-chV
+cnG
 cha
 cha
 aaa
@@ -129606,17 +129882,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uXV
+ijZ
+lPo
+lPo
+lPo
+vSV
+uXV
 aam
-chb
+cha
 ckp
-chV
+cnG
 chb
 aaI
 aaa
@@ -129908,17 +130184,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uXV
+uXV
+sgG
+lPo
+lPo
+lPo
+uXV
 aam
 cha
 ckp
-chV
+cnG
 chb
 aaI
 aaa
@@ -130212,11 +130488,11 @@ aaS
 aaS
 aaS
 afk
-aaa
-aaa
-aaa
-aaa
-aaa
+uXV
+giF
+gFT
+ocg
+uXV
 aam
 cha
 ckp
@@ -130515,10 +130791,10 @@ abA
 lMk
 aaF
 afk
-aaa
-aaa
-aaa
-aaa
+uXV
+uXV
+uXV
+uXV
 aam
 cha
 atR

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -41973,6 +41973,13 @@
 	icon_state = "fgreen2"
 	},
 /area/station/engine/engineering/ce)
+"mZu" = (
+/obj/machinery/light/incandescent/cool{
+	dir = 8
+	},
+/obj/machinery/light_switch/north,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "mZA" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -118187,7 +118194,7 @@ mpb
 xVi
 eVo
 xlH
-pBo
+mZu
 kvS
 pBo
 xlH

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -43689,7 +43689,7 @@
 	},
 /obj/mapping_helper/access/computer_core,
 /obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/plating,
+/turf/simulated/floor,
 /area/station/turret_protected/Zeta)
 "nCa" = (
 /obj/machinery/light/small/sticky{

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -1471,6 +1471,12 @@
 	icon_state = "13"
 	},
 /area/shuttle/asylum/medbay)
+"atX" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "atY" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/disposalpipe/segment/mail,
@@ -5593,6 +5599,17 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/garden)
+"bGt" = (
+/obj/table/auto,
+/obj/item/storage/box/tapebox,
+/obj/item/storage/box/diskbox,
+/obj/item/storage/box/diskbox,
+/obj/item/storage/box/tapebox,
+/obj/machinery/light/incandescent/cool{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "bGw" = (
 /turf/simulated/floor/stairs/medical{
 	dir = 4
@@ -6174,6 +6191,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
+"bPx" = (
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Backup"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "bPz" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/specialroom/cafeteria,
@@ -10199,6 +10224,19 @@
 	dir = 8
 	},
 /area/station/engine/storage)
+"dar" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "artlab";
+	opacity = 0
+	},
+/obj/machinery/light/incandescent/cool{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/science/artifact)
 "daL" = (
 /obj/table/reinforced/auto,
 /turf/simulated/floor/plating/jen,
@@ -13804,6 +13842,18 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/omni,
 /area/station/medical/head)
+"ehE" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "ehJ" = (
 /turf/simulated/wall/auto/jen/blue,
 /area/station/hallway/primary/northwest)
@@ -24489,6 +24539,10 @@
 "hBW" = (
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
+"hCh" = (
+/obj/machinery/firealarm/directional/north,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "hCx" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -24774,6 +24828,20 @@
 	dir = 6
 	},
 /area/station/chapel/sanctuary)
+"hGH" = (
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Control";
+	locked = 0;
+	name = "Databank - Control";
+	setup_drive_type = /obj/item/disk/data/tape/master
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/obj/machinery/light/incandescent/cool{
+	dir = 4
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "hGL" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -30366,9 +30434,6 @@
 /obj/cable{
 	icon_state = "6-8"
 	},
-/obj/machinery/networked/mainframe/zeta{
-	tag = "ZETA_MAINFRAME"
-	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-8"
@@ -31999,12 +32064,6 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = "Control";
-	locked = 0;
-	name = "Databank - Control";
-	setup_drive_type = /obj/item/disk/data/tape/master
-	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -32504,6 +32563,13 @@
 	dir = 8
 	},
 /area/station/solar/west)
+"kdi" = (
+/obj/machinery/vending/computer3,
+/obj/machinery/light/incandescent/cool{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "kdk" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/disposalpipe/segment{
@@ -33622,6 +33688,12 @@
 	},
 /turf/space,
 /area/space)
+"kvS" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "kvT" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -34179,6 +34251,9 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/emergency)
+"kDQ" = (
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "kEn" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -34582,6 +34657,9 @@
 "kMf" = (
 /obj/machinery/camera/directional/south{
 	pixel_x = 10
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
 /area/station/science/lab)
@@ -35094,6 +35172,9 @@
 	},
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grey,
 /area/station/science/lab)
@@ -37668,6 +37749,14 @@
 /obj/storage/closet/welding_supply,
 /turf/simulated/floor/yellow,
 /area/station/engine/inner)
+"lJx" = (
+/obj/machinery/computer3/terminal/zeta/os_loaded,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "lJB" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/light/small/sticky,
@@ -37932,6 +38021,15 @@
 	dir = 9
 	},
 /area/station/engine/engineering)
+"lNk" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "lNp" = (
 /turf/simulated/floor/white,
 /area/station/medical/medbooth)
@@ -38213,6 +38311,15 @@
 	dir = 8
 	},
 /area/station/security/evidence)
+"lRK" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "lRY" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -39273,6 +39380,13 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/garden)
+"mhW" = (
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "mhX" = (
 /obj/mesh/catwalk/jen,
 /obj/cable{
@@ -39628,6 +39742,14 @@
 	},
 /turf/space,
 /area/shuttle/asylum/medbay)
+"moU" = (
+/obj/table/auto,
+/obj/item/paper/book/from_file/guardbot_guide,
+/obj/item/paper/book/from_file/dwainedummies,
+/obj/item/device/multitool,
+/obj/item/screwdriver,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "mpb" = (
 /obj/fluid_spawner{
 	amount = 700;
@@ -41747,6 +41869,20 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/medical/asylum/computer)
+"mYd" = (
+/obj/table/auto,
+/obj/item/disk/data/floppy/read_only/bank_progs,
+/obj/item/disk/data/floppy/read_only/communications,
+/obj/item/disk/data/floppy/read_only/engine_prog,
+/obj/item/disk/data/floppy/read_only/ext_research_progs,
+/obj/item/disk/data/floppy/read_only/medical_progs,
+/obj/item/disk/data/floppy/read_only/network_progs,
+/obj/item/disk/data/floppy/read_only/security_progs,
+/obj/item/disk/data/floppy/read_only/terminal_os,
+/obj/item/disk/data/floppy/computer3boot,
+/obj/item/circuitboard/robotics,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "mYf" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/table/auto,
@@ -42052,6 +42188,9 @@
 	dir = 8
 	},
 /obj/machinery/light/incandescent/harsh,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/grey,
 /area/station/science/lab)
 "ndN" = (
@@ -43540,6 +43679,18 @@
 /obj/mapping_helper/access/robotics,
 /turf/simulated/floor/circuit,
 /area/station/medical/robotics)
+"nBM" = (
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Computer Core"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/mapping_helper/access/computer_core,
+/obj/mapping_helper/firedoor_spawn,
+/turf/simulated/floor/plating,
+/area/station/turret_protected/Zeta)
 "nCa" = (
 /obj/machinery/light/small/sticky{
 	dir = 1
@@ -50004,6 +50155,23 @@
 	dir = 8
 	},
 /area/station/engine/inner)
+"pBo" = (
+/obj/machinery/light/incandescent/cool{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
+"pBL" = (
+/obj/machinery/networked/radio,
+/obj/machinery/power/data_terminal,
+/obj/machinery/light/incandescent/cool{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "pBO" = (
 /obj/machinery/camera/directional/south{
 	pixel_x = -10
@@ -50224,6 +50392,10 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/wood/six,
 /area/station/library)
+"pEq" = (
+/obj/machinery/camera/directional/south,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "pEF" = (
 /obj/machinery/computer3/generic/secure_data{
 	dir = 4
@@ -59024,6 +59196,12 @@
 /obj/disposalpipe/junction/left/north,
 /turf/simulated/floor/black,
 /area/station/security/brig/solitary)
+"sqt" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "sqy" = (
 /obj/cable{
 	icon_state = "5-8"
@@ -59595,6 +59773,22 @@
 	},
 /turf/simulated/floor/white/checker,
 /area/station/hallway/primary/south)
+"szR" = (
+/obj/machinery/networked/mainframe/zeta{
+	tag = "ZETA_MAINFRAME"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "szT" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -61017,6 +61211,20 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
+"sWi" = (
+/obj/table/auto,
+/obj/machinery/networked/storage/scanner{
+	bank_id = "Mainframe"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "sWl" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/mesh/catwalk/jen,
@@ -61158,6 +61366,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
+"sYK" = (
+/obj/machinery/alarm/directional/east,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "sYR" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable,
@@ -62523,6 +62735,18 @@
 	name = "reinforced plating"
 	},
 /area/station/hangar/qm)
+"tuv" = (
+/obj/table/auto,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/item/disk/data/tape/master/readonly,
+/obj/item/disk/data/tape/test,
+/obj/item/disk/data/tape/boot2,
+/obj/item/disk/data/tape/guardbot_tools,
+/obj/item/disk/data/tape/artifact_research,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "tuB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -65562,6 +65786,14 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/east)
+"usC" = (
+/obj/item/device/net_sniffer,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "usH" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8;
@@ -72737,6 +72969,12 @@
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/maintenance/inner/sw)
+"wwi" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "wwj" = (
 /obj/machinery/sink{
 	dir = 8
@@ -75123,6 +75361,18 @@
 	dir = 1
 	},
 /area/station/security/main)
+"xdp" = (
+/obj/table/auto,
+/obj/machinery/networked/printer{
+	print_id = "Mainframe"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/light/incandescent/cool,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "xdw" = (
 /obj/machinery/space_heater,
 /obj/decal/mule/beacon,
@@ -75693,6 +75943,9 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/ghostdrone_factory)
+"xlH" = (
+/turf/simulated/wall/auto/reinforced/jen/purple,
+/area/station/turret_protected/Zeta)
 "xlJ" = (
 /obj/machinery/light{
 	dir = 4;
@@ -76330,6 +76583,17 @@
 	dir = 1
 	},
 /area/station/medical/medbay)
+"xvj" = (
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer3/generic/radio,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/light/incandescent/cool{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "xvF" = (
 /obj/table/auto,
 /obj/item/kitchen/utensil/fork{
@@ -76527,6 +76791,10 @@
 	},
 /turf/simulated/floor/sanitary/blue,
 /area/station/medical/asylum/bathroom)
+"xyL" = (
+/obj/machinery/camera/directional/north,
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "xyT" = (
 /obj/decal/cleanable/rust/jen,
 /obj/table/reinforced/auto,
@@ -78830,7 +79098,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/networked/radio,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
@@ -116709,7 +116976,7 @@ cpa
 aKX
 aKX
 aKX
-aKX
+hyr
 kDc
 qnG
 lmi
@@ -117618,9 +117885,9 @@ hyr
 hyr
 hyr
 hyr
-hyr
-hyr
-hyr
+xlH
+nBM
+xlH
 hyr
 jrN
 otz
@@ -117919,14 +118186,14 @@ aAz
 mpb
 xVi
 eVo
-hyr
-rdj
-rdj
-rdj
-hyr
-hyr
-hyr
-hyr
+xlH
+pBo
+kvS
+pBo
+xlH
+xlH
+xlH
+xlH
 rdj
 rdj
 rdj
@@ -118221,14 +118488,14 @@ dkB
 dkB
 dkB
 dkB
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+xlH
+hCh
+kvS
+kDQ
+moU
+mYd
+bGt
+xlH
 rdj
 rdj
 rdj
@@ -118523,14 +118790,14 @@ xJu
 tbu
 nDE
 hKs
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+xlH
+xyL
+kvS
+kDQ
+kDQ
+kDQ
+pEq
+xlH
 rdj
 rdj
 rdj
@@ -118825,14 +119092,14 @@ bQT
 vcE
 ceb
 srn
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+xlH
+xvj
+lNk
+kDQ
+kDQ
+kDQ
+xdp
+xlH
 rdj
 rdj
 rdj
@@ -119127,14 +119394,14 @@ gIT
 mnb
 wkm
 kDs
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+xlH
+lJx
+ehE
+tuv
+wwi
+kDQ
+sWi
+xlH
 rdj
 rdj
 rdj
@@ -119429,14 +119696,14 @@ bQT
 vcE
 pBX
 iJq
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+xlH
+usC
+ehE
+bPx
+lRK
+atX
+sqt
+xlH
 rdj
 rdj
 rdj
@@ -119731,14 +119998,14 @@ thx
 mlS
 pay
 lml
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+xlH
+pBL
+szR
+hGH
+mhW
+sYK
+kdi
+xlH
 rdj
 rdj
 rdj
@@ -120034,13 +120301,13 @@ uBi
 uBi
 rOT
 rOT
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+xlH
+xlH
+xlH
+xlH
+xlH
+xlH
+xlH
 tXv
 rdj
 rdj
@@ -120940,7 +121207,7 @@ cpF
 bCY
 gnK
 bHn
-ncS
+dar
 rdj
 rdj
 rdj


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Creates new Computer Cores on cogmap2 and donut3, relocates the mainframe to the new rooms, and sets rooms to sysadmin access.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The mainframes on cogmap2 and donut3 are in bad places (the bridge and the AI core) that don't allow anyone but heads to access them. By moving them to their own rooms like on other maps, i can allow Computer Operators to access as well.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I spawned as a computer operator and was able to access the mainframe on both maps. The new rooms function correctly on both maps and all equipment is accessible on the network from outside.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bonnedav
(*)Added new computer core to cogmap2.
(*)Added new computer core to donut3.
```
