### PR TITLE
Set computer cores to sysadmin access.

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -33442,6 +33442,8 @@
 	enter_id = "outer";
 	name = "AI Core"
 	},
+/obj/mapping_helper/access/ai_upload,
+/obj/mapping_helper/access/computer_core,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "svK" = (
@@ -35423,8 +35425,8 @@
 /obj/machinery/door/airlock/pyro/glass/command{
 	dir = 4
 	},
-/obj/mapping_helper/access/heads,
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/computer_core,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "tID" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -36629,7 +36629,6 @@
 	dir = 4;
 	name = "AI and Computer Core"
 	},
-/obj/mapping_helper/access/heads,
 /obj/decal/stripe_delivery,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -36642,6 +36641,8 @@
 	enter_id = "outer";
 	name = "AI Airbridge"
 	},
+/obj/mapping_helper/access/ai_upload,
+/obj/mapping_helper/access/computer_core,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "eli" = (
@@ -37985,7 +37986,6 @@
 	dir = 4;
 	name = "Electrical Substation"
 	},
-/obj/mapping_helper/access/heads,
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment{
 	dir = 4
@@ -37995,6 +37995,8 @@
 	enter_id = "inner";
 	name = "AI Power"
 	},
+/obj/mapping_helper/access/ai_upload,
+/obj/mapping_helper/access/computer_core,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
 "ffm" = (
@@ -53642,7 +53644,6 @@
 	dir = 4;
 	name = "AI and Computer Core"
 	},
-/obj/mapping_helper/access/heads,
 /obj/decal/stripe_delivery,
 /obj/forcefield/energyshield/perma/doorlink{
 	desc = "A door-linked force field that prevents gasses from passing through it.";
@@ -53655,6 +53656,8 @@
 	enter_id = "inner";
 	name = "AI Airbridge"
 	},
+/obj/mapping_helper/access/ai_upload,
+/obj/mapping_helper/access/computer_core,
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload_foyer)
 "qoP" = (
@@ -56022,8 +56025,9 @@
 	name = "Computer Core Access"
 	},
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/heads,
 /obj/decal/stripe_delivery,
+/obj/mapping_helper/access/ai_upload,
+/obj/mapping_helper/access/computer_core,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "rYg" = (

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -27036,7 +27036,7 @@
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/heads,
+/obj/mapping_helper/access/computer_core,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "jzx" = (
@@ -49497,7 +49497,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass/command,
-/obj/mapping_helper/access/heads,
+/obj/mapping_helper/access/computer_core,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "wiL" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -33379,7 +33379,8 @@
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/heads,
+/obj/mapping_helper/access/ai_upload,
+/obj/mapping_helper/access/computer_core,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "gRQ" = (

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -9075,7 +9075,8 @@
 /obj/machinery/door/airlock/pyro/command/alt{
 	dir = 4
 	},
-/obj/mapping_helper/access/heads,
+/obj/mapping_helper/access/computer_core,
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "eew" = (
@@ -27579,7 +27580,7 @@
 	dir = 4
 	},
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/heads,
+/obj/mapping_helper/access/computer_core,
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
 "lSq" = (
@@ -30104,8 +30105,9 @@
 	},
 /obj/machinery/door/airlock/pyro/command/alt,
 /obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/heads,
 /obj/forcefield/energyshield/perma/doorlink,
+/obj/mapping_helper/access/computer_core,
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "mYj" = (

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -17546,7 +17546,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/mapping_helper/access/heads,
+/obj/mapping_helper/access/computer_core,
 /turf/simulated/floor,
 /area/station/turret_protected/Zeta)
 "man" = (
@@ -22584,7 +22584,7 @@
 	icon_state = "4-8"
 	},
 /obj/mapping_helper/access/robotdepot,
-/obj/mapping_helper/access/heads,
+/obj/mapping_helper/access/computer_core,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "pMP" = (
@@ -32273,7 +32273,6 @@
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/access/robotdepot,
-/obj/mapping_helper/access/heads,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "wyP" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -33130,11 +33130,12 @@
 /area/station/maintenance/northwest)
 "jXL" = (
 /obj/machinery/door/airlock/pyro/command/alt,
-/obj/mapping_helper/access/heads,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/computer_core,
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
 "jXW" = (
@@ -44203,11 +44204,12 @@
 	dir = 4;
 	name = "Computer Core"
 	},
-/obj/mapping_helper/access/heads,
 /obj/mapping_helper/firedoor_spawn,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/mapping_helper/access/computer_core,
+/obj/mapping_helper/access/ai_upload,
 /turf/simulated/floor,
 /area/station/turret_protected/Zeta)
 "tsu" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets computer cores on nadir, oshan, kondaru, and cogmap to be sysadmin or upload access.
Sets computer cores on neon, donut2, and clarion to be sysadmin access.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Computer cores should have their own access separate form bridge access.  This allows Computer Operators to have access by default and allows antags to be able to convince the HoP to give them computer core access for crime without having to convince them to give full bridge access. 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I have spawned as a Computer Operator on each map and was able to access the computer core and open the mainframe ui.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bonnedav
(+)Most computer cores are now locked behind Systems Administrator access, any with the killswitch inside can also be accessed with AI Upload access.
```
