### PR TITLE
Nerf printing additional authdisks

### DIFF
--- a/code/modules/networks/computer3/disks.dm
+++ b/code/modules/networks/computer3/disks.dm
@@ -330,7 +330,9 @@
 #endif
 
 TYPEINFO(/obj/item/disk/data/floppy/read_only/authentication)
-	mats = 15
+	mats = list("metal_superdense" = 5,
+				"conductive_high" = 15,
+				"crystal_dense" = 10)
 
 /obj/item/disk/data/floppy/read_only/authentication
 	name = "Authentication Disk"
@@ -342,6 +344,7 @@ TYPEINFO(/obj/item/disk/data/floppy/read_only/authentication)
 	w_class = W_CLASS_TINY
 	random_color = 0
 	file_amount = 32
+	is_syndicate = 1
 	HELP_MESSAGE_OVERRIDE({"Use on an armed nuclear bomb to alter the time remaining until detonation.
 	Use on an armory authorization computer to issue an emergency authorization or unauthorization.
 	Use on an escape shuttle launch computer to alter the time until departure."})

--- a/code/modules/networks/computer3/disks.dm
+++ b/code/modules/networks/computer3/disks.dm
@@ -330,9 +330,7 @@
 #endif
 
 TYPEINFO(/obj/item/disk/data/floppy/read_only/authentication)
-	mats = list("metal_superdense" = 5,
-				"conductive_high" = 15,
-				"crystal_dense" = 10)
+	mats = 15
 
 /obj/item/disk/data/floppy/read_only/authentication
 	name = "Authentication Disk"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The authentication disk can now only be scanned by syndicate analysers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
With the authentication disk having more importance placed on it it should be harder to get ahold of one. Its reasonable that NanoTrasen would blacklist the authentication disk from their scanners, thus allowing jailbroken syndicate analysers to scan it and give syndicate engineers a stealthier option for stealing the authentication codes via the codereader.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="496" height="86" alt="image" src="https://github.com/user-attachments/assets/81678d50-7a4b-4778-a9be-e01ea1246713" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)The Authentication Disk can now only be scanned by syndicate device analyzers.
```
