### PR TITLE
Adds Batiline to the ore siphon extraction options

### DIFF
--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -263,7 +263,7 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 
 /datum/siphon_mineral/batiline
 	name = "Batiline"
-	tick_req = 16
+	tick_req = 35
 	shear = 18
 	x_torque = 12
 	y_torque = 5

--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -170,6 +170,15 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 		"Type-AX Resonator, Position H7, 1 Intensity<br>"
 	)
 
+/datum/siphon_mineral/batiline
+	name = "Batiline"
+	tick_req = 35
+	shear = 18
+	x_torque = 12
+	y_torque = 5
+	sens_window = 4
+	product = /obj/item/raw_material/batiline
+
 /datum/siphon_mineral/fibrilith
 	name = "Fibrilith"
 	x_torque = 0
@@ -260,15 +269,6 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	shear = 54
 	sens_window = 2
 	product = /obj/item/raw_material/uqill
-
-/datum/siphon_mineral/batiline
-	name = "Batiline"
-	tick_req = 35
-	shear = 18
-	x_torque = 12
-	y_torque = 5
-	sens_window = 4
-	product = /obj/item/raw_material/batiline
 
 //variable materials
 

--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -261,6 +261,15 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	sens_window = 2
 	product = /obj/item/raw_material/uqill
 
+/datum/siphon_mineral/batiline
+	name = "Batiline"
+	tick_req = 16
+	shear = 18
+	x_torque = 12
+	y_torque = 5
+	sens_window = 4
+	product = /obj/item/raw_material/batiline
+
 //variable materials
 
 /datum/siphon_mineral/telecrystal

--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -178,6 +178,12 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	y_torque = 5
 	sens_window = 4
 	product = /obj/item/raw_material/batiline
+	setup_guide = list(
+		"Type-AX Resonator, Position C6, 1 Intensity<br>",
+		"Type-AX Resonator, Position G6, 2 Intensity<br>",
+		"Type-AX Resonator, Position G4, 2 Intensity<br>",
+		"Type-AX Resonator, Position G2, 1 Intensity<br>"
+	)
 
 /datum/siphon_mineral/fibrilith
 	name = "Fibrilith"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[A-Materials] [C-QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds the new Batiline ore to the siphon, with the following requirements:
- Required EEU: 35  (it's very heavy, should take some time to drill)
- Shear: 18
- Lateral Resonance: 12 (relatively low values here, it IS a rather brittle material)
- Vertical Resonance: 5
- Margin: = 4 (on par with bohrum)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The majority of other ores are already available with the siphon, especially the more common ones (rarity level 2, where Batiline, Bohrum, and Claretine all sit at), and due to its special properties, it may be desirable to get in larger amounts for experimentation. I see no reason for this to not be in the siphon.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Note: This screenshot was before I changed the required EEU from 16 to 35
<img width="750" height="500" alt="image" src="https://github.com/user-attachments/assets/3e12df2b-7e5d-4f0a-8111-2a9175505003" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chasu
(+)Nadir's ore siphon can now extract Batiline
```
