### PR TITLE
Create new computer core on Donut3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -1689,6 +1689,15 @@
 /obj/cable,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
+"axz" = (
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/simulated/floor/green/side{
+	dir = 9
+	},
+/area/station/turret_protected/Zeta)
 "axC" = (
 /obj/stool/chair/blue{
 	dir = 4
@@ -3328,6 +3337,18 @@
 /obj/random_item_spawner/snacks/one,
 /turf/simulated/floor/wood,
 /area/station/quartermaster/office)
+"aWk" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_south,
+/obj/table/reinforced/auto,
+/obj/random_item_spawner/peripherals/some,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "aWo" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -3385,18 +3406,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/west)
-"aXj" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_south,
-/obj/table/reinforced/auto,
-/obj/random_item_spawner/peripherals/some,
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "aXm" = (
 /obj/storage/secure/closet/command/hos,
 /turf/simulated/floor/carpet/red/fancy/edge{
@@ -4484,18 +4493,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/science/storage)
-"bqj" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = "Backup";
-	locked = 0;
-	name = "Databank - Backup"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "bqn" = (
 /obj/item/storage/toilet,
 /turf/simulated/floor/white,
@@ -4657,18 +4654,6 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating/jen,
 /area/station/medical/asylum/maintenance)
-"btb" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/green/side{
-	dir = 6
-	},
-/area/station/turret_protected/Zeta)
 "btd" = (
 /obj/stool/chair/pew/fancy/right{
 	dir = 1
@@ -4744,6 +4729,18 @@
 /obj/machinery/light/incandescent/cool,
 /turf/simulated/floor/sanitary/blue,
 /area/station/medical/asylum/bathroom)
+"btQ" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/green/side{
+	dir = 6
+	},
+/area/station/turret_protected/Zeta)
 "btZ" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 8
@@ -6151,6 +6148,17 @@
 	dir = 1
 	},
 /area/station/hallway/primary/northwest)
+"bOg" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/item/device/net_sniffer,
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/turret_protected/Zeta)
 "bOm" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/mesh/catwalk/jen,
@@ -6191,6 +6199,9 @@
 	},
 /turf/simulated/wall/auto/jen/blue,
 /area/station/hallway/primary/west)
+"bOZ" = (
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "bPa" = (
 /obj/decal/boxingrope,
 /obj/table/wood/round/auto,
@@ -7185,6 +7196,14 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/asylum/main)
+"cgH" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/mainframe/zeta,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "cgS" = (
 /obj/table/auto,
 /obj/linen_bin/bedsheet,
@@ -7684,6 +7703,18 @@
 /obj/random_item_spawner/armory_goggle_supplies,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"cmx" = (
+/obj/machinery/door/airlock/pyro/glass/command{
+	dir = 8
+	},
+/obj/mapping_helper/access/computer_core,
+/obj/mapping_helper/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/mapping_helper/access/ai_upload,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "cmD" = (
 /obj/cable{
 	icon_state = "4-10"
@@ -8149,16 +8180,6 @@
 /obj/effects/background_objects/x0,
 /turf/space,
 /area/space)
-"csp" = (
-/obj/machinery/computer3/terminal/zeta/os_loaded,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "csv" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -8399,12 +8420,6 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/spacehabitat/owlery)
-"cvU" = (
-/obj/machinery/light_switch/west,
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/turret_protected/Zeta)
 "cvV" = (
 /obj/railing/green{
 	dir = 8;
@@ -9310,6 +9325,12 @@
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/turret_protected/ai)
+"cJi" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "cKj" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9453,12 +9474,6 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/private)
-"cMZ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "cNi" = (
 /obj/machinery/conveyor/WE{
 	id = "qm_tohall"
@@ -9777,6 +9792,14 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
+"cRl" = (
+/obj/table/reinforced/auto,
+/obj/item/device/multitool,
+/obj/item/screwdriver,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "cRq" = (
 /obj/mesh/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -10557,12 +10580,6 @@
 	dir = 8
 	},
 /area/station/solar/small_backup1)
-"dfu" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green/checker,
-/area/station/turret_protected/Zeta)
 "dfM" = (
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
@@ -11048,20 +11065,6 @@
 	},
 /turf/simulated/wall/auto/jen,
 /area/station/maintenance/outer/north)
-"dnE" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/table/reinforced/auto,
-/obj/machinery/networked/printer{
-	print_id = "Mainframe"
-	},
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "dnF" = (
 /obj/decal/mule/beacon,
 /obj/machinery/flasher/portable,
@@ -13491,10 +13494,6 @@
 	},
 /turf/simulated/floor/white/checker,
 /area/station/medical/asylum/main)
-"ebB" = (
-/obj/machinery/camera/directional/south,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "ebH" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon10,
 /turf/simulated/floor/carpet/red/fancy/narrow/north,
@@ -17325,31 +17324,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"fpC" = (
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/table/reinforced/auto,
-/obj/item/storage/box/diskbox{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/storage/box/diskbox{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/storage/box/tapebox{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/tapebox{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/turf/simulated/floor/green/side{
-	dir = 5
-	},
-/area/station/turret_protected/Zeta)
 "fpP" = (
 /obj/railing/orange{
 	dir = 4
@@ -17702,6 +17676,12 @@
 	dir = 8
 	},
 /area/station/hangar/main)
+"fvO" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "fvQ" = (
 /turf/simulated/floor/darkblue,
 /area/station/ai_monitored/storage/eva)
@@ -18007,6 +17987,11 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/cloner)
+"fBb" = (
+/obj/machinery/turret,
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "fBg" = (
 /obj/item_dispenser/latex_gloves,
 /turf/simulated/floor/purpleblack{
@@ -21772,15 +21757,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
-"gKl" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "gKm" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/white/checker{
@@ -21876,14 +21852,6 @@
 /obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
-"gLT" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "gMa" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe,
 /obj/cable{
@@ -23630,6 +23598,18 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
+"hnA" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/stool/chair/office/green{
+	dir = 1
+	},
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "hnE" = (
 /obj/stool/bee_bed/heisenbee,
 /turf/simulated/floor/black,
@@ -24656,6 +24636,14 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
+"hCL" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "hCP" = (
 /obj/machinery/door/airlock/pyro/engineering,
 /obj/mapping_helper/access/engineering_mechanic,
@@ -25453,6 +25441,13 @@
 	},
 /turf/simulated/grass,
 /area/station/hallway/secondary/exit)
+"hRV" = (
+/obj/machinery/turret,
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "hSc" = (
 /obj/machinery/light/incandescent/warm,
 /obj/disposalpipe/segment{
@@ -25510,18 +25505,6 @@
 	},
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/arcade/dungeon)
-"hTo" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "hTp" = (
 /obj/disposalpipe/segment/mail,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -27721,6 +27704,14 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"iFo" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "iFp" = (
 /obj/decal/tile_edge/line/white{
 	color = "#ffccff";
@@ -28096,17 +28087,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
-"iKy" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/item/device/net_sniffer,
-/obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/turret_protected/Zeta)
 "iKD" = (
 /obj/storage/secure/closet/personal,
 /obj/machinery/light/incandescent/netural{
@@ -28223,15 +28203,6 @@
 	},
 /turf/simulated/floor/circuit/red,
 /area/station/security/main)
-"iME" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "iMF" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -29271,10 +29242,6 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/science/storage)
-"jcc" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/grey,
-/area/station/turret_protected/Zeta)
 "jcf" = (
 /obj/machinery/light/small/floor,
 /obj/disposalpipe/segment/morgue{
@@ -29285,6 +29252,30 @@
 	dir = 1
 	},
 /area/station/crew_quarters/cafeteria)
+"jcj" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
+"jcy" = (
+/obj/table/reinforced/auto,
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/item/disk/data/floppy/computer3boot,
+/obj/item/disk/data/floppy/read_only/terminal_os,
+/obj/item/disk/data/floppy/read_only/network_progs,
+/obj/item/disk/data/floppy/read_only/medical_progs,
+/obj/item/disk/data/floppy/read_only/engine_prog,
+/obj/item/disk/data/floppy/read_only/security_progs,
+/obj/item/disk/data/floppy/read_only/communications,
+/obj/item/disk/data/floppy/read_only/bank_progs,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "jcA" = (
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -29949,6 +29940,12 @@
 	dir = 1
 	},
 /area/station/medical/research)
+"jnf" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "jnk" = (
 /turf/simulated/wall/auto/jen/yellow,
 /area/station/quartermaster/office)
@@ -29967,6 +29964,22 @@
 	},
 /turf/simulated/floor/carpet/red/fancy,
 /area/station/security/hos)
+"jnp" = (
+/obj/table/reinforced/auto,
+/obj/item/paper/book/from_file/dwainedummies{
+	pixel_x = 7
+	},
+/obj/item/paper/book/from_file/guardbot_guide{
+	pixel_x = -7
+	},
+/obj/item/paper/book/from_file/guardbot_guide{
+	pixel_x = -7
+	},
+/obj/machinery/camera/directional/north,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "jnx" = (
 /obj/stool/chair{
 	dir = 8
@@ -30942,6 +30955,12 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
+"jDF" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "jDM" = (
 /turf/simulated/floor/black/grime,
 /area/station/maintenance/inner/north)
@@ -32248,9 +32267,6 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
-"jWK" = (
-/turf/simulated/floor/green/checker,
-/area/station/turret_protected/Zeta)
 "jWM" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
@@ -33829,6 +33845,16 @@
 /obj/machinery/light/small/floor,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
+"kwL" = (
+/obj/machinery/computer3/terminal/zeta/os_loaded,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "kwO" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -34417,6 +34443,15 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/exit)
+"kFH" = (
+/obj/table/reinforced/auto,
+/obj/machinery/light/incandescent/greenish,
+/obj/item/disk/data/tape/boot2,
+/obj/item/disk/data/tape/master,
+/obj/item/disk/data/tape/guardbot_tools,
+/obj/item/disk/data/tape/artifact_research,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "kFW" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 1;
@@ -37342,6 +37377,18 @@
 	dir = 10
 	},
 /area/station/medical/breakroom)
+"lDd" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Backup";
+	locked = 0;
+	name = "Databank - Backup"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "lDg" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
@@ -37747,6 +37794,12 @@
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
+"lIl" = (
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/turret_protected/Zeta)
 "lIp" = (
 /obj/cable,
 /obj/cable{
@@ -39916,6 +39969,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
+"mqW" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/radio,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "mqX" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
 	pixel_y = 24
@@ -40172,6 +40233,16 @@
 /obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
+"mve" = (
+/obj/machinery/computer3/generic/radio,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "mvu" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -40412,6 +40483,12 @@
 	dir = 4
 	},
 /area/station/science/lobby)
+"mzd" = (
+/obj/machinery/vending/computer3,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "mzg" = (
 /obj/cable,
 /obj/cable{
@@ -40658,6 +40735,11 @@
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen/freezer)
+"mCR" = (
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "mDc" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -40878,6 +40960,21 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/interrogation)
+"mGL" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/table/reinforced/auto,
+/obj/machinery/networked/storage/scanner{
+	bank_id = "Mainframe"
+	},
+/obj/machinery/camera/directional/south,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "mHd" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41239,18 +41336,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/security/main)
-"mNE" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/stool/chair/office/green{
-	dir = 1
-	},
-/turf/simulated/floor/green/checker,
-/area/station/turret_protected/Zeta)
 "mNV" = (
 /obj/cable{
 	icon_state = "2-6"
@@ -41508,6 +41593,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
+"mSy" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/table/reinforced/auto,
+/obj/machinery/networked/printer{
+	print_id = "Mainframe"
+	},
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "mSD" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/blue/side,
@@ -41768,12 +41867,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/station/crewquarters/fuq3)
-"mWI" = (
-/obj/machinery/vending/computer3,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "mWN" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -42115,15 +42208,6 @@
 	},
 /turf/simulated/wall/auto/jen,
 /area/station/hangar/main)
-"ncf" = (
-/obj/machinery/camera/directional/north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer/robotics,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "ncn" = (
 /obj/tree{
 	desc = "It's a tree. You see the phrase 'Haine <3 SpyGuy' carved into it."
@@ -42582,6 +42666,15 @@
 /obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
+"nil" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "niG" = (
 /obj/decal/tile_edge/line/white{
 	color = "#ffccff";
@@ -44176,11 +44269,6 @@
 	},
 /turf/simulated/floor/wood/eight,
 /area/station/ai_monitored/armory)
-"nJB" = (
-/turf/simulated/floor/green/corner{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "nJT" = (
 /obj/mesh/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -44410,17 +44498,6 @@
 	icon_state = "fblue6"
 	},
 /area/station/bridge)
-"nNG" = (
-/obj/machinery/door/airlock/pyro/glass/command{
-	dir = 8
-	},
-/obj/mapping_helper/access/computer_core,
-/obj/mapping_helper/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grey,
-/area/station/turret_protected/Zeta)
 "nNI" = (
 /obj/pool/perspective{
 	dir = 8;
@@ -45493,15 +45570,6 @@
 	dir = 6
 	},
 /area/station/solar/east)
-"oeS" = (
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/simulated/floor/green/side{
-	dir = 9
-	},
-/area/station/turret_protected/Zeta)
 "oeY" = (
 /obj/table/glass/auto,
 /obj/random_item_spawner/desk_stuff/one_or_zero,
@@ -45832,6 +45900,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge/customs)
+"ojR" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "ojV" = (
 /obj/mesh/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -45998,12 +46070,6 @@
 	dir = 8
 	},
 /area/station/crew_quarters/cafeteria)
-"omt" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/space,
-/area/space)
 "omu" = (
 /obj/machinery/light/small,
 /obj/table/auto,
@@ -47222,12 +47288,6 @@
 	dir = 1
 	},
 /area/station/crew_quarters/kitchen)
-"oFq" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "oFu" = (
 /obj/mesh/catwalk/jen,
 /obj/cable{
@@ -51566,16 +51626,6 @@
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
-"pVm" = (
-/obj/machinery/computer3/generic/radio,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "pVE" = (
 /turf/simulated/floor/stairs/wide{
 	dir = 1
@@ -52174,6 +52224,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
+"qfJ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "qfR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -52312,6 +52370,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
+"qhT" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/space,
+/area/space)
 "qip" = (
 /obj/machinery/door/airlock/pyro/glass/security/alt,
 /obj/mapping_helper/firedoor_spawn,
@@ -53211,14 +53275,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/crewquarters/fuq3)
-"qxh" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/radio,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "qxi" = (
 /obj/storage/closet/dresser,
 /obj/item/clothing/under/gimmick/maid,
@@ -54589,14 +54645,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
-"qUf" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/mainframe/zeta,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "qUg" = (
 /obj/lattice{
 	dir = 5;
@@ -54665,9 +54713,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/east)
-"qVk" = (
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "qVv" = (
 /obj/decal/stripe_delivery,
 /obj/cable{
@@ -56064,6 +56109,17 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/inner)
+"rrz" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/turretid/computer_core{
+	pixel_x = 24
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "rrU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56985,17 +57041,6 @@
 /obj/fakeobject/palmtree,
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
-"rGn" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/turretid/computer_core{
-	pixel_x = 24
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "rGo" = (
 /turf/simulated/wall/auto/jen/purple,
 /area/station/science/gen_storage)
@@ -58504,6 +58549,15 @@
 	},
 /turf/space,
 /area/station/turret_protected/armory_outside)
+"scj" = (
+/obj/machinery/camera/directional/north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer/robotics,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "sck" = (
 /obj/cable/orange{
 	icon_state = "4-8"
@@ -58870,6 +58924,31 @@
 /obj/table/reinforced/chemistry/auto/auxsup,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"siU" = (
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/table/reinforced/auto,
+/obj/item/storage/box/diskbox{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/storage/box/diskbox{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/storage/box/tapebox{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/tapebox{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/simulated/floor/green/side{
+	dir = 5
+	},
+/area/station/turret_protected/Zeta)
 "siV" = (
 /turf/simulated/floor/grasstodirt{
 	dir = 4
@@ -60378,14 +60457,6 @@
 /obj/item/light/tube,
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
-"sIH" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "sIK" = (
 /turf/space,
 /area/station/turret_protected/armory_outside)
@@ -60782,6 +60853,11 @@
 	dir = 4
 	},
 /area/station/engine/engineering)
+"sNV" = (
+/turf/simulated/floor/green/corner{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "sNX" = (
 /obj/machinery/traymachine/morgue,
 /obj/machinery/light/incandescent/cool/very,
@@ -60915,6 +60991,19 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
+"sQQ" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Control";
+	locked = 0;
+	name = "Databank - Control";
+	setup_drive_type = /obj/item/disk/data/tape/master
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "sRc" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/disposalpipe/segment{
@@ -62409,15 +62498,6 @@
 	},
 /turf/simulated/floor/circuit/red,
 /area/station/security/main)
-"tnj" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light/incandescent/greenish,
-/obj/item/disk/data/tape/boot2,
-/obj/item/disk/data/tape/master,
-/obj/item/disk/data/tape/guardbot_tools,
-/obj/item/disk/data/tape/artifact_research,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "tnn" = (
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
@@ -64232,14 +64312,6 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/bridge)
-"tOX" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "tPp" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/light/small/sticky{
@@ -65572,14 +65644,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/northwest)
-"unb" = (
-/obj/table/reinforced/auto,
-/obj/item/device/multitool,
-/obj/item/screwdriver,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "unp" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/wood/seven,
@@ -66243,12 +66307,6 @@
 	},
 /turf/simulated/floor/carpet/arcade/half,
 /area/station/crew_quarters/arcade/dungeon)
-"uxg" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/turret_protected/Zeta)
 "uxm" = (
 /turf/simulated/wall/auto/jen/blue,
 /area/station/medical/medbay/surgery/storage)
@@ -68475,11 +68533,6 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"vey" = (
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "veI" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -69631,6 +69684,18 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor/plating/jen,
 /area/station/storage/tools)
+"vwA" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "vwI" = (
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass,
@@ -70251,21 +70316,6 @@
 	dir = 10
 	},
 /area/station/science/lobby)
-"vEI" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/item/disk/data/floppy/computer3boot,
-/obj/item/disk/data/floppy/read_only/terminal_os,
-/obj/item/disk/data/floppy/read_only/network_progs,
-/obj/item/disk/data/floppy/read_only/medical_progs,
-/obj/item/disk/data/floppy/read_only/engine_prog,
-/obj/item/disk/data/floppy/read_only/security_progs,
-/obj/item/disk/data/floppy/read_only/communications,
-/obj/item/disk/data/floppy/read_only/bank_progs,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "vES" = (
 /obj/item/clothing/glasses/sunglasses{
 	pixel_x = -3;
@@ -71973,19 +72023,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
-"wgx" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = "Control";
-	locked = 0;
-	name = "Databank - Control";
-	setup_drive_type = /obj/item/disk/data/tape/master
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "wgJ" = (
 /obj/machinery/shield_generator{
 	desc = "Protects the chief's aquarium from outside threats. Must have pulled some strings for this.";
@@ -72445,13 +72482,6 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/artifact)
-"wnn" = (
-/obj/machinery/turret,
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "wnq" = (
 /obj/machinery/door/airlock/pyro/command{
 	req_access = null;
@@ -74361,6 +74391,12 @@
 /obj/table/wood/round/auto,
 /turf/simulated/floor/carpet/arcade,
 /area/station/medical/asylum/rec)
+"wNS" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "wNT" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/mesh/catwalk/jen,
@@ -75557,6 +75593,9 @@
 /obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor/black,
 /area/station/science/bot_storage)
+"xfc" = (
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "xfe" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -76539,21 +76578,6 @@
 	dir = 4
 	},
 /area/spacehabitat/pool)
-"xsp" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/table/reinforced/auto,
-/obj/machinery/networked/storage/scanner{
-	bank_id = "Mainframe"
-	},
-/obj/machinery/camera/directional/south,
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "xsr" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/carpet/arcade,
@@ -77604,6 +77628,10 @@
 "xJS" = (
 /turf/simulated/wall/auto/jen/purple,
 /area/station/science/lobby)
+"xJV" = (
+/obj/machinery/camera/directional/south,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "xKc" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -77719,6 +77747,19 @@
 /obj/machinery/light/runway_light,
 /turf/space,
 /area/space)
+"xLu" = (
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	name = "Computer Core"
+	},
+/obj/mapping_helper/access/computer_core,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/ai_upload,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "xLE" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/disposalpipe/segment/mail,
@@ -78194,22 +78235,6 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
-"xSd" = (
-/obj/table/reinforced/auto,
-/obj/item/paper/book/from_file/dwainedummies{
-	pixel_x = 7
-	},
-/obj/item/paper/book/from_file/guardbot_guide{
-	pixel_x = -7
-	},
-/obj/item/paper/book/from_file/guardbot_guide{
-	pixel_x = -7
-	},
-/obj/machinery/camera/directional/north,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "xSp" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -78732,19 +78757,6 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/solar/west)
-"xYa" = (
-/obj/machinery/door/airlock/pyro/command/alt{
-	dir = 4;
-	name = "Computer Core"
-	},
-/obj/mapping_helper/access/computer_core,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/ai_upload,
-/turf/simulated/floor/grey,
-/area/station/turret_protected/Zeta)
 "xYd" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -78824,12 +78836,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"xZb" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "xZi" = (
 /obj/shrub{
 	dir = 1;
@@ -78866,11 +78872,6 @@
 	dir = 1
 	},
 /area/station/bridge/customs)
-"xZZ" = (
-/obj/machinery/turret,
-/obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "yab" = (
 /obj/decal/stage_edge{
 	layer = 2.8
@@ -118021,7 +118022,7 @@ hyr
 hyr
 hyr
 ncS
-xYa
+xLu
 ncS
 hyr
 jrN
@@ -118038,10 +118039,10 @@ rdj
 rdj
 rdj
 rdj
-omt
+qhT
 rdj
-omt
-omt
+qhT
+qhT
 rdj
 rdj
 rdj
@@ -118322,9 +118323,9 @@ mpb
 xVi
 eVo
 ncS
-oeS
-gLT
-cvU
+axz
+iFo
+lIl
 ncS
 ncS
 ncS
@@ -118339,7 +118340,7 @@ rdj
 rdj
 rdj
 rdj
-omt
+qhT
 rdj
 rdj
 rdj
@@ -118624,11 +118625,11 @@ dkB
 dkB
 dkB
 ncS
-mWI
-uxg
-nJB
-vey
-iKy
+mzd
+fvO
+sNV
+mCR
+bOg
 ncS
 rdj
 rdj
@@ -118639,8 +118640,8 @@ rdj
 rdj
 rdj
 rdj
-omt
-omt
+qhT
+qhT
 rdj
 rdj
 rdj
@@ -118926,11 +118927,11 @@ tbu
 nDE
 hKs
 ncS
-csp
-mNE
-jWK
-jWK
-dnE
+kwL
+hnA
+bOZ
+bOZ
+mSy
 ncS
 rdj
 rdj
@@ -118940,7 +118941,7 @@ rdj
 rdj
 rdj
 rdj
-omt
+qhT
 rdj
 rdj
 rdj
@@ -119228,11 +119229,11 @@ vcE
 ceb
 srn
 ncS
-xSd
-dfu
-jWK
-jWK
-xsp
+jnp
+wNS
+bOZ
+bOZ
+mGL
 ncS
 rdj
 rdj
@@ -119530,11 +119531,11 @@ mnb
 wkm
 kDs
 ncS
-pVm
-mNE
-jWK
-jWK
-aXj
+mve
+hnA
+bOZ
+bOZ
+aWk
 ncS
 rdj
 rdj
@@ -119832,11 +119833,11 @@ vcE
 pBX
 iJq
 ncS
-unb
-dfu
-jWK
-jWK
-cMZ
+cRl
+wNS
+bOZ
+bOZ
+jDF
 ncS
 rdj
 rdj
@@ -120134,11 +120135,11 @@ mlS
 pay
 lml
 ncS
-fpC
-sIH
-tOX
-rGn
-btb
+siU
+hCL
+qfJ
+rrz
+btQ
 ncS
 rdj
 rdj
@@ -120437,10 +120438,10 @@ uBi
 rOT
 rOT
 ncS
-jcc
-jcc
-jcc
-nNG
+ojR
+ojR
+ojR
+cmx
 ncS
 ncS
 ncS
@@ -120739,12 +120740,12 @@ pTE
 adf
 vhl
 ncS
-wnn
-qVk
-qVk
-oFq
-qVk
-xZZ
+hRV
+xfc
+xfc
+cJi
+xfc
+fBb
 ncS
 rdj
 rdj
@@ -121041,12 +121042,12 @@ dxm
 lGE
 nyK
 ncS
-ncf
-gKl
-iME
-hTo
-xZb
-ebB
+scj
+jcj
+nil
+vwA
+jnf
+xJV
 ncS
 rdj
 rdj
@@ -121343,12 +121344,12 @@ bCY
 gnK
 bHn
 ncS
-vEI
-qxh
-qUf
-wgx
-bqj
-tnj
+jcy
+mqW
+cgH
+sQQ
+lDd
+kFH
 ncS
 rdj
 rdj

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -604,6 +604,14 @@
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
+"ahg" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "ahj" = (
 /turf/simulated/floor/carpet{
 	dir = 6;
@@ -1496,17 +1504,6 @@
 /obj/machinery/genetics_booth,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
-"auk" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/item/device/net_sniffer,
-/obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/turret_protected/Zeta)
 "aup" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 1;
@@ -2054,16 +2051,6 @@
 /obj/decal/poster/wallsign/fire,
 /turf/simulated/wall/auto/reinforced/supernorn/colored/yellow,
 /area/station/engine/ptl)
-"aBF" = (
-/obj/machinery/computer3/terminal/zeta/os_loaded,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "aBW" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -4050,6 +4037,12 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/construction2)
+"bhN" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "bhW" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -4511,6 +4504,12 @@
 /obj/random_item_spawner/desk_stuff/one_or_zero,
 /turf/simulated/floor/carpet,
 /area/station/hallway/secondary/exit)
+"bqC" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "bqD" = (
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/bathroom/extra1{
@@ -6208,19 +6207,6 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/engine/engineering/ce)
-"bPG" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = "Control";
-	locked = 0;
-	name = "Databank - Control";
-	setup_drive_type = /obj/item/disk/data/tape/master
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "bPZ" = (
 /obj/machinery/door/airlock/pyro/command{
 	req_access = null;
@@ -6993,6 +6979,13 @@
 	dir = 1
 	},
 /area/station/bridge)
+"cdg" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/box/tapebox,
+/obj/item/storage/box/tapebox,
+/obj/machinery/camera/directional/south,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "cdv" = (
 /obj/random_item_spawner/junk/five,
 /obj/decal/cleanable/rust/jen,
@@ -9868,14 +9861,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
-"cTn" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "cTz" = (
 /obj/item/device/radio/beacon,
 /obj/disposalpipe/segment/brig,
@@ -10573,23 +10558,6 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"dgM" = (
-/obj/table/reinforced/auto,
-/obj/item/paper/book/from_file/dwainedummies{
-	pixel_x = 7
-	},
-/obj/item/paper/book/from_file/guardbot_guide{
-	pixel_x = -7
-	},
-/obj/item/paper/book/from_file/guardbot_guide{
-	pixel_x = -7
-	},
-/obj/item/circuitboard/robotics,
-/obj/machinery/camera/directional/north,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "dgS" = (
 /obj/table/wood/auto,
 /obj/machinery/light/lamp/black{
@@ -11606,12 +11574,6 @@
 /obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
-"dyi" = (
-/obj/machinery/light_switch/west,
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/turret_protected/Zeta)
 "dyz" = (
 /obj/decal/cleanable/rust/jen,
 /obj/disposalpipe/segment{
@@ -14189,6 +14151,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
+"enQ" = (
+/obj/machinery/vending/computer3,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "enV" = (
 /turf/simulated/floor/stairs/wide{
 	dir = 1
@@ -14317,6 +14285,11 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
+"eqa" = (
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "eqD" = (
 /obj/machinery/camera/directional/south{
 	pixel_x = 10
@@ -15426,6 +15399,19 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
+"eLZ" = (
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	name = "Computer Core"
+	},
+/obj/mapping_helper/access/computer_core,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/ai_upload,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "eMk" = (
 /obj/mesh/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -16985,14 +16971,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
-"fjJ" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/radio,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "fjP" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -19131,6 +19109,18 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/security/beepsky)
+"fSK" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_south,
+/obj/table/reinforced/auto,
+/obj/random_item_spawner/peripherals/some,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "fSL" = (
 /obj/item/storage/wall/research_supplies{
 	dir = 8;
@@ -19139,9 +19129,6 @@
 	},
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/chemistry)
-"fSO" = (
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "fSR" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/reinforced/jen,
@@ -20149,21 +20136,6 @@
 /obj/machinery/light/traffic_light/trader_left/delay2,
 /turf/space,
 /area/space)
-"gjS" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/table/reinforced/auto,
-/obj/machinery/networked/storage/scanner{
-	bank_id = "Mainframe"
-	},
-/obj/machinery/camera/directional/south,
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "gjU" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio{
@@ -21221,6 +21193,17 @@
 	dir = 8
 	},
 /area/station/science/lab)
+"gBd" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/item/device/net_sniffer,
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/turret_protected/Zeta)
 "gBg" = (
 /turf/simulated/floor/redwhite,
 /area/station/security/checkpoint/sec_foyer)
@@ -22786,6 +22769,21 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
+"hau" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/table/reinforced/auto,
+/obj/machinery/networked/storage/scanner{
+	bank_id = "Mainframe"
+	},
+/obj/machinery/camera/directional/south,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "haF" = (
 /obj/stool/chair/comfy/purple,
 /obj/landmark/start/job/research_director,
@@ -23694,6 +23692,12 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
+"hpx" = (
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/turret_protected/Zeta)
 "hpF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -23785,6 +23789,17 @@
 	icon_state = "fred2"
 	},
 /area/station/crew_quarters/cafeteria)
+"hrr" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/turretid/computer_core{
+	pixel_x = 24
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "hrF" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -24480,21 +24495,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
-"hAb" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/item/disk/data/floppy/computer3boot,
-/obj/item/disk/data/floppy/read_only/terminal_os,
-/obj/item/disk/data/floppy/read_only/network_progs,
-/obj/item/disk/data/floppy/read_only/medical_progs,
-/obj/item/disk/data/floppy/read_only/engine_prog,
-/obj/item/disk/data/floppy/read_only/security_progs,
-/obj/item/disk/data/floppy/read_only/communications,
-/obj/item/disk/data/floppy/read_only/bank_progs,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "hAc" = (
 /obj/stool/chair/comfy/blue{
 	dir = 8
@@ -25290,18 +25290,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
-"hNP" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_south,
-/obj/table/reinforced/auto,
-/obj/random_item_spawner/peripherals/some,
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "hNR" = (
 /obj/mapping_helper/access/maint,
 /obj/decal/stripe_delivery,
@@ -26889,12 +26877,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/white,
 /area/spacehabitat/pool)
-"irV" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "isc" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/disposalpipe/segment/ejection,
@@ -27405,6 +27387,12 @@
 	},
 /turf/simulated/floor/stairs/wide/other,
 /area/station/hallway/primary/southeast)
+"iAx" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "iAB" = (
 /obj/shrub{
 	dir = 1;
@@ -27770,11 +27758,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/jen/red,
 /area/station/maintenance/outer/sw)
-"iGo" = (
-/turf/simulated/floor/green/corner{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "iGs" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/decal/stripe_caution,
@@ -27842,6 +27825,18 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/west)
+"iHn" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "iHL" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -28217,16 +28212,6 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/quartersC)
-"iNE" = (
-/obj/machinery/computer3/generic/radio,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "iNG" = (
 /obj/machinery/conveyor/EW{
 	id = "disposals";
@@ -28366,6 +28351,18 @@
 	dir = 9
 	},
 /area/station/bridge/reception)
+"iQD" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Backup";
+	locked = 0;
+	name = "Databank - Backup"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "iQG" = (
 /obj/disposalpipe/segment/mail,
 /obj/health_scanner/wall{
@@ -28392,6 +28389,19 @@
 /area/station/crew_quarters/bathroom/extra2{
 	name = "North Restroom #2"
 	})
+"iQU" = (
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/machinery/computer/robotics,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 5
+	},
+/area/station/turret_protected/Zeta)
 "iQY" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black/grime,
@@ -28771,6 +28781,23 @@
 	},
 /turf/space,
 /area/space)
+"iWv" = (
+/obj/table/reinforced/auto,
+/obj/item/paper/book/from_file/dwainedummies{
+	pixel_x = 7
+	},
+/obj/item/paper/book/from_file/guardbot_guide{
+	pixel_x = -7
+	},
+/obj/item/paper/book/from_file/guardbot_guide{
+	pixel_x = -7
+	},
+/obj/item/circuitboard/robotics,
+/obj/machinery/camera/directional/north,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "iWE" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -29001,6 +29028,13 @@
 "iZp" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/outer/sw)
+"iZs" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/box/diskbox,
+/obj/item/storage/box/diskbox,
+/obj/machinery/camera/directional/north,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "iZu" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29217,6 +29251,11 @@
 	dir = 1
 	},
 /area/station/engine/inner)
+"jbO" = (
+/turf/simulated/floor/green/corner{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "jbQ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -29461,6 +29500,16 @@
 	},
 /turf/simulated/floor/circuit/off,
 /area/station/turret_protected/ai)
+"jfA" = (
+/obj/machinery/computer3/generic/radio,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "jfL" = (
 /obj/stool/chair/dining/wood{
 	dir = 4
@@ -29997,17 +30046,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/science/storage)
-"joq" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/turretid/computer_core{
-	pixel_x = 24
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "joH" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
@@ -30052,13 +30090,6 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy,
 /area/station/chapel/sanctuary)
-"jqc" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/box/tapebox,
-/obj/item/storage/box/tapebox,
-/obj/machinery/camera/directional/south,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "jqd" = (
 /obj/table/auto,
 /obj/random_item_spawner/desk_stuff,
@@ -31941,6 +31972,9 @@
 	},
 /turf/space,
 /area/space)
+"jRx" = (
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "jRM" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -32417,6 +32451,17 @@
 "jYB" = (
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/quartersB)
+"jYD" = (
+/obj/machinery/door/airlock/pyro/glass/command{
+	dir = 8
+	},
+/obj/mapping_helper/access/computer_core,
+/obj/mapping_helper/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "jYH" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -33778,14 +33823,6 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
-"kwi" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "kwl" = (
 /obj/machinery/power/solar,
 /turf/simulated/floor/airless/solar,
@@ -35466,19 +35503,6 @@
 	},
 /turf/simulated/floor/wood/six,
 /area/station/hallway/primary/west)
-"kYc" = (
-/obj/machinery/door/airlock/pyro/command/alt{
-	dir = 4;
-	name = "Computer Core"
-	},
-/obj/mapping_helper/access/computer_core,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/ai_upload,
-/turf/simulated/floor/grey,
-/area/station/turret_protected/Zeta)
 "kYf" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/right,
@@ -36733,14 +36757,6 @@
 /area/station/wreckage{
 	name = "Restricted Area"
 	})
-"lur" = (
-/obj/table/reinforced/auto,
-/obj/item/device/multitool,
-/obj/item/screwdriver,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "luv" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -36903,6 +36919,11 @@
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
+"lxt" = (
+/obj/machinery/turret,
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "lxA" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
 	dir = 1
@@ -37068,6 +37089,13 @@
 	dir = 10
 	},
 /area/station/medical/medbooth)
+"lzj" = (
+/obj/machinery/turret,
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "lzl" = (
 /obj/machinery/camera/directional/south{
 	pixel_x = 10
@@ -37122,18 +37150,6 @@
 "lzM" = (
 /turf/simulated/floor/stairs/wood2/middle,
 /area/station/hallway/primary/south)
-"lAa" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "lAb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -38364,11 +38380,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/construction)
-"lQI" = (
-/obj/machinery/turret,
-/obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "lQM" = (
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -38874,19 +38885,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/head)
-"lWz" = (
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/machinery/computer/robotics,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/green/side{
-	dir = 5
-	},
-/area/station/turret_protected/Zeta)
 "lWJ" = (
 /obj/stool/chair/blue{
 	dir = 4
@@ -42985,6 +42983,18 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay/lobby)
+"noH" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/green/side{
+	dir = 6
+	},
+/area/station/turret_protected/Zeta)
 "noK" = (
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/maintenance/outer/north)
@@ -43289,6 +43299,15 @@
 	},
 /turf/simulated/floor/wood/five,
 /area/station/medical/asylum/main)
+"nue" = (
+/obj/table/reinforced/auto,
+/obj/machinery/light/incandescent/greenish,
+/obj/item/disk/data/tape/boot2,
+/obj/item/disk/data/tape/master,
+/obj/item/disk/data/tape/guardbot_tools,
+/obj/item/disk/data/tape/artifact_research,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "nuH" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -45397,6 +45416,12 @@
 /obj/machinery/bot/firebot,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"oco" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "ocq" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 6;
@@ -47239,6 +47264,16 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
+"oFD" = (
+/obj/machinery/computer3/terminal/zeta/os_loaded,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "oFH" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating,
@@ -47474,15 +47509,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
-"oIG" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light/incandescent/greenish,
-/obj/item/disk/data/tape/boot2,
-/obj/item/disk/data/tape/master,
-/obj/item/disk/data/tape/guardbot_tools,
-/obj/item/disk/data/tape/artifact_research,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "oIL" = (
 /obj/machinery/vending/security_ammo,
 /obj/decal/stripe_caution,
@@ -47946,6 +47972,20 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/exit)
+"oPF" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/stool/chair/office/green{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "oPJ" = (
 /obj/machinery/light/runway_light/delay2,
 /obj/lattice{
@@ -49346,6 +49386,18 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/wood/two,
 /area/station/hallway/primary/northwest)
+"pme" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/stool/chair/office/green{
+	dir = 1
+	},
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "pmj" = (
 /obj/table/glass/reinforced/auto,
 /obj/random_item_spawner/snacks/one_or_zero,
@@ -49387,18 +49439,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/greenwhite/other,
 /area/station/crew_quarters/market)
-"pnd" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/green/side{
-	dir = 6
-	},
-/area/station/turret_protected/Zeta)
 "pni" = (
 /turf/simulated/floor/white,
 /area/station/security/main)
@@ -51594,6 +51634,14 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/arcade)
+"pVT" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "pVU" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -51941,6 +51989,15 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
+"qcG" = (
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/simulated/floor/green/side{
+	dir = 9
+	},
+/area/station/turret_protected/Zeta)
 "qcO" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable{
@@ -52963,12 +53020,6 @@
 	},
 /turf/simulated/floor/carpet/green/fancy,
 /area/station/engine/engineering/ce)
-"qtG" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "qtL" = (
 /obj/mesh/catwalk/jen,
 /obj/cable{
@@ -54279,12 +54330,6 @@
 /obj/disposalpipe/junction/right/west,
 /turf/simulated/floor/black,
 /area/station/science/lobby)
-"qOJ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/turret_protected/Zeta)
 "qOK" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -54624,6 +54669,14 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
+"qUl" = (
+/obj/table/reinforced/auto,
+/obj/item/device/multitool,
+/obj/item/screwdriver,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "qUI" = (
 /obj/decal/tile_edge/line/red{
 	dir = 5;
@@ -55330,9 +55383,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"res" = (
-/turf/simulated/floor/green/checker,
-/area/station/turret_protected/Zeta)
 "reD" = (
 /obj/machinery/loudspeaker,
 /obj/machinery/light/incandescent/netural,
@@ -55718,16 +55768,19 @@
 	dir = 8
 	},
 /area/spacehabitat/pool)
-"rlp" = (
-/obj/cable{
-	icon_state = "0-8"
+"rlg" = (
+/obj/table/reinforced/auto,
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
 	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = "Backup";
-	locked = 0;
-	name = "Databank - Backup"
-	},
+/obj/item/disk/data/floppy/computer3boot,
+/obj/item/disk/data/floppy/read_only/terminal_os,
+/obj/item/disk/data/floppy/read_only/network_progs,
+/obj/item/disk/data/floppy/read_only/medical_progs,
+/obj/item/disk/data/floppy/read_only/engine_prog,
+/obj/item/disk/data/floppy/read_only/security_progs,
+/obj/item/disk/data/floppy/read_only/communications,
+/obj/item/disk/data/floppy/read_only/bank_progs,
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
 "rlw" = (
@@ -56465,6 +56518,20 @@
 /obj/mesh/catwalk/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/east)
+"rxA" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/table/reinforced/auto,
+/obj/machinery/networked/printer{
+	print_id = "Mainframe"
+	},
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "rxO" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -57291,6 +57358,10 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"rKR" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "rKY" = (
 /obj/machinery/floorflusher/minibrig,
 /obj/disposalpipe/trunk/brig,
@@ -57747,6 +57818,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"rRu" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "rRw" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/item/device/radio/beacon,
@@ -57990,12 +58067,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/medical/cdc)
-"rVw" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green/checker,
-/area/station/turret_protected/Zeta)
 "rVz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -58869,20 +58940,6 @@
 	dir = 4
 	},
 /area/station/ranch)
-"siY" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/stool/chair/office/green{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "sjd" = (
 /obj/disposalpipe/segment,
 /obj/decal/tile_edge/stripe/corner/big2{
@@ -59500,20 +59557,6 @@
 /obj/machinery/light_switch/south,
 /turf/simulated/floor/black,
 /area/station/science/lobby)
-"ssW" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/table/reinforced/auto,
-/obj/machinery/networked/printer{
-	print_id = "Mainframe"
-	},
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "ssX" = (
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -61201,12 +61244,6 @@
 	dir = 1
 	},
 /area/station/security/main)
-"sUY" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "sVb" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio/headset/research{
@@ -62817,13 +62854,6 @@
 	name = "reinforced plating"
 	},
 /area/station/hangar/qm)
-"tuv" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/box/diskbox,
-/obj/item/storage/box/diskbox,
-/obj/machinery/camera/directional/north,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "tuB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -63132,13 +63162,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
-"tzu" = (
-/obj/machinery/turret,
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "tzD" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -64646,14 +64669,6 @@
 	dir = 10
 	},
 /area/station/hallway/secondary/entry)
-"tVu" = (
-/obj/machinery/door/airlock/pyro/glass/command{
-	dir = 8
-	},
-/obj/mapping_helper/access/computer_core,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/grey,
-/area/station/turret_protected/Zeta)
 "tVx" = (
 /obj/machinery/camera/directional/north{
 	pixel_x = -10
@@ -65212,11 +65227,6 @@
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
-"ued" = (
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "ueB" = (
 /obj/table/reinforced/auto,
 /obj/machinery/coffeemaker/medbay{
@@ -65418,12 +65428,6 @@
 	},
 /turf/simulated/floor/carpet/purple/decal/outercross,
 /area/station/chapel/sanctuary)
-"ujp" = (
-/obj/machinery/vending/computer3,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "ujy" = (
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/storage/tech)
@@ -66732,18 +66736,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
-"uEc" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/stool/chair/office/green{
-	dir = 1
-	},
-/turf/simulated/floor/green/checker,
-/area/station/turret_protected/Zeta)
 "uEm" = (
 /obj/table/wood/auto,
 /obj/item/plate{
@@ -67310,15 +67302,6 @@
 	dir = 6
 	},
 /area/station/crew_quarters/quarters)
-"uMy" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "uMR" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light/incandescent/netural{
@@ -68627,12 +68610,6 @@
 	dir = 10
 	},
 /area/station/hangar/main)
-"vfI" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "vfO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -69059,6 +69036,19 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
+"vmE" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Control";
+	locked = 0;
+	name = "Databank - Control";
+	setup_drive_type = /obj/item/disk/data/tape/master
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "vmV" = (
 /obj/machinery/light/small/floor/warm,
 /turf/simulated/floor/black,
@@ -71869,14 +71859,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
-"wdO" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/mainframe/zeta,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "wec" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/wood/eight{
@@ -72571,6 +72553,15 @@
 	icon_state = "fblue3"
 	},
 /area/station/medical/head)
+"woz" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "woF" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -72917,6 +72908,9 @@
 	},
 /turf/simulated/floor/stairs/wood2/wide,
 /area/station/crew_quarters/cafeteria)
+"wtk" = (
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "wtq" = (
 /obj/submachine/chicken_incubator,
 /obj/item/reagent_containers/food/snacks/ingredient/egg{
@@ -73855,15 +73849,6 @@
 /obj/machinery/light/traffic_light/medical_medbay/delay2,
 /turf/space,
 /area/space)
-"wGP" = (
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/simulated/floor/green/side{
-	dir = 9
-	},
-/area/station/turret_protected/Zeta)
 "wGQ" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -76777,6 +76762,12 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
+"xwu" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "xwE" = (
 /turf/simulated/wall/auto/reinforced/jen/red,
 /area/station/security/checkpoint/escape)
@@ -77266,6 +77257,14 @@
 	dir = 5
 	},
 /area/station/medical/medbay)
+"xEb" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/mainframe/zeta,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "xEe" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -77745,10 +77744,6 @@
 	},
 /turf/simulated/floor/red/checker,
 /area/station/security/checkpoint/sec_foyer)
-"xLW" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/grey,
-/area/station/turret_protected/Zeta)
 "xLX" = (
 /obj/decal/poster/wallsign/security,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
@@ -78947,6 +78942,14 @@
 /obj/random_item_spawner/junk/maybe_few,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/nw)
+"ybo" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/radio,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "ybr" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
@@ -117993,7 +117996,7 @@ hyr
 hyr
 hyr
 ncS
-kYc
+eLZ
 ncS
 hyr
 jrN
@@ -118294,9 +118297,9 @@ mpb
 xVi
 eVo
 ncS
-wGP
-cTn
-dyi
+qcG
+pVT
+hpx
 ncS
 ncS
 ncS
@@ -118596,11 +118599,11 @@ dkB
 dkB
 dkB
 ncS
-ujp
-qOJ
-iGo
-ued
-auk
+enQ
+xwu
+jbO
+eqa
+gBd
 ncS
 rdj
 rdj
@@ -118898,11 +118901,11 @@ tbu
 nDE
 hKs
 ncS
-aBF
-uEc
-res
-res
-ssW
+oFD
+pme
+jRx
+jRx
+rxA
 ncS
 rdj
 rdj
@@ -119200,11 +119203,11 @@ vcE
 ceb
 srn
 ncS
-dgM
-rVw
-res
-res
-gjS
+iWv
+iAx
+jRx
+jRx
+hau
 ncS
 rdj
 rdj
@@ -119502,11 +119505,11 @@ mnb
 wkm
 kDs
 ncS
-iNE
-uEc
-res
-res
-hNP
+jfA
+pme
+jRx
+jRx
+fSK
 ncS
 rdj
 rdj
@@ -119804,11 +119807,11 @@ vcE
 pBX
 iJq
 ncS
-lur
-rVw
-res
-res
-irV
+qUl
+iAx
+jRx
+jRx
+rRu
 ncS
 rdj
 rdj
@@ -120106,11 +120109,11 @@ mlS
 pay
 lml
 ncS
-lWz
-siY
-kwi
-joq
-pnd
+iQU
+oPF
+ahg
+hrr
+noH
 ncS
 rdj
 rdj
@@ -120409,10 +120412,10 @@ uBi
 rOT
 rOT
 ncS
-xLW
-xLW
-xLW
-tVu
+rKR
+rKR
+rKR
+jYD
 ncS
 ncS
 ncS
@@ -120711,12 +120714,12 @@ pTE
 adf
 vhl
 ncS
-tzu
-fSO
-fSO
-qtG
-fSO
-lQI
+lzj
+wtk
+wtk
+bhN
+wtk
+lxt
 ncS
 rdj
 rdj
@@ -121013,12 +121016,12 @@ dxm
 lGE
 nyK
 ncS
-tuv
-sUY
-uMy
-lAa
-vfI
-jqc
+iZs
+oco
+woz
+iHn
+bqC
+cdg
 ncS
 rdj
 rdj
@@ -121315,12 +121318,12 @@ bCY
 gnK
 bHn
 ncS
-hAb
-fjJ
-wdO
-bPG
-rlp
-oIG
+rlg
+ybo
+xEb
+vmE
+iQD
+nue
 ncS
 rdj
 rdj

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -604,14 +604,6 @@
 /obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
-"ahg" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "ahj" = (
 /turf/simulated/floor/carpet{
 	dir = 6;
@@ -3393,6 +3385,18 @@
 	dir = 8
 	},
 /area/station/hallway/primary/west)
+"aXj" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_south,
+/obj/table/reinforced/auto,
+/obj/random_item_spawner/peripherals/some,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "aXm" = (
 /obj/storage/secure/closet/command/hos,
 /turf/simulated/floor/carpet/red/fancy/edge{
@@ -4037,12 +4041,6 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/construction2)
-"bhN" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "bhW" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -4486,6 +4484,18 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/science/storage)
+"bqj" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Backup";
+	locked = 0;
+	name = "Databank - Backup"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "bqn" = (
 /obj/item/storage/toilet,
 /turf/simulated/floor/white,
@@ -4504,12 +4514,6 @@
 /obj/random_item_spawner/desk_stuff/one_or_zero,
 /turf/simulated/floor/carpet,
 /area/station/hallway/secondary/exit)
-"bqC" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "bqD" = (
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/bathroom/extra1{
@@ -4653,6 +4657,18 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating/jen,
 /area/station/medical/asylum/maintenance)
+"btb" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/green/side{
+	dir = 6
+	},
+/area/station/turret_protected/Zeta)
 "btd" = (
 /obj/stool/chair/pew/fancy/right{
 	dir = 1
@@ -6979,13 +6995,6 @@
 	dir = 1
 	},
 /area/station/bridge)
-"cdg" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/box/tapebox,
-/obj/item/storage/box/tapebox,
-/obj/machinery/camera/directional/south,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "cdv" = (
 /obj/random_item_spawner/junk/five,
 /obj/decal/cleanable/rust/jen,
@@ -8140,6 +8149,16 @@
 /obj/effects/background_objects/x0,
 /turf/space,
 /area/space)
+"csp" = (
+/obj/machinery/computer3/terminal/zeta/os_loaded,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "csv" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -8380,6 +8399,12 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/spacehabitat/owlery)
+"cvU" = (
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/turret_protected/Zeta)
 "cvV" = (
 /obj/railing/green{
 	dir = 8;
@@ -9428,6 +9453,12 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/private)
+"cMZ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "cNi" = (
 /obj/machinery/conveyor/WE{
 	id = "qm_tohall"
@@ -10526,6 +10557,12 @@
 	dir = 8
 	},
 /area/station/solar/small_backup1)
+"dfu" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "dfM" = (
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
@@ -11011,6 +11048,20 @@
 	},
 /turf/simulated/wall/auto/jen,
 /area/station/maintenance/outer/north)
+"dnE" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/table/reinforced/auto,
+/obj/machinery/networked/printer{
+	print_id = "Mainframe"
+	},
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "dnF" = (
 /obj/decal/mule/beacon,
 /obj/machinery/flasher/portable,
@@ -13440,6 +13491,10 @@
 	},
 /turf/simulated/floor/white/checker,
 /area/station/medical/asylum/main)
+"ebB" = (
+/obj/machinery/camera/directional/south,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "ebH" = (
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon10,
 /turf/simulated/floor/carpet/red/fancy/narrow/north,
@@ -14151,12 +14206,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
-"enQ" = (
-/obj/machinery/vending/computer3,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "enV" = (
 /turf/simulated/floor/stairs/wide{
 	dir = 1
@@ -14285,11 +14334,6 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
-"eqa" = (
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "eqD" = (
 /obj/machinery/camera/directional/south{
 	pixel_x = 10
@@ -15399,19 +15443,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
-"eLZ" = (
-/obj/machinery/door/airlock/pyro/command/alt{
-	dir = 4;
-	name = "Computer Core"
-	},
-/obj/mapping_helper/access/computer_core,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/ai_upload,
-/turf/simulated/floor/grey,
-/area/station/turret_protected/Zeta)
 "eMk" = (
 /obj/mesh/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -17294,6 +17325,31 @@
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"fpC" = (
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/table/reinforced/auto,
+/obj/item/storage/box/diskbox{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/storage/box/diskbox{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/storage/box/tapebox{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/tapebox{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/simulated/floor/green/side{
+	dir = 5
+	},
+/area/station/turret_protected/Zeta)
 "fpP" = (
 /obj/railing/orange{
 	dir = 4
@@ -19109,18 +19165,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/security/beepsky)
-"fSK" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_south,
-/obj/table/reinforced/auto,
-/obj/random_item_spawner/peripherals/some,
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "fSL" = (
 /obj/item/storage/wall/research_supplies{
 	dir = 8;
@@ -21193,17 +21237,6 @@
 	dir = 8
 	},
 /area/station/science/lab)
-"gBd" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/item/device/net_sniffer,
-/obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/turret_protected/Zeta)
 "gBg" = (
 /turf/simulated/floor/redwhite,
 /area/station/security/checkpoint/sec_foyer)
@@ -21739,6 +21772,15 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
+"gKl" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "gKm" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/white/checker{
@@ -21834,6 +21876,14 @@
 /obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
+"gLT" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "gMa" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe,
 /obj/cable{
@@ -22769,21 +22819,6 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
-"hau" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/table/reinforced/auto,
-/obj/machinery/networked/storage/scanner{
-	bank_id = "Mainframe"
-	},
-/obj/machinery/camera/directional/south,
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "haF" = (
 /obj/stool/chair/comfy/purple,
 /obj/landmark/start/job/research_director,
@@ -23692,12 +23727,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
-"hpx" = (
-/obj/machinery/light_switch/west,
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/turret_protected/Zeta)
 "hpF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -23789,17 +23818,6 @@
 	icon_state = "fred2"
 	},
 /area/station/crew_quarters/cafeteria)
-"hrr" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/turretid/computer_core{
-	pixel_x = 24
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "hrF" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -25492,6 +25510,18 @@
 	},
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/arcade/dungeon)
+"hTo" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "hTp" = (
 /obj/disposalpipe/segment/mail,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -27387,12 +27417,6 @@
 	},
 /turf/simulated/floor/stairs/wide/other,
 /area/station/hallway/primary/southeast)
-"iAx" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green/checker,
-/area/station/turret_protected/Zeta)
 "iAB" = (
 /obj/shrub{
 	dir = 1;
@@ -27825,18 +27849,6 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/west)
-"iHn" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "iHL" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -28084,6 +28096,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
+"iKy" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/item/device/net_sniffer,
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/turret_protected/Zeta)
 "iKD" = (
 /obj/storage/secure/closet/personal,
 /obj/machinery/light/incandescent/netural{
@@ -28200,6 +28223,15 @@
 	},
 /turf/simulated/floor/circuit/red,
 /area/station/security/main)
+"iME" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "iMF" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -28351,18 +28383,6 @@
 	dir = 9
 	},
 /area/station/bridge/reception)
-"iQD" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = "Backup";
-	locked = 0;
-	name = "Databank - Backup"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "iQG" = (
 /obj/disposalpipe/segment/mail,
 /obj/health_scanner/wall{
@@ -28389,19 +28409,6 @@
 /area/station/crew_quarters/bathroom/extra2{
 	name = "North Restroom #2"
 	})
-"iQU" = (
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/machinery/computer/robotics,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/green/side{
-	dir = 5
-	},
-/area/station/turret_protected/Zeta)
 "iQY" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black/grime,
@@ -28781,23 +28788,6 @@
 	},
 /turf/space,
 /area/space)
-"iWv" = (
-/obj/table/reinforced/auto,
-/obj/item/paper/book/from_file/dwainedummies{
-	pixel_x = 7
-	},
-/obj/item/paper/book/from_file/guardbot_guide{
-	pixel_x = -7
-	},
-/obj/item/paper/book/from_file/guardbot_guide{
-	pixel_x = -7
-	},
-/obj/item/circuitboard/robotics,
-/obj/machinery/camera/directional/north,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "iWE" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -29028,13 +29018,6 @@
 "iZp" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/outer/sw)
-"iZs" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/box/diskbox,
-/obj/item/storage/box/diskbox,
-/obj/machinery/camera/directional/north,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "iZu" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29251,11 +29234,6 @@
 	dir = 1
 	},
 /area/station/engine/inner)
-"jbO" = (
-/turf/simulated/floor/green/corner{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "jbQ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -29293,6 +29271,10 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/science/storage)
+"jcc" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "jcf" = (
 /obj/machinery/light/small/floor,
 /obj/disposalpipe/segment/morgue{
@@ -29500,16 +29482,6 @@
 	},
 /turf/simulated/floor/circuit/off,
 /area/station/turret_protected/ai)
-"jfA" = (
-/obj/machinery/computer3/generic/radio,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "jfL" = (
 /obj/stool/chair/dining/wood{
 	dir = 4
@@ -31972,9 +31944,6 @@
 	},
 /turf/space,
 /area/space)
-"jRx" = (
-/turf/simulated/floor/green/checker,
-/area/station/turret_protected/Zeta)
 "jRM" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -32279,6 +32248,9 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
+"jWK" = (
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "jWM" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
@@ -32451,17 +32423,6 @@
 "jYB" = (
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/quartersB)
-"jYD" = (
-/obj/machinery/door/airlock/pyro/glass/command{
-	dir = 8
-	},
-/obj/mapping_helper/access/computer_core,
-/obj/mapping_helper/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grey,
-/area/station/turret_protected/Zeta)
 "jYH" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -36919,11 +36880,6 @@
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
-"lxt" = (
-/obj/machinery/turret,
-/obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "lxA" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
 	dir = 1
@@ -37089,13 +37045,6 @@
 	dir = 10
 	},
 /area/station/medical/medbooth)
-"lzj" = (
-/obj/machinery/turret,
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "lzl" = (
 /obj/machinery/camera/directional/south{
 	pixel_x = 10
@@ -41290,6 +41239,18 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/security/main)
+"mNE" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/stool/chair/office/green{
+	dir = 1
+	},
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "mNV" = (
 /obj/cable{
 	icon_state = "2-6"
@@ -41807,6 +41768,12 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/station/crewquarters/fuq3)
+"mWI" = (
+/obj/machinery/vending/computer3,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "mWN" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -42148,6 +42115,15 @@
 	},
 /turf/simulated/wall/auto/jen,
 /area/station/hangar/main)
+"ncf" = (
+/obj/machinery/camera/directional/north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer/robotics,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "ncn" = (
 /obj/tree{
 	desc = "It's a tree. You see the phrase 'Haine <3 SpyGuy' carved into it."
@@ -42983,18 +42959,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/medbay/lobby)
-"noH" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/green/side{
-	dir = 6
-	},
-/area/station/turret_protected/Zeta)
 "noK" = (
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/maintenance/outer/north)
@@ -43299,15 +43263,6 @@
 	},
 /turf/simulated/floor/wood/five,
 /area/station/medical/asylum/main)
-"nue" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light/incandescent/greenish,
-/obj/item/disk/data/tape/boot2,
-/obj/item/disk/data/tape/master,
-/obj/item/disk/data/tape/guardbot_tools,
-/obj/item/disk/data/tape/artifact_research,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "nuH" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -44221,6 +44176,11 @@
 	},
 /turf/simulated/floor/wood/eight,
 /area/station/ai_monitored/armory)
+"nJB" = (
+/turf/simulated/floor/green/corner{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "nJT" = (
 /obj/mesh/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -44450,6 +44410,17 @@
 	icon_state = "fblue6"
 	},
 /area/station/bridge)
+"nNG" = (
+/obj/machinery/door/airlock/pyro/glass/command{
+	dir = 8
+	},
+/obj/mapping_helper/access/computer_core,
+/obj/mapping_helper/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "nNI" = (
 /obj/pool/perspective{
 	dir = 8;
@@ -45416,12 +45387,6 @@
 /obj/machinery/bot/firebot,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
-"oco" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "ocq" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 6;
@@ -45528,6 +45493,15 @@
 	dir = 6
 	},
 /area/station/solar/east)
+"oeS" = (
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/simulated/floor/green/side{
+	dir = 9
+	},
+/area/station/turret_protected/Zeta)
 "oeY" = (
 /obj/table/glass/auto,
 /obj/random_item_spawner/desk_stuff/one_or_zero,
@@ -46024,6 +45998,12 @@
 	dir = 8
 	},
 /area/station/crew_quarters/cafeteria)
+"omt" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/space,
+/area/space)
 "omu" = (
 /obj/machinery/light/small,
 /obj/table/auto,
@@ -47242,6 +47222,12 @@
 	dir = 1
 	},
 /area/station/crew_quarters/kitchen)
+"oFq" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "oFu" = (
 /obj/mesh/catwalk/jen,
 /obj/cable{
@@ -47264,16 +47250,6 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
-"oFD" = (
-/obj/machinery/computer3/terminal/zeta/os_loaded,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "oFH" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /turf/simulated/floor/plating,
@@ -47972,20 +47948,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/exit)
-"oPF" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/stool/chair/office/green{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "oPJ" = (
 /obj/machinery/light/runway_light/delay2,
 /obj/lattice{
@@ -49386,18 +49348,6 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/wood/two,
 /area/station/hallway/primary/northwest)
-"pme" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/stool/chair/office/green{
-	dir = 1
-	},
-/turf/simulated/floor/green/checker,
-/area/station/turret_protected/Zeta)
 "pmj" = (
 /obj/table/glass/reinforced/auto,
 /obj/random_item_spawner/snacks/one_or_zero,
@@ -51616,6 +51566,16 @@
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
+"pVm" = (
+/obj/machinery/computer3/generic/radio,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "pVE" = (
 /turf/simulated/floor/stairs/wide{
 	dir = 1
@@ -51634,14 +51594,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/arcade)
-"pVT" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "pVU" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -51989,15 +51941,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
-"qcG" = (
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/simulated/floor/green/side{
-	dir = 9
-	},
-/area/station/turret_protected/Zeta)
 "qcO" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/cable{
@@ -53268,6 +53211,14 @@
 	},
 /turf/simulated/floor/white,
 /area/station/crewquarters/fuq3)
+"qxh" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/radio,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "qxi" = (
 /obj/storage/closet/dresser,
 /obj/item/clothing/under/gimmick/maid,
@@ -54638,6 +54589,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
+"qUf" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/mainframe/zeta,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "qUg" = (
 /obj/lattice{
 	dir = 5;
@@ -54669,14 +54628,6 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
-"qUl" = (
-/obj/table/reinforced/auto,
-/obj/item/device/multitool,
-/obj/item/screwdriver,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "qUI" = (
 /obj/decal/tile_edge/line/red{
 	dir = 5;
@@ -54714,6 +54665,9 @@
 	dir = 4
 	},
 /area/station/hallway/primary/east)
+"qVk" = (
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "qVv" = (
 /obj/decal/stripe_delivery,
 /obj/cable{
@@ -55768,21 +55722,6 @@
 	dir = 8
 	},
 /area/spacehabitat/pool)
-"rlg" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/item/disk/data/floppy/computer3boot,
-/obj/item/disk/data/floppy/read_only/terminal_os,
-/obj/item/disk/data/floppy/read_only/network_progs,
-/obj/item/disk/data/floppy/read_only/medical_progs,
-/obj/item/disk/data/floppy/read_only/engine_prog,
-/obj/item/disk/data/floppy/read_only/security_progs,
-/obj/item/disk/data/floppy/read_only/communications,
-/obj/item/disk/data/floppy/read_only/bank_progs,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "rlw" = (
 /obj/decal/boxingrope{
 	dir = 4
@@ -56518,20 +56457,6 @@
 /obj/mesh/catwalk/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/east)
-"rxA" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/table/reinforced/auto,
-/obj/machinery/networked/printer{
-	print_id = "Mainframe"
-	},
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "rxO" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -57060,6 +56985,17 @@
 /obj/fakeobject/palmtree,
 /turf/simulated/floor/grass,
 /area/station/medical/dome)
+"rGn" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/turretid/computer_core{
+	pixel_x = 24
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "rGo" = (
 /turf/simulated/wall/auto/jen/purple,
 /area/station/science/gen_storage)
@@ -57358,10 +57294,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"rKR" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/grey,
-/area/station/turret_protected/Zeta)
 "rKY" = (
 /obj/machinery/floorflusher/minibrig,
 /obj/disposalpipe/trunk/brig,
@@ -57818,12 +57750,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"rRu" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "rRw" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/item/device/radio/beacon,
@@ -58271,6 +58197,15 @@
 	},
 /obj/cable{
 	icon_state = "5-10"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/circuit/off,
 /area/station/turret_protected/ai)
@@ -59824,6 +59759,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/computer/robotics{
+	dir = 4
+	},
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
@@ -60440,6 +60378,14 @@
 /obj/item/light/tube,
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
+"sIH" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "sIK" = (
 /turf/space,
 /area/station/turret_protected/armory_outside)
@@ -62463,6 +62409,15 @@
 	},
 /turf/simulated/floor/circuit/red,
 /area/station/security/main)
+"tnj" = (
+/obj/table/reinforced/auto,
+/obj/machinery/light/incandescent/greenish,
+/obj/item/disk/data/tape/boot2,
+/obj/item/disk/data/tape/master,
+/obj/item/disk/data/tape/guardbot_tools,
+/obj/item/disk/data/tape/artifact_research,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "tnn" = (
 /obj/machinery/shuttle/engine/heater{
 	dir = 8;
@@ -64277,6 +64232,14 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/bridge)
+"tOX" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "tPp" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/light/small/sticky{
@@ -65609,6 +65572,14 @@
 	dir = 4
 	},
 /area/station/hallway/primary/northwest)
+"unb" = (
+/obj/table/reinforced/auto,
+/obj/item/device/multitool,
+/obj/item/screwdriver,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "unp" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/wood/seven,
@@ -66272,6 +66243,12 @@
 	},
 /turf/simulated/floor/carpet/arcade/half,
 /area/station/crew_quarters/arcade/dungeon)
+"uxg" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "uxm" = (
 /turf/simulated/wall/auto/jen/blue,
 /area/station/medical/medbay/surgery/storage)
@@ -68498,6 +68475,11 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"vey" = (
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "veI" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -69036,19 +69018,6 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
-"vmE" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = "Control";
-	locked = 0;
-	name = "Databank - Control";
-	setup_drive_type = /obj/item/disk/data/tape/master
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "vmV" = (
 /obj/machinery/light/small/floor/warm,
 /turf/simulated/floor/black,
@@ -70282,6 +70251,21 @@
 	dir = 10
 	},
 /area/station/science/lobby)
+"vEI" = (
+/obj/table/reinforced/auto,
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/item/disk/data/floppy/computer3boot,
+/obj/item/disk/data/floppy/read_only/terminal_os,
+/obj/item/disk/data/floppy/read_only/network_progs,
+/obj/item/disk/data/floppy/read_only/medical_progs,
+/obj/item/disk/data/floppy/read_only/engine_prog,
+/obj/item/disk/data/floppy/read_only/security_progs,
+/obj/item/disk/data/floppy/read_only/communications,
+/obj/item/disk/data/floppy/read_only/bank_progs,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "vES" = (
 /obj/item/clothing/glasses/sunglasses{
 	pixel_x = -3;
@@ -71989,6 +71973,19 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
+"wgx" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Control";
+	locked = 0;
+	name = "Databank - Control";
+	setup_drive_type = /obj/item/disk/data/tape/master
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "wgJ" = (
 /obj/machinery/shield_generator{
 	desc = "Protects the chief's aquarium from outside threats. Must have pulled some strings for this.";
@@ -72448,6 +72445,13 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/artifact)
+"wnn" = (
+/obj/machinery/turret,
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "wnq" = (
 /obj/machinery/door/airlock/pyro/command{
 	req_access = null;
@@ -72553,15 +72557,6 @@
 	icon_state = "fblue3"
 	},
 /area/station/medical/head)
-"woz" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "woF" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -72908,9 +72903,6 @@
 	},
 /turf/simulated/floor/stairs/wood2/wide,
 /area/station/crew_quarters/cafeteria)
-"wtk" = (
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "wtq" = (
 /obj/submachine/chicken_incubator,
 /obj/item/reagent_containers/food/snacks/ingredient/egg{
@@ -76547,6 +76539,21 @@
 	dir = 4
 	},
 /area/spacehabitat/pool)
+"xsp" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/table/reinforced/auto,
+/obj/machinery/networked/storage/scanner{
+	bank_id = "Mainframe"
+	},
+/obj/machinery/camera/directional/south,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "xsr" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/carpet/arcade,
@@ -76762,12 +76769,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
-"xwu" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/turret_protected/Zeta)
 "xwE" = (
 /turf/simulated/wall/auto/reinforced/jen/red,
 /area/station/security/checkpoint/escape)
@@ -77257,14 +77258,6 @@
 	dir = 5
 	},
 /area/station/medical/medbay)
-"xEb" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/mainframe/zeta,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "xEe" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -78201,6 +78194,22 @@
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
+"xSd" = (
+/obj/table/reinforced/auto,
+/obj/item/paper/book/from_file/dwainedummies{
+	pixel_x = 7
+	},
+/obj/item/paper/book/from_file/guardbot_guide{
+	pixel_x = -7
+	},
+/obj/item/paper/book/from_file/guardbot_guide{
+	pixel_x = -7
+	},
+/obj/machinery/camera/directional/north,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "xSp" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -78723,6 +78732,19 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/solar/west)
+"xYa" = (
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	name = "Computer Core"
+	},
+/obj/mapping_helper/access/computer_core,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/ai_upload,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "xYd" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -78802,6 +78824,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"xZb" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "xZi" = (
 /obj/shrub{
 	dir = 1;
@@ -78838,6 +78866,11 @@
 	dir = 1
 	},
 /area/station/bridge/customs)
+"xZZ" = (
+/obj/machinery/turret,
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "yab" = (
 /obj/decal/stage_edge{
 	layer = 2.8
@@ -78942,14 +78975,6 @@
 /obj/random_item_spawner/junk/maybe_few,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/nw)
-"ybo" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/radio,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "ybr" = (
 /obj/mapping_helper/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
@@ -117996,7 +118021,7 @@ hyr
 hyr
 hyr
 ncS
-eLZ
+xYa
 ncS
 hyr
 jrN
@@ -118013,10 +118038,10 @@ rdj
 rdj
 rdj
 rdj
+omt
 rdj
-rdj
-rdj
-rdj
+omt
+omt
 rdj
 rdj
 rdj
@@ -118297,9 +118322,9 @@ mpb
 xVi
 eVo
 ncS
-qcG
-pVT
-hpx
+oeS
+gLT
+cvU
 ncS
 ncS
 ncS
@@ -118314,7 +118339,7 @@ rdj
 rdj
 rdj
 rdj
-rdj
+omt
 rdj
 rdj
 rdj
@@ -118599,11 +118624,11 @@ dkB
 dkB
 dkB
 ncS
-enQ
-xwu
-jbO
-eqa
-gBd
+mWI
+uxg
+nJB
+vey
+iKy
 ncS
 rdj
 rdj
@@ -118614,8 +118639,8 @@ rdj
 rdj
 rdj
 rdj
-rdj
-rdj
+omt
+omt
 rdj
 rdj
 rdj
@@ -118901,11 +118926,11 @@ tbu
 nDE
 hKs
 ncS
-oFD
-pme
-jRx
-jRx
-rxA
+csp
+mNE
+jWK
+jWK
+dnE
 ncS
 rdj
 rdj
@@ -118915,7 +118940,7 @@ rdj
 rdj
 rdj
 rdj
-rdj
+omt
 rdj
 rdj
 rdj
@@ -119203,11 +119228,11 @@ vcE
 ceb
 srn
 ncS
-iWv
-iAx
-jRx
-jRx
-hau
+xSd
+dfu
+jWK
+jWK
+xsp
 ncS
 rdj
 rdj
@@ -119505,11 +119530,11 @@ mnb
 wkm
 kDs
 ncS
-jfA
-pme
-jRx
-jRx
-fSK
+pVm
+mNE
+jWK
+jWK
+aXj
 ncS
 rdj
 rdj
@@ -119807,11 +119832,11 @@ vcE
 pBX
 iJq
 ncS
-qUl
-iAx
-jRx
-jRx
-rRu
+unb
+dfu
+jWK
+jWK
+cMZ
 ncS
 rdj
 rdj
@@ -120109,11 +120134,11 @@ mlS
 pay
 lml
 ncS
-iQU
-oPF
-ahg
-hrr
-noH
+fpC
+sIH
+tOX
+rGn
+btb
 ncS
 rdj
 rdj
@@ -120412,10 +120437,10 @@ uBi
 rOT
 rOT
 ncS
-rKR
-rKR
-rKR
-jYD
+jcc
+jcc
+jcc
+nNG
 ncS
 ncS
 ncS
@@ -120714,12 +120739,12 @@ pTE
 adf
 vhl
 ncS
-lzj
-wtk
-wtk
-bhN
-wtk
-lxt
+wnn
+qVk
+qVk
+oFq
+qVk
+xZZ
 ncS
 rdj
 rdj
@@ -121016,12 +121041,12 @@ dxm
 lGE
 nyK
 ncS
-iZs
-oco
-woz
-iHn
-bqC
-cdg
+ncf
+gKl
+iME
+hTo
+xZb
+ebB
 ncS
 rdj
 rdj
@@ -121318,12 +121343,12 @@ bCY
 gnK
 bHn
 ncS
-rlg
-ybo
-xEb
-vmE
-iQD
-nue
+vEI
+qxh
+qUf
+wgx
+bqj
+tnj
 ncS
 rdj
 rdj

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -1832,6 +1832,11 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
+"ayY" = (
+/turf/simulated/floor/green/corner{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "azp" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -3281,6 +3286,11 @@
 	dir = 6
 	},
 /area/station/hallway/primary/south)
+"aVG" = (
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "aVI" = (
 /turf/simulated/wall/auto/reinforced/jen/red,
 /area/station/maintenance/outer/west)
@@ -4210,6 +4220,9 @@
 /obj/item/storage/toolbox/emergency,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/hallway/primary/south)
+"bkJ" = (
+/turf/simulated/wall/auto/reinforced/jen/purple,
+/area/station/turret_protected/Zeta)
 "bkQ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -4523,6 +4536,16 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
+"brh" = (
+/obj/machinery/light/incandescent/greenish,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/vending/computer3,
+/turf/simulated/floor/green/side{
+	dir = 6
+	},
+/area/station/turret_protected/Zeta)
 "brj" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/wood/two,
@@ -6280,6 +6303,18 @@
 	},
 /turf/simulated/wall/auto/jen,
 /area/station/maintenance/outer/north)
+"bRr" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "bRs" = (
 /obj/machinery/vending/floppy,
 /obj/machinery/light/incandescent,
@@ -11041,6 +11076,12 @@
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/crew_quarters/clown)
+"dof" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "dol" = (
 /obj/stool/chair/office{
 	dir = 1
@@ -11793,6 +11834,12 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/stockex)
+"dDo" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "dDv" = (
 /obj/decal/tile_edge/line/white{
 	color = "#ffccff";
@@ -13323,6 +13370,23 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
+"eaO" = (
+/obj/table/reinforced/auto,
+/obj/item/paper/book/from_file/dwainedummies{
+	pixel_x = 7
+	},
+/obj/item/paper/book/from_file/guardbot_guide{
+	pixel_x = -7
+	},
+/obj/item/paper/book/from_file/guardbot_guide{
+	pixel_x = -7
+	},
+/obj/item/circuitboard/robotics,
+/obj/machinery/camera/directional/north,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "eaQ" = (
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -14919,6 +14983,16 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
+"eCA" = (
+/obj/machinery/computer3/terminal/zeta/os_loaded,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "eCB" = (
 /turf/simulated/floor/black,
 /area/station/bridge/reception)
@@ -15560,6 +15634,14 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
+"eOZ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "ePf" = (
 /obj/railing/orange{
 	dir = 1
@@ -17662,6 +17744,14 @@
 /obj/mesh/catwalk/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/east)
+"fwx" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "fwI" = (
 /obj/machinery/networked/test_apparatus/pitching_machine{
 	dir = 4
@@ -19587,6 +19677,9 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
+"gbY" = (
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "gca" = (
 /obj/machinery/conveyor_switch{
 	id = "toxins_plasma";
@@ -21063,6 +21156,14 @@
 /obj/disposalpipe/segment/brig,
 /turf/simulated/wall/auto/jen/red,
 /area/station/hallway/primary/west)
+"gAa" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/table/reinforced/auto,
+/obj/random_item_spawner/peripherals/some,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "gAo" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -22452,6 +22553,17 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
+"gWH" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/turretid/computer_core{
+	pixel_x = 24
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "gWM" = (
 /obj/table/auto,
 /obj/random_item_spawner/desk_stuff/one_or_zero,
@@ -25680,6 +25792,10 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/surgery/storage)
+"hZK" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "hZS" = (
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -26209,6 +26325,15 @@
 	},
 /turf/simulated/floor/circuit/off,
 /area/station/turret_protected/ai)
+"ihc" = (
+/obj/table/reinforced/auto,
+/obj/machinery/light/incandescent/greenish,
+/obj/item/disk/data/tape/boot2,
+/obj/item/disk/data/tape/master,
+/obj/item/disk/data/tape/guardbot_tools,
+/obj/item/disk/data/tape/artifact_research,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "ihr" = (
 /turf/simulated/floor/redblack{
 	dir = 8
@@ -26844,6 +26969,17 @@
 /obj/mesh/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
+"itT" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "itU" = (
 /obj/decal/stripe_delivery,
 /obj/mapping_helper/firedoor_spawn,
@@ -27203,6 +27339,9 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
+"izn" = (
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "izp" = (
 /obj/disposalpipe/segment/food{
 	icon_state = "pipe-c"
@@ -30215,6 +30354,12 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
+"juO" = (
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/turret_protected/Zeta)
 "jvb" = (
 /turf/simulated/wall/auto/jen,
 /area/station/hangar/science)
@@ -33630,6 +33775,18 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
+"kvU" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/stool/chair/office/green{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "kwl" = (
 /obj/machinery/power/solar,
 /turf/simulated/floor/airless/solar,
@@ -34583,6 +34740,9 @@
 /obj/machinery/camera/directional/south{
 	pixel_x = 10
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grey,
 /area/station/science/lab)
 "kMo" = (
@@ -34749,6 +34909,11 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
+"kPc" = (
+/obj/machinery/turret,
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "kPe" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -35094,6 +35259,9 @@
 	},
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grey,
 /area/station/science/lab)
@@ -37124,6 +37292,15 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/quartermaster/office)
+"lCq" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "lCu" = (
 /obj/machinery/chem_master{
 	dir = 1
@@ -41789,6 +41966,14 @@
 "mYB" = (
 /turf/simulated/wall/auto/reinforced/jen/yellow,
 /area/station/mining/staff_room)
+"mYR" = (
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/turf/simulated/floor/green/side{
+	dir = 5
+	},
+/area/station/turret_protected/Zeta)
 "mYY" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/decal/stripe_delivery,
@@ -41983,7 +42168,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/station/science/artifact)
+/area/station/turret_protected/Zeta)
 "ncZ" = (
 /obj/machinery/light_switch/east,
 /turf/simulated/floor,
@@ -42052,6 +42237,9 @@
 	dir = 8
 	},
 /obj/machinery/light/incandescent/harsh,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/grey,
 /area/station/science/lab)
 "ndN" = (
@@ -45666,6 +45854,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/southeast)
+"oky" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/box/tapebox,
+/obj/item/storage/box/tapebox,
+/obj/machinery/camera/directional/south,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "okB" = (
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass,
@@ -46215,6 +46410,19 @@
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen/freezer)
+"osu" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Control";
+	locked = 0;
+	name = "Databank - Control";
+	setup_drive_type = /obj/item/disk/data/tape/master
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "osx" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -47298,6 +47506,13 @@
 /area/station/wreckage{
 	name = "Restricted Area"
 	})
+"oJy" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/box/diskbox,
+/obj/item/storage/box/diskbox,
+/obj/machinery/camera/directional/north,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "oJI" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger{
@@ -49371,6 +49586,15 @@
 	dir = 6
 	},
 /area/station/hydroponics/bay)
+"prH" = (
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/simulated/floor/green/side{
+	dir = 9
+	},
+/area/station/turret_protected/Zeta)
 "prO" = (
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
@@ -50962,6 +51186,18 @@
 	},
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/kitchen/freezer)
+"pPu" = (
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	name = "Computer Core"
+	},
+/obj/mapping_helper/access/computer_core,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/mapping_helper/firedoor_spawn,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "pPz" = (
 /obj/machinery/light/incandescent/harsh{
 	dir = 1
@@ -52167,6 +52403,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"qkH" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "qkJ" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -52914,6 +53156,13 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor/darkblue/checker,
 /area/station/ai_monitored/storage/eva)
+"qvP" = (
+/obj/machinery/turret,
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "qwb" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 9;
@@ -56080,6 +56329,14 @@
 	},
 /turf/simulated/floor/white/checker,
 /area/station/medical/medbay/lobby)
+"rvQ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "rvX" = (
 /obj/disposalpipe/segment/food{
 	dir = 8;
@@ -56930,6 +57187,17 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/robotics)
+"rIH" = (
+/obj/machinery/light/incandescent/greenish,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/item/device/net_sniffer,
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/turret_protected/Zeta)
 "rII" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -61960,6 +62228,15 @@
 	dir = 8
 	},
 /area/station/security/quarters)
+"tkw" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/table/reinforced/auto,
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/printer,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "tky" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -65282,6 +65559,14 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/wood/seven,
 /area/station/security/detectives_office)
+"unB" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/mainframe/zeta,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "unD" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -65389,6 +65674,21 @@
 	},
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
+"upK" = (
+/obj/table/reinforced/auto,
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/item/disk/data/floppy/computer3boot,
+/obj/item/disk/data/floppy/read_only/terminal_os,
+/obj/item/disk/data/floppy/read_only/network_progs,
+/obj/item/disk/data/floppy/read_only/medical_progs,
+/obj/item/disk/data/floppy/read_only/engine_prog,
+/obj/item/disk/data/floppy/read_only/security_progs,
+/obj/item/disk/data/floppy/read_only/communications,
+/obj/item/disk/data/floppy/read_only/bank_progs,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "upS" = (
 /obj/machinery/light/incandescent{
 	dir = 4
@@ -65449,6 +65749,14 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/medical/breakroom)
+"uqG" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/radio,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "uqL" = (
 /obj/machinery/light/incandescent/cool,
 /obj/cable{
@@ -66405,6 +66713,18 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
+"uEh" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = Backup;
+	locked = 0;
+	name = "Databank - Backup"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "uEm" = (
 /obj/table/wood/auto,
 /obj/item/plate{
@@ -68279,6 +68599,11 @@
 	dir = 10
 	},
 /area/station/hangar/main)
+"vfL" = (
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "vfO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -69515,6 +69840,14 @@
 /obj/mesh/catwalk/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/se)
+"vyF" = (
+/obj/machinery/door/airlock/pyro/glass/command{
+	dir = 8
+	},
+/obj/mapping_helper/access/computer_core,
+/obj/mapping_helper/firedoor_spawn,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "vyH" = (
 /obj/disposalpipe/junction{
 	name = "factory pipe"
@@ -70030,6 +70363,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"vHg" = (
+/obj/machinery/computer3/generic/radio,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "vHi" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -70125,6 +70468,19 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
+"vIl" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/table/reinforced/auto,
+/obj/item/device/multitool,
+/obj/item/screwdriver,
+/obj/machinery/power/apc/autoname_south,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "vIm" = (
 /turf/simulated/floor/arrival/corner{
 	dir = 8
@@ -71391,6 +71747,19 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
+"wbK" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/table/reinforced/auto,
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/scanner,
+/obj/machinery/camera/directional/south,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "wbM" = (
 /obj/table/auto,
 /obj/item/storage/box/trash_bags{
@@ -73081,6 +73450,12 @@
 	icon_state = "nt_logo"
 	},
 /area/station/crew_quarters/courtroom)
+"wAu" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "wAy" = (
 /obj/decal/stripe_delivery,
 /obj/cable{
@@ -117618,9 +117993,9 @@ hyr
 hyr
 hyr
 hyr
-hyr
-hyr
-hyr
+bkJ
+pPu
+bkJ
 hyr
 jrN
 otz
@@ -117919,15 +118294,15 @@ aAz
 mpb
 xVi
 eVo
-hyr
-rdj
-rdj
-rdj
-hyr
-hyr
-hyr
-hyr
-rdj
+bkJ
+prH
+eOZ
+juO
+bkJ
+bkJ
+bkJ
+bkJ
+bkJ
 rdj
 rdj
 rdj
@@ -118221,15 +118596,15 @@ dkB
 dkB
 dkB
 dkB
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+bkJ
+aVG
+qkH
+ayY
+vfL
+vfL
+vfL
+rIH
+bkJ
 rdj
 rdj
 rdj
@@ -118523,15 +118898,15 @@ xJu
 tbu
 nDE
 hKs
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+bkJ
+eCA
+kvU
+gbY
+gbY
+gbY
+gbY
+tkw
+bkJ
 rdj
 rdj
 rdj
@@ -118825,15 +119200,15 @@ bQT
 vcE
 ceb
 srn
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+bkJ
+eaO
+qkH
+gbY
+gbY
+gbY
+gbY
+wbK
+bkJ
 rdj
 rdj
 rdj
@@ -119127,15 +119502,15 @@ gIT
 mnb
 wkm
 kDs
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+bkJ
+vHg
+kvU
+gbY
+gbY
+gbY
+gbY
+vIl
+bkJ
 rdj
 rdj
 rdj
@@ -119429,15 +119804,15 @@ bQT
 vcE
 pBX
 iJq
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+bkJ
+aVG
+qkH
+gbY
+gbY
+gbY
+gbY
+gAa
+bkJ
 rdj
 rdj
 rdj
@@ -119731,15 +120106,15 @@ thx
 mlS
 pay
 lml
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+bkJ
+mYR
+fwx
+rvQ
+gWH
+itT
+rvQ
+brh
+bkJ
 rdj
 rdj
 rdj
@@ -120034,14 +120409,14 @@ uBi
 uBi
 rOT
 rOT
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-tXv
+bkJ
+hZK
+hZK
+hZK
+vyF
+hZK
+hZK
+bkJ
 rdj
 rdj
 rdj
@@ -120337,13 +120712,13 @@ pTE
 adf
 vhl
 ncS
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+qvP
+izn
+izn
+dDo
+izn
+kPc
+bkJ
 rdj
 rdj
 rdj
@@ -120639,13 +121014,13 @@ dxm
 lGE
 nyK
 ncS
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+oJy
+dof
+lCq
+bRr
+wAu
+oky
+bkJ
 rdj
 rdj
 rdj
@@ -120941,13 +121316,13 @@ bCY
 gnK
 bHn
 ncS
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+upK
+uqG
+unB
+osu
+uEh
+ihc
+bkJ
 rdj
 rdj
 rdj
@@ -121242,14 +121617,14 @@ rOT
 rOT
 rOT
 rOT
-rOT
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+bkJ
+bkJ
+bkJ
+bkJ
+bkJ
+bkJ
+bkJ
+bkJ
 rdj
 rdj
 rdj

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -59838,9 +59838,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer/robotics{
-	dir = 4
-	},
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -456,6 +456,12 @@
 	dir = 1
 	},
 /area/station/crew_quarters/kitchen)
+"adE" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "adN" = (
 /obj/rack,
 /obj/item/clothing/shoes/magnetic,
@@ -1832,11 +1838,6 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
-"ayY" = (
-/turf/simulated/floor/green/corner{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "azp" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -3286,11 +3287,6 @@
 	dir = 6
 	},
 /area/station/hallway/primary/south)
-"aVG" = (
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "aVI" = (
 /turf/simulated/wall/auto/reinforced/jen/red,
 /area/station/maintenance/outer/west)
@@ -3323,6 +3319,23 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
+"aWb" = (
+/obj/table/reinforced/auto,
+/obj/item/paper/book/from_file/dwainedummies{
+	pixel_x = 7
+	},
+/obj/item/paper/book/from_file/guardbot_guide{
+	pixel_x = -7
+	},
+/obj/item/paper/book/from_file/guardbot_guide{
+	pixel_x = -7
+	},
+/obj/item/circuitboard/robotics,
+/obj/machinery/camera/directional/north,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "aWf" = (
 /obj/table/round/auto,
 /obj/item/reagent_containers/applicator/condiment/shaker/pepper{
@@ -3568,6 +3581,17 @@
 /obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/red/checker,
 /area/station/security/checkpoint/sec_foyer)
+"aZW" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/turretid/computer_core{
+	pixel_x = 24
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "baj" = (
 /obj/decal/tile_edge/line/white{
 	dir = 4;
@@ -4201,6 +4225,12 @@
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
+"bkl" = (
+/obj/machinery/vending/computer3,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "bko" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -4220,9 +4250,6 @@
 /obj/item/storage/toolbox/emergency,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/hallway/primary/south)
-"bkJ" = (
-/turf/simulated/wall/auto/reinforced/jen/purple,
-/area/station/turret_protected/Zeta)
 "bkQ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1
@@ -4536,16 +4563,6 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
-"brh" = (
-/obj/machinery/light/incandescent/greenish,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/vending/computer3,
-/turf/simulated/floor/green/side{
-	dir = 6
-	},
-/area/station/turret_protected/Zeta)
 "brj" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/wood/two,
@@ -6303,18 +6320,6 @@
 	},
 /turf/simulated/wall/auto/jen,
 /area/station/maintenance/outer/north)
-"bRr" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "bRs" = (
 /obj/machinery/vending/floppy,
 /obj/machinery/light/incandescent,
@@ -8148,6 +8153,15 @@
 /obj/effects/background_objects/x0,
 /turf/space,
 /area/space)
+"csr" = (
+/obj/table/reinforced/auto,
+/obj/machinery/light/incandescent/greenish,
+/obj/item/disk/data/tape/boot2,
+/obj/item/disk/data/tape/master,
+/obj/item/disk/data/tape/guardbot_tools,
+/obj/item/disk/data/tape/artifact_research,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "csv" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -8362,6 +8376,12 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
+"cvm" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "cvv" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -9228,6 +9248,18 @@
 "cHm" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/maintenance/outer/east)
+"cHC" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/green/side{
+	dir = 6
+	},
+/area/station/turret_protected/Zeta)
 "cHD" = (
 /obj/mesh/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -10566,6 +10598,12 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"dgC" = (
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/turret_protected/Zeta)
 "dgS" = (
 /obj/table/wood/auto,
 /obj/machinery/light/lamp/black{
@@ -11076,12 +11114,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/crew_quarters/clown)
-"dof" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "dol" = (
 /obj/stool/chair/office{
 	dir = 1
@@ -11570,6 +11602,13 @@
 	icon_state = "fred2"
 	},
 /area/station/chapel/office)
+"dxS" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/box/diskbox,
+/obj/item/storage/box/diskbox,
+/obj/machinery/camera/directional/north,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "dye" = (
 /obj/decal/stripe_delivery,
 /obj/mapping_helper/firedoor_spawn,
@@ -11834,12 +11873,6 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/stockex)
-"dDo" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "dDv" = (
 /obj/decal/tile_edge/line/white{
 	color = "#ffccff";
@@ -13354,6 +13387,17 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/solar/east)
+"dZO" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/item/device/net_sniffer,
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/turret_protected/Zeta)
 "eag" = (
 /obj/machinery/chem_dispenser/soda,
 /obj/machinery/light/emergency{
@@ -13370,23 +13414,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
-"eaO" = (
-/obj/table/reinforced/auto,
-/obj/item/paper/book/from_file/dwainedummies{
-	pixel_x = 7
-	},
-/obj/item/paper/book/from_file/guardbot_guide{
-	pixel_x = -7
-	},
-/obj/item/paper/book/from_file/guardbot_guide{
-	pixel_x = -7
-	},
-/obj/item/circuitboard/robotics,
-/obj/machinery/camera/directional/north,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "eaQ" = (
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -14983,16 +15010,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
-"eCA" = (
-/obj/machinery/computer3/terminal/zeta/os_loaded,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "eCB" = (
 /turf/simulated/floor/black,
 /area/station/bridge/reception)
@@ -15063,6 +15080,11 @@
 	dir = 4
 	},
 /area/station/medical/medbay/surgery/storage)
+"eEt" = (
+/turf/simulated/floor/green/corner{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "eEy" = (
 /obj/decal/stage_edge{
 	layer = 2.8
@@ -15237,6 +15259,12 @@
 	},
 /turf/simulated/floor/redwhite,
 /area/station/security/quarters)
+"eHW" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "eIb" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
@@ -15634,14 +15662,6 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
-"eOZ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "ePf" = (
 /obj/railing/orange{
 	dir = 1
@@ -15778,6 +15798,21 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/science/lobby)
+"eRo" = (
+/obj/table/reinforced/auto,
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/item/disk/data/floppy/computer3boot,
+/obj/item/disk/data/floppy/read_only/terminal_os,
+/obj/item/disk/data/floppy/read_only/network_progs,
+/obj/item/disk/data/floppy/read_only/medical_progs,
+/obj/item/disk/data/floppy/read_only/engine_prog,
+/obj/item/disk/data/floppy/read_only/security_progs,
+/obj/item/disk/data/floppy/read_only/communications,
+/obj/item/disk/data/floppy/read_only/bank_progs,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "eRI" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
@@ -15901,6 +15936,15 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
+"eTI" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "eTU" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -17744,14 +17788,6 @@
 /obj/mesh/catwalk/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/east)
-"fwx" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "fwI" = (
 /obj/machinery/networked/test_apparatus/pitching_machine{
 	dir = 4
@@ -19616,6 +19652,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
+"gaN" = (
+/obj/machinery/computer3/generic/radio,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "gaS" = (
 /turf/simulated/wall/auto/jen/purple{
 	icon_state = "5"
@@ -19677,9 +19723,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
-"gbY" = (
-/turf/simulated/floor,
-/area/station/turret_protected/Zeta)
 "gca" = (
 /obj/machinery/conveyor_switch{
 	id = "toxins_plasma";
@@ -21156,14 +21199,6 @@
 /obj/disposalpipe/segment/brig,
 /turf/simulated/wall/auto/jen/red,
 /area/station/hallway/primary/west)
-"gAa" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/table/reinforced/auto,
-/obj/random_item_spawner/peripherals/some,
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "gAo" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -21175,6 +21210,15 @@
 	dir = 1
 	},
 /area/station/medical/medbay/treatment)
+"gAw" = (
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/machinery/computer/robotics,
+/turf/simulated/floor/green/side{
+	dir = 5
+	},
+/area/station/turret_protected/Zeta)
 "gAF" = (
 /obj/decal/stripe_caution,
 /obj/rack,
@@ -22553,17 +22597,6 @@
 /obj/mapping_helper/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
-"gWH" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/turretid/computer_core{
-	pixel_x = 24
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "gWM" = (
 /obj/table/auto,
 /obj/random_item_spawner/desk_stuff/one_or_zero,
@@ -25463,6 +25496,18 @@
 	},
 /turf/simulated/wall/auto/reinforced/jen/purple,
 /area/station/science/lab)
+"hSr" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/table/reinforced/auto,
+/obj/machinery/networked/printer,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "hSD" = (
 /obj/item/device/audio_log/wall_mounted{
 	anchored = 1;
@@ -25792,10 +25837,6 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/surgery/storage)
-"hZK" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/grey,
-/area/station/turret_protected/Zeta)
 "hZS" = (
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -26325,15 +26366,6 @@
 	},
 /turf/simulated/floor/circuit/off,
 /area/station/turret_protected/ai)
-"ihc" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light/incandescent/greenish,
-/obj/item/disk/data/tape/boot2,
-/obj/item/disk/data/tape/master,
-/obj/item/disk/data/tape/guardbot_tools,
-/obj/item/disk/data/tape/artifact_research,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "ihr" = (
 /turf/simulated/floor/redblack{
 	dir = 8
@@ -26715,6 +26747,9 @@
 	},
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
+"inG" = (
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "inM" = (
 /obj/machinery/shower{
 	dir = 4
@@ -26969,17 +27004,6 @@
 /obj/mesh/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
-"itT" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "itU" = (
 /obj/decal/stripe_delivery,
 /obj/mapping_helper/firedoor_spawn,
@@ -27339,9 +27363,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
-"izn" = (
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "izp" = (
 /obj/disposalpipe/segment/food{
 	icon_state = "pipe-c"
@@ -28227,6 +28248,14 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/quartersC)
+"iNi" = (
+/obj/machinery/door/airlock/pyro/glass/command{
+	dir = 8
+	},
+/obj/mapping_helper/access/computer_core,
+/obj/mapping_helper/firedoor_spawn,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "iNG" = (
 /obj/machinery/conveyor/EW{
 	id = "disposals";
@@ -30354,12 +30383,6 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
-"juO" = (
-/obj/machinery/light_switch/west,
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/turret_protected/Zeta)
 "jvb" = (
 /turf/simulated/wall/auto/jen,
 /area/station/hangar/science)
@@ -33775,18 +33798,6 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
-"kvU" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/stool/chair/office/green{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/turret_protected/Zeta)
 "kwl" = (
 /obj/machinery/power/solar,
 /turf/simulated/floor/airless/solar,
@@ -34557,6 +34568,11 @@
 /obj/mapping_helper/access/hydro,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
+"kJz" = (
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "kKf" = (
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass{
@@ -34909,11 +34925,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
-"kPc" = (
-/obj/machinery/turret,
-/obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "kPe" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37292,15 +37303,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/quartermaster/office)
-"lCq" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "lCu" = (
 /obj/machinery/chem_master{
 	dir = 1
@@ -39420,6 +39422,13 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
+"mhd" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/box/tapebox,
+/obj/item/storage/box/tapebox,
+/obj/machinery/camera/directional/south,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "mhe" = (
 /turf/simulated/wall/auto/jen/yellow,
 /area/station/hangar/qm)
@@ -39674,6 +39683,18 @@
 /obj/cable,
 /turf/simulated/floor/grey,
 /area/station/science/artifact)
+"mlV" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/stool/chair/office/green{
+	dir = 1
+	},
+/turf/simulated/floor/bluegreen,
+/area/station/turret_protected/Zeta)
 "mmc" = (
 /obj/machinery/loudspeaker,
 /obj/disposalpipe/segment/food,
@@ -41762,6 +41783,12 @@
 /obj/table/reinforced/auto,
 /turf/simulated/floor/green,
 /area/station/medical/cdc)
+"mWw" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "mWB" = (
 /obj/table/auto,
 /obj/item/clothing/head/merchant_hat,
@@ -41966,14 +41993,6 @@
 "mYB" = (
 /turf/simulated/wall/auto/reinforced/jen/yellow,
 /area/station/mining/staff_room)
-"mYR" = (
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/turf/simulated/floor/green/side{
-	dir = 5
-	},
-/area/station/turret_protected/Zeta)
 "mYY" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/decal/stripe_delivery,
@@ -42160,14 +42179,7 @@
 /turf/space,
 /area/station/turret_protected/armory_outside)
 "ncS" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "artlab";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/auto/reinforced/jen/purple,
 /area/station/turret_protected/Zeta)
 "ncZ" = (
 /obj/machinery/light_switch/east,
@@ -42800,6 +42812,18 @@
 /obj/item/clothing/head/cakehat,
 /turf/simulated/floor/black,
 /area/station/security/visitation)
+"nmu" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/stool/chair/office/green{
+	dir = 1
+	},
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "nmG" = (
 /obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/black,
@@ -45854,13 +45878,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/southeast)
-"oky" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/box/tapebox,
-/obj/item/storage/box/tapebox,
-/obj/machinery/camera/directional/south,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "okB" = (
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass,
@@ -46410,19 +46427,6 @@
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen/freezer)
-"osu" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = "Control";
-	locked = 0;
-	name = "Databank - Control";
-	setup_drive_type = /obj/item/disk/data/tape/master
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "osx" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -47506,13 +47510,6 @@
 /area/station/wreckage{
 	name = "Restricted Area"
 	})
-"oJy" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/box/diskbox,
-/obj/item/storage/box/diskbox,
-/obj/machinery/camera/directional/north,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "oJI" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger{
@@ -48042,6 +48039,14 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/medbooth)
+"oRz" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/mainframe/zeta,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "oSc" = (
 /obj/machinery/sink/slim{
 	pixel_y = 11
@@ -49586,15 +49591,6 @@
 	dir = 6
 	},
 /area/station/hydroponics/bay)
-"prH" = (
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/simulated/floor/green/side{
-	dir = 9
-	},
-/area/station/turret_protected/Zeta)
 "prO" = (
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
@@ -50238,6 +50234,15 @@
 "pBP" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hop)
+"pBR" = (
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/simulated/floor/green/side{
+	dir = 9
+	},
+/area/station/turret_protected/Zeta)
 "pBX" = (
 /obj/decal/tile_edge/stripe/corner/big2{
 	dir = 10
@@ -50976,6 +50981,12 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
+"pLW" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegreen,
+/area/station/turret_protected/Zeta)
 "pMc" = (
 /obj/stool/chair/comfy/blue{
 	dir = 4
@@ -51186,18 +51197,6 @@
 	},
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/kitchen/freezer)
-"pPu" = (
-/obj/machinery/door/airlock/pyro/command/alt{
-	dir = 4;
-	name = "Computer Core"
-	},
-/obj/mapping_helper/access/computer_core,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/grey,
-/area/station/turret_protected/Zeta)
 "pPz" = (
 /obj/machinery/light/incandescent/harsh{
 	dir = 1
@@ -52147,6 +52146,12 @@
 /obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
+"qfc" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "qfk" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -52403,12 +52408,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
-"qkH" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/turret_protected/Zeta)
 "qkJ" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -53156,13 +53155,6 @@
 /obj/decal/stripe_caution,
 /turf/simulated/floor/darkblue/checker,
 /area/station/ai_monitored/storage/eva)
-"qvP" = (
-/obj/machinery/turret,
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "qwb" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 9;
@@ -54195,6 +54187,9 @@
 "qNg" = (
 /turf/simulated/floor/black/grime,
 /area/station/routing/depot)
+"qNl" = (
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "qNn" = (
 /turf/simulated/grass,
 /area/station/crew_quarters/garden)
@@ -55470,6 +55465,19 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/crew_quarters/kitchen)
+"rgV" = (
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	name = "Computer Core"
+	},
+/obj/mapping_helper/access/computer_core,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/ai_upload,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "rhc" = (
 /obj/cable{
 	icon_state = "5-6"
@@ -56076,6 +56084,14 @@
 	icon_state = "blue2"
 	},
 /area/station/hallway/primary/west)
+"rsa" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "rsc" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
@@ -56329,14 +56345,6 @@
 	},
 /turf/simulated/floor/white/checker,
 /area/station/medical/medbay/lobby)
-"rvQ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "rvX" = (
 /obj/disposalpipe/segment/food{
 	dir = 8;
@@ -57187,17 +57195,6 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/robotics)
-"rIH" = (
-/obj/machinery/light/incandescent/greenish,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/item/device/net_sniffer,
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/turret_protected/Zeta)
 "rII" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -57376,6 +57373,11 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
+"rMa" = (
+/obj/machinery/turret,
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "rMi" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
@@ -58001,6 +58003,16 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/medical/cdc)
+"rVy" = (
+/obj/machinery/computer3/terminal/zeta/os_loaded,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "rVz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -58874,6 +58886,12 @@
 	dir = 4
 	},
 /area/station/ranch)
+"sjb" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "sjd" = (
 /obj/disposalpipe/segment,
 /obj/decal/tile_edge/stripe/corner/big2{
@@ -59491,6 +59509,10 @@
 /obj/machinery/light_switch/south,
 /turf/simulated/floor/black,
 /area/station/science/lobby)
+"ssV" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "ssX" = (
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -60017,6 +60039,19 @@
 	},
 /turf/simulated/floor/circuit/red,
 /area/station/security/hos)
+"sBZ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/table/reinforced/auto,
+/obj/machinery/networked/storage/scanner,
+/obj/machinery/camera/directional/south,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "sCb" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner{
 	dir = 10
@@ -60038,6 +60073,18 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
+"sCe" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "sCi" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/green,
@@ -62228,15 +62275,6 @@
 	dir = 8
 	},
 /area/station/security/quarters)
-"tkw" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/table/reinforced/auto,
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/printer,
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "tky" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -63102,6 +63140,17 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
+"tzp" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/stool/chair/office/green{
+	dir = 1
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "tzr" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/carpet/red/standard/edge{
@@ -63209,6 +63258,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
+"tBr" = (
+/obj/table/reinforced/auto,
+/obj/item/device/multitool,
+/obj/item/screwdriver,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "tBw" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -65559,14 +65616,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/wood/seven,
 /area/station/security/detectives_office)
-"unB" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/mainframe/zeta,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "unD" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -65674,21 +65723,6 @@
 	},
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
-"upK" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/item/disk/data/floppy/computer3boot,
-/obj/item/disk/data/floppy/read_only/terminal_os,
-/obj/item/disk/data/floppy/read_only/network_progs,
-/obj/item/disk/data/floppy/read_only/medical_progs,
-/obj/item/disk/data/floppy/read_only/engine_prog,
-/obj/item/disk/data/floppy/read_only/security_progs,
-/obj/item/disk/data/floppy/read_only/communications,
-/obj/item/disk/data/floppy/read_only/bank_progs,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "upS" = (
 /obj/machinery/light/incandescent{
 	dir = 4
@@ -65749,14 +65783,6 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/medical/breakroom)
-"uqG" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/radio,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "uqL" = (
 /obj/machinery/light/incandescent/cool,
 /obj/cable{
@@ -66713,18 +66739,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
-"uEh" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = Backup;
-	locked = 0;
-	name = "Databank - Backup"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "uEm" = (
 /obj/table/wood/auto,
 /obj/item/plate{
@@ -67277,6 +67291,9 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
+"uMg" = (
+/turf/simulated/floor/bluegreen,
+/area/station/turret_protected/Zeta)
 "uMr" = (
 /obj/lattice/auto/turf_attaching,
 /obj/machinery/light/runway_light/delay2,
@@ -67737,6 +67754,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
+"uSx" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "uSy" = (
 /obj/disposalpipe/switch_junction/right/east{
 	mail_tag = "robotics"
@@ -68599,11 +68624,6 @@
 	dir = 10
 	},
 /area/station/hangar/main)
-"vfL" = (
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "vfO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -69840,14 +69860,6 @@
 /obj/mesh/catwalk/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/se)
-"vyF" = (
-/obj/machinery/door/airlock/pyro/glass/command{
-	dir = 8
-	},
-/obj/mapping_helper/access/computer_core,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/grey,
-/area/station/turret_protected/Zeta)
 "vyH" = (
 /obj/disposalpipe/junction{
 	name = "factory pipe"
@@ -70363,16 +70375,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
-"vHg" = (
-/obj/machinery/computer3/generic/radio,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "vHi" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -70468,19 +70470,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
-"vIl" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/table/reinforced/auto,
-/obj/item/device/multitool,
-/obj/item/screwdriver,
-/obj/machinery/power/apc/autoname_south,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "vIm" = (
 /turf/simulated/floor/arrival/corner{
 	dir = 8
@@ -71157,6 +71146,18 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/ghostdrone_factory)
+"vSD" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = Backup;
+	locked = 0;
+	name = "Databank - Backup"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "vSE" = (
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -71747,19 +71748,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
-"wbK" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/table/reinforced/auto,
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/scanner,
-/obj/machinery/camera/directional/south,
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "wbM" = (
 /obj/table/auto,
 /obj/item/storage/box/trash_bags{
@@ -71890,6 +71878,14 @@
 	dir = 4
 	},
 /area/station/crew_quarters/cafeteria)
+"wee" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/radio,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "weM" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 2;
@@ -72203,6 +72199,19 @@
 /obj/disposalpipe/segment/mail/bent/west,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
+"wjn" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Control";
+	locked = 0;
+	name = "Databank - Control";
+	setup_drive_type = /obj/item/disk/data/tape/master
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "wjo" = (
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/solar/east)
@@ -73450,12 +73459,6 @@
 	icon_state = "nt_logo"
 	},
 /area/station/crew_quarters/courtroom)
-"wAu" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "wAy" = (
 /obj/decal/stripe_delivery,
 /obj/cable{
@@ -74610,6 +74613,13 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
+"wRk" = (
+/obj/machinery/turret,
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "wRx" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -77553,6 +77563,18 @@
 /obj/machinery/light/traffic_light/medical_medbay/delay5,
 /turf/space,
 /area/space)
+"xJb" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_south,
+/obj/table/reinforced/auto,
+/obj/random_item_spawner/peripherals/some,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "xJc" = (
 /turf/simulated/floor/shuttlebay,
 /area/spacehabitat/owlery)
@@ -117993,9 +118015,9 @@ hyr
 hyr
 hyr
 hyr
-bkJ
-pPu
-bkJ
+ncS
+rgV
+ncS
 hyr
 jrN
 otz
@@ -118294,15 +118316,15 @@ aAz
 mpb
 xVi
 eVo
-bkJ
-prH
-eOZ
-juO
-bkJ
-bkJ
-bkJ
-bkJ
-bkJ
+ncS
+pBR
+rsa
+dgC
+ncS
+ncS
+ncS
+hyr
+rdj
 rdj
 rdj
 rdj
@@ -118596,15 +118618,15 @@ dkB
 dkB
 dkB
 dkB
-bkJ
-aVG
-qkH
-ayY
-vfL
-vfL
-vfL
-rIH
-bkJ
+ncS
+bkl
+eHW
+eEt
+kJz
+dZO
+ncS
+rdj
+rdj
 rdj
 rdj
 rdj
@@ -118898,15 +118920,15 @@ xJu
 tbu
 nDE
 hKs
-bkJ
-eCA
-kvU
-gbY
-gbY
-gbY
-gbY
-tkw
-bkJ
+ncS
+rVy
+mlV
+inG
+uMg
+hSr
+ncS
+rdj
+rdj
 rdj
 rdj
 rdj
@@ -119200,15 +119222,15 @@ bQT
 vcE
 ceb
 srn
-bkJ
-eaO
-qkH
-gbY
-gbY
-gbY
-gbY
-wbK
-bkJ
+ncS
+aWb
+cvm
+inG
+inG
+sBZ
+ncS
+rdj
+rdj
 rdj
 rdj
 rdj
@@ -119502,15 +119524,15 @@ gIT
 mnb
 wkm
 kDs
-bkJ
-vHg
-kvU
-gbY
-gbY
-gbY
-gbY
-vIl
-bkJ
+ncS
+gaN
+nmu
+inG
+inG
+xJb
+ncS
+rdj
+rdj
 rdj
 rdj
 rdj
@@ -119804,15 +119826,15 @@ bQT
 vcE
 pBX
 iJq
-bkJ
-aVG
-qkH
-gbY
-gbY
-gbY
-gbY
-gAa
-bkJ
+ncS
+tBr
+pLW
+inG
+uMg
+qfc
+ncS
+rdj
+rdj
 rdj
 rdj
 rdj
@@ -120106,15 +120128,15 @@ thx
 mlS
 pay
 lml
-bkJ
-mYR
-fwx
-rvQ
-gWH
-itT
-rvQ
-brh
-bkJ
+ncS
+gAw
+tzp
+uSx
+aZW
+cHC
+ncS
+rdj
+rdj
 rdj
 rdj
 rdj
@@ -120409,14 +120431,14 @@ uBi
 uBi
 rOT
 rOT
-bkJ
-hZK
-hZK
-hZK
-vyF
-hZK
-hZK
-bkJ
+ncS
+ssV
+ssV
+ssV
+iNi
+ncS
+ncS
+ncS
 rdj
 rdj
 rdj
@@ -120712,13 +120734,13 @@ pTE
 adf
 vhl
 ncS
-qvP
-izn
-izn
-dDo
-izn
-kPc
-bkJ
+wRk
+qNl
+qNl
+mWw
+qNl
+rMa
+ncS
 rdj
 rdj
 rdj
@@ -121014,13 +121036,13 @@ dxm
 lGE
 nyK
 ncS
-oJy
-dof
-lCq
-bRr
-wAu
-oky
-bkJ
+dxS
+sjb
+eTI
+sCe
+adE
+mhd
+ncS
 rdj
 rdj
 rdj
@@ -121316,13 +121338,13 @@ bCY
 gnK
 bHn
 ncS
-upK
-uqG
-unB
-osu
-uEh
-ihc
-bkJ
+eRo
+wee
+oRz
+wjn
+vSD
+csr
+ncS
 rdj
 rdj
 rdj
@@ -121617,14 +121639,14 @@ rOT
 rOT
 rOT
 rOT
-bkJ
-bkJ
-bkJ
-bkJ
-bkJ
-bkJ
-bkJ
-bkJ
+ncS
+ncS
+ncS
+ncS
+ncS
+ncS
+ncS
+ncS
 rdj
 rdj
 rdj

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -456,12 +456,6 @@
 	dir = 1
 	},
 /area/station/crew_quarters/kitchen)
-"adE" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "adN" = (
 /obj/rack,
 /obj/item/clothing/shoes/magnetic,
@@ -1502,6 +1496,17 @@
 /obj/machinery/genetics_booth,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
+"auk" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/item/device/net_sniffer,
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/turret_protected/Zeta)
 "aup" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 1;
@@ -2049,6 +2054,16 @@
 /obj/decal/poster/wallsign/fire,
 /turf/simulated/wall/auto/reinforced/supernorn/colored/yellow,
 /area/station/engine/ptl)
+"aBF" = (
+/obj/machinery/computer3/terminal/zeta/os_loaded,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "aBW" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -3319,23 +3334,6 @@
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
-"aWb" = (
-/obj/table/reinforced/auto,
-/obj/item/paper/book/from_file/dwainedummies{
-	pixel_x = 7
-	},
-/obj/item/paper/book/from_file/guardbot_guide{
-	pixel_x = -7
-	},
-/obj/item/paper/book/from_file/guardbot_guide{
-	pixel_x = -7
-	},
-/obj/item/circuitboard/robotics,
-/obj/machinery/camera/directional/north,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "aWf" = (
 /obj/table/round/auto,
 /obj/item/reagent_containers/applicator/condiment/shaker/pepper{
@@ -3581,17 +3579,6 @@
 /obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/red/checker,
 /area/station/security/checkpoint/sec_foyer)
-"aZW" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/turretid/computer_core{
-	pixel_x = 24
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "baj" = (
 /obj/decal/tile_edge/line/white{
 	dir = 4;
@@ -4225,12 +4212,6 @@
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
-"bkl" = (
-/obj/machinery/vending/computer3,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "bko" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -6227,6 +6208,19 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/engine/engineering/ce)
+"bPG" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Control";
+	locked = 0;
+	name = "Databank - Control";
+	setup_drive_type = /obj/item/disk/data/tape/master
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "bPZ" = (
 /obj/machinery/door/airlock/pyro/command{
 	req_access = null;
@@ -8153,15 +8147,6 @@
 /obj/effects/background_objects/x0,
 /turf/space,
 /area/space)
-"csr" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light/incandescent/greenish,
-/obj/item/disk/data/tape/boot2,
-/obj/item/disk/data/tape/master,
-/obj/item/disk/data/tape/guardbot_tools,
-/obj/item/disk/data/tape/artifact_research,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "csv" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -8376,12 +8361,6 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
-"cvm" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green/checker,
-/area/station/turret_protected/Zeta)
 "cvv" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -9248,18 +9227,6 @@
 "cHm" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/maintenance/outer/east)
-"cHC" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/green/side{
-	dir = 6
-	},
-/area/station/turret_protected/Zeta)
 "cHD" = (
 /obj/mesh/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -9901,6 +9868,14 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
+"cTn" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "cTz" = (
 /obj/item/device/radio/beacon,
 /obj/disposalpipe/segment/brig,
@@ -10598,10 +10573,21 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"dgC" = (
-/obj/machinery/light_switch/west,
+"dgM" = (
+/obj/table/reinforced/auto,
+/obj/item/paper/book/from_file/dwainedummies{
+	pixel_x = 7
+	},
+/obj/item/paper/book/from_file/guardbot_guide{
+	pixel_x = -7
+	},
+/obj/item/paper/book/from_file/guardbot_guide{
+	pixel_x = -7
+	},
+/obj/item/circuitboard/robotics,
+/obj/machinery/camera/directional/north,
 /turf/simulated/floor/green/side{
-	dir = 10
+	dir = 1
 	},
 /area/station/turret_protected/Zeta)
 "dgS" = (
@@ -11602,13 +11588,6 @@
 	icon_state = "fred2"
 	},
 /area/station/chapel/office)
-"dxS" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/box/diskbox,
-/obj/item/storage/box/diskbox,
-/obj/machinery/camera/directional/north,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "dye" = (
 /obj/decal/stripe_delivery,
 /obj/mapping_helper/firedoor_spawn,
@@ -11627,6 +11606,12 @@
 /obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/science/testchamber)
+"dyi" = (
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/turret_protected/Zeta)
 "dyz" = (
 /obj/decal/cleanable/rust/jen,
 /obj/disposalpipe/segment{
@@ -13387,17 +13372,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/solar/east)
-"dZO" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/item/device/net_sniffer,
-/obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/green/side{
-	dir = 10
-	},
-/area/station/turret_protected/Zeta)
 "eag" = (
 /obj/machinery/chem_dispenser/soda,
 /obj/machinery/light/emergency{
@@ -15080,11 +15054,6 @@
 	dir = 4
 	},
 /area/station/medical/medbay/surgery/storage)
-"eEt" = (
-/turf/simulated/floor/green/corner{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "eEy" = (
 /obj/decal/stage_edge{
 	layer = 2.8
@@ -15259,12 +15228,6 @@
 	},
 /turf/simulated/floor/redwhite,
 /area/station/security/quarters)
-"eHW" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/turret_protected/Zeta)
 "eIb" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
@@ -15798,21 +15761,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/science/lobby)
-"eRo" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/item/disk/data/floppy/computer3boot,
-/obj/item/disk/data/floppy/read_only/terminal_os,
-/obj/item/disk/data/floppy/read_only/network_progs,
-/obj/item/disk/data/floppy/read_only/medical_progs,
-/obj/item/disk/data/floppy/read_only/engine_prog,
-/obj/item/disk/data/floppy/read_only/security_progs,
-/obj/item/disk/data/floppy/read_only/communications,
-/obj/item/disk/data/floppy/read_only/bank_progs,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "eRI" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/decal/cleanable/rust/jen,
@@ -15936,15 +15884,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
-"eTI" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "eTU" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -17046,6 +16985,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
+"fjJ" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/radio,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "fjP" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -19192,6 +19139,9 @@
 	},
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/chemistry)
+"fSO" = (
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "fSR" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/reinforced/jen,
@@ -19652,16 +19602,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
-"gaN" = (
-/obj/machinery/computer3/generic/radio,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "gaS" = (
 /turf/simulated/wall/auto/jen/purple{
 	icon_state = "5"
@@ -20209,6 +20149,21 @@
 /obj/machinery/light/traffic_light/trader_left/delay2,
 /turf/space,
 /area/space)
+"gjS" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/table/reinforced/auto,
+/obj/machinery/networked/storage/scanner{
+	bank_id = "Mainframe"
+	},
+/obj/machinery/camera/directional/south,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "gjU" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio{
@@ -21210,15 +21165,6 @@
 	dir = 1
 	},
 /area/station/medical/medbay/treatment)
-"gAw" = (
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/machinery/computer/robotics,
-/turf/simulated/floor/green/side{
-	dir = 5
-	},
-/area/station/turret_protected/Zeta)
 "gAF" = (
 /obj/decal/stripe_caution,
 /obj/rack,
@@ -24534,6 +24480,21 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
+"hAb" = (
+/obj/table/reinforced/auto,
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/item/disk/data/floppy/computer3boot,
+/obj/item/disk/data/floppy/read_only/terminal_os,
+/obj/item/disk/data/floppy/read_only/network_progs,
+/obj/item/disk/data/floppy/read_only/medical_progs,
+/obj/item/disk/data/floppy/read_only/engine_prog,
+/obj/item/disk/data/floppy/read_only/security_progs,
+/obj/item/disk/data/floppy/read_only/communications,
+/obj/item/disk/data/floppy/read_only/bank_progs,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "hAc" = (
 /obj/stool/chair/comfy/blue{
 	dir = 8
@@ -25329,6 +25290,18 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
+"hNP" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_south,
+/obj/table/reinforced/auto,
+/obj/random_item_spawner/peripherals/some,
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "hNR" = (
 /obj/mapping_helper/access/maint,
 /obj/decal/stripe_delivery,
@@ -25496,18 +25469,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/jen/purple,
 /area/station/science/lab)
-"hSr" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/table/reinforced/auto,
-/obj/machinery/networked/printer,
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "hSD" = (
 /obj/item/device/audio_log/wall_mounted{
 	anchored = 1;
@@ -26747,9 +26708,6 @@
 	},
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
-"inG" = (
-/turf/simulated/floor/green/checker,
-/area/station/turret_protected/Zeta)
 "inM" = (
 /obj/machinery/shower{
 	dir = 4
@@ -26931,6 +26889,12 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/white,
 /area/spacehabitat/pool)
+"irV" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/green/side,
+/area/station/turret_protected/Zeta)
 "isc" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
 /obj/disposalpipe/segment/ejection,
@@ -27806,6 +27770,11 @@
 	},
 /turf/simulated/wall/auto/reinforced/jen/red,
 /area/station/maintenance/outer/sw)
+"iGo" = (
+/turf/simulated/floor/green/corner{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "iGs" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/decal/stripe_caution,
@@ -28248,13 +28217,15 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/quartersC)
-"iNi" = (
-/obj/machinery/door/airlock/pyro/glass/command{
-	dir = 8
+"iNE" = (
+/obj/machinery/computer3/generic/radio,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/obj/mapping_helper/access/computer_core,
-/obj/mapping_helper/firedoor_spawn,
-/turf/simulated/floor/grey,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
 /area/station/turret_protected/Zeta)
 "iNG" = (
 /obj/machinery/conveyor/EW{
@@ -30026,6 +29997,17 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/science/storage)
+"joq" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/turretid/computer_core{
+	pixel_x = 24
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "joH" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
@@ -30070,6 +30052,13 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy,
 /area/station/chapel/sanctuary)
+"jqc" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/box/tapebox,
+/obj/item/storage/box/tapebox,
+/obj/machinery/camera/directional/south,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "jqd" = (
 /obj/table/auto,
 /obj/random_item_spawner/desk_stuff,
@@ -30533,9 +30522,6 @@
 	},
 /obj/cable{
 	icon_state = "6-8"
-	},
-/obj/machinery/networked/mainframe/zeta{
-	tag = "ZETA_MAINFRAME"
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -32167,12 +32153,6 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = "Control";
-	locked = 0;
-	name = "Databank - Control";
-	setup_drive_type = /obj/item/disk/data/tape/master
-	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -33798,6 +33778,14 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
+"kwi" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
+/area/station/turret_protected/Zeta)
 "kwl" = (
 /obj/machinery/power/solar,
 /turf/simulated/floor/airless/solar,
@@ -34568,11 +34556,6 @@
 /obj/mapping_helper/access/hydro,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
-"kJz" = (
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "kKf" = (
 /obj/decal/stripe_delivery,
 /obj/machinery/door/airlock/pyro/glass{
@@ -35483,6 +35466,19 @@
 	},
 /turf/simulated/floor/wood/six,
 /area/station/hallway/primary/west)
+"kYc" = (
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	name = "Computer Core"
+	},
+/obj/mapping_helper/access/computer_core,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/mapping_helper/firedoor_spawn,
+/obj/mapping_helper/access/ai_upload,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "kYf" = (
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/window_blinds/cog2/right,
@@ -36737,6 +36733,14 @@
 /area/station/wreckage{
 	name = "Restricted Area"
 	})
+"lur" = (
+/obj/table/reinforced/auto,
+/obj/item/device/multitool,
+/obj/item/screwdriver,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "luv" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -37118,6 +37122,18 @@
 "lzM" = (
 /turf/simulated/floor/stairs/wood2/middle,
 /area/station/hallway/primary/south)
+"lAa" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "lAb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -38348,6 +38364,11 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/construction)
+"lQI" = (
+/obj/machinery/turret,
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "lQM" = (
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -38853,6 +38874,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/head)
+"lWz" = (
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/machinery/computer/robotics,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/green/side{
+	dir = 5
+	},
+/area/station/turret_protected/Zeta)
 "lWJ" = (
 /obj/stool/chair/blue{
 	dir = 4
@@ -39422,13 +39456,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
-"mhd" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/box/tapebox,
-/obj/item/storage/box/tapebox,
-/obj/machinery/camera/directional/south,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "mhe" = (
 /turf/simulated/wall/auto/jen/yellow,
 /area/station/hangar/qm)
@@ -39683,18 +39710,6 @@
 /obj/cable,
 /turf/simulated/floor/grey,
 /area/station/science/artifact)
-"mlV" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/stool/chair/office/green{
-	dir = 1
-	},
-/turf/simulated/floor/bluegreen,
-/area/station/turret_protected/Zeta)
 "mmc" = (
 /obj/machinery/loudspeaker,
 /obj/disposalpipe/segment/food,
@@ -41783,12 +41798,6 @@
 /obj/table/reinforced/auto,
 /turf/simulated/floor/green,
 /area/station/medical/cdc)
-"mWw" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "mWB" = (
 /obj/table/auto,
 /obj/item/clothing/head/merchant_hat,
@@ -42812,18 +42821,6 @@
 /obj/item/clothing/head/cakehat,
 /turf/simulated/floor/black,
 /area/station/security/visitation)
-"nmu" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/stool/chair/office/green{
-	dir = 1
-	},
-/turf/simulated/floor/green/checker,
-/area/station/turret_protected/Zeta)
 "nmG" = (
 /obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/black,
@@ -47477,6 +47474,15 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
+"oIG" = (
+/obj/table/reinforced/auto,
+/obj/machinery/light/incandescent/greenish,
+/obj/item/disk/data/tape/boot2,
+/obj/item/disk/data/tape/master,
+/obj/item/disk/data/tape/guardbot_tools,
+/obj/item/disk/data/tape/artifact_research,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "oIL" = (
 /obj/machinery/vending/security_ammo,
 /obj/decal/stripe_caution,
@@ -48039,14 +48045,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/medbooth)
-"oRz" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/mainframe/zeta,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "oSc" = (
 /obj/machinery/sink/slim{
 	pixel_y = 11
@@ -49389,6 +49387,18 @@
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/greenwhite/other,
 /area/station/crew_quarters/market)
+"pnd" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/incandescent/greenish,
+/turf/simulated/floor/green/side{
+	dir = 6
+	},
+/area/station/turret_protected/Zeta)
 "pni" = (
 /turf/simulated/floor/white,
 /area/station/security/main)
@@ -50234,15 +50244,6 @@
 "pBP" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hop)
-"pBR" = (
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/simulated/floor/green/side{
-	dir = 9
-	},
-/area/station/turret_protected/Zeta)
 "pBX" = (
 /obj/decal/tile_edge/stripe/corner/big2{
 	dir = 10
@@ -50981,12 +50982,6 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
-"pLW" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegreen,
-/area/station/turret_protected/Zeta)
 "pMc" = (
 /obj/stool/chair/comfy/blue{
 	dir = 4
@@ -52146,12 +52141,6 @@
 /obj/mapping_helper/glassware_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
-"qfc" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "qfk" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -52974,6 +52963,12 @@
 	},
 /turf/simulated/floor/carpet/green/fancy,
 /area/station/engine/engineering/ce)
+"qtG" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "qtL" = (
 /obj/mesh/catwalk/jen,
 /obj/cable{
@@ -54187,9 +54182,6 @@
 "qNg" = (
 /turf/simulated/floor/black/grime,
 /area/station/routing/depot)
-"qNl" = (
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "qNn" = (
 /turf/simulated/grass,
 /area/station/crew_quarters/garden)
@@ -54287,6 +54279,12 @@
 /obj/disposalpipe/junction/right/west,
 /turf/simulated/floor/black,
 /area/station/science/lobby)
+"qOJ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/turret_protected/Zeta)
 "qOK" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -55332,6 +55330,9 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"res" = (
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "reD" = (
 /obj/machinery/loudspeaker,
 /obj/machinery/light/incandescent/netural,
@@ -55465,19 +55466,6 @@
 /obj/mapping_helper/firedoor_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/crew_quarters/kitchen)
-"rgV" = (
-/obj/machinery/door/airlock/pyro/command/alt{
-	dir = 4;
-	name = "Computer Core"
-	},
-/obj/mapping_helper/access/computer_core,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/mapping_helper/firedoor_spawn,
-/obj/mapping_helper/access/ai_upload,
-/turf/simulated/floor/grey,
-/area/station/turret_protected/Zeta)
 "rhc" = (
 /obj/cable{
 	icon_state = "5-6"
@@ -55730,6 +55718,18 @@
 	dir = 8
 	},
 /area/spacehabitat/pool)
+"rlp" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/storage/tape_drive{
+	bank_id = "Backup";
+	locked = 0;
+	name = "Databank - Backup"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "rlw" = (
 /obj/decal/boxingrope{
 	dir = 4
@@ -56084,14 +56084,6 @@
 	icon_state = "blue2"
 	},
 /area/station/hallway/primary/west)
-"rsa" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/turret_protected/Zeta)
 "rsc" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
@@ -57373,11 +57365,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
-"rMa" = (
-/obj/machinery/turret,
-/obj/machinery/light/incandescent/greenish,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "rMi" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
@@ -58003,15 +57990,11 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/medical/cdc)
-"rVy" = (
-/obj/machinery/computer3/terminal/zeta/os_loaded,
+"rVw" = (
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
+/turf/simulated/floor/green/checker,
 /area/station/turret_protected/Zeta)
 "rVz" = (
 /obj/cable{
@@ -58886,11 +58869,19 @@
 	dir = 4
 	},
 /area/station/ranch)
-"sjb" = (
+"siY" = (
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/circuit/green,
+/obj/stool/chair/office/green{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/green/side{
+	dir = 4
+	},
 /area/station/turret_protected/Zeta)
 "sjd" = (
 /obj/disposalpipe/segment,
@@ -59509,9 +59500,19 @@
 /obj/machinery/light_switch/south,
 /turf/simulated/floor/black,
 /area/station/science/lobby)
-"ssV" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/grey,
+"ssW" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/obj/table/reinforced/auto,
+/obj/machinery/networked/printer{
+	print_id = "Mainframe"
+	},
+/turf/simulated/floor/green/side,
 /area/station/turret_protected/Zeta)
 "ssX" = (
 /obj/machinery/status_display{
@@ -59776,9 +59777,6 @@
 /obj/cable{
 	icon_state = "2-5"
 	},
-/obj/machinery/computer/robotics{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -60039,19 +60037,6 @@
 	},
 /turf/simulated/floor/circuit/red,
 /area/station/security/hos)
-"sBZ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/table/reinforced/auto,
-/obj/machinery/networked/storage/scanner,
-/obj/machinery/camera/directional/south,
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "sCb" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner{
 	dir = 10
@@ -60073,18 +60058,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
-"sCe" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "sCi" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/green,
@@ -61228,6 +61201,12 @@
 	dir = 1
 	},
 /area/station/security/main)
+"sUY" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "sVb" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio/headset/research{
@@ -62838,6 +62817,13 @@
 	name = "reinforced plating"
 	},
 /area/station/hangar/qm)
+"tuv" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/box/diskbox,
+/obj/item/storage/box/diskbox,
+/obj/machinery/camera/directional/north,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "tuB" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -63140,23 +63126,19 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
-"tzp" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/stool/chair/office/green{
-	dir = 1
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "tzr" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/carpet/red/standard/edge{
 	dir = 4
 	},
 /area/station/hallway/primary/west)
+"tzu" = (
+/obj/machinery/turret,
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "tzD" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -63258,14 +63240,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
-"tBr" = (
-/obj/table/reinforced/auto,
-/obj/item/device/multitool,
-/obj/item/screwdriver,
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/turret_protected/Zeta)
 "tBw" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -64672,6 +64646,14 @@
 	dir = 10
 	},
 /area/station/hallway/secondary/entry)
+"tVu" = (
+/obj/machinery/door/airlock/pyro/glass/command{
+	dir = 8
+	},
+/obj/mapping_helper/access/computer_core,
+/obj/mapping_helper/firedoor_spawn,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "tVx" = (
 /obj/machinery/camera/directional/north{
 	pixel_x = -10
@@ -65230,6 +65212,11 @@
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
+"ued" = (
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/turret_protected/Zeta)
 "ueB" = (
 /obj/table/reinforced/auto,
 /obj/machinery/coffeemaker/medbay{
@@ -65431,6 +65418,12 @@
 	},
 /turf/simulated/floor/carpet/purple/decal/outercross,
 /area/station/chapel/sanctuary)
+"ujp" = (
+/obj/machinery/vending/computer3,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/turret_protected/Zeta)
 "ujy" = (
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/storage/tech)
@@ -66739,6 +66732,18 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
+"uEc" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/stool/chair/office/green{
+	dir = 1
+	},
+/turf/simulated/floor/green/checker,
+/area/station/turret_protected/Zeta)
 "uEm" = (
 /obj/table/wood/auto,
 /obj/item/plate{
@@ -67291,9 +67296,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
-"uMg" = (
-/turf/simulated/floor/bluegreen,
-/area/station/turret_protected/Zeta)
 "uMr" = (
 /obj/lattice/auto/turf_attaching,
 /obj/machinery/light/runway_light/delay2,
@@ -67308,6 +67310,15 @@
 	dir = 6
 	},
 /area/station/crew_quarters/quarters)
+"uMy" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "uMR" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light/incandescent/netural{
@@ -67754,14 +67765,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
-"uSx" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/green/side{
-	dir = 4
-	},
-/area/station/turret_protected/Zeta)
 "uSy" = (
 /obj/disposalpipe/switch_junction/right/east{
 	mail_tag = "robotics"
@@ -68624,6 +68627,12 @@
 	dir = 10
 	},
 /area/station/hangar/main)
+"vfI" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "vfO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -71146,18 +71155,6 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/ghostdrone_factory)
-"vSD" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = Backup;
-	locked = 0;
-	name = "Databank - Backup"
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "vSE" = (
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -71872,20 +71869,20 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
+"wdO" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/mainframe/zeta,
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/Zeta)
 "wec" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/wood/eight{
 	dir = 4
 	},
 /area/station/crew_quarters/cafeteria)
-"wee" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/radio,
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "weM" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 2;
@@ -72199,19 +72196,6 @@
 /obj/disposalpipe/segment/mail/bent/west,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
-"wjn" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/networked/storage/tape_drive{
-	bank_id = "Control";
-	locked = 0;
-	name = "Databank - Control";
-	setup_drive_type = /obj/item/disk/data/tape/master
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "wjo" = (
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/solar/east)
@@ -73871,6 +73855,15 @@
 /obj/machinery/light/traffic_light/medical_medbay/delay2,
 /turf/space,
 /area/space)
+"wGP" = (
+/obj/machinery/light/incandescent/greenish{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/simulated/floor/green/side{
+	dir = 9
+	},
+/area/station/turret_protected/Zeta)
 "wGQ" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -74613,13 +74606,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
-"wRk" = (
-/obj/machinery/turret,
-/obj/machinery/light/incandescent/greenish{
-	dir = 1
-	},
-/turf/simulated/floor/circuit/green,
-/area/station/turret_protected/Zeta)
 "wRx" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -77563,18 +77549,6 @@
 /obj/machinery/light/traffic_light/medical_medbay/delay5,
 /turf/space,
 /area/space)
-"xJb" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_south,
-/obj/table/reinforced/auto,
-/obj/random_item_spawner/peripherals/some,
-/turf/simulated/floor/green/side,
-/area/station/turret_protected/Zeta)
 "xJc" = (
 /turf/simulated/floor/shuttlebay,
 /area/spacehabitat/owlery)
@@ -77771,6 +77745,10 @@
 	},
 /turf/simulated/floor/red/checker,
 /area/station/security/checkpoint/sec_foyer)
+"xLW" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/grey,
+/area/station/turret_protected/Zeta)
 "xLX" = (
 /obj/decal/poster/wallsign/security,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced/crystal,
@@ -79227,7 +79205,6 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/networked/radio,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
@@ -118016,7 +117993,7 @@ hyr
 hyr
 hyr
 ncS
-rgV
+kYc
 ncS
 hyr
 jrN
@@ -118317,9 +118294,9 @@ mpb
 xVi
 eVo
 ncS
-pBR
-rsa
-dgC
+wGP
+cTn
+dyi
 ncS
 ncS
 ncS
@@ -118619,11 +118596,11 @@ dkB
 dkB
 dkB
 ncS
-bkl
-eHW
-eEt
-kJz
-dZO
+ujp
+qOJ
+iGo
+ued
+auk
 ncS
 rdj
 rdj
@@ -118921,11 +118898,11 @@ tbu
 nDE
 hKs
 ncS
-rVy
-mlV
-inG
-uMg
-hSr
+aBF
+uEc
+res
+res
+ssW
 ncS
 rdj
 rdj
@@ -119223,11 +119200,11 @@ vcE
 ceb
 srn
 ncS
-aWb
-cvm
-inG
-inG
-sBZ
+dgM
+rVw
+res
+res
+gjS
 ncS
 rdj
 rdj
@@ -119525,11 +119502,11 @@ mnb
 wkm
 kDs
 ncS
-gaN
-nmu
-inG
-inG
-xJb
+iNE
+uEc
+res
+res
+hNP
 ncS
 rdj
 rdj
@@ -119827,11 +119804,11 @@ vcE
 pBX
 iJq
 ncS
-tBr
-pLW
-inG
-uMg
-qfc
+lur
+rVw
+res
+res
+irV
 ncS
 rdj
 rdj
@@ -120129,11 +120106,11 @@ mlS
 pay
 lml
 ncS
-gAw
-tzp
-uSx
-aZW
-cHC
+lWz
+siY
+kwi
+joq
+pnd
 ncS
 rdj
 rdj
@@ -120432,10 +120409,10 @@ uBi
 rOT
 rOT
 ncS
-ssV
-ssV
-ssV
-iNi
+xLW
+xLW
+xLW
+tVu
 ncS
 ncS
 ncS
@@ -120734,12 +120711,12 @@ pTE
 adf
 vhl
 ncS
-wRk
-qNl
-qNl
-mWw
-qNl
-rMa
+tzu
+fSO
+fSO
+qtG
+fSO
+lQI
 ncS
 rdj
 rdj
@@ -121036,12 +121013,12 @@ dxm
 lGE
 nyK
 ncS
-dxS
-sjb
-eTI
-sCe
-adE
-mhd
+tuv
+sUY
+uMy
+lAa
+vfI
+jqc
 ncS
 rdj
 rdj
@@ -121338,12 +121315,12 @@ bCY
 gnK
 bHn
 ncS
-eRo
-wee
-oRz
-wjn
-vSD
-csr
+hAb
+fjJ
+wdO
+bPG
+rlp
+oIG
 ncS
 rdj
 rdj


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new computer core room to Donut3 and moves the mainframe and killswitch to it.

<img width="617" height="453" alt="image" src="https://github.com/user-attachments/assets/69ee39bd-8b16-47b4-bfff-e423a2d5d990" />


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This brings it in line with other maps that have a separate computer core room, and allows Computer Operators and others with only Systems Administrator access to access the mainframe.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I joined as a Computer Operator and was able to access the new computer core. I check each device in the room and all are connected to the network and the mainframe is accessible from outside the room.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bonnedav
(*)Added new Computer Core to Donut3.
```
