### PR TITLE
Give Computer Operators access to Mechanics Lab.

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -263,7 +263,7 @@
 		if("Hall Monitor")
 			return list(access_ticket)
 		if("Computer Operator")
-			return list(access_maint_tunnels, access_tech_storage, access_sysadmin, access_research, access_researchfoyer, access_robotdepot)
+			return list(access_maint_tunnels, access_tech_storage, access_sysadmin, access_research, access_researchfoyer, access_robotdepot, access_engineering_mechanic)
 		if("Admin")
 			return access_all_actually
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives Computer Operators access to Mechanics Lab.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A lot of network related gimmicks require access to Mechcomp, the pownet component in particular. Access to the Rkit would let them print out computer parts for more computer building. The job currently in my opinion does not have enough to do and this would give them more to do.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Made sure they have access.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bonnedav
(+)Computer Operators now have Mechanics Lab access.
```
