### PR TITLE
Rework Cinematics

### DIFF
--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -106,6 +106,9 @@
 	disposing()
 		for (var/mob/M in src.mobs)
 			M.detach_hud(src)
+		for (var/client/C in src.clients)
+			src.remove_client(C)
+
 		for (var/atom/movable/Obj in src.objects)
 			Obj.plane = initial(Obj.plane)
 			if(istype(Obj, /atom/movable/screen/hud))
@@ -117,9 +120,6 @@
 		for (var/datum/hud_zone/zone in src.hud_zones)
 			qdel(zone)
 		src.hud_zones = null
-
-		for (var/client/C in src.clients)
-			remove_client(C)
 
 		src.clear_master()
 		..()

--- a/code/datums/hud/cinematic.dm
+++ b/code/datums/hud/cinematic.dm
@@ -1,26 +1,52 @@
 /datum/hud/cinematic
 	click_check = 0
+	var/atom/movable/screen/hud/background
+	var/atom/movable/screen/hud/animation
+
+	proc/create_background()
+		src.background = create_screen("bg", "", 'icons/mob/hud_common.dmi', "cinematic_bg", "1, 1 to NORTH, EAST", 98)
+		src.objects += src.background
 
 	proc/play(name)
-		create_screen("bg", "", 'icons/mob/hud_common.dmi', "cinematic_bg", "1, 1 to NORTH, EAST", 98)
-		switch (name)
-			if ("nuke")
-				var/atom/movable/screen/hud/anim = create_screen("cinematic", "", 'icons/effects/station_explosion.dmi', "start_nuke", "1:6, 1:50", 99)
-				playsound_global(clients, 'sound/misc/airraid_loop_short.ogg', vol=100)
-				SPAWN(3.5 SECONDS)//45)
-					anim.icon_state = "explode"
-					sleep(1 SECOND)
-					playsound_global(clients, 'sound/effects/kaboom.ogg', vol=100)
-					sleep(8 SECONDS)
-					anim.icon_state = "loss_nuke"
-			if ("malf")
-				var/atom/movable/screen/hud/anim = create_screen("cinematic", "", 'icons/effects/station_explosion.dmi', "start_malf", "1:6, 1:50", 99)
-				SPAWN(3.5 SECONDS)//45)
-					anim.icon_state = "explode"
-					sleep(1 SECOND)
-					playsound_global(clients, 'sound/effects/kaboom.ogg', vol=100)
-					sleep(7 SECONDS)
-					anim.icon_state = "loss_malf"
-			if ("sadbuddy")
-				create_screen("cinematic", "", 'icons/effects/160x160.dmi', "sadbuddy", "CENTER-2,CENTER-2", 99)
-				playsound_global(clients, 'sound/misc/sad_server_death.ogg', vol=100)
+		src.create_background()
+
+/datum/hud/cinematic/all_clients
+	var/excluded_mob_types //A list of mob types this global cinematic won't affect, e.g. list(/mob/living/carbon/human/tutorial)
+
+	play()
+		for (var/client/C in global.clients)
+			if (src.excluded_mob_types && istypes(C.mob, src.excluded_mob_types))
+				continue
+			src.add_client(C)
+		. = ..()
+
+/datum/hud/cinematic/all_clients/nuclear_bomb
+	var/intro_state = "start_nuke"
+	var/loss_state = "loss_nuke"
+
+	play()
+		. = ..()
+		src.animation = create_screen("cinematic", "", 'icons/effects/station_explosion.dmi', src.intro_state, "1:6, 1:50", 99)
+		src.objects += src.animation
+		SPAWN(3.5 SECONDS)
+			src.animation.icon_state = "explode"
+			sleep(1 SECOND)
+			playsound_global(clients, 'sound/effects/kaboom.ogg', vol=100)
+			sleep(8 SECONDS)
+			src.animation.icon_state = src.loss_state
+
+/datum/hud/cinematic/all_clients/nuclear_bomb/malf_ai
+	intro_state = "start_malf"
+	loss_state = "loss_malf"
+
+/datum/hud/cinematic/all_clients/sadbuddy
+	excluded_mob_types = list(/mob/living/carbon/human/tutorial)
+
+	play()
+		. = ..()
+		src.animation = create_screen("cinematic", "", 'icons/effects/160x160.dmi', "sadbuddy", "CENTER-2,CENTER-2", 99)
+		src.objects += src.animation
+		playsound_global(clients, 'sound/misc/sad_server_death.ogg', vol=100)
+		SPAWN(5 SECONDS)
+			qdel(src)
+

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -464,10 +464,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 		//explosion(src, src.loc, 35, 45, 55, 55)
 
 
-		var/datum/hud/cinematic/cinematic = new
-		for (var/client/C in clients)
-			cinematic.add_client(C)
-		cinematic.play("nuke")
+		var/datum/hud/cinematic/all_clients/nuclear_bomb/cinematic = new
+		cinematic.play()
 		if(istype(gamemode))
 			gamemode.nuke_detonated = 1
 			gamemode.check_win()

--- a/code/z_adventurezones/solarium.dm
+++ b/code/z_adventurezones/solarium.dm
@@ -153,20 +153,11 @@ var/global/derelict_mode = 0
 						H.emote("scream")
 			creepify_station() // creep as heck
 			sleep(12.5 SECONDS)
-			var/datum/hud/cinematic/cinematic = new
-			for (var/client/C in clients)
-				if (istype(C.mob, /mob/living/carbon/human/tutorial))
-					continue
-				cinematic.add_client(C)
-			cinematic.play("sadbuddy")
+			var/datum/hud/cinematic/all_clients/sadbuddy/cinematic = new
+			cinematic.play()
 			sleep(1 SECOND)
 			boutput(world, "<tt>BUG: CPU0 on fire!</tt>")
 			logTheThing(LOG_DIARY, null, "The server would have restarted, if I hadn't removed the line of code that does that. Instead, we play through.", "game")
-
-			SPAWN(5 SECONDS)
-				for (var/client/C in clients)
-					cinematic.remove_client(C)
-
 
 			// sleep(15 SECONDS)
 			// Reboot_server()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reworks cinematics internally to be different types rather than one type passed a string.
Cinematics now add their cinematic screens (background and animation) to their list of objects so they are properly deleted on disposing.
The all_clients subtype of cinematic will automatically add all clients to itself before playing (any new cinematics not typed to this must handle adding clients manually), has an optional variable for excluded mob types.
All /datum/huds now remove all clients before removing all their objects so deleting hud datums targeting clients directly (instead of through their mob) properly removes all associated objects from their screen. This means you can delete a cinematic when it is done.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Code quality, and i want to add some admin tools for cinematics e.g. being able to actually get rid of any playing.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested detonating a nuke and manually triggering the sadbuddy cinematics, both played as expected.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
