### PR TITLE
Added the Engineering Specialist Manufacturer to devtest

### DIFF
--- a/maps/utilities/devtest.dmm
+++ b/maps/utilities/devtest.dmm
@@ -1061,7 +1061,7 @@
 /turf/unsimulated/floor/orangeblack,
 /area/station/devzone)
 "sE" = (
-/obj/reagent_dispensers/fueltank,
+/obj/machinery/manufacturer/engineering,
 /turf/simulated/floor,
 /area/station/devzone)
 "sG" = (
@@ -2431,6 +2431,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/blue/checker,
+/area/station/devzone)
+"PX" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor,
 /area/station/devzone)
 "Ql" = (
 /obj/disposalpipe/switch_junction/right/west{
@@ -3966,7 +3973,7 @@ hL
 hL
 Cn
 Dh
-Cv
+PX
 Xo
 xi
 ng


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the missing Engineering Specialist Manufacturer to devtest.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

its a testing map, why shouldn't it have a manufacturer that appears on all maps and has exclusive items, especially when it has "complex" items like the spartial interdictor you might want to test.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="528" height="527" alt="image" src="https://github.com/user-attachments/assets/21f6106f-2239-4e97-9721-e7af0eb2fb56" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

