### PR TITLE
Interaction between Lunchbox trinket and picky eater traits

### DIFF
--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -686,16 +686,17 @@ Equip items from body traits.
 		else // Picky eater trait holders get a custom lunchbox with 3 of their favourite foods
 			var/lunchbox = new /obj/item/storage/lunchbox(src)
 			trinket = lunchbox
-			var/list/fav_foods = src.traitHolder.getTrait("picky_eater").fav_foods
+			var/datum/trait/picky_eater/picky_trait = src.traitHolder.getTrait("picky_eater")
+			var/list/fav_foods = picky_trait.fav_foods
 			for (var/i in 1 to 3)
 				var/obj/item/food = fav_foods[i]
 				trinket.storage.add_contents(new food(src))
-			var/list = list(/obj/item/reagent_containers/food/drinks/water,\
+			var/list/lunch_list = list(/obj/item/reagent_containers/food/drinks/water,\
 			/obj/item/kitchen/utensil/fork,\
 			/obj/item/kitchen/utensil/spoon,\
 			/obj/item/paper/lunchbox_note)
-			for (var/i in list)
-				trinket.storage.add_contents(new i(src))
+			for (var/lunch_item_type in lunch_list)
+				trinket.storage.add_contents(new lunch_item_type(src))
 	else if (src.traitHolder && src.traitHolder.hasTrait("wheelchair"))
 		SPAWN(0) // Ensures wheelchair spawns with you even if you aren't latejoining at arrivals.
 			var/obj/stool/chair/comfy/wheelchair/the_chair = new /obj/stool/chair/comfy/wheelchair(get_turf(src))

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -680,8 +680,22 @@ Equip items from body traits.
 		carrier.trap_mob(pet, src)
 		trinket = carrier
 	else if (src.traitHolder && src.traitHolder.hasTrait("lunchbox"))
-		var/random_lunchbox_path = pick(childrentypesof(/obj/item/storage/lunchbox))
-		trinket = new random_lunchbox_path(src)
+		if (!src.traitHolder.hasTrait("picky_eater"))
+			var/random_lunchbox_path = pick(childrentypesof(/obj/item/storage/lunchbox))
+			trinket = new random_lunchbox_path(src)
+		else // Picky eater trait holders get a custom lunchbox with 3 of their favourite foods
+			var/lunchbox = new /obj/item/storage/lunchbox(src)
+			trinket = lunchbox
+			var/list/fav_foods = src.traitHolder.getTrait("picky_eater").fav_foods
+			for (var/i in 1 to 3)
+				var/obj/item/food = fav_foods[i]
+				trinket.storage.add_contents(new food(src))
+			var/list = list(/obj/item/reagent_containers/food/drinks/water,\
+			/obj/item/kitchen/utensil/fork,\
+			/obj/item/kitchen/utensil/spoon,\
+			/obj/item/paper/lunchbox_note)
+			for (var/i in list)
+				trinket.storage.add_contents(new i(src))
 	else if (src.traitHolder && src.traitHolder.hasTrait("wheelchair"))
 		SPAWN(0) // Ensures wheelchair spawns with you even if you aren't latejoining at arrivals.
 			var/obj/stool/chair/comfy/wheelchair/the_chair = new /obj/stool/chair/comfy/wheelchair(get_turf(src))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes the lunchbox trinket give picky eaters their favourite foods instead of foods they can't eat.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It makes lunchbox work correctly as described to give you you're favourite foods, even if your a picky eater.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested both traits together and got my picky eater foods spawned in the lunchbox
<img width="741" height="697" alt="image" src="https://github.com/user-attachments/assets/ea665515-8623-46aa-9fbf-34db4142833e" />
<img width="621" height="32" alt="image" src="https://github.com/user-attachments/assets/979532b5-5684-4ce0-ac27-d7425e05af24" />
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sandwichi
(+)The Lunchbox trinket trait can now come packed with a Picky Eater's favourite foods.
```


