### PR TITLE
Add messages for when artifacts gain faults

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -30,9 +30,9 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //------------ OPTIONS TO GO FAST ------------//
 
-#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
+//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
 
-#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
+//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
 
 //#define SKIP_FEA_SETUP // Skip setting up atmospheric system
 //#define SKIP_Z5_SETUP // Skip generation of mining level
@@ -56,7 +56,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define NO_PREGAME_HTML // Don't spawn the HTML pregame browser lobby screen
 //#define I_HATE_WAITING_FOR_GENES // Marks nearly all genes as researched, gives chromosomes/materials/autodecryptors, increases gene storage cap, and removes time/cost limitations on the gene console
 
-#define STOP_DISTRACTING_ME //All of the below
+//#define STOP_DISTRACTING_ME //All of the below
 
 //#define I_AM_ABOVE_THE_LAW // Prevents all secbots and guardbuddies from spawning, useful for gun testing
 //#define ALL_ROBOT_AND_COMPUTERS_MUST_SHUT_THE_HELL_UP // Prevents ALL bots from spawning (not cyborgs)

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -30,9 +30,9 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //------------ OPTIONS TO GO FAST ------------//
 
-//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
+#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
 
-//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
+#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
 
 //#define SKIP_FEA_SETUP // Skip setting up atmospheric system
 //#define SKIP_Z5_SETUP // Skip generation of mining level
@@ -56,7 +56,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define NO_PREGAME_HTML // Don't spawn the HTML pregame browser lobby screen
 //#define I_HATE_WAITING_FOR_GENES // Marks nearly all genes as researched, gives chromosomes/materials/autodecryptors, increases gene storage cap, and removes time/cost limitations on the gene console
 
-//#define STOP_DISTRACTING_ME //All of the below
+#define STOP_DISTRACTING_ME //All of the below
 
 //#define I_AM_ABOVE_THE_LAW // Prevents all secbots and guardbuddies from spawning, useful for gun testing
 //#define ALL_ROBOT_AND_COMPUTERS_MUST_SHUT_THE_HELL_UP // Prevents ALL bots from spawning (not cyborgs)

--- a/code/obj/artifacts/artifact_items/agitator.dm
+++ b/code/obj/artifacts/artifact_items/agitator.dm
@@ -34,13 +34,13 @@
 			artifact.faults -= pick(artifact.faults)
 			if (prob(5))
 				for (var/i in 1 to rand(1, 3))
-					O.ArtifactDevelopFault(100)
+					O.ArtifactDevelopFault(100, 100)
 				boutput(user, SPAN_ALERT("[art] burns your hand! Fuck that hurt!"))
 				user.TakeDamage("All", burn = rand(1, 10))
 			else
-				O.ArtifactDevelopFault(100)
+				O.ArtifactDevelopFault(100, 100)
 		else
-			O.ArtifactDevelopFault(100) // bad effect guaranteed if fault didn't exist before
+			O.ArtifactDevelopFault(100, 100) // bad effect guaranteed if fault didn't exist before
 
 		for (var/datum/artifact_fault/fault in artifact.faults)
 			if (fault.trigger_prob == initial(fault.trigger_prob))

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -592,7 +592,7 @@
 	qdel(src)
 	return
 
-/obj/proc/ArtifactDevelopFault(var/faultprob)
+/obj/proc/ArtifactDevelopFault(var/faultprob, var/messageprob = 5)
 	// This proc is used for randomly giving an artifact a fault. It's usually used in the New() proc of an artifact so that
 	// newly spawned artifacts have a chance of being faulty by default, though this can also be called whenever an artifact is
 	// damaged or otherwise poorly handled, so you could potentially turn a good artifact into a dangerous piece of shit if you
@@ -613,6 +613,10 @@
 		var/new_fault = weighted_pick(A.fault_types)
 		if (ispath(new_fault))
 			var/datum/artifact_fault/F = new new_fault(A)
+			if (A.activated && prob(messageprob))
+				var/turf/T = get_turf(src)
+				if (T)
+					T.visible_message(SPAN_NOTICE("The [src.name] [F.add_message]"))
 			F.holder = A
 			A.faults += F
 

--- a/code/obj/artifacts/faults.dm
+++ b/code/obj/artifacts/faults.dm
@@ -9,6 +9,7 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 	// these are booby traps, self-defense mechanisms, hardware faults or just other nasty shit that can fuck you up when you
 	// use the artifact for anything
 	var/type_name = "bad artifact code"
+	var/add_message = "does a thing. This message shouldn't be displayed!" //message displayed when the fault is added by an agitator
 	var/trigger_prob = 0
 	var/tmp/datum/artifact/holder = null
 	var/halt_loop = 0
@@ -21,6 +22,7 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 /datum/artifact_fault/burn
 	// sets the victim on fire
 	type_name = "Fire"
+	add_message = "seems to burst into flames, before immediately extinguishing itself."
 	trigger_prob = 8
 	var/burn_amount = 40
 
@@ -35,6 +37,7 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 /datum/artifact_fault/irradiate
 	// irradiates the victim
 	type_name = "Radiation"
+	add_message = "seems to briefly emit a green light." //unsure if this wording is correct
 	trigger_prob = 8
 	var/rads_amount = 2 SIEVERTS
 
@@ -47,6 +50,7 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 /datum/artifact_fault/shutdown
 	// deactivates the artifact
 	type_name = "Deactivation"
+	add_message = "'s glow seems to dim slightly."
 	trigger_prob = 10
 	halt_loop = 1
 
@@ -61,6 +65,7 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 /datum/artifact_fault/warp
 	// warps the user off somewhere random
 	type_name = "Teleportation"
+	add_message = "vanishes for a moment, then immediately reappears."
 	trigger_prob = 15
 
 	deploy(var/obj/O,var/mob/living/user,var/atom/cosmeticSource)
@@ -79,6 +84,7 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 /datum/artifact_fault/grow
 	// embiggens the artifact
 	type_name = "Growth"
+	add_message = "seems to grow slightly larger."
 	trigger_prob = 10
 
 	deploy(var/obj/O,var/mob/living/user,var/atom/cosmeticSource)
@@ -101,6 +107,7 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 /datum/artifact_fault/shrink
 	// ensmallens the artifact
 	type_name = "Shrinkage"
+	add_message = "seems to shrink slightly."
 	trigger_prob = 10
 
 	deploy(var/obj/O,var/mob/living/user,var/atom/cosmeticSource)
@@ -122,6 +129,7 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 /datum/artifact_fault/murder
 	// gibs the user
 	type_name = "Vaporization"
+	add_message = "sparks violently!"
 	trigger_prob = 1
 	halt_loop = 1
 
@@ -142,6 +150,7 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 /datum/artifact_fault/explode
 	// causes an explosion and destroys the artifact
 	type_name = "Explosion"
+	add_message = "shudders violently!"
 	trigger_prob = 1
 	halt_loop = 1
 
@@ -160,6 +169,7 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 /datum/artifact_fault/zap
 	// electrocutes the user
 	type_name = "Electricity"
+	add_message = "releases sparks."
 	trigger_prob = 6
 
 	deploy(var/obj/O,var/mob/living/user,var/atom/cosmeticSource)
@@ -175,6 +185,7 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 
 ABSTRACT_TYPE(/datum/artifact_fault/messager/)
 /datum/artifact_fault/messager
+	add_message = "makes a strange noise."
 	trigger_prob = 30
 	var/say_instead = FALSE
 	var/text_style = null
@@ -274,6 +285,7 @@ ABSTRACT_TYPE(/datum/artifact_fault/messager/)
 
 /datum/artifact_fault/poison
 	type_name = "Toxins"
+	add_message = "opens a hidden compartment containing a sharp needle, before closing again."
 	trigger_prob = 8
 	var/poison_type = "toxin"
 	var/poison_amount = 10


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR 
 
Added messages for when artifacts gain faults. These have a 5% chance of being displayed when an activated artifact gains a fault, and a 100% chance of displaying when an artifact gains a fault from an agitator

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You can better weaponise faults and agitators if you know which fault the artifact has. It's possible to figure it out, but it can be annoying and potentially lethal. 
I also thought it would be fun to add a chance for artifacts to display the message in other circumstances, but this can easily be removed if it is not wanted.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spawned in some artifacts and an agitator, and everything seemed to work

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)grasswitch
(+)Artifacts sometimes hint at newly developed faults. Agitator artifacts always cause hints to be displayed.
```
