### PR TITLE
Enables midroll wizard ghost spawn on RP

### DIFF
--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -19,10 +19,6 @@
 	centcom_message = "Aggressive macrocellular organism detected aboard the station. All personnel must contain the outbreak."
 	message_delay = 5 MINUTES // (+ ghost_confirmation_delay). Don't out them too early, blobs in particular need time to establish themselves.
 	targetable = TRUE
-	//sigh
-#ifdef RP_MODE
-	disabled = 1
-#endif
 	var/antagonist_type = "Blob"
 	var/ghost_confirmation_delay = 2 MINUTES // time to acknowledge or deny respawn offer.
 	var/respawn_lock = 0
@@ -70,7 +66,7 @@
 			#ifndef RP_MODE
 			possible_antags = list("Blob", "Hunter", "Werewolf", "Wizard", "Wraith", "Wrestler", "Wrestle Doodle", "Vampire", "Changeling", "Flockmind", "Space Phoenix")
 			#else
-			possible_antags = list("Space Phoenix")
+			possible_antags = list("Wizard")
 			#endif
 			#ifdef MAP_OVERRIDE_NADIR
 			possible_antags -= list("Blob")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR reenables the antag_ghost_respawn event on RP but only for wizard. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
With space phoenix disabled, RP has no natural midroll ghost antag spawns. On rounds where most antags are dead or too few antags exist (as pop has increased), latejoins are still rare in practice and sleeper agents can often be underwhelming, resulting in boring rounds. Wizard is a powerful antag that works well on RP and I believe it is a good way to make rounds where antags have been wiped/where the antag ratio is too low more interesting. I think the potential for more ghost roles on RP in general would be good for the game, and I believe this would be a fairly safe place to start. The event only selects one ghost to spawn as wizard and the expected number of alive antags on RP is low so I don't believe it's too destructive etc. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested on local server by firing event manually with RP mode enabled. 

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bamlord
(*)Wizards can now appear midround on RP servers via ghost role. 
```
