### PR TITLE
Fix for iridium plates not stacking

### DIFF
--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -57,7 +57,7 @@
 			..(user)
 
 	attackby(obj/item/W, mob/user)
-		if(W.type == src.type)
+		if(W.stack_type == src.stack_type)
 			stack_item(W)
 			if(!user.is_in_hands(src))
 				user.put_in_hand(src)
@@ -249,6 +249,7 @@
 	default_material = "iridiumalloy"
 	uses_default_material_appearance = TRUE
 	amount = 5
+	stack_type = /obj/item/material_piece/iridiumalloy
 
 	New()
 		..()


### PR DESCRIPTION
## About the PR
- Fixes iridium alloy plates not stacking with each other if they spawn with different stack sizes.

## Why's this needed?
- Fixes #26703

## Testing
<img width="503" height="270" alt="Screenshot 2026-05-27 232618" src="https://github.com/user-attachments/assets/9b2a3e95-61e7-4506-8d29-23172a755230" />

