### PR TITLE
Fix for player vending machine materials & forensics

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -644,6 +644,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/vending, proc/throw_item)
 					for (var/datum/data/vending_product/player_product/R in player_list)
 						if(ref(R) == params["target"])
 							P.promoimage = R.icon
+							P.promoimage.appearance_flags = KEEP_APART | RESET_COLOR // Promo image should keep original coloring
 							P.updateAppearance()
 		// return cash
 		if("returncash")
@@ -2167,6 +2168,7 @@ TYPEINFO(/obj/item/machineboard/vending/monkeys)
 			var/obj/machinery/vending/B = new vendingtype(src.loc)
 			B.forensic_holder = src.forensic_holder
 			B.setMaterial(src.material)
+			B.material_amt = src.material_amt
 			logTheThing(LOG_STATION, user, "assembles [B] [log_loc(B)]")
 			qdel(src)
 		else if (ispryingtool(target))
@@ -2191,7 +2193,6 @@ TYPEINFO(/obj/item/machineboard/vending/monkeys)
 	layer = OBJ_LAYER - 0.3
 	default_material = "steel"
 	mat_changename = FALSE
-	material_amt = 0.3
 
 	//Product loading chute
 	var/loading = FALSE

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2165,6 +2165,8 @@ TYPEINFO(/obj/item/machineboard/vending/monkeys)
 		else if (isscrewingtool(target) && glassed)
 			boutput(user, SPAN_NOTICE("You connect the screen."))
 			var/obj/machinery/vending/B = new vendingtype(src.loc)
+			B.forensic_holder = src.forensic_holder
+			B.setMaterial(src.material)
 			logTheThing(LOG_STATION, user, "assembles [B] [log_loc(B)]")
 			qdel(src)
 		else if (ispryingtool(target))
@@ -2187,6 +2189,10 @@ TYPEINFO(/obj/item/machineboard/vending/monkeys)
 	desc = "A vending machine offering presumably legal goods sold by other crewmembers."
 	pay = 1
 	layer = OBJ_LAYER - 0.3
+	default_material = "steel"
+	mat_changename = FALSE
+	material_amt = 0.3
+
 	//Product loading chute
 	var/loading = FALSE
 	var/unlocked = FALSE


### PR DESCRIPTION
## About the PR
- Player vending machines now inherit the material and forensics of the frame that they were built with.

## Why's this needed?
- This is the expected behavior of a custom-built object.

## Testing
<img width="321" height="250" alt="Screenshot 2026-05-28 001555" src="https://github.com/user-attachments/assets/2057dc89-6dd5-4206-a2df-8788665b68cc" />
