### PR TITLE
Fixes a bunch of "the the" spelling mistakes.

### DIFF
--- a/.github/AUDIO_GUIDELINES.md
+++ b/.github/AUDIO_GUIDELINES.md
@@ -8,7 +8,7 @@ Have a gun that needs to go bang? A pen that needs a satisfying clicking sound? 
 
 ## Your audio workstation
 
-Whether you're using sounds already made or you'd like to create your own effects, the first thing you'll need is an editing program! No, you don't need to go buy a professional-level digital audio workstation, there are many open-source programs like [Tenacity](https://tenacityaudio.org) and [Ardour](https://ardour.org) that you can use. As long as the the software can do the things you want (recording, editing, producing) and export your project as an .ogg file with different quality settings, you should be fine. Get to know your program of choice, learn the hotkeys and layout so you know what it's capable of.
+Whether you're using sounds already made or you'd like to create your own effects, the first thing you'll need is an editing program! No, you don't need to go buy a professional-level digital audio workstation, there are many open-source programs like [Tenacity](https://tenacityaudio.org) and [Ardour](https://ardour.org) that you can use. As long as the software can do the things you want (recording, editing, producing) and export your project as an .ogg file with different quality settings, you should be fine. Get to know your program of choice, learn the hotkeys and layout so you know what it's capable of.
 
 ## Where do I get sound files?
 

--- a/code/WorkInProgress/ObjectProperties.dm
+++ b/code/WorkInProgress/ObjectProperties.dm
@@ -113,7 +113,7 @@ var/list/globalPropList = null
 	var/defaultValue = 1 //Default value. Used to get an idea of what's "normal" for any given property.
 	var/goodDirection = 1 //Dumb name. Tells us which direction the number should grow in for it to be considered "good", 1=positive, -1 negative
 	var/hidden = 0 //does not get printed in item tooltips
-	var/inline = 0 //For use on properties on blocks only: gets printed in the the blocking-inline section of tooltips
+	var/inline = 0 //For use on properties on blocks only: gets printed in the blocking-inline section of tooltips
 				   //ignores hidden (and should be used with hidden unless you want it printed both in the inline section and with the rest of the properties)
 
 	proc/onAdd(var/obj/owner, var/value) //When property is added to an object

--- a/code/datums/components/itemblock/warmsup.dm
+++ b/code/datums/components/itemblock/warmsup.dm
@@ -9,7 +9,7 @@
 	. = ..()
 	RegisterSignal(parent, COMSIG_ITEM_BLOCK_TOOLTIP_BLOCKING_APPEND, PROC_REF(append_to_tooltip))
 
-//arguments are sent from the the SendSignal() in Life.dm:140
+//arguments are sent from the SendSignal() in Life.dm:140
 //SEND_SIGNAL(src, COMSIG_LIVING_LIFE_TICK, (life_time_passed / tick_spacing))
 //first argument, src, is the atom to be sending the signal to, and is also the first argument of the proc triggered by the signal
 //second argument, COMSIG_LIVING_LIFE_TICK, is the type of signal that was send. This matches the signal we are registered to,

--- a/code/modules/antagonists/revolutionary/head_revolutionary.dm
+++ b/code/modules/antagonists/revolutionary/head_revolutionary.dm
@@ -104,7 +104,7 @@
 
 		// Inform the player about the uplink and save information regarding it to the owner's memory.
 		if (istype(uplink_source, /obj/item/device/pda2))
-			boutput(H, "The Syndicate have cunningly disguised a head revolutionary uplink as your [uplink_source.name] [loc_string]. Simply enter the the code <b>\"[uplink.lock_code]\"</b> as the ringtone in its Messenger app to unlock its hidden features.")
+			boutput(H, "The Syndicate have cunningly disguised a head revolutionary uplink as your [uplink_source.name] [loc_string]. Simply enter the code <b>\"[uplink.lock_code]\"</b> as the ringtone in its Messenger app to unlock its hidden features.")
 			logTheThing(LOG_DEBUG, H, "Head revolutionary PDA uplink created: [uplink_source.name]. Location given: [loc_string]. Code: [uplink.lock_code]")
 			src.owner.store_memory("<b>Uplink password:</b> [uplink.lock_code].")
 		else if (istype(uplink_source, /obj/item/device/radio))

--- a/code/modules/antagonists/spy_thief/spy_thief.dm
+++ b/code/modules/antagonists/spy_thief/spy_thief.dm
@@ -86,7 +86,7 @@
 			var/obj/item/uplink/integrated/pda/spy/uplink = new /obj/item/uplink/integrated/pda/spy(PDA)
 			uplink.setup(H.mind, PDA)
 
-			boutput(H, "The Syndicate have cunningly disguised a spy thief uplink as your [uplink_source.name] [loc_string]. Simply enter the the code <b>\"[uplink.lock_code]\"</b> as the ringtone in its Messenger app to unlock its hidden features.")
+			boutput(H, "The Syndicate have cunningly disguised a spy thief uplink as your [uplink_source.name] [loc_string]. Simply enter the code <b>\"[uplink.lock_code]\"</b> as the ringtone in its Messenger app to unlock its hidden features.")
 			logTheThing(LOG_DEBUG, H, "Spy Thief PDA uplink created: [uplink_source.name]. Location given: [loc_string]. Code: [uplink.lock_code]")
 			src.owner.store_memory("<b>Uplink password:</b> [uplink.lock_code].")
 

--- a/code/modules/antagonists/traitor/traitor.dm
+++ b/code/modules/antagonists/traitor/traitor.dm
@@ -88,7 +88,7 @@
 
 		// step 3 of uplinkification: inform the player about it and store the code in their memory
 		if (istype(uplink_source, /obj/item/device/pda2))
-			boutput(H, "The Syndicate have cunningly disguised an uplink as your [uplink_source.name] [loc_string]. Simply enter the the code <b>\"[uplink.lock_code]\"</b> as the ringtone in its Messenger app to unlock its hidden features.")
+			boutput(H, "The Syndicate have cunningly disguised an uplink as your [uplink_source.name] [loc_string]. Simply enter code <b>\"[uplink.lock_code]\"</b> as the ringtone in its Messenger app to unlock its hidden features.")
 			logTheThing(LOG_DEBUG, H, "Traitor PDA uplink created: [uplink_source.name]. Location given: [loc_string]. Code: [uplink.lock_code]")
 			src.owner.store_memory("<b>Uplink password:</b> [uplink.lock_code].")
 		else if (istype(uplink_source, /obj/item/device/radio))

--- a/code/modules/atmospherics/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/portable/portable_atmospherics.dm
@@ -107,7 +107,7 @@
 /obj/machinery/portable_atmospherics/attackby(var/obj/item/W, var/mob/user)
 	if(istype(W, /obj/item/tank))
 		if(!src.holding)
-			boutput(user, SPAN_NOTICE("You attach the [W.name] to the the [src.name]"))
+			boutput(user, SPAN_NOTICE("You attach the [W.name] to the [src.name]"))
 			user.drop_item()
 			W.set_loc(src)
 			src.holding = W

--- a/code/modules/chemistry/tools/chemistry_hints.dm
+++ b/code/modules/chemistry/tools/chemistry_hints.dm
@@ -27,7 +27,7 @@
 				has_been_read = 0
 				return
 			user.client.add_to_bank(3500)
-			boutput(user,"You slowly unfurl the the scroll","red")
+			boutput(user,"You slowly unfurl the scroll","red")
 			icon_state = "scroll_open"
 			SPAWN(1 SECOND)
 				boutput(user,"<B>THE HORROR!</B>")

--- a/code/modules/mapping/_helper_parent.dm
+++ b/code/modules/mapping/_helper_parent.dm
@@ -1,6 +1,6 @@
 /* Mapping helper parent
  * intended for mapping helpers which do something on an atom on loc and delete themselves such as access spawners
- * if the the orginal location is needed for anything a landmark should be used instead
+ * if the orginal location is needed for anything a landmark should be used instead
 */
 ABSTRACT_TYPE(/obj/mapping_helper)
 /obj/mapping_helper

--- a/code/modules/medical/diseases/space_madness.dm
+++ b/code/modules/medical/diseases/space_madness.dm
@@ -25,7 +25,7 @@
 			if (probmult(8))
 				for (var/mob/living/M in view(7,affected_mob))
 					if(M!= affected_mob)
-						boutput(affected_mob, "<b>[M.name]</b> says, \"[pick("I'm going to kill you!","I'm the the traitor.", "TRAITOR!")]\"")
+						boutput(affected_mob, "<b>[M.name]</b> says, \"[pick("I'm going to kill you!","I'm the traitor.", "TRAITOR!")]\"")
 						break
 			if (probmult(9))
 				boutput(affected_mob, pick(SPAN_ALERT("<i><b><font face =Tempus Sans ITC>Kill them all!!!!!</b></i></FONT>"), SPAN_ALERT("<i><b><font face = Tempus Sans ITC>They are out to get you!</b></FONT></i>"), SPAN_ALERT("<i><b><font face = Tempus Sans ITC>They know what you did!!!!</b></FONT></i>"), SPAN_ALERT("<i><b><font face = Tempus Sans ITC>They are watching you!!!</b></i></FONT>")))
@@ -66,7 +66,7 @@
 			if (probmult(8))
 				for (var/mob/living/M in view(7,affected_mob))
 					if(M!= affected_mob)
-						boutput(affected_mob, "<b>[M.name]</b> says, \"[pick("I'm going to kill you!","I'm the the traitor.", "You are a loser!")]\"")
+						boutput(affected_mob, "<b>[M.name]</b> says, \"[pick("I'm going to kill you!","I'm the traitor.", "You are a loser!")]\"")
 						break
 
 		if(5)
@@ -105,7 +105,7 @@
 			if (probmult(8))
 				for (var/mob/living/M in view(7,affected_mob))
 					if(M!= affected_mob)
-						boutput(affected_mob, "<b>[M.name]</b> says, \"[pick("I'm going to kill you!","I'm the the traitor.", "You are a loser!")]\"")
+						boutput(affected_mob, "<b>[M.name]</b> says, \"[pick("I'm going to kill you!","I'm the traitor.", "You are a loser!")]\"")
 						break
 
 /datum/ailment/disease/space_madness/on_remove(var/mob/living/affected_mob, var/datum/ailment_data/D)

--- a/code/modules/networks/computer3/mainframe2/programs/os/kernel/syscalls/exit.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/os/kernel/syscalls/exit.dm
@@ -35,7 +35,7 @@
 		var/user_id = user.user_id
 		src.kernel.logout_user(user, FALSE)
 
-		// As they didn't disconnect the the terminal, we should present a new login screen there.
+		// As they didn't disconnect the terminal, we should present a new login screen there.
 		src.kernel.login_temp_user(user_id)
 
 	else

--- a/code/modules/transport/pods/preassembled_frame_kit.dm
+++ b/code/modules/transport/pods/preassembled_frame_kit.dm
@@ -144,7 +144,7 @@ ABSTRACT_TYPE(/obj/structure/preassembeled_vehicleframe)
 				user.visible_message("[user] begins screwing down the frame's circuit boards and its engine...")
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				action_bar.proc_path = /obj/structure/preassembeled_vehicleframe/proc/step_screw_1
-				action_bar.end_message = "[user] finishes screwing the the frame's circuit boards and its engine."
+				action_bar.end_message = "[user] finishes screwing the frame's circuit boards and its engine."
 				actions.start(action_bar, user)
 			else
 				boutput(user, "You need a screwdriver to screw the circuit boards and the engine together.")

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -3176,14 +3176,14 @@ TYPEINFO(/obj/machinery/vending/janitor)
 
 	proc/insert_tank(obj/item/tank/tank, mob/user)
 		if (!src.holding)
-			boutput(user, "You insert the [tank] into the the [src].</span>")
+			boutput(user, "You insert the [tank] into the [src].</span>")
 			UpdateOverlays(holding_overlay_image, "o2_vend_tank_overlay")
 			user.drop_item()
 			tank.set_loc(src)
 			src.holding = tank
 			tgui_process.update_uis(src)
 		else
-			boutput(user, "You try to insert the [tank] into the the [src], but there's already a tank there!</span>")
+			boutput(user, "You try to insert the [tank] into [src], but there's already a tank there!</span>")
 
 	ui_interact(mob/user, datum/tgui/ui)
 		ui = tgui_process.try_update_ui(user, src, ui)

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -3183,7 +3183,7 @@ TYPEINFO(/obj/machinery/vending/janitor)
 			src.holding = tank
 			tgui_process.update_uis(src)
 		else
-			boutput(user, "You try to insert the [tank] into [src], but there's already a tank there!</span>")
+			boutput(user, "You try to insert the [tank] into the [src], but there's already a tank there!</span>")
 
 	ui_interact(mob/user, datum/tgui/ui)
 		ui = tgui_process.try_update_ui(user, src, ui)

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -668,7 +668,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 //0.22
 /obj/item/gun/kinetic/faith
 	name = "Faith"
-	desc = "'Cause ya gotta have Faith. A custom upgrade to Auklet .22 pocket pistol from Cormorant Precision Arms."
+	desc = "'Cause ya gotta have Faith. A custom upgrade to the Auklet .22 pocket pistol from Cormorant Precision Arms."
 	icon_state = "faith"
 	force = MELEE_DMG_PISTOL
 	ammo_cats = list(AMMO_PISTOL_22)

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -668,7 +668,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 //0.22
 /obj/item/gun/kinetic/faith
 	name = "Faith"
-	desc = "'Cause ya gotta have Faith. A custom upgrade to the the Auklet .22 pocket pistol from Cormorant Precision Arms."
+	desc = "'Cause ya gotta have Faith. A custom upgrade to Auklet .22 pocket pistol from Cormorant Precision Arms."
 	icon_state = "faith"
 	force = MELEE_DMG_PISTOL
 	ammo_cats = list(AMMO_PISTOL_22)

--- a/strings/books/pharmacopia.txt
+++ b/strings/books/pharmacopia.txt
@@ -52,7 +52,7 @@
 		<div class = "calomel">
 		<ul>
 			<li>Calomel, or Mercurous Chloride, is a rapid purgative that will remove other reagents from the body. It is quite toxic.
-			<li>It should be used only when poisons in your patient are worse than Calomel itself.
+			<li>It should be used only when the poisons in your patient are worse than Calomel itself.
 			<li>Preparation: heat mercury and chlorine together to 374 K.
 		<br>
 		<h4><i>Advanced:</i></h4>

--- a/strings/books/pharmacopia.txt
+++ b/strings/books/pharmacopia.txt
@@ -52,7 +52,7 @@
 		<div class = "calomel">
 		<ul>
 			<li>Calomel, or Mercurous Chloride, is a rapid purgative that will remove other reagents from the body. It is quite toxic.
-			<li>It should be used only when the the poisons in your patient are worse than Calomel itself.
+			<li>It should be used only when poisons in your patient are worse than Calomel itself.
 			<li>Preparation: heat mercury and chlorine together to 374 K.
 		<br>
 		<h4><i>Advanced:</i></h4>


### PR DESCRIPTION
## About the PR 
Changes text in 15 files to not include an extra "the" this includes comments.

## Why's this needed? 
Code cleanliness and game  cleanliness.

## Testing 
I just deleted the extra "the", so no testing.