### PR TITLE
Rework turret EMP act

### DIFF
--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -196,6 +196,8 @@
 		return
 	if (!( istype(T, /turf) ))
 		return
+	if(GET_COOLDOWN(src, "emp_timer"))
+		return
 
 	if(shot_type == 1)
 		return
@@ -245,9 +247,11 @@
 
 /obj/machinery/turret/emp_act()
 	..()
-	src.enabled = 0
-	src.lasers = 0
-	src.power_change()
+	var/length = rand(30, 60) SECONDS
+	EXTEND_COOLDOWN(src, "emp_timer", length)
+	src.add_filter("emp_outline", 1, outline_filter(1, "#00FFFF", OUTLINE_SHARP))
+	SPAWN(length)
+		src.remove_filter("emp_outline")
 	return
 
 /obj/machinery/turret/proc/die()

--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -90,6 +90,12 @@
 
 	if (src.cover==null)
 		src.cover = new /obj/machinery/turretcover(src.loc)
+
+	if(GET_COOLDOWN(src, "emp_timer"))
+		return
+	else
+		src.remove_filter("emp_outline")
+
 	var/area/area = get_area(loc)
 	if (istype(area))
 		if(!target_list)
@@ -196,8 +202,6 @@
 		return
 	if (!( istype(T, /turf) ))
 		return
-	if(GET_COOLDOWN(src, "emp_timer"))
-		return
 
 	if(shot_type == 1)
 		return
@@ -247,12 +251,9 @@
 
 /obj/machinery/turret/emp_act()
 	..()
-	var/length = rand(30, 60) SECONDS
+	var/length = rand(30, 45) SECONDS
 	EXTEND_COOLDOWN(src, "emp_timer", length)
 	src.add_filter("emp_outline", 1, outline_filter(1, "#00FFFF", OUTLINE_SHARP))
-	SPAWN(length)
-		src.remove_filter("emp_outline")
-	return
 
 /obj/machinery/turret/proc/die()
 	src.health = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Instead of turning a turret off, EMPing them will now prevent them from firing for 30-45 seconds and add an overlay to indicate the turret is disabled.
The overlay is only removed when the cooldown is over and the turret processes another shot, meaning if you don't keep it topped up on EMPs the turret will likely get a free shot on you when the timer runs out

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the only feedback that a turret is EMPd is that it turns off, which is countered by anyone just turning it on again from the control panel, this allows strategic EMPing of turrets to counterplay a rogue AI and hopefully reduce the need for spam clicking the control panel.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="198" height="230" alt="image" src="https://github.com/user-attachments/assets/2083a916-863e-4808-bebc-1a55968106d8" />
<img width="663" height="239" alt="image" src="https://github.com/user-attachments/assets/f8c56341-57a8-4649-b761-dbe212e7a324" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)EMPing an AI turret will now prevent it from firing for 30-45 seconds, instead of just turning it off.
```
