### PR TITLE
Convert rev trackers to event

### DIFF
--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -96,16 +96,12 @@
 	waittimed = TRUE
 
 /datum/game_mode/revolution/proc/send_tracker()
-	command_alert("Foreign mutiny located [station_or_ship()]wide, a program to track revolutionary leaders have been sent to all crew member PDA's.", "Central Command Security Alert", 'sound/misc/announcement_1.ogg', alert_origin = ALERT_WATCHFUL_EYE)
-	command_alert("Relevant biometric signatures of Command have been identified. To aid with the ongoing revolution, station command can now be tracked through the transmitted PDA program.", "Unregistered Signal Insertion", alert_origin = ALERT_EGERIA_PROVIDENCE)
-	var/datum/signal/signal1 = get_free_signal()
-	signal1.data_file = (new /datum/computer/file/pda_program/revheadtracker)
-	signal1.data = list("command"="file_send", "file_name" = "Revolutionary Leader Locater", "file_ext" = "PPROG", "file_size" = "1", "tag" = "auto_fileshare", "sender_name"="Central Command Distribution Line", "sender"="00000000")
-	radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(signal1)
-	var/datum/signal/signal2 = get_free_signal()
-	signal2.data_file = (new /datum/computer/file/pda_program/headtracker)
-	signal2.data = list("command"="file_send", "file_name" = "Nanotrasen Command Tracker", "file_ext" = "PPROG", "file_size" = "1", "tag" = "auto_fileshare", "sender"="00000000")
-	radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(signal2)
+	var/datum/random_event/special/command_tracker/command_distribution = locate() in random_events.special_events
+	if(!command_distribution.already_released)
+		command_distribution.event_effect("Triggered by revolution mode")
+	var/datum/random_event/special/headrev_tracker/headrev_distribution = locate() in random_events.special_events
+	if(!headrev_distribution.already_released)
+		headrev_distribution.event_effect("Triggered by revolution mode")
 	trackertimed = TRUE
 
 #ifndef ME_AND_MY_40_ALT_ACCOUNTS

--- a/code/modules/events/rev_trackers.dm
+++ b/code/modules/events/rev_trackers.dm
@@ -1,0 +1,36 @@
+/datum/random_event/special/command_tracker
+	name = "Command Tracker Distribution"
+	disabled = TRUE
+	centcom_headline = "Unregistered Signal Insertion"
+	centcom_origin = ALERT_EGERIA_PROVIDENCE
+	var/already_released = FALSE
+
+	event_effect(var/source)
+		var/ongoing_revolution_text = "S"
+		if(length(get_all_antagonists(ROLE_REVOLUTIONARY)) || length(get_all_antagonists(ROLE_HEAD_REVOLUTIONARY)))
+			ongoing_revolution_text = "To aid with the ongoing revolution, s"
+		src.centcom_message = "Relevant biometric signatures of Command have been identified. [ongoing_revolution_text]tation command can now be tracked through the transmitted PDA program."
+		. = ..()
+
+		var/datum/signal/signal = get_free_signal()
+		signal.data_file = (new /datum/computer/file/pda_program/headtracker)
+		signal.data = list("command"="file_send", "file_name" = "Nanotrasen Command Tracker", "file_ext" = "PPROG", "file_size" = "1", "tag" = "auto_fileshare", "sender"="00000000")
+		radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(signal)
+		src.already_released = TRUE
+
+/datum/random_event/special/headrev_tracker
+	name = "Headrev Tracker Distribution"
+	disabled = TRUE
+	centcom_headline = "Central Command Security Alert"
+	centcom_origin = ALERT_WATCHFUL_EYE
+	var/already_released = FALSE
+
+	event_effect(var/source)
+		src.centcom_message = "Foreign mutiny located [station_or_ship()]wide, a program to track revolutionary leaders have been sent to all crew member PDA's."
+		. = ..()
+
+		var/datum/signal/signal = get_free_signal()
+		signal.data_file = (new /datum/computer/file/pda_program/revheadtracker)
+		signal.data = list("command"="file_send", "file_name" = "Revolutionary Leader Locater", "file_ext" = "PPROG", "file_size" = "1", "tag" = "auto_fileshare", "sender_name"="Central Command Distribution Line", "sender"="00000000")
+		radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(signal)
+		src.already_released = TRUE

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1308,6 +1308,7 @@
 #include "code\modules\events\pretty_space.dm"
 #include "code\modules\events\radiation.dm"
 #include "code\modules\events\random_event.dm"
+#include "code\modules\events\rev_trackers.dm"
 #include "code\modules\events\salvagers.dm"
 #include "code\modules\events\sleeperagent.dm"
 #include "code\modules\events\solar_flare.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Converts the command+headrev trackers from the revolutionary mode to individual fireable events.
The revolution gamemode will only automatically fire the events that have not already been fired, to avoid it being triggered twice if an admin activates one early.
The command tracker announcement will only include the "to aid the ongoing revolution" bit if there are actually any revs so it can be fired without immediate panic from command outside of rev rounds

NOTE: These apps currently do not work outside of the revolution mode.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows an admin to fire these events early if people are hiding early

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="521" height="613" alt="image" src="https://github.com/user-attachments/assets/74609307-be5a-4bee-8159-1a497f5fbe67" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
