### PR TITLE
Fixes missing textures for monkey barrel hologloves

### DIFF
--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -712,6 +712,8 @@ TYPEINFO(/mob/living/carbon/human/npc/monkey)
 
 			if (templateclothes)
 				holoclothes = src.get_slot(slot)
+				if (slot == "gloves")
+					holoclothes.item_state = templateclothes.item_state
 				holoclothes.icon = templateclothes.icon
 				holoclothes.wear_image_icon = templateclothes.wear_image_icon
 				holoclothes.icon_state = templateclothes.icon_state

--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -712,8 +712,7 @@ TYPEINFO(/mob/living/carbon/human/npc/monkey)
 
 			if (templateclothes)
 				holoclothes = src.get_slot(slot)
-				if (slot == "gloves")
-					holoclothes.item_state = templateclothes.item_state
+				holoclothes.item_state = templateclothes.item_state
 				holoclothes.icon = templateclothes.icon
 				holoclothes.wear_image_icon = templateclothes.wear_image_icon
 				holoclothes.icon_state = templateclothes.icon_state


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Sets item_state in the copy_clothes proc so gloves appear with the right look and not a missing texture.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #26773.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested with multiple gloves and other clothes set with them, seems to work.