### PR TITLE
Syndicate stealth description for syndicate implanters

### DIFF
--- a/code/datums/syndicate_buylist/buylist_generic.dm
+++ b/code/datums/syndicate_buylist/buylist_generic.dm
@@ -125,7 +125,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 
 /datum/syndicate_buylist/generic/marionette_implant
 	name = "Marionette Implant"
-	items = list(/obj/item/implanter/marionette)
+	items = list(/obj/item/implanter/sneaky/marionette)
 	cost = 1
 	desc = "Receives data signals and converts them into synaptic impulses, for remote-control puppeting! Packet compatible.<br><br>\
 		The first purchase of this item will be contained in a box that also includes instructions and a remote. Subsequent purchases will only \
@@ -367,7 +367,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/traitor)
 
 /datum/syndicate_buylist/traitor/microbomb
 	name = "Microbomb Implant"
-	items = list(/obj/item/implanter/uplink_microbomb)
+	items = list(/obj/item/implanter/sneaky/uplink_microbomb)
 	cost = 1
 	vr_allowed = FALSE
 	desc = "This miniaturized explosive packs a decent punch and will detonate upon the unintentional death of the host. Do not swallow and keep out of reach of children."

--- a/code/datums/syndicate_buylist/buylist_job.dm
+++ b/code/datums/syndicate_buylist/buylist_job.dm
@@ -165,7 +165,7 @@
 
 	run_on_spawn(obj/item/our_item, mob/living/owner, in_surplus_crate)
 		if(in_surplus_crate)
-			new /obj/item/implanter/wasp(our_item.loc)
+			new /obj/item/implanter/sneaky/wasp(our_item.loc)
 			return
 		..()
 
@@ -180,7 +180,7 @@
 
 	run_on_spawn(obj/item/our_item, mob/living/owner, in_surplus_crate)
 		if(in_surplus_crate)
-			new /obj/item/implanter/wasp(our_item.loc)
+			new /obj/item/implanter/sneaky/wasp(our_item.loc)
 			return
 		..()
 
@@ -275,7 +275,7 @@
 
 /datum/syndicate_buylist/traitor/zappy_implant
 	name = "Flyzapper Implant"
-	items = list(/obj/item/implanter/zappy)
+	items = list(/obj/item/implanter/sneaky/zappy)
 	cost = 1
 	desc = "This implant turns you into a living (or dying) generator, zapping those around you with a volume of electricity that scales with the number of implants upon your demise."
 	job = list(ALL_ENGINEERS)

--- a/code/modules/events/minor/dead_drops.dm
+++ b/code/modules/events/minor/dead_drops.dm
@@ -320,7 +320,7 @@ ABSTRACT_TYPE(/datum/dead_drop)
 /datum/dead_drop/destruction
 	items_max = 4
 	items = list(/obj/item/card/id/syndicate=100,
-				/obj/item/implanter/uplink_microbomb=25,
+				/obj/item/implanter/sneaky/uplink_microbomb=25,
 				/obj/item/breaching_charge/thermite=50,
 				/obj/item/breaching_charge=50,
 				/obj/item/gun/kinetic/pistol=10,

--- a/code/modules/medical/implants/implanter.dm
+++ b/code/modules/medical/implants/implanter.dm
@@ -176,19 +176,20 @@
 		src.imp = new /obj/item/implant/mindhack/super( src )
 		..()
 
-/obj/item/implanter/microbomb
-	name = "microbomb implanter"
-	icon_state = "implanter1-g"
+/obj/item/implanter/sneaky
 	sneaky = TRUE
+	tooltip_flags = parent_type::tooltip_flags | REBUILD_USER
+	SYNDICATE_STEALTH_DESCRIPTION("It has stealth injection systems installed, making it harder for victims to notice being implanted.", null)
+
+/obj/item/implanter/sneaky/microbomb
+	icon_state = "implanter1-g"
 
 	New()
 		src.imp = new /obj/item/implant/revenge/microbomb( src )
 		..()
 
-/obj/item/implanter/uplink_microbomb
-	name = "microbomb implanter"
+/obj/item/implanter/sneaky/uplink_microbomb
 	icon_state = "implanter1-g"
-	sneaky = TRUE
 	HELP_MESSAGE_OVERRIDE({"When someone dies while implanted with this, an explosion relative to the amount of microbombs in them will occur. Suiciding will likely cause no explosion, but succumbing while in crit will."})
 
 	New()
@@ -197,29 +198,25 @@
 		src.imp = newbomb
 		..()
 
-/obj/item/implanter/zappy
-	name = "flyzapper implanter"
+/obj/item/implanter/sneaky/zappy
 	icon_state = "implanter1-g"
-	sneaky = TRUE
 	HELP_MESSAGE_OVERRIDE({"When someone dies while implanted with this, a ball of lightning relative to the amount of flyzapper implants in them will occur. Suiciding will cause no lightning."})
 
 	New()
 		src.imp = new /obj/item/implant/revenge/zappy(src)
 		..()
 
-/obj/item/implanter/wasp
+/obj/item/implanter/sneaky/wasp
 	name = "wasp implanter"
 	icon_state = "implanter1-g"
-	sneaky = TRUE
 	HELP_MESSAGE_OVERRIDE({"When someone dies while implanted with this, they will explode into a cloud of angry wasps. Suiciding will cause no cloud of wasps to appear. This implant will also make wasps friendly to the user."})
 
 	New()
 		src.imp = new /obj/item/implant/revenge/wasp(src)
 		..()
 
-/obj/item/implanter/marionette
+/obj/item/implanter/sneaky/marionette
 	icon_state = "implanter1-g"
-	sneaky = TRUE
 	HELP_MESSAGE_OVERRIDE({"Allows remote signals to exert limited control over the implanted target. Compatible with packets. \
 	You can hit this implanter with a marionette implant remote to scan it, causing the contained implant to send status updates to it."})
 

--- a/code/modules/medical/implants/implanter.dm
+++ b/code/modules/medical/implants/implanter.dm
@@ -182,6 +182,7 @@
 	SYNDICATE_STEALTH_DESCRIPTION("It has stealth injection systems installed, making it harder for victims to notice being implanted.", null)
 
 /obj/item/implanter/sneaky/microbomb
+	name = "microbomb implanter"
 	icon_state = "implanter1-g"
 
 	New()
@@ -189,6 +190,7 @@
 		..()
 
 /obj/item/implanter/sneaky/uplink_microbomb
+	name = "microbomb implanter"
 	icon_state = "implanter1-g"
 	HELP_MESSAGE_OVERRIDE({"When someone dies while implanted with this, an explosion relative to the amount of microbombs in them will occur. Suiciding will likely cause no explosion, but succumbing while in crit will."})
 
@@ -199,6 +201,7 @@
 		..()
 
 /obj/item/implanter/sneaky/zappy
+	name = "flyzapper implanter"
 	icon_state = "implanter1-g"
 	HELP_MESSAGE_OVERRIDE({"When someone dies while implanted with this, a ball of lightning relative to the amount of flyzapper implants in them will occur. Suiciding will cause no lightning."})
 

--- a/code/obj/item/gift.dm
+++ b/code/obj/item/gift.dm
@@ -359,7 +359,7 @@ var/global/list/questionable_generic_gift_paths = list(/obj/item/relic,
 	/obj/item/storage/box/spy_sticker_kit,
 	/obj/item/reagent_containers/food/snacks/pizza/xmas,
 #ifndef RP_MODE
-	/obj/item/implanter/microbomb,
+	/obj/item/implanter/sneaky/microbomb,
 	/obj/item/old_grenade/light_gimmick,
 	/obj/item/gun/energy/bfg,
 	/obj/item/engibox/station_locked,

--- a/code/obj/item/storage/implant.dm
+++ b/code/obj/item/storage/implant.dm
@@ -38,4 +38,4 @@
 	New(loc, flag_that_prevents_the_box_from_having_its_free_implanter)
 		..()
 		if (!flag_that_prevents_the_box_from_having_its_free_implanter)
-			src.storage.add_contents(new /obj/item/implanter/marionette)
+			src.storage.add_contents(new /obj/item/implanter/sneaky/marionette)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Parents sneaky syndicate implanters to a common /sneaky type, with a syndicate stealth description

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Tells traitors that these implanters may have additional use beyond the implants they contain, such as sneakily implanting someone with a tracker or other implant.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
All implanters were still found in surplus crates and purchasable via the uplink.
<img width="490" height="85" alt="image" src="https://github.com/user-attachments/assets/f2978e14-a6ec-4e72-afe3-f0dd33b1c0e0" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Syndicate implanters with stealthy capabilities (not showing a chat message) now have a syndicate-only description telling you so.
```
