### PR TITLE
Fix floppy disks not registering properly

### DIFF
--- a/code/modules/networks/computer3/peripherals.dm
+++ b/code/modules/networks/computer3/peripherals.dm
@@ -1310,7 +1310,10 @@ TYPEINFO(/obj/item/peripheral/sound_card)
 		if(istype(P, setup_disk_type))
 			if(!src.disk)
 				user.drop_item()
-				P.loc = src
+				if (src.host)
+					P.set_loc(src.host)
+				else
+					P.set_loc(src)
 				src.disk = P
 				boutput(user, "You insert [P] into the drive.")
 				return 0


### PR DESCRIPTION
## About the PR

Fixes #26776, a bug where floppy disks were not registered properly when inserted by clicking a computer with them in hand.

## Why's this needed?

bug bad, fix good

## Testing

clicked on a computer with a floppy in hand. the floppy drive was inserted, the UI updated, `drive` command showed `fd0` as an option.

