### PR TITLE
ABCU Blacklist Update

### DIFF
--- a/code/WorkInProgress/blueprints.dm
+++ b/code/WorkInProgress/blueprints.dm
@@ -565,6 +565,7 @@
 // blacklist overrules whitelist
 #define BLACKLIST_OBJECTS list( \
 	/obj/disposalpipe/loafer, \
+	/obj/machinery/disposal/extradimensional, \
 	/obj/submachine/slot_machine/item, \
 	/obj/machinery/portable_atmospherics/canister, \
 	/obj/window/crystal, \
@@ -576,6 +577,7 @@
 	/turf/simulated/floor/auto/elevator_shaft, \
 	/turf/simulated/shuttle, \
 	/turf/simulated/floor/shuttle, \
+	/turf/simulated/floor/arctic_elevator_shaft, \
 	/turf/simulated/wall/auto/shuttle, \
 	/turf/simulated/wall/void, \
 	/turf/simulated/wall/auto/feather/strong, \


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the Syndicate Hideout to the objects blacklist and the elevator shaft on the Ice Moon to the turf blacklist.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Updates blacklist to include simulated turf of an elevator shaft and a piece of machinery only obtainable through traitor/spief items.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Attempted to take make blueprints from the newly blacklisted items and was unable to.