### PR TITLE
Adds the ability to blind people with flat caps

### DIFF
--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -313,6 +313,46 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 			return
 		. = ..()
 
+	attack(mob/living/carbon/human/target, mob/user, def_zone, is_special, params)
+		if (def_zone != "head" || !src.blade || !istype(target))
+			return ..()
+		//need to grab them close
+		var/obj/item/grab/grab = user.find_type_in_hand(/obj/item/grab)
+		if (!grab || grab.affecting != target || grab.state < GRAB_AGGRESSIVE)
+			return ..()
+		//anything covering their eyes?
+		if (target.wear_mask?.c_flags & COVERSEYES || target.head?.c_flags & COVERSEYES || target.glasses?.c_flags & COVERSEYES)
+			return ..()
+		//don't let them do this more than once
+		if ((!target.organHolder.left_eye || target.organHolder.left_eye.broken) && (!target.organHolder.right_eye || target.organHolder.right_eye.broken))
+			return ..()
+		src.visible_message(SPAN_BOLD(SPAN_COMBAT("[user] begins to slowly drag their blade across [target]'s eyes!")))
+		victim.emote("scream")
+		var/datum/action/bar/razor_blind/actionbar = new()
+		actionbar.victim = target
+		actions.start(actionbar, user)
+
+//is this too far? maybe?? It's kind of badass though...
+/datum/action/bar/razor_blind
+	duration = 10 SECONDS
+	var/mob/living/carbon/human/victim
+
+	onUpdate()
+		take_bleeding_damage(src.victim, src.owner, 5)
+		if (TIME - src.started >= 5 SECONDS && src.victim.organHolder.left_eye && !src.victim.organHolder.left_eye.broken)
+			src.victim.emote("scream")
+			playsound(get_turf(src.victim), 'sound/impact_sounds/Flesh_Cut_1.ogg', 50, 1)
+			src.victim.organHolder.left_eye.take_damage(src.victim.organHolder.left_eye.max_damage)
+		..()
+
+	onEnd()
+		if (src.victim.organHolder.right_eye && !src.victim.organHolder.right_eye.broken)
+			src.victim.emote("scream")
+			playsound(get_turf(src.victim), 'sound/impact_sounds/Flesh_Cut_1.ogg', 50, 1)
+			src.victim.organHolder.right_eye.take_damage(src.victim.organHolder.right_eye.max_damage)
+		..()
+
+
 // Donk clothes
 
 /obj/item/clothing/head/helmet/space/donk

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -280,23 +280,19 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 	item_state = "detective"
 	var/obj/item/razor_blade/blade = null
 
+	razor
+		New()
+			. = ..()
+			var/obj/item/razor_blade/razor = new()
+			src.insert_razor(razor)
+
 	attackby(obj/item/W, mob/user, params) //https://www.youtube.com/watch?v=KGD2N5hJ2e0
 		if (istype(W, /obj/item/razor_blade))
 			boutput(user, SPAN_NOTICE("You sneakily insert [W] into the brim of [src]."))
-			src.desc += " This one has something metal hidden in the brim."
-			src.hit_type = W.hit_type
-			src.tool_flags = W.tool_flags
-			src.force = W.force
-			src.hitsound = W.hitsound
-			src.throwforce = W.throwforce
-			src.throw_speed = W.throw_speed
-			src.throw_range = W.throw_range
-			src.setItemSpecial(W.special.type)
 			user.drop_item(W)
-			W.set_loc(src)
-			src.blade = W
+			src.insert_razor(W)
 			return
-		else if (issnippingtool(W) && src.blade)
+		if (issnippingtool(W) && src.blade)
 			playsound(src, 'sound/items/Scissor.ogg', 40, 1)
 			boutput(user, SPAN_NOTICE("You snip [src.blade] out of the brim of [src]."))
 			src.desc = initial(src.desc)
@@ -312,6 +308,19 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 			src.blade = null
 			return
 		. = ..()
+
+	proc/insert_razor(obj/item/razor)
+		src.desc += " This one has something metal hidden in the brim."
+		src.hit_type = razor.hit_type
+		src.tool_flags = razor.tool_flags
+		src.force = razor.force
+		src.hitsound = razor.hitsound
+		src.throwforce = razor.throwforce
+		src.throw_speed = razor.throw_speed
+		src.throw_range = razor.throw_range
+		src.setItemSpecial(razor.special.type)
+		razor.set_loc(src)
+		src.blade = razor
 
 	attack(mob/living/carbon/human/target, mob/user, def_zone, is_special, params)
 		if (def_zone != "head" || !src.blade || !istype(target))

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -327,7 +327,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/fake_waldo)
 		if ((!target.organHolder.left_eye || target.organHolder.left_eye.broken) && (!target.organHolder.right_eye || target.organHolder.right_eye.broken))
 			return ..()
 		src.visible_message(SPAN_BOLD(SPAN_COMBAT("[user] begins to slowly drag their blade across [target]'s eyes!")))
-		victim.emote("scream")
+		target.emote("scream")
 		var/datum/action/bar/razor_blind/actionbar = new()
 		actionbar.victim = target
 		actions.start(actionbar, user)

--- a/code/obj/storage/gang_crate.dm
+++ b/code/obj/storage/gang_crate.dm
@@ -1119,6 +1119,10 @@ ABSTRACT_TYPE(/obj/loot_spawner/random/medium)
 			spawn_item(C,I,/obj/item/reagent_containers/emergency_injector/random,off_y=0,rot=45,scale_x=0.75,scale_y=0.75)
 			spawn_item(C,I,/obj/item/reagent_containers/emergency_injector/random,off_y=-4,rot=45,scale_x=0.75,scale_y=0.75)
 
+	flatcap
+		spawn_loot(loc, datum/loot_spawner_info/I)
+			spawn_item(loc, I, /obj/item/clothing/head/flatcap/razor)
+
 
 ABSTRACT_TYPE(/obj/loot_spawner/random/long)
 /obj/loot_spawner/random/long //3x1
@@ -1301,7 +1305,7 @@ ABSTRACT_TYPE(/obj/loot_spawner/random/medium_tall)
 	helmet
 		tier = GANG_CRATE_GEAR
 		spawn_loot(var/C,var/datum/loot_spawner_info/I)
-			var/helmet = pick(filtered_concrete_typesof(/obj/item/clothing/head/helmet, PROC_REF(filter_trait_hats)))
+			var/helmet = pick(filtered_concrete_typesof(/obj/item/clothing/head/helmet, GLOBAL_PROC_REF(filter_trait_hats)))
 			spawn_item(C,I,helmet,off_y=-2,scale_x=0.7,scale_y=0.7)
 			spawn_item(C,I,helmet,off_y=0,scale_x=0.7,scale_y=0.7)
 			spawn_item(C,I,helmet,off_y=2,scale_x=0.7,scale_y=0.7)
@@ -1322,9 +1326,10 @@ ABSTRACT_TYPE(/obj/loot_spawner/random/medium_tall)
 
 	hat
 		spawn_loot(var/C,var/datum/loot_spawner_info/I)
-			spawn_item(C,I,pick(filtered_concrete_typesof(/obj/item/clothing/head, PROC_REF(filter_trait_hats))),off_y=-2,scale_x=0.7,scale_y=0.7)
-			spawn_item(C,I,pick(filtered_concrete_typesof(/obj/item/clothing/head, PROC_REF(filter_trait_hats))),off_y=0,scale_x=0.7,scale_y=0.7)
-			spawn_item(C,I,pick(filtered_concrete_typesof(/obj/item/clothing/head, PROC_REF(filter_trait_hats))),off_y=2,scale_x=0.7,scale_y=0.7)
+			//always at least one if we get hats
+			spawn_item(C,I,/obj/item/clothing/head/flatcap/razor,off_y=-2,scale_x=0.7,scale_y=0.7)
+			spawn_item(C,I,pick(filtered_concrete_typesof(/obj/item/clothing/head, GLOBAL_PROC_REF(filter_trait_hats))),off_y=0,scale_x=0.7,scale_y=0.7)
+			spawn_item(C,I,pick(filtered_concrete_typesof(/obj/item/clothing/head, GLOBAL_PROC_REF(filter_trait_hats))),off_y=2,scale_x=0.7,scale_y=0.7)
 	medkits
 		spawn_loot(var/C,var/datum/loot_spawner_info/I)
 			spawn_item(C,I,/obj/item/storage/firstaid/crit,off_y=2)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Aggressive grabbing someone and then attacking them in the head with a flat cap with a razor hidden in it starts an action bar that slashes both their eyes.
Also adds flat caps with razors already sewn into them to gang crate loot pool.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A way for gangs to do lasting damage to those who have wronged them that isn't just turning them into a corpse. A very blatant reference to an old birmingham street gang.
I don't know, this might be too brutal, tell me if it is :P
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="143" height="143" alt="image" src="https://github.com/user-attachments/assets/d76fbbba-6d8e-40e6-b4f2-4fb45688eb61" />
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Razors hidden in flat caps can now be used to blind people. Requires an aggressive grab and head targeting, blocked by anything that covers the eyes.
(+)Gang crates can now contain flat caps with razors hidden in them.
```
