### PR TITLE
fix admin mouse ghost_spawned

### DIFF
--- a/code/mob/living/critter/small_animal/mouse.dm
+++ b/code/mob/living/critter/small_animal/mouse.dm
@@ -454,8 +454,6 @@ TYPEINFO(/mob/living/critter/small_animal/mouse/weak/mentor/admin)
 	New()
 		. = ..()
 		src.fur_color = "#be5a53"
-		// true when making the mob to not make the respawn timer reset...false here to allow for crime
-		ghost_spawned = FALSE
 		new /obj/item/implant/access/infinite/admin_mouse(src)
 		SPAWN(1 SECOND)
 			src.bioHolder?.AddEffect("radio_brain", power = 3, do_stability = FALSE, magical = TRUE)

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -596,7 +596,7 @@ var/list/antag_respawn_critter_types =  list(/mob/living/critter/small_animal/fl
 
 	var/mob/selfmob = src
 	src = null
-	var/mob/living/critter/C = selfmob.make_critter(/mob/living/critter/small_animal/mouse/weak/mentor/admin, spawnpoint, ghost_spawned=TRUE)
+	var/mob/living/critter/C = selfmob.make_critter(/mob/living/critter/small_animal/mouse/weak/mentor/admin, spawnpoint, ghost_spawned=FALSE)
 	C.mind.assigned_role = "Animal"
 	C.literate = 1
 	C.original_name = selfmob.real_name


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Fix `ghost_spawned` being set to `true` on admin mice
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* so I can stop manually disabling it every time I want to commit mouse pranks
