### PR TITLE
Fix default mimics not being able to travel through disposal pipes

### DIFF
--- a/code/datums/abilities/critter/disposal_travel.dm
+++ b/code/datums/abilities/critter/disposal_travel.dm
@@ -51,7 +51,7 @@
 				boutput(holder.owner, SPAN_ALERT("That pipe is a mangled mess of pain!  Best to stay here for now."))
 				return TRUE
 
-			if (istype(holder.owner, /mob/living/critter/mimic/antag_spawn) && holder.owner.max_health >= 50)
+			if (istype(holder.owner, /mob/living/critter/mimic/antag_spawn) && holder.owner.max_health > 50)
 				boutput(holder.owner, SPAN_ALERT("Your disguise is too big to fit inside!"))
 				return TRUE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The code was checking if you were 50 health or higher to prevent you from going in, so I just made it a > only.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Disposal travel is a mimic's main escape option, doesn't make sense not to be able to do it in your default form.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Multiple tests with different chutes and using different disguises.

