### PR TITLE
Gorillas can now rip off all your limbs

### DIFF
--- a/code/modules/antagonists/wrestler/abilities/throw.dm
+++ b/code/modules/antagonists/wrestler/abilities/throw.dm
@@ -44,7 +44,6 @@
 		M.emote("scream")
 		var/i = 0
 		var/spin_start = TIME
-		var/limb_severed = FALSE // for the gorilla variant
 		while (TIME < spin_start + 2.5 SECONDS)
 			var/delay = 5
 			switch (i)
@@ -117,10 +116,12 @@
 
 			var/turf/T = get_edge_target_turf(M, M.dir)
 			if (T && isturf(T))
-				if (!limb_severed && ishuman(HH) && gorilla_mode == TRUE)
+				if (ishuman(HH) && gorilla_mode == TRUE)
 					var/mob/living/carbon/human/limb_loser = HH
-					limb_loser.sever_limb("l_arm")
-					limb_severed = TRUE
+					if(!limb_loser.limbs)
+						return
+					else
+						limb_loser.sever_limb(pick(list("l_arm", "r_arm", "l_leg", "r_leg")))
 				if (!fake)
 					HH.set_loc(get_turf(M))
 					HH.throw_at(T, 10, 4, bonus_throwforce = 33) // y e e t

--- a/code/modules/antagonists/wrestler/abilities/throw.dm
+++ b/code/modules/antagonists/wrestler/abilities/throw.dm
@@ -118,9 +118,7 @@
 			if (T && isturf(T))
 				if (ishuman(HH) && gorilla_mode == TRUE)
 					var/mob/living/carbon/human/limb_loser = HH
-					if(!limb_loser.limbs)
-						return
-					else
+					if(limb_loser.limbs)
 						limb_loser.sever_limb(pick(list("l_arm", "r_arm", "l_leg", "r_leg")))
 				if (!fake)
 					HH.set_loc(get_turf(M))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes gorilla fling so it picks a random limb instead of always the left arm.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Was kind of lazy of me to make it only the left arm. The less limbs you have the less likely you'll lose one (also you'd probably be dead before you lose them all) so I don't think it's a significant buff or anything. 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Works on local
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bamlord
(+)Gorillas have learned how to rip off all your limbs.
```
