### PR TITLE
Allow Cyborgs to swap their mining scoop to junk collection mode

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -2900,7 +2900,11 @@ TYPEINFO(/obj/item/ore_scoop)
 
 	attack_self(var/mob/user as mob)
 		if(issilicon(user))
-			boutput(user, SPAN_ALERT("The satchel is firmly secured to the scoop."))
+			src.collect_junk = !src.collect_junk
+			if (src.collect_junk)
+				boutput(user, SPAN_NOTICE("Now collecting junk."))
+			else
+				boutput(user, SPAN_NOTICE("No longer collecting junk."))
 			return
 		if (!satchel)
 			src.collect_junk = !src.collect_junk


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Brings over the junk-collection (picking up rocks, ice, scrap, etc.) functionality of the mining scoop to the Cyborg mining module. The only difference is that the satchel stays attached to them instead of dropping to the floor (as it's attached to their body).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cyborgs can already currently pick up junk by swapping to a satchel and manually dragging the ore/scrap to it, so this PR eliminates the needless hassle by making the two versions equal in function.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
- Spawned in as a Cyborg and mined various asteroids with the mode on and off
- Made sure I couldn't drop the satchel or somehow lose it

## Changelog
```
(u)Driftered
(+)Cyborgs can now swap their mining scoop to junk-collection mode.
```

[A-Silicons] [C-QoL]