### PR TITLE
Add a safety CRASH to cloud data put

### DIFF
--- a/code/datums/cloud_saves.dm
+++ b/code/datums/cloud_saves.dm
@@ -106,7 +106,8 @@
 	proc/putData(key, value)
 		if(value == src.data[key]) //don't bother sending data if we'd be making no change
 			return TRUE
-
+		if (!istext(value) && !isnum_safe(value))
+			CRASH("Attempt to put cloud data with unsupported type, value: [value]")
 		if (src.simulating)
 			// Local fallback, update JSON file
 			src.putSimulatedCloud("data", key, value)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Call CRASH if `cloudSaves.putData` is called with anything other than a string or a number.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
<img width="776" height="26" alt="image" src="https://github.com/user-attachments/assets/77a4f4fa-517a-4b9f-a489-e2ba5979d0c7" />

The API does not appreciate being fed Byond lists.