### PR TITLE
QM Trader Cloth Nerfs

### DIFF
--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -387,7 +387,7 @@
 			var/datum/commodity/C1 = src.commodities[ctype]
 			for(var/datum/trader/T in src.active_traders)
 				for(var/datum/commodity/C2 in T.goods_sell)
-					if(C1.comtype == C2.comtype)
+					if(ispath(C2.comtype, C1.comtype))
 						if(C1.indemand)
 							C2.amount = 0
 

--- a/code/modules/economy/traders/generic.dm
+++ b/code/modules/economy/traders/generic.dm
@@ -69,8 +69,8 @@
 /datum/commodity/trader/generic/fabric
 	comname = "Cloth Fabric"
 	comtype = /obj/item/material_piece/cloth/cottonfabric
-	amount = 300
-	price_boundary = list(PAY::UNTRAINED/10,PAY::UNTRAINED/5)
+	amount = 50
+	price_boundary = list(PAY::UNTRAINED/2,PAY::UNTRAINED)
 	possible_names = list("We have lots of cloth for sale. Good for making clothes with.",
 	"We have a great deal of cloth we need to shift soon, so please buy it!")
 

--- a/code/modules/economy/traders/generic.dm
+++ b/code/modules/economy/traders/generic.dm
@@ -70,7 +70,7 @@
 	comname = "Cloth Fabric"
 	comtype = /obj/item/material_piece/cloth/cottonfabric
 	amount = 50
-	price_boundary = list(PAY::UNTRAINED/2,PAY::UNTRAINED)
+	price_boundary = list(PAY::UNTRAINED/2,PAY::UNTRAINED*(4/5))
 	possible_names = list("We have lots of cloth for sale. Good for making clothes with.",
 	"We have a great deal of cloth we need to shift soon, so please buy it!")
 

--- a/code/modules/economy/traders/generic.dm
+++ b/code/modules/economy/traders/generic.dm
@@ -69,7 +69,7 @@
 /datum/commodity/trader/generic/fabric
 	comname = "Cloth Fabric"
 	comtype = /obj/item/material_piece/cloth/cottonfabric
-	amount = 50
+	amount = 60
 	price_boundary = list(PAY::UNTRAINED/2,PAY::UNTRAINED*(4/5))
 	possible_names = list("We have lots of cloth for sale. Good for making clothes with.",
 	"We have a great deal of cloth we need to shift soon, so please buy it!")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduces the amount of cloth generic QM Traders sell to 60, increases the price/price range it's sold at, and causes commodities going hot to sell out subtypes from traders (ex: cloth/metal sheets).
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cloth is exceedingly cheap for how much you can profit off of it, since currently it costs less per material to buy cloth than metal sheets from traders. Using conservative estimates, Cloth can be consistently gotten at 20 credits per bar, while jumpsuits can be sold on average for 225 each, and shoes for 100 each.
300 cloth can be converted into 1000 shoes, sold for 100k (-6k invest) for 94k profit
300 jumpsuits (one to one with cloth) sell for 67.5k (-6k invest) for 61.5k profit
Selling to market when it hits over 80 per mat bar gets 24k (-6k invest) for 18k profit
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Traders came and Cloth amounts/prices were within the expected ranges. Materials going hot bought out Cloth from traders, and they properly restocked after a couple cycles as well. Everything else functioned properly, including other Traders/Trader items, the commodity market in general, and whatnot. 
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->