### PR TITLE
Remove salvager pod tints

### DIFF
--- a/code/WorkInProgress/salvager/salvager_magpie.dm
+++ b/code/WorkInProgress/salvager/salvager_magpie.dm
@@ -82,6 +82,9 @@ var/datum/magpie_manager/magpie_man = new
 		myhud.update_systems()
 		myhud.update_states()
 
+/obj/machinery/vehicle/miniputt/armed/salvager/tinted
+	color = list(-0.269231,0.75,3.73077,0.269231,-0.249999,-2.73077,1,0.5,0)
+
 /datum/manufacture/pod/armor_light/salvager
 	name = "Salvager Pod Armor"
 	item_requirements = list("metal_dense" = 30,
@@ -96,8 +99,8 @@ var/datum/magpie_manager/magpie_man = new
 	desc = "Exterior plating for vehicle pods."
 	icon = 'icons/obj/electronics.dmi'
 	icon_state = "dbox"
-	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/armed/salvager,
-						 "/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/salvsub )
+	vehicle_types = list("/obj/structure/vehicleframe/puttframe" = /obj/machinery/vehicle/miniputt/armed/salvager/tinted,
+						 "/obj/structure/vehicleframe/subframe" = /obj/machinery/vehicle/tank/minisub/salvsub/tinted )
 
 /datum/manufacture/communications/salvager
 	name = "Salvager Communication Array"
@@ -302,6 +305,8 @@ var/datum/magpie_manager/magpie_man = new
 		src.install_part(null, new /obj/item/shipcomponent/secondary_system/cargo(src), POD_PART_SECONDARY)
 		src.install_part(null, new /obj/item/shipcomponent/secondary_system/lock/bioscan(src), POD_PART_LOCK)
 
+/obj/machinery/vehicle/tank/minisub/salvsub/tinted
+	color = list(-0.269231,0.75,3.73077,0.269231,-0.249999,-2.73077,1,0.5,0)
 
 
 /obj/machinery/manufacturer/hangar/magpie

--- a/code/WorkInProgress/salvager/salvager_magpie.dm
+++ b/code/WorkInProgress/salvager/salvager_magpie.dm
@@ -69,8 +69,6 @@ var/datum/magpie_manager/magpie_man = new
 
 // MAGPIE Equipment
 /obj/machinery/vehicle/miniputt/armed/salvager
-	desc = "A repeatedly rebuilt and refitted pod.  Looks like it has seen some things."
-	color = list(-0.269231,0.75,3.73077,0.269231,-0.249999,-2.73077,1,0.5,0)
 	init_comms_type = /obj/item/shipcomponent/communications/salvager
 
 	health = 250
@@ -296,7 +294,6 @@ var/datum/magpie_manager/magpie_man = new
 	maxhealth = 150
 	acid_damage_multiplier = 0.5
 	init_comms_type = /obj/item/shipcomponent/communications/salvager
-	color = list(-0.269231,0.75,3.73077,0.269231,-0.249999,-2.73077,1,0.5,0)
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the unique tints and special descriptions from salvager pods and subs.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Letting everyone know exactly what the gamemode is as soon as they see 2 frames of a pod crossing their screen is fine for nukies but less ideal for salvagers. Restores a little bit of intrigue by not letting security immediately identify brown pods as evil and to be shot at.
They retain their slightly boosted stats and pre-installed upgrades.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="167" height="108" alt="image" src="https://github.com/user-attachments/assets/5b6b275a-6da8-46be-af10-779de41e64b1" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Salvager pods no longer have a unique tint. Pods built using the purchasable salvager pod armour retain the tint.
```
