### PR TITLE
Remove priority from the secoff role

### DIFF
--- a/code/datums/jobs/jobs_security.dm
+++ b/code/datums/jobs/jobs_security.dm
@@ -13,8 +13,6 @@ ABSTRACT_TYPE(/datum/job/security)
 	limit = 5
 	lower_limit = 3
 	variable_limit = TRUE
-	high_priority_job = TRUE
-	high_priority_limit = 2 //always try to make sure there's at least a couple of secoffs
 	order_priority = 2 //fill secoffs after captain and AI
 	wages = PAY::TRADESMAN
 	trait_list = list("training_security")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove priority from secoff, making it respect people's occupation preferences
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Since security priority been added, the amount of secoffs on average decreased a lot. This is because people feel they are forced into security every round if they have it enabled. At the end it did the opposite of what it was supposed to do, and hence need to be gone.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I can't really test the rolling statistics alone as far as i'm aware sadly, but i could role secoff in my local attempt
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ANNmagedon
(*)Due to repeated requests from officers who wanted to diversify their resume, security priority roll has been disabled
```
