### PR TITLE
Allows AIs who use "Go Offline" to respawn

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2572,6 +2572,7 @@ proc/get_mobs_trackable_by_AI()
 	if (src.mind)
 		src.mind.register_death()
 		src.mind.get_player()?.dnr = TRUE
+	respawn_controller.subscribeNewRespawnee(src.ckey)
 	var/mob/dead/observer/ghost = src.ghostize()
 	ghost.corpse = null //no coming back
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
[SILICONS] [QOL]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR gives AIs who use the "go offline" verb the normal 10-minute respawn timer on RP, rather than completely disabling their ability to rejoin the round.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This makes going offline consistent with the human/cyborg equivalent (entering cryo), which removes a character from a round and opens a job slot, but still allows the player to respawn as a new character. 
Punishing AI players specifically feels odd to me, and since AI is a priority role there are a few cases where a player with AI set to low may genuinely just not want to play AI, or a player may just want to play a less intensive role without needing to wait for a full RP round to end. 
The current implementation also doesn't acknowledge the fact that AIs can use the suicide command, which allows them to respawn but doesn't immediately allow another player to take their place as the AI. This makes it feel more like an oversight that was given  justification after the fact, instead of a feature that was intended from the outset.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
![image.png](https://github.com/user-attachments/assets/cab68976-5c66-4d85-bd68-9906a365c7f2)

Tested going offline, then respawned as normal.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
