### PR TITLE
Fix bad indent on DMM suite API

### DIFF
--- a/code/z_dmm_suite/api.dm
+++ b/code/z_dmm_suite/api.dm
@@ -38,8 +38,8 @@
 
 */
 //-- Reference -----------------------------------------------------------------
-
-verb/read_map(dmm_text as text, coordX as num, coordY as num, coordZ as num)/*
+dmm_suite
+	verb/read_map(dmm_text as text, coordX as num, coordY as num, coordZ as num)/*
 	Description:
 		Loads maps from DMM formatted text.
 	Arguments:
@@ -50,7 +50,7 @@ verb/read_map(dmm_text as text, coordX as num, coordY as num, coordZ as num)/*
 	Returns: TRUE if successful, FALSE otherwise
 	*/
 
-verb/write_map(turf/corner1, turf/corner2, flags as num)/*
+	verb/write_map(turf/corner1, turf/corner2, flags as num)/*
 	Description:
 		Writes all contents of a region of turfs to a DMM formatted string. The region is
 		defined as all turfs within a rectangular prism where t1 and t2 are opposite corners.
@@ -69,7 +69,7 @@ verb/write_map(turf/corner1, turf/corner2, flags as num)/*
 		location via read_map
 	*/
 
-verb/write_area(area/save_area, flags as num)/*
+	verb/write_area(area/save_area, flags as num)/*
 	Description: Writes all contents of the provided area to a DMM formatted string.
 	Arguments:
 		save_area: An area object to save.
@@ -78,7 +78,7 @@ verb/write_area(area/save_area, flags as num)/*
 		location via read_map
 	*/
 
-verb/write_cube(startX as num, startY as num, startZ as num, width as num, height as num, depth as num, flags as num)/*
+	verb/write_cube(startX as num, startY as num, startZ as num, width as num, height as num, depth as num, flags as num)/*
 	Descriptions:
 		Writes all contents of a region of turfs (defined by the provided arguments) to a
 		DMM formatted string.
@@ -91,7 +91,7 @@ verb/write_cube(startX as num, startY as num, startZ as num, width as num, heigh
 		location via read_map
 	*/
 
-verb/load_map(dmm_file as file, z_offset as num)/*
+	verb/load_map(dmm_file as file, z_offset as num)/*
 	Deprecated: load_map has been deprecated. Use or read_map instead.
 	Arguments:
 		dmm_file: A .dmm file to load (Required).

--- a/code/z_dmm_suite/api.dm
+++ b/code/z_dmm_suite/api.dm
@@ -39,7 +39,7 @@
 */
 //-- Reference -----------------------------------------------------------------
 
-	verb/read_map(dmm_text as text, coordX as num, coordY as num, coordZ as num)/*
+verb/read_map(dmm_text as text, coordX as num, coordY as num, coordZ as num)/*
 	Description:
 		Loads maps from DMM formatted text.
 	Arguments:
@@ -50,7 +50,7 @@
 	Returns: TRUE if successful, FALSE otherwise
 	*/
 
-	verb/write_map(turf/corner1, turf/corner2, flags as num)/*
+verb/write_map(turf/corner1, turf/corner2, flags as num)/*
 	Description:
 		Writes all contents of a region of turfs to a DMM formatted string. The region is
 		defined as all turfs within a rectangular prism where t1 and t2 are opposite corners.
@@ -69,7 +69,7 @@
 		location via read_map
 	*/
 
-	verb/write_area(area/save_area, flags as num)/*
+verb/write_area(area/save_area, flags as num)/*
 	Description: Writes all contents of the provided area to a DMM formatted string.
 	Arguments:
 		save_area: An area object to save.
@@ -78,7 +78,7 @@
 		location via read_map
 	*/
 
-	verb/write_cube(startX as num, startY as num, startZ as num, width as num, height as num, depth as num, flags as num)/*
+verb/write_cube(startX as num, startY as num, startZ as num, width as num, height as num, depth as num, flags as num)/*
 	Descriptions:
 		Writes all contents of a region of turfs (defined by the provided arguments) to a
 		DMM formatted string.
@@ -91,7 +91,7 @@
 		location via read_map
 	*/
 
-	verb/load_map(dmm_file as file, z_offset as num)/*
+verb/load_map(dmm_file as file, z_offset as num)/*
 	Deprecated: load_map has been deprecated. Use or read_map instead.
 	Arguments:
 		dmm_file: A .dmm file to load (Required).


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The entirety of this file had an indent, which really should not have compiled and triggers error recovery on OD

oh god no it's worse than that. The indent was basically inherited from the previous included file, which meant these were defined under `/dmm_suite` but only because BYOND was stitching the files together. This is an abomination.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Making error recovery an error since OD's compiler is complete

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
it's a bunch of stubs, if it compiles it's fine
