### PR TITLE
Remy AI patch

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1443,6 +1443,9 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 /mob/living/critter/proc/should_critter_retaliate(var/mob/attcker, var/obj/attcked_with)
 	return src.ai_retaliates && (src._ai_patience_count <= 0)
 
+/// Used for the go_home AI task. Returns the type.
+/mob/living/critter/proc/home_area()
+	return null
 
 /mob/living/critter/bump(atom/A)
 	var/atom/movable/AM = A

--- a/code/mob/living/critter/ai/generic_critter.dm
+++ b/code/mob/living/critter/ai/generic_critter.dm
@@ -449,6 +449,26 @@
 		C.set_a_intent(INTENT_HARM)	//we an angry critter
 		src.persistence = C.ai_retaliate_persistence
 
+/datum/aiTask/sequence/goalbased/critter/go_home
+	name = "going home"
+	weight = 0.1
+	distance_from_target = 0
+	max_dist = 50
+
+	precondition()
+		if (prob(80)) //we only go home *sometimes*
+			return
+		var/mob/living/critter/C = holder.owner
+		return !istype(get_area(holder.owner), C.home_area())
+
+	get_targets()
+		var/mob/living/critter/C = holder.owner
+		var/area/A = locate(C.home_area())
+		return list(get_turf(pick(A.contents)))
+
+	get_best_target(list/atom/targets)
+		return targets[1]
+
 // Don't worry about this, we need to enable unsimulated turf pathing for the critter gauntlet
 /datum/aiTask/sequence/goalbased/critter
 	move_through_space = TRUE

--- a/code/mob/living/critter/ai/mouse.dm
+++ b/code/mob/living/critter/ai/mouse.dm
@@ -22,4 +22,9 @@
 /datum/aiHolder/mouse_remy
 	New()
 		..()
-		default_task = get_instance(/datum/aiTask/timed/wander/floor_only, list(src))
+		default_task = get_instance(/datum/aiTask/prioritizer/critter/remy, list(src))
+
+/datum/aiTask/prioritizer/critter/remy/New()
+	..()
+	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/floor_only/less, list(holder, src))
+	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/go_home, list(holder, src))

--- a/code/mob/living/critter/ai/shared.dm
+++ b/code/mob/living/critter/ai/shared.dm
@@ -99,6 +99,12 @@
 	holder?.stop_move() // Just in case they yeet themselves out of existance
 	holder?.owner.move_dir = null // clear out direction so it doesn't get latched when client is attached
 
+/datum/aiTask/timed/wander/floor_only/less
+
+/datum/aiTask/timed/wander/floor_only/less/on_tick()
+	if (prob(30))
+		..()
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TARGETED TASK
 // a timed task that also relates to a target and the acquisition of said target

--- a/code/mob/living/critter/small_animal/mouse.dm
+++ b/code/mob/living/critter/small_animal/mouse.dm
@@ -254,6 +254,9 @@ ADMIN_INTERACT_PROCS(/mob/living/critter/small_animal/mouse, proc/glorp)
 					return SPAN_EMOTE("<b>[src]</b> squeaks!")
 		return ..()
 
+	home_area()
+		return /area/station/crew_quarters/kitchen
+
 /* =============================================== */
 /* ----------- mentor & admin mice --------------- */
 /* =============================================== */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remy now has a small chance to pathfind back to the kitchen whenever he's outside it. He also moves around less to make clicking on him a bit easier.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Remy is never where you want him to be, this still allows him to wander while not straying too far from the kitchen.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested putting Remy in the kitchen, tested putting Remy not in the kitchen. Remy behaves as expected.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Remy will now wander back to the kitchen if he strays too far.
```
