### PR TITLE
Makes Blobfish available in RP and Starstonefish available and present in the Fish Collection.

### DIFF
--- a/code/modules/fishing/fish.dm
+++ b/code/modules/fishing/fish.dm
@@ -70,6 +70,7 @@ Alien/mutant/other fish:
 		Tree fish
 		Origami fish
 		Cardboard fish
+		Starstonefish
 	Unimplemented:
 		Blood fish
 */

--- a/code/modules/fishing/fish.dm
+++ b/code/modules/fishing/fish.dm
@@ -72,7 +72,6 @@ Alien/mutant/other fish:
 		Cardboard fish
 	Unimplemented:
 		Blood fish
-		Starstonefish
 */
 
 // These catagories aren't used currently.

--- a/code/modules/fishing/fish.dm
+++ b/code/modules/fishing/fish.dm
@@ -909,7 +909,10 @@ TYPEINFO(/obj/item/reagent_containers/food/fish/cardboardfish)
 		src.reagents.add_reagent("ash", 20)
 		return
 
-/obj/item/reagent_containers/food/fish/starstonefish // Unused for now. Feel free to take.
+TYPEINFO(/obj/item/reagent_containers/food/fish/starstonefish)
+	appears_in_fish_collection = TRUE
+
+/obj/item/reagent_containers/food/fish/starstonefish
 	name = "starstonefish"
 	desc = "A light blue starfish suspected to have been hunted to extinction by rock worms. This might be the only one left."
 	icon_state = "starstonefish"

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -1015,4 +1015,44 @@ datum/fishing_spot/golden_toilet
 	/obj/item/clothing/shoes/flippers = 5, //like fishing up a boot (cartoonstyle)
 	/mob/living/critter/small_animal/pikaia = 5,
 	/mob/living/critter/small_animal/trilobite = 5,
-	/mob/living/critter/small_animal/hallucigenia = 5)
+	/mob/living/critter/small_animal/hallucigenia = 5,
+	/obj/item/reagent_containers/food/fish/blobfish = 1)
+
+//deeper trench hole (cultist base/polaris)
+/datum/fishing_spot/deeperhole
+	fishing_atom_type = /turf/unsimulated/floor/polarispit
+	rod_tier_required = 3
+	fish_available = list(/obj/item/raw_material/rock = 20,
+	/obj/item/seashell = 20,
+	/obj/item/clothing/shoes/flippers = 10,
+	/mob/living/critter/small_animal/pikaia = 10,
+	/mob/living/critter/small_animal/trilobite = 10,
+	/mob/living/critter/small_animal/hallucigenia = 10,
+	/obj/item/reagent_containers/food/fish/blobfish = 5)
+
+//rockworm
+/datum/fishing_spot/rockworm
+	fishing_atom_type = /mob/living/critter/rockworm
+	rod_tier_required = 3
+	fish_available = list(/obj/item/raw_material/rock = 50,
+	/obj/item/raw_material/mauxite = 10,
+	/obj/item/raw_material/pharosium = 10,
+	/obj/item/raw_material/molitz = 10,
+	/obj/item/raw_material/char = 10,
+	/obj/item/raw_material/cobryl = 5,
+	/obj/item/raw_material/syreline = 5,
+	/obj/item/raw_material/batiline = 5,
+	/obj/item/raw_material/bohrum = 5,
+	/obj/item/raw_material/claretine = 5,
+	/obj/item/raw_material/gold = 5,
+	/obj/item/raw_material/uqill = 2,
+	/obj/item/raw_material/gemstone = 2,
+	/obj/item/raw_material/starstone = 1, //wrong one, bucko
+	/obj/item/reagent_containers/food/fish/starstonefish = 1) //YOU SAVED IT!
+
+//starstone geode
+/datum/fishing_spot/stargeode
+	fishing_atom_type = /obj/geode/crystal/starstone
+	rod_tier_required = 3
+	fish_available = list(/obj/item/raw_material/rock = 30,
+	/obj/item/reagent_containers/food/fish/starstonefish = 5)


### PR DESCRIPTION
## About the PR
The Blobfish is only currently obtainable by fishing in blob tiles, an antagonist that doesn't appear in the Roleplay servers. This makes it available from areas where blobfish usually reside.
It also makes Starstonefish available and very rare, a challege for the true space angler. 

## Why's this needed?
A fish shouldn't be limited to just one server, and more fish is more fun.

## Testing 
The fish were fished successfully.

## Changelog 

```changelog
(u)TekoTheTeapot
(+) Makes Blobfish available in RP and Starstonefish available and present in the Fish Collection.
```