### PR TITLE
Reduces the credit requirement for the CE's PTL objective

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -161,14 +161,13 @@ ABSTRACT_TYPE(/datum/objective/crew/chiefengineer)
 					break
 			return check_result
 /datum/objective/crew/chiefengineer/ptl
-	explanation_text = "Earn at least one hundred thousand credits via the PTL."
-	medal_name = "1.21 Jiggawatts"
+	explanation_text = "Earn at least fifty thousand credits via the PTL."
 	var/static/check_result = null
 	check_completion()
 		if(isnull(check_result))
 			check_result = FALSE
 			for(var/obj/machinery/power/pt_laser/P in machine_registry[MACHINES_POWER])
-				if(P.lifetime_earnings >= 100 KILO)
+				if(P.lifetime_earnings >= 50 KILO)
 					check_result = TRUE
 		return check_result
 

--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -161,14 +161,14 @@ ABSTRACT_TYPE(/datum/objective/crew/chiefengineer)
 					break
 			return check_result
 /datum/objective/crew/chiefengineer/ptl
-	explanation_text = "Earn at least a million credits via the PTL."
+	explanation_text = "Earn at least ten thousand credits via the PTL."
 	medal_name = "1.21 Jiggawatts"
 	var/static/check_result = null
 	check_completion()
 		if(isnull(check_result))
 			check_result = FALSE
 			for(var/obj/machinery/power/pt_laser/P in machine_registry[MACHINES_POWER])
-				if(P.lifetime_earnings >= 1 MEGA)
+				if(P.lifetime_earnings >= 100 KILO)
 					check_result = TRUE
 		return check_result
 

--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -161,13 +161,14 @@ ABSTRACT_TYPE(/datum/objective/crew/chiefengineer)
 					break
 			return check_result
 /datum/objective/crew/chiefengineer/ptl
-	explanation_text = "Earn at least fifty thousand credits via the PTL."
+	explanation_text = "Earn at least one hundred thousand credits via the PTL."
+	medal_name = "1.21 Jiggawatts"
 	var/static/check_result = null
 	check_completion()
 		if(isnull(check_result))
 			check_result = FALSE
 			for(var/obj/machinery/power/pt_laser/P in machine_registry[MACHINES_POWER])
-				if(P.lifetime_earnings >= 50 KILO)
+				if(P.lifetime_earnings >= 100 KILO)
 					check_result = TRUE
 		return check_result
 

--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -161,7 +161,7 @@ ABSTRACT_TYPE(/datum/objective/crew/chiefengineer)
 					break
 			return check_result
 /datum/objective/crew/chiefengineer/ptl
-	explanation_text = "Earn at least ten thousand credits via the PTL."
+	explanation_text = "Earn at least one hundred thousand credits via the PTL."
 	medal_name = "1.21 Jiggawatts"
 	var/static/check_result = null
 	check_completion()


### PR DESCRIPTION
[C-Balance]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
After a discussion on the Discord, the consensus appears to be that the CE's million credit requirement is way to much. It is too difficult and time consuming. This makes it a more manageable 100 thousand.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There are only two "practical" methods, a hellburn in the TEG and an automated heavy load feeder for the Singularity. This leaves the ocean maps with no real way to earn a million credits. Even with the TEG and Singulo, getting a million is very difficult. Often, getting the million credit objective is just an automatic fail. All other crew objectives are reasonably easy, such as wearing your own butt or being drunk. Getting a million credits is something that you have to no only go out of your way to do, but will also take the majority of the shift.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Due to the nature of the PR it *should* work fine as-is.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Calphrick
(+)Reduced the credit requirement of the Chief Engineer's "Earn at least x credits via the PTL" from one million to one hundred thousand.
```
