### PR TITLE
Syndie uplink purchase logs use refs

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -123,9 +123,7 @@
 				logTheThing(LOG_DEBUG, user, "spy thief reward spawned: [item] at [log_loc(user)]")
 				user.show_text("Your PDA accepts the bounty and spits out [reward] in exchange.", "red")
 				reward.run_on_spawn(item, user, FALSE, hostpda.uplink)
-			if (!hostpda.uplink.purchase_log[reward.type])
-				hostpda.uplink.purchase_log[reward.type] = 0
-			hostpda.uplink.purchase_log[reward.type]++
+			hostpda.uplink.add_to_purchase_log(reward)
 			if (istype(antag_role))
 				antag_role.redeemed_items.Add(reward)
 

--- a/code/datums/syndicate_buylist/buylist_generic.dm
+++ b/code/datums/syndicate_buylist/buylist_generic.dm
@@ -134,7 +134,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/generic)
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
 	run_on_spawn(obj/item, mob/living/owner, in_surplus_crate, obj/item/uplink/uplink)
-		if (!uplink?.purchase_log[src.type])
+		if (!uplink?.get_purchase_log(src))
 			var/obj/item/storage/box/marionetteimp_kit/MI = new(item.loc, TRUE)
 			// Spief uplinks put the spawned item in the player's hands after this proc,
 			// so we need to account for that and make sure we don't spit the box out onto the ground

--- a/code/obj/item/uplinks/integrated_uplinks.dm
+++ b/code/obj/item/uplinks/integrated_uplinks.dm
@@ -97,27 +97,27 @@
 		if (src.items_general && islist(src.items_general) && length(src.items_general))
 			for (var/G in src.items_general)
 				var/datum/syndicate_buylist/I1 = src.items_general[G]
-				src.menu_message += "<tr><td><A href='byond://?src=\ref[src];buy_item=\ref[src.items_general[G]]'>[I1.name]</A> ([I1.cost])</td><td><A href='byond://?src=\ref[src];abt_item=\ref[src.items_general[G]]'>About</A> [I1.max_buy == INFINITY  ? "" :"([src.purchase_log[I1.type] ? src.purchase_log[I1.type] : 0]/[I1.max_buy])"]</td>"
+				src.menu_message += "<tr><td><A href='byond://?src=\ref[src];buy_item=\ref[src.items_general[G]]'>[I1.name]</A> ([I1.cost])</td><td><A href='byond://?src=\ref[src];abt_item=\ref[src.items_general[G]]'>About</A> [I1.max_buy == INFINITY  ? "" :"([src.get_purchase_log(I1)]/[I1.max_buy])"]</td>"
 		if (src.items_job && islist(src.items_job) && length(src.items_job))
 			src.menu_message += "</table><B>Job Specific:</B><BR><table cellspacing=5>"
 			for (var/J in src.items_job)
 				var/datum/syndicate_buylist/I2 = src.items_job[J]
-				src.menu_message += "<tr><td><A href='byond://?src=\ref[src];buy_item=\ref[src.items_job[J]]'>[I2.name]</A> ([I2.cost])</td><td><A href='byond://?src=\ref[src];abt_item=\ref[src.items_job[J]]'>About</A> [I2.max_buy == INFINITY  ? "" :"([src.purchase_log[I2.type] ? src.purchase_log[I2.type] : 0]/[I2.max_buy])"]</td>"
+				src.menu_message += "<tr><td><A href='byond://?src=\ref[src];buy_item=\ref[src.items_job[J]]'>[I2.name]</A> ([I2.cost])</td><td><A href='byond://?src=\ref[src];abt_item=\ref[src.items_job[J]]'>About</A> [I2.max_buy == INFINITY  ? "" :"([src.get_purchase_log(I2)]/[I2.max_buy])"]</td>"
 		if (src.items_objective && islist(src.items_objective) && length(src.items_objective))
 			src.menu_message += "</table><B>Objective Specific:</B><BR><table cellspacing=5>"
 			for (var/O in src.items_objective)
 				var/datum/syndicate_buylist/I3 = src.items_objective[O]
-				src.menu_message += "<tr><td><A href='byond://?src=\ref[src];buy_item=\ref[src.items_objective[O]]'>[I3.name]</A> ([I3.cost])</td><td><A href='byond://?src=\ref[src];abt_item=\ref[src.items_objective[O]]'>About</A> [I3.max_buy == INFINITY  ? "" :"([src.purchase_log[I3.type] ? src.purchase_log[I3.type] : 0]/[I3.max_buy])"]</td>"
+				src.menu_message += "<tr><td><A href='byond://?src=\ref[src];buy_item=\ref[src.items_objective[O]]'>[I3.name]</A> ([I3.cost])</td><td><A href='byond://?src=\ref[src];abt_item=\ref[src.items_objective[O]]'>About</A> [I3.max_buy == INFINITY  ? "" :"([src.get_purchase_log(I3)]/[I3.max_buy])"]</td>"
 		if (src.items_ammo && islist(src.items_ammo) && length(src.items_ammo))
 			src.menu_message += "</table><B>Special ammunition:</B><BR><table cellspacing=5>"
 			for (var/A in src.items_ammo)
 				var/datum/syndicate_buylist/I4 = src.items_ammo[A]
-				src.menu_message += "<tr><td><A href='byond://?src=\ref[src];buy_item=\ref[src.items_ammo[A]]'>[I4.name]</A> ([I4.cost])</td><td><A href='byond://?src=\ref[src];abt_item=\ref[src.items_ammo[A]]'>About</A> [I4.max_buy == INFINITY  ? "" :"([src.purchase_log[I4.type] ? src.purchase_log[I4.type] : 0]/[I4.max_buy])"]</td>"
+				src.menu_message += "<tr><td><A href='byond://?src=\ref[src];buy_item=\ref[src.items_ammo[A]]'>[I4.name]</A> ([I4.cost])</td><td><A href='byond://?src=\ref[src];abt_item=\ref[src.items_ammo[A]]'>About</A> [I4.max_buy == INFINITY  ? "" :"([src.get_purchase_log(I4)]/[I4.max_buy])"]</td>"
 		if (src.items_telecrystal && islist(src.items_telecrystal) && length(src.items_telecrystal))
 			src.menu_message += "</table><B>Ejectable [syndicate_currency]:</B><BR><table cellspacing=5>"
 			for (var/T in src.items_telecrystal)
 				var/datum/syndicate_buylist/I5 = src.items_telecrystal[T]
-				src.menu_message += "<tr><td><A href='byond://?src=\ref[src];buy_item=\ref[src.items_telecrystal[T]]'>[I5.name]</A> ([I5.cost])</td><td><A href='byond://?src=\ref[src];abt_item=\ref[src.items_telecrystal[T]]'>About</A> [I5.max_buy == INFINITY  ? "" :"([src.purchase_log[I5.type] ? src.purchase_log[I5.type] : 0]/[I5.max_buy])"]</td>"
+				src.menu_message += "<tr><td><A href='byond://?src=\ref[src];buy_item=\ref[src.items_telecrystal[T]]'>[I5.name]</A> ([I5.cost])</td><td><A href='byond://?src=\ref[src];abt_item=\ref[src.items_telecrystal[T]]'>About</A> [I5.max_buy == INFINITY  ? "" :"([src.get_purchase_log(I5)]/[I5.max_buy])"]</td>"
 
 		src.menu_message += "</table><HR>"
 		if(has_synd_int && !src.is_VR_uplink)
@@ -150,7 +150,7 @@
 				return
 
 			if (src.is_VR_uplink == 0)
-				if (src.purchase_log[I.type] >= I.max_buy)
+				if (src.get_purchase_log(I) >= I.max_buy)
 					boutput(usr, SPAN_ALERT("You have already bought as many of those as you can!"))
 					return
 				if (src.uses < I.cost)
@@ -182,9 +182,7 @@
 				if (src.is_VR_uplink == 0)
 					var/datum/eventRecord/AntagItemPurchase/antagItemPurchaseEvent = new()
 					antagItemPurchaseEvent.buildAndSend(usr, I.name, I.cost)
-					if (!src.purchase_log[I.type])
-						src.purchase_log[I.type] = 0
-					src.purchase_log[I.type]++
+					src.add_to_purchase_log(I)
 
 		else if (href_list["abt_item"])
 			var/datum/syndicate_buylist/I = locate(href_list["abt_item"])

--- a/code/obj/item/uplinks/uplink_parent.dm
+++ b/code/obj/item/uplinks/uplink_parent.dm
@@ -31,7 +31,7 @@
 	var/purchase_flags
 	var/owner_ckey = null
 
-	/// Associative list, where keys are /datum/syndicate_buylist instances and values are the number of purchases.
+	/// Associative list, where keys are /datum/syndicate_buylist refs and values are the number of purchases.
 	var/list/purchase_log = list()
 
 	// Spawned uplinks for which setup() wasn't called manually only get the standard (generic) items.
@@ -309,27 +309,27 @@
 					dat += "</table><B>Ejectable [syndicate_currency]:</B><BR><table cellspacing=5>"
 					for (var/T in src.items_telecrystal)
 						var/datum/syndicate_buylist/I4 = src.items_telecrystal[T]
-						dat += "<tr><td><A href='byond://?src=\ref[src];spawn=\ref[src.items_telecrystal[T]]'>[I4.name]</A> ([I4.cost])</td><td><A href='byond://?src=\ref[src];about=\ref[src.items_telecrystal[T]]'>About</A> [I4.max_buy == INFINITY  ? "" :"([src.purchase_log[I4.type] ? src.purchase_log[I4.type] : 0]/[I4.max_buy])"]</td>"
+						dat += "<tr><td><A href='byond://?src=\ref[src];spawn=\ref[src.items_telecrystal[T]]'>[I4.name]</A> ([I4.cost])</td><td><A href='byond://?src=\ref[src];about=\ref[src.items_telecrystal[T]]'>About</A> [I4.max_buy == INFINITY  ? "" :"([src.get_purchase_log(I4)]/[I4.max_buy])"]</td>"
 				if (src.items_objective && islist(src.items_objective) && length(src.items_objective))
 					dat += "</table><B>Objective Specific:</B><BR><table cellspacing=5>"
 					for (var/O in src.items_objective)
 						var/datum/syndicate_buylist/I3 = src.items_objective[O]
-						dat += "<tr><td><A href='byond://?src=\ref[src];spawn=\ref[src.items_objective[O]]'>[I3.name]</A> ([I3.cost])</td><td><A href='byond://?src=\ref[src];about=\ref[src.items_objective[O]]'>About</A> [I3.max_buy == INFINITY  ? "" :"([src.purchase_log[I3.type] ? src.purchase_log[I3.type] : 0]/[I3.max_buy])"]</td>"
+						dat += "<tr><td><A href='byond://?src=\ref[src];spawn=\ref[src.items_objective[O]]'>[I3.name]</A> ([I3.cost])</td><td><A href='byond://?src=\ref[src];about=\ref[src.items_objective[O]]'>About</A> [I3.max_buy == INFINITY  ? "" :"([src.get_purchase_log(I3)]/[I3.max_buy])"]</td>"
 				if (src.items_job && islist(src.items_job) && length(src.items_job))
 					dat += "</table><B>Job Specific:</B><BR><table cellspacing=5>"
 					for (var/J in src.items_job)
 						var/datum/syndicate_buylist/I2 = src.items_job[J]
-						dat += "<tr><td><A href='byond://?src=\ref[src];spawn=\ref[src.items_job[J]]'>[I2.name]</A> ([I2.cost])</td><td><A href='byond://?src=\ref[src];about=\ref[src.items_job[J]]'>About</A> [I2.max_buy == INFINITY  ? "" :"([src.purchase_log[I2.type] ? src.purchase_log[I2.type] : 0]/[I2.max_buy])"]</td>"
+						dat += "<tr><td><A href='byond://?src=\ref[src];spawn=\ref[src.items_job[J]]'>[I2.name]</A> ([I2.cost])</td><td><A href='byond://?src=\ref[src];about=\ref[src.items_job[J]]'>About</A> [I2.max_buy == INFINITY  ? "" :"([src.get_purchase_log(I2)]/[I2.max_buy])"]</td>"
 				if (src.items_general && islist(src.items_general) && length(src.items_general))
 					dat += "</table><B>Standard Equipment:</B><BR><table cellspacing=5>"
 					for (var/G in src.items_general)
 						var/datum/syndicate_buylist/I1 = src.items_general[G]
-						dat += "<tr><td><A href='byond://?src=\ref[src];spawn=\ref[src.items_general[G]]'>[I1.name]</A> ([I1.cost])</td><td><A href='byond://?src=\ref[src];about=\ref[src.items_general[G]]'>About</A> [I1.max_buy == INFINITY  ? "" :"([src.purchase_log[I1.type] ? src.purchase_log[I1.type] : 0]/[I1.max_buy])"]</td>"
+						dat += "<tr><td><A href='byond://?src=\ref[src];spawn=\ref[src.items_general[G]]'>[I1.name]</A> ([I1.cost])</td><td><A href='byond://?src=\ref[src];about=\ref[src.items_general[G]]'>About</A> [I1.max_buy == INFINITY  ? "" :"([src.get_purchase_log(I1)]/[I1.max_buy])"]</td>"
 				if (src.items_ammo && islist(src.items_ammo) && length(src.items_ammo))
 					dat += "</table><B>Special ammunition:</B><BR><table cellspacing=5>"
 					for (var/A in src.items_ammo)
 						var/datum/syndicate_buylist/I5 = src.items_ammo[A]
-						dat += "<tr><td><A href='byond://?src=\ref[src];spawn=\ref[src.items_ammo[A]]'>[I5.name]</A> ([I5.cost])</td><td><A href='byond://?src=\ref[src];about=\ref[src.items_ammo[A]]'>About</A> [I5.max_buy == INFINITY  ? "" :"([src.purchase_log[I5.type] ? src.purchase_log[I5.type] : 0]/[I5.max_buy])"]</td>"
+						dat += "<tr><td><A href='byond://?src=\ref[src];spawn=\ref[src.items_ammo[A]]'>[I5.name]</A> ([I5.cost])</td><td><A href='byond://?src=\ref[src];about=\ref[src.items_ammo[A]]'>About</A> [I5.max_buy == INFINITY  ? "" :"([src.get_purchase_log(I5)]/[I5.max_buy])"]</td>"
 				dat += "</table>"
 				var/do_divider = 1
 
@@ -442,7 +442,7 @@
 				if (src.uses < I.cost)
 					boutput(usr, SPAN_ALERT("The uplink doesn't have enough [syndicate_currency] left for that!"))
 					return
-				if (src.purchase_log[I.type] >= I.max_buy)
+				if (src.get_purchase_log(I) >= I.max_buy)
 					boutput(usr, SPAN_ALERT("You have already bought as many of those as you can!"))
 					return
 				src.uses = max(0, src.uses - I.cost)
@@ -471,9 +471,7 @@
 				if (src.is_VR_uplink == 0)
 					var/datum/eventRecord/AntagItemPurchase/antagItemPurchaseEvent = new()
 					antagItemPurchaseEvent.buildAndSend(usr, I.name, I.cost)
-					if (!src.purchase_log[I.type])
-						src.purchase_log[I.type] = 0
-					src.purchase_log[I.type]++
+					src.add_to_purchase_log(I)
 
 		else if (href_list["about"])
 			reading_about = locate(href_list["about"])
@@ -508,3 +506,11 @@
 		return
 #undef CHECK1
 #undef CHECK2
+
+/obj/item/uplink/proc/add_to_purchase_log(var/datum/syndicate_buylist/buylist_entry)
+	if (!src.purchase_log[ref(buylist_entry)])
+		src.purchase_log[ref(buylist_entry)] = 0
+	src.purchase_log[ref(buylist_entry)]++
+
+/obj/item/uplink/proc/get_purchase_log(var/datum/syndicate_buylist/buylist_entry)
+	return src.purchase_log[ref(buylist_entry)] || 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Syndicate (including spy thief) uplinks now store their purchase_logs as ref = count instead of type = count
Consolidates the incrementing of the purchase log and fetching into two new procs: add_to_purchase_log(buylist_datum) and get_purchase_log(buylist_datum)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Code quality and perf improvement for TGUI standalone uplinks (eventually) instead of having to locate the type in the 5 item lists in ui_data as the TGUI end uses refs for the purchase log. Makes it slightly harder to varedit with vv but I dont really see this being something anyone needs to varedit (and wizard uplinks store their purchase logs as this)

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Item refs are properly added to the purchase log
<img width="390" height="66" alt="image" src="https://github.com/user-attachments/assets/e25f1935-37ce-46ac-addf-494c039e81b3" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
