### PR TITLE
Makes the fishbowl helmet see-through

### DIFF
--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -81,7 +81,7 @@
 		..()
 		SPAWN(1 SECOND)
 			src.equip_new_if_possible(/obj/item/clothing/suit/space, SLOT_WEAR_SUIT)
-			src.equip_new_if_possible(/obj/item/clothing/head/helmet/space, SLOT_HEAD)
+			src.equip_new_if_possible(/obj/item/clothing/head/helmet/space/fishbowl, SLOT_HEAD)
 
 /mob/living/carbon/human/npc/monkey/von_braun
 	name = "Von Braun"

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -49,18 +49,6 @@
 	desc = "You're about 90% sure this isn't just a regular fishbowl."
 	item_state = "s_helmet"
 
-	setupProperties()
-		..()
-		setProperty("coldprot", 20)
-		setProperty("heatprot", 5)
-		setProperty("viralprot", 50)
-		setProperty("chemprot", 20)
-		setProperty("disorient_resist_eye", 8)
-		setProperty("disorient_resist_ear", 8)
-		setProperty("space_movespeed", 0.2)
-		setProperty("radprot", 5)
-
-
 /obj/item/clothing/head/helmet/space/engineer
 	name = "engineering space helmet"
 	desc = "Comes equipped with a built-in flashlight."

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -40,12 +40,26 @@
 		icon_state = "space-OLD"
 		desc = "A relic of the past."
 		item_state = null
-	fishbowl
-		name = "fishbowl helmet"
-		icon_state = "space-fish"
-		desc = "You're about 90% sure this isn't just a regular fishbowl."
-		item_state = "s_helmet"
-		c_flags = parent_type::c_flags & ~COVERSHAIR
+
+/obj/item/clothing/head/helmet/space/fishbowl
+	name = "fishbowl helmet"
+	icon_state = "space-fish"
+	c_flags = SPACEWEAR | BLOCKCHOKE
+	see_face = TRUE
+	desc = "You're about 90% sure this isn't just a regular fishbowl."
+	item_state = "s_helmet"
+
+	setupProperties()
+		..()
+		setProperty("coldprot", 20)
+		setProperty("heatprot", 5)
+		setProperty("viralprot", 50)
+		setProperty("chemprot", 20)
+		setProperty("disorient_resist_eye", 8)
+		setProperty("disorient_resist_ear", 8)
+		setProperty("space_movespeed", 0.2)
+		setProperty("radprot", 5)
+
 
 /obj/item/clothing/head/helmet/space/engineer
 	name = "engineering space helmet"


### PR DESCRIPTION
[A-Clothing] [C-Balance]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so that the fishbowl helmet is see-through, because it is made of glass. It also makes the helmet a separate object instead of a subtype of the regular helmet.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You can clearly see through it, why should it hide identities?
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
<img width="295" height="166" alt="image" src="https://github.com/user-attachments/assets/9e77987f-5571-4106-99fe-e24a9c5f9895" />

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Calphrick
(+)Made the fishbowl helmet see-through
```
