### PR TITLE
NT Representative now accepts Agent Cards

### DIFF
--- a/code/WorkInProgress/dialogue/dialogue_NTcommander.dm
+++ b/code/WorkInProgress/dialogue/dialogue_NTcommander.dm
@@ -229,6 +229,7 @@
 		canShow(var/client/C)
 			if(istype(C.mob.equipped(), /obj/item/factionrep/ntboard)) return 1
 			if(istype(C.mob.equipped(), /obj/item/blackbox)) return 1
+			if(istype(C.mob.equipped(), /obj/item/card/id/syndicate)) return 1
 			else return 0
 
 		getNodeText(var/client/C)


### PR DESCRIPTION
[C-Feature]
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows players to turn in Agent Cards to the NT Representative on Oshan for rep. It's the same 50 rep the other objects give. I wanted it to be higher, but there's a hardcap set for rep per minute.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I know the feature is still considered experimental, but it's strange that the Rep doesn't accept ID cards when he says he will.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="1266" height="1015" alt="image" src="https://github.com/user-attachments/assets/8a291a3d-8288-45e0-aae1-b37a81641149" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Calphrick
(+)The NT Representative on Oshan now accepts Syndicate ID cards.
```
