### PR TITLE
Debug variables /image fix

### DIFF
--- a/code/modules/admin/viewvariables/datumvars.dm
+++ b/code/modules/admin/viewvariables/datumvars.dm
@@ -178,7 +178,10 @@
 			body += debug_variable(V, global.vars[V], D, 0, 10)
 	else
 		for (var/V in names)
-			body += debug_variable(V, D.vars[V], D, 0)
+			try
+				body += debug_variable(V, D.vars[V], D, 0)
+			catch(var/exception/e)
+				body += debug_variable_read_error(V, D, e)
 		//body += debug_variable_link(V, D, (istype(D.vars[V], /datum) && src.holder.level >= LEVEL_CODER) ? 1 : 0)
 
 	body += "</tbody></table>"
@@ -289,6 +292,15 @@
 			<a href='byond://?src=\ref[src];Vars=\ref[D];varToEdit=[V]'>Edit</a> &middot;
 		</div>
 		"}
+
+/client/proc/debug_variable_read_error(name, var/fullvar, var/exception/e)
+	return {"
+	<tr>
+		<td></td>
+		<th>\[[name]\]</th>
+		<td><em class='value'>Unable to read var: [html_encode(e?.name || "unknown error")]</em></td>
+	</tr>
+	"}
 	//Really, move this out to a .css file or something, too lazy and don't know how offhand
 /proc/Make_view_variabls_style()
 	return {"	<style>

--- a/code/modules/admin/viewvariables/datumvars.dm
+++ b/code/modules/admin/viewvariables/datumvars.dm
@@ -298,7 +298,7 @@
 	<tr>
 		<td></td>
 		<th>\[[name]\]</th>
-		<td><em class='value'>Unable to read var: [html_encode(e?.name || "unknown error")]</em></td>
+		<td><em class='value'>Error: [html_encode(e?.name || "unknown error")]</em></td>
 	</tr>
 	"}
 	//Really, move this out to a .css file or something, too lazy and don't know how offhand

--- a/code/modules/admin/viewvariables/datumvars.dm
+++ b/code/modules/admin/viewvariables/datumvars.dm
@@ -181,7 +181,7 @@
 			try
 				body += debug_variable(V, D.vars[V], D, 0)
 			catch(var/exception/e)
-				body += debug_variable_read_error(V, D, e)
+				body += debug_variable_read_error(V, e)
 		//body += debug_variable_link(V, D, (istype(D.vars[V], /datum) && src.holder.level >= LEVEL_CODER) ? 1 : 0)
 
 	body += "</tbody></table>"
@@ -293,7 +293,7 @@
 		</div>
 		"}
 
-/client/proc/debug_variable_read_error(name, var/fullvar, var/exception/e)
+/client/proc/debug_variable_read_error(name, var/exception/e)
 	return {"
 	<tr>
 		<td></td>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds try catch logic to `debug_variables` around the building of the var list html
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Handle runtime caused by https://www.byond.com/forum/post/2973824 
```dm
Summary
code/modules/admin/viewvariables/datumvars.dm, line 171: undefined variable /var/pixloc

Description
proc name: View Variables (/client/proc/debug_variables)
  source file: code/modules/admin/viewvariables/datumvars.dm,171
  usr: the cute admin mouse (/mob/living/critter/small_animal/mouse/weak/mentor/admin)
  src: Sovexe (/client)
  usr.loc: the floor (251,164,2) (/turf/unsimulated/floor/grey/side)
  call stack:
Sovexe (/client): View Variables()
Sovexe (/client): Topic("src=\[0x500002f];Vars=\[0xd00d...", /list (/list), Sovexe (/client))
Sovexe (/client): Topic("src=\[0x500002f];Vars=\[0xd00d...", /list (/list), Sovexe (/client))
```
<img width="602" height="432" alt="image" src="https://github.com/user-attachments/assets/a901a766-8c4b-431f-9470-700b5e4b7fc7" />

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
* See screencap