### PR TITLE
Artifact Namespace

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -199,6 +199,7 @@
 #include "macros\turf.dm"
 #include "macros\twitch_sbill.dm"
 #include "macros\vehicles.dm"
+#include "namespaces\artifact.dm"
 #include "namespaces\pay.dm"
 #include "color.dm"
 #include "compare.dm"

--- a/_std/namespaces/artifact.dm
+++ b/_std/namespaces/artifact.dm
@@ -1,0 +1,28 @@
+
+CREATE_NAMESPACE(ARTIFACT)
+
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/list/obj/list_artifacts) //! list of all artifacts
+
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/list/datum/artifact_origin/list_origins) //! Instance of each artifact origin
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/datum/artifact_origin/ancient/origin_ancient = null)
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/datum/artifact_origin/eldritch/origin_eldritch = null)
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/datum/artifact_origin/lattice/origin_lattice = null)
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/datum/artifact_origin/martian/origin_martian = null)
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/datum/artifact_origin/precursor/origin_precursor = null)
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/datum/artifact_origin/wizard/origin_wizard = null)
+
+/// Instance of each artifact type, sorted by size and alphabetically
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/list/datum/artifact/list_types)
+/// Associative list with the instance from above, with the key being the type name
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/list/datum/artifact/types_from_name)
+
+/// associative list of lists, with the keys being artifact origin names (and "all") and artifact types
+/// the value is the rarity of the type.
+/// This is used with weighted_pick for randomly generated artifacts (sometimes of specific origin)
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/list/list_rarities)
+
+// Lists of names for artifact forms
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/list/list_name_origins = list())
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/list/list_name_types = list())
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/list/list_name_faults = list())
+ADD_TO_NAMESPACE(ARTIFACT)(var/static/list/list_name_triggers = list())

--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -1,73 +1,58 @@
 var/datum/artifact_controller/artifact_controls
 
 /datum/artifact_controller
-	/// list of all artifacts
-	var/list/artifacts = list()
-	/// list with an instance of each artifact type, sorted by size and alphabetically
-	var/list/datum/artifact/artifact_types = list()
-	/// associative list with the instance from above, with the key being the type name
-	var/list/datum/artifact/artifact_types_from_name = list()
-	/// associative list of lists, with the keys being artifact origin names (and "all") and artifact types
-	/// the value is the rarity of the type.
-	/// This is used with weighted_pick for randomly generated artifacts (sometimes of specific origin)
-	var/list/artifact_rarities = list()
-	/// list with an instance of each artifact origin
-	var/list/artifact_origins = list()
 
-	/// list of artifact origin names, for artifact forms
-	var/list/artifact_origin_names = list()
-	/// list of artifact type names, for artifact forms
-	var/list/artifact_type_names = list()
-	/// list of artifact fault names, for artifact forms
-	var/list/artifact_fault_names = list()
-	/// list of artifact trigger names, for artifact forms (unused)
-	var/list/artifact_trigger_names = list()
 	var/spawner_type = null
 	var/spawner_cine = 0
 
 	New()
 		..()
-		artifact_rarities["all"] = list()
+		ARTIFACT::list_origins = list()
+		ARTIFACT::list_types = list()
+		ARTIFACT::types_from_name = list()
+		ARTIFACT::list_artifacts = list()
+		ARTIFACT::list_rarities = list()
+		ARTIFACT::list_rarities["all"] = list()
 
 		// origin list
 		for (var/X in childrentypesof(/datum/artifact_origin))
 			var/datum/artifact_origin/AO = new X
-			artifact_origins += AO
-			artifact_origin_names += AO.type_name
-			artifact_rarities[AO.name] = list()
+			ARTIFACT::list_origins += AO
+			ARTIFACT::list_name_origins += AO.type_name
+			ARTIFACT::list_rarities[AO.name] = list()
 
 		for (var/A in concrete_typesof(/datum/artifact))
 			var/datum/artifact/AI = new A
 			if(!AI.type_name)
 				continue
-			artifact_types += AI
-			artifact_types_from_name[AI.type_name] = AI
+			ARTIFACT::list_types += AI
+			ARTIFACT::types_from_name[AI.type_name] = AI
 
-			artifact_rarities["all"][A] = AI.rarity_weight
-			for (var/origin in artifact_rarities)
+			ARTIFACT::list_rarities["all"][A] = AI.rarity_weight
+			for (var/origin in ARTIFACT::list_rarities)
 				if(origin in AI.validtypes)
-					artifact_rarities[origin][A] = AI.rarity_weight
+					ARTIFACT::list_rarities[origin][A] = AI.rarity_weight
 
-		sortList(artifact_types, /proc/compareArtifactTypes)
+		sortList(ARTIFACT::list_types, /proc/compareArtifactTypes)
 
-		for (var/datum/artifact/AI in artifact_types)
-			artifact_type_names += list(list(AI.type_name, AI.type_size))
+		for (var/datum/artifact/AI in ARTIFACT::list_types)
+			ARTIFACT::list_name_types += list(list(AI.type_name, AI.type_size))
 
 		// fault list
 		for (var/X in concrete_typesof(/datum/artifact_fault))
 			var/datum/artifact_fault/AF = new X
-			artifact_fault_names += AF.type_name
+			ARTIFACT::list_name_faults += AF.type_name
 
 		// trigger list
 		for (var/X in concrete_typesof(/datum/artifact_trigger))
 			var/datum/artifact_trigger/AT = new X
 			if(AT.used)
-				artifact_trigger_names += AT.type_name
+				ARTIFACT::list_name_triggers += AT.type_name
 
 	proc/get_origin_from_string(var/string)
 		if (!istext(string))
 			return
-		for (var/datum/artifact_origin/AO in src.artifact_origins)
+		for (var/datum/artifact_origin/AO in ARTIFACT::list_origins)
 			if (AO.name == string)
 				return AO
 		return null
@@ -110,7 +95,7 @@ var/datum/artifact_controller/artifact_controls
 
 		var/datum/artifact/A = null
 		var/turf/T = null
-		for (var/obj/O in src.artifacts)
+		for (var/obj/O in ARTIFACT::list_artifacts)
 			if (!istype(O.artifact,/datum/artifact/))
 				continue
 			A = O.artifact
@@ -148,7 +133,7 @@ var/datum/artifact_controller/artifact_controls
 	Topic(href, href_list[])
 		USR_ADMIN_ONLY
 		if (href_list["Activate"])
-			var/obj/O = locate(href_list["Activate"]) in src.artifacts
+			var/obj/O = locate(href_list["Activate"]) in ARTIFACT::list_artifacts
 			if (!istype(O,/obj/))
 				return
 			if (!istype(O.artifact,/datum/artifact/))
@@ -162,7 +147,7 @@ var/datum/artifact_controller/artifact_controls
 			src.log_me(usr, O, A.activated ? "activates" : "deactivates", 1)
 
 		else if (href_list["Jumpto"])
-			var/obj/O = locate(href_list["Jumpto"]) in src.artifacts
+			var/obj/O = locate(href_list["Jumpto"]) in ARTIFACT::list_artifacts
 			if (!istype(O,/obj/))
 				return
 			var/turf/T = O.loc
@@ -171,7 +156,7 @@ var/datum/artifact_controller/artifact_controls
 			src.log_me(usr, O, "jumps to", 0)
 
 		else if (href_list["Get"])
-			var/obj/O = locate(href_list["Get"]) in src.artifacts
+			var/obj/O = locate(href_list["Get"]) in ARTIFACT::list_artifacts
 			if (!istype(O,/obj/))
 				return
 			var/turf/T = usr.loc
@@ -180,7 +165,7 @@ var/datum/artifact_controller/artifact_controls
 			src.log_me(usr, O, "teleports", 0)
 
 		else if (href_list["Destroy"])
-			var/obj/O = locate(href_list["Destroy"]) in src.artifacts
+			var/obj/O = locate(href_list["Destroy"]) in ARTIFACT::list_artifacts
 			if (!istype(O,/obj/))
 				return
 			if (!istype(O.artifact,/datum/artifact/))
@@ -222,7 +207,6 @@ var/datum/artifact_controller/artifact_controls
 	var/fx_alpha_max = 255
 	var/nofx = 0 // If set to 1, does not apply an overlay but a flat icon_state change.
 	var/scramblechance = 10 //probability to have "fake" artifact with altered appearance
-	var/chapel_block = FALSE // Artifact does not work inside chapels
 	var/list/activation_sounds = list()
 	var/list/instrument_sounds = list()
 	var/list/lightswitch_sounds = list('sound/misc/lightswitch.ogg')
@@ -252,9 +236,24 @@ var/datum/artifact_controller/artifact_controls
 			if(artifact.blend_mode == BLEND_SUBTRACT)
 				artifact.plane = PLANE_FLOOR
 
+	proc/may_activate(var/obj/artifact)
+		return TRUE
+
+	proc/pre_destroyed(var/obj/artifact)
+		return
+
 	proc/generate_name()
 		return "unknown object"
 
+	proc/Artifact_chapel_block(var/datum/component/component, var/area/old_area, var/area/new_area)
+		var/obj/O = component.parent
+		var/datum/artifact/artifact = O.artifact
+		var/is_chapel = istype(new_area, /area/station/chapel)
+		if(is_chapel && artifact.activated)
+			playsound(O.loc, 'sound/effects/bamf.ogg', 50, 1, pitch = 1.25)
+			O.ArtifactDeactivated()
+		if(!is_chapel && !artifact.activated && artifact.automatic_activation)
+			O.ArtifactActivated()
 
 /datum/artifact_origin/ancient
 	type_name = "Silicon"
@@ -285,8 +284,20 @@ var/datum/artifact_controller/artifact_controls
 	nouns_small = list("implement","device","instrument","apparatus","appliance","mechanism","tool")
 	touch_descriptors = list("It feels cold.","It feels smooth.","Touching it makes you feel uneasy.")
 
+	New()
+		. = ..()
+		if(ARTIFACT::origin_ancient != null)
+			CRASH("Duplicate artifact origin of type \"Ancient\" created.")
+		ARTIFACT::origin_ancient = src
+
 	post_setup(obj/artifact)
 		. = ..()
+		post_setup_appearance(artifact)
+
+	generate_name()
+		return "unit [pick("alpha","sigma","tau","phi","gamma","epsilon")]-[pick("x","z","d","e","k")] [rand(100,999)]"
+
+	proc/post_setup_appearance(obj/artifact)
 		var/datum/artifact/AD = artifact.artifact
 		var/rarityMod = AD.get_rarity_modifier()
 		if(prob(50 * rarityMod))
@@ -300,9 +311,6 @@ var/datum/artifact_controller/artifact_controls
 		else if(prob(100 * rarityMod))
 			var/bright = randfloat(1.1, 1.5)
 			artifact.color = list(bright, 0, 0, 0, bright, 0, 0, 0, bright)
-
-	generate_name()
-		return "unit [pick("alpha","sigma","tau","phi","gamma","epsilon")]-[pick("x","z","d","e","k")] [rand(100,999)]"
 
 /datum/artifact_origin/martian
 	type_name = "Martian"
@@ -338,6 +346,12 @@ var/datum/artifact_controller/artifact_controls
 	var/list/prefix = list("cardio","neuro","physio","morpho","brachio","bronchi","dermo","ossu")
 	var/list/thingy = list("cystic","genetic","metabolic","static","vascular","muscular")
 	var/list/action = list("stimulator","suppressor","regenerator","depressor","mutator")
+
+	New()
+		. = ..()
+		if(ARTIFACT::origin_martian != null)
+			CRASH("Duplicate artifact origin of type \"Martian\" created.")
+		ARTIFACT::origin_martian = src
 
 	post_setup(obj/artifact)
 		. = ..()
@@ -400,7 +414,6 @@ var/datum/artifact_controller/artifact_controls
 		/datum/artifact_fault/messager/what_dead_people_said = 5,
 		/datum/artifact_fault/messager/what_people_said = 5,
 		/datum/artifact_fault/messager/emoji = 5)
-	chapel_block = TRUE
 	activation_sounds = list('sound/machines/ArtifactWiz1.ogg')
 	instrument_sounds = list('sound/musical_instruments/artifact/Artifact_Wizard_1.ogg',
 		'sound/musical_instruments/artifact/Artifact_Wizard_2.ogg',
@@ -426,8 +439,31 @@ var/datum/artifact_controller/artifact_controls
 	var/list/object = list("jewel","trophy","favor","boon","token","crown","treasure","sacrament","oath")
 	var/list/aspect = list("wonder","splendor","power","plenty","mystery","glory","majesty","eminence","grace")
 
-	post_setup(obj/artifact)
+	New()
 		. = ..()
+		if(ARTIFACT::origin_wizard != null)
+			CRASH("Duplicate artifact origin of type \"Wizard\" created.")
+		ARTIFACT::origin_wizard = src
+
+	post_setup(var/obj/artifact)
+		. = ..()
+		RegisterSignal(artifact, XSIG_MOVABLE_AREA_CHANGED, PROC_REF(Artifact_chapel_block))
+		src.post_setup_appearance(artifact)
+
+	pre_destroyed(var/obj/artifact)
+		. = ..()
+		UnregisterSignal(artifact, XSIG_MOVABLE_AREA_CHANGED)
+
+	may_activate(var/obj/artifact)
+		. = ..()
+		var/is_chapel = istype(get_area(artifact), /area/station/chapel)
+		if(is_chapel)
+			playsound(artifact.loc, 'sound/effects/bamf.ogg', 50, 1, pitch = 1.25)
+			var/turf/T = get_turf(artifact)
+			T.visible_message(SPAN_ALERT("<b>[artifact] attempts to activate but fails!</b>"))
+			return FALSE
+
+	proc/post_setup_appearance(obj/artifact)
 		var/datum/artifact/AD = artifact.artifact
 		var/rarityMod = AD.get_rarity_modifier()
 		if(prob(300*rarityMod))
@@ -475,7 +511,6 @@ var/datum/artifact_controller/artifact_controls
 /datum/artifact_origin/eldritch
 	type_name = "Eldritch"
 	name = "eldritch"
-	chapel_block = TRUE
 	activation_sounds = list('sound/machines/ArtifactEld1.ogg','sound/machines/ArtifactEld2.ogg')
 	instrument_sounds = list('sound/musical_instruments/artifact/Artifact_Eldritch_1.ogg',
 		'sound/musical_instruments/artifact/Artifact_Eldritch_2.ogg',
@@ -516,6 +551,29 @@ var/datum/artifact_controller/artifact_controls
 	var/list/horror_name_start = list("trog","yogg","ta","y","has","shub","az","cth","cha","ul","xel","og","flu","wrk")
 	var/list/horror_name_mid = list("sog","ran","gon","ni","a","hul","ttur","ay","o","lo","ncac","sin","fel","di")
 	var/list/horror_name_end = list("dyte","oth","tula","olac","tur","bburath","thoth","hu","dha","aoth","tath","goth","ter")
+
+	New()
+		. = ..()
+		if(ARTIFACT::origin_eldritch != null)
+			CRASH("Duplicate artifact origin of type \"Eldritch\" created.")
+		ARTIFACT::origin_eldritch = src
+
+	post_setup(var/obj/artifact)
+		. = ..()
+		RegisterSignal(artifact, XSIG_MOVABLE_AREA_CHANGED, PROC_REF(Artifact_chapel_block))
+
+	pre_destroyed(var/obj/artifact)
+		. = ..()
+		UnregisterSignal(artifact, XSIG_MOVABLE_AREA_CHANGED)
+
+	may_activate(var/obj/artifact)
+		. = ..()
+		var/is_chapel = istype(get_area(artifact), /area/station/chapel)
+		if(is_chapel)
+			playsound(artifact.loc, 'sound/effects/bamf.ogg', 50, 1, pitch = 1.25)
+			var/turf/T = get_turf(artifact)
+			T.visible_message(SPAN_ALERT("<b>[artifact] attempts to activate but fails!</b>"))
+			return FALSE
 
 	generate_name()
 		var/the_horror = src.horror_name()
@@ -584,6 +642,12 @@ var/datum/artifact_controller/artifact_controls
 	var/list/prefixes = list("meta","poly","anti","hyper","hypo","nano","mega","infra","ultra","trans","micro","macro")
 	var/list/particles = list("quark","tachyon","neutron","positron","photon","neutrino","lepton","baryon","atom","molecule")
 	var/list/verber = list("stabilizer","synchroniser","generator","coupler","fuser","linker","materializer")
+
+	New()
+		. = ..()
+		if(ARTIFACT::origin_precursor != null)
+			CRASH("Duplicate artifact origin of type \"Precursor\" created.")
+		ARTIFACT::origin_precursor = src
 
 	post_setup(obj/artifact)
 		. = ..()
@@ -671,6 +735,12 @@ var/datum/artifact_controller/artifact_controls
 	nouns_large = list("heap", "craft", "harp")
 	nouns_small = list("instrument", "bell", "tool")
 	touch_descriptors = list("You feel air rushing around the surface.", "It feels almost like running water.", "You feel vibrations.")
+
+	New()
+		. = ..()
+		if(ARTIFACT::origin_lattice != null)
+			CRASH("Duplicate artifact origin of type \"Lattice\" created.")
+		ARTIFACT::origin_lattice = src
 
 	generate_name()
 		var/namestring = ""

--- a/code/modules/scanners/market.dm
+++ b/code/modules/scanners/market.dm
@@ -43,7 +43,7 @@ TYPEINFO(/obj/item/device/appraisal)
 			if (pap?.artifactType)
 				out_text = "<strong>The following values depend on correct analysis of the artifact<br>Average price for [pap.artifactType] type artifacts</strong><br>"
 				// the unrandomized sell value for an artifact of the type detailed on the form, with perfect analysis
-				sell_value = shippingmarket.calculate_artifact_price(artifact_controls.artifact_types_from_name[pap.artifactType].get_rarity_modifier(), 3)
+				sell_value = shippingmarket.calculate_artifact_price(ARTIFACT::types_from_name[pap.artifactType].get_rarity_modifier(), 3)
 				sell_value = round(sell_value, 5)
 			else if (pap)
 				boutput(user, SPAN_ALERT("Attached Analysis Form&trade; needs to be filled out!"))

--- a/code/obj/artifacts/artifact_objects/container.dm
+++ b/code/obj/artifacts/artifact_objects/container.dm
@@ -73,5 +73,5 @@
 		O.ArtifactFaultUsed(user)
 		playsound(O.loc, 'sound/effects/warp2.ogg', 50, 1)
 		O.remove_artifact_forms()
-		artifact_controls.artifacts -= src
+		ARTIFACT::list_artifacts -= src
 		qdel(O)

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -54,7 +54,7 @@
 		// start with obscured name
 		src.artifactName = O.real_name
 		// get an instance of the artifact origin
-		for(var/datum/artifact_origin/origin as() in artifact_controls.artifact_origins)
+		for(var/datum/artifact_origin/origin as() in ARTIFACT::list_origins)
 			if(origin.type_name == src.artifactOrigin)
 				// have we already generated a name for that origin?
 				// the actual name with the actual origin should be in the list by default
@@ -119,9 +119,9 @@
 
 	ui_static_data(mob/user)
 		. = list(
-			"allArtifactOrigins" = artifact_controls.artifact_origin_names,
-			"allArtifactTypes" = artifact_controls.artifact_type_names,
-			"allArtifactTriggers" = artifact_controls.artifact_trigger_names
+			"allArtifactOrigins" = ARTIFACT::list_name_origins,
+			"allArtifactTypes" = ARTIFACT::list_name_types,
+			"allArtifactTriggers" = ARTIFACT::list_name_triggers
 		)
 
 	ui_act(action, params)

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -48,10 +48,6 @@ ABSTRACT_TYPE(/datum/artifact/)
 	var/deact_sound = null
 	/// What message the artifact gives when deactivated
 	var/deact_text = null
-	/// How likely this artifact is to appear to be from an origin that it isn't from
-	var/scramblechance = 10
-	/// used to set straight icon_states on activation instead of fx overlays
-	var/nofx = 0
 	/// special_addendum for ArtifactLogs() proc
 	var/log_addendum = null
 
@@ -122,6 +118,11 @@ ABSTRACT_TYPE(/datum/artifact/)
 		src.artitype.post_setup(holder)
 		OTHER_START_TRACKING_CAT(holder, TR_CAT_ARTIFACTS)
 
+	proc/pre_destroyed(var/obj/O)
+		if(!O)
+			return 0
+		return src.artitype.pre_destroyed(O)
+
 	disposing()
 		if(src.artitype)
 			OTHER_STOP_TRACKING_CAT(holder, TR_CAT_ARTIFACTS)
@@ -140,7 +141,7 @@ ABSTRACT_TYPE(/datum/artifact/)
 	proc/may_activate(var/obj/O)
 		if (!O)
 			return 0
-		return 1
+		return src.artitype.may_activate(O)
 
 	/// What the artifact does once when activated.
 	proc/effect_activate(var/obj/O)

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -6,9 +6,9 @@
 
 	var/list/artifactweights
 	if(forceartiorigin)
-		artifactweights = artifact_controls.artifact_rarities[forceartiorigin]
+		artifactweights = ARTIFACT::list_rarities[forceartiorigin]
 	else
-		artifactweights = artifact_controls.artifact_rarities["all"]
+		artifactweights = ARTIFACT::list_rarities["all"]
 
 	var/datum/artifact/picked
 	if(forceartitype)
@@ -62,18 +62,17 @@
 		qdel(src)
 		return
 	A.artitype = AO
-	A.scramblechance = AO.scramblechance
 	// Refers to the artifact datum's list of origins it's allowed to be from and selects one at random. This way we can avoid
 	// stuff that doesn't make sense like ancient robot plant seeds or eldritch healing devices
 
 	var/datum/artifact_origin/appearance = artifact_controls.get_origin_from_string(AO.name)
-	if (prob(A.scramblechance))
+	if (prob(A.artitype.scramblechance))
 		appearance = null
 	// rare-ish chance of an artifact appearing to be a different origin, just to throw things off
 
 	if (!istype(appearance,/datum/artifact_origin/))
 		var/list/all_origin_names = list()
-		for (var/datum/artifact_origin/O in artifact_controls.artifact_origins)
+		for (var/datum/artifact_origin/O in ARTIFACT::list_origins)
 			all_origin_names += O.name
 		appearance = artifact_controls.get_origin_from_string(pick(all_origin_names))
 
@@ -121,13 +120,10 @@
 	A.fault_types |= AO.fault_types - A.fault_blacklist
 	A.internal_name = AO.generate_name()
 	A.used_names[AO.type_name] = A.internal_name
-	A.nofx = AO.nofx
 
 	ArtifactDevelopFault(10)
 
-	if(A.artitype.chapel_block)
-		src.RegisterSignal(src, XSIG_MOVABLE_AREA_CHANGED, PROC_REF(Artifact_chapel_block))
-	if (A.automatic_activation)
+	if(A.automatic_activation)
 		src.ArtifactActivated()
 
 	var/list/valid_triggers = A.validtriggers
@@ -141,7 +137,7 @@
 			A.triggers += AT
 			valid_triggers -= selection
 
-	artifact_controls.artifacts += src
+	ARTIFACT::list_artifacts += src
 	A.post_setup()
 
 /obj/proc/ArtifactActivated()
@@ -154,22 +150,15 @@
 		return 1
 	if (length(A.triggers) < 1 && !A.automatic_activation)
 		return 1 // can't activate these ones at all by design
-	if (!A.may_activate(src))
+	if(!A.may_activate(src))
 		return 1
-	if(A.artitype.chapel_block)
-		var/is_chapel = istype(get_area(src), /area/station/chapel)
-		if(is_chapel)
-			playsound(src.loc, 'sound/effects/bamf.ogg', 50, 1, pitch = 1.25)
-			var/turf/T = get_turf(src)
-			T.visible_message(SPAN_ALERT("<b>[src] attempts to activate but fails!</b>"))
-			return 1
 	if (A.activ_sound)
 		playsound(src.loc, A.activ_sound, 100, 1)
 	if (A.activ_text)
 		var/turf/T = get_turf(src)
 		if (T) T.visible_message("<b>[src] [A.activ_text]</b>") //ZeWaka: Fix for null.visible_message()
 	A.activated = 1
-	if (A.nofx)
+	if (A.artitype.nofx)
 		src.icon_state = src.icon_state + "fx"
 	else
 		A.show_fx(src)
@@ -197,7 +186,7 @@
 		var/turf/T = get_turf(src)
 		T.visible_message("<b>[src] [A.deact_text]</b>")
 	A.activated = 0
-	if (A.nofx)
+	if (A.artitype.nofx)
 		src.icon_state = src.icon_state - "fx"
 	else
 		A.hide_fx(src)
@@ -390,14 +379,6 @@
 	src.ArtifactHitWith(W, user)
 	return 1
 
-/obj/proc/Artifact_chapel_block(var/thing, var/area/old_area, var/area/new_area)
-	var/is_chapel = istype(new_area, /area/station/chapel)
-	if(is_chapel && src.artifact.activated)
-		playsound(src.loc, 'sound/effects/bamf.ogg', 50, 1, pitch = 1.25)
-		src.ArtifactDeactivated()
-	if(!is_chapel && !src.artifact.activated && src.artifact.automatic_activation)
-		src.ArtifactActivated()
-
 #define FAULT_RESULT_INVALID 2 // artifact can't do faults
 #define FAULT_RESULT_STOP	1		 // we gotta stop, artifact was destroyed or deactivated
 #define FAULT_RESULT_SUCCESS 0 // everything's cool!
@@ -582,12 +563,11 @@
 	src.remove_artifact_forms()
 
 	src.ArtifactDeactivated()
-	if(src.artifact.artitype.chapel_block)
-		UnregisterSignal(src, XSIG_MOVABLE_AREA_CHANGED)
+	src.artifact.pre_destroyed(src)
 
 	ArtifactLogs(usr, null, src, "destroyed", null, 0)
 
-	artifact_controls.artifacts -= src
+	ARTIFACT::list_artifacts -= src
 
 	qdel(src)
 	return

--- a/code/obj/artifacts/artifacts.dm
+++ b/code/obj/artifacts/artifacts.dm
@@ -22,7 +22,7 @@
 			src.ArtifactSetup()
 
 	disposing()
-		artifact_controls.artifacts -= src
+		ARTIFACT::list_artifacts -= src
 		..()
 
 	UpdateName()
@@ -129,7 +129,7 @@
 			src.ArtifactSetup()
 
 	disposing()
-		artifact_controls.artifacts -= src
+		ARTIFACT::list_artifacts -= src
 		..()
 
 	examine()
@@ -234,7 +234,7 @@
 			src.ArtifactSetup()
 
 	disposing()
-		artifact_controls.artifacts -= src
+		ARTIFACT::list_artifacts -= src
 		..()
 
 	examine()

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -156,7 +156,7 @@ var/datum/score_tracker/score_tracker
 		final_score_eng = (score_power_outages + score_structural_damage) * 0.5
 
 		// RESEARCH DEPARTMENT SECTION
-		for(var/obj/O in artifact_controls.artifacts)
+		for(var/obj/O in ARTIFACT::list_artifacts)
 			if(O.disposed)
 				continue
 			var/obj/item/sticker/postit/artifact_paper/pap = locate(/obj/item/sticker/postit/artifact_paper/) in O.vis_contents


### PR DESCRIPTION
## About the PR
- Adds the `ARTIFACT` namespace.
- Moves some variables from the artifact controller to the new namespace.
- Moves some code to artifact origins that was already origin-based.

## Why's this needed?
- Cleans up artifact code a little.
- First dip into DM namespaces 

## Testing
<img width="325" height="243" alt="Screenshot 2026-06-12 101115" src="https://github.com/user-attachments/assets/e45452e6-b0b3-4deb-8de9-8612e0ad80d8" />
