### PR TITLE
Artifact chapel deactivation code cleanup

### DIFF
--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -222,7 +222,6 @@ var/datum/artifact_controller/artifact_controls
 	var/fx_alpha_max = 255
 	var/nofx = 0 // If set to 1, does not apply an overlay but a flat icon_state change.
 	var/scramblechance = 10 //probability to have "fake" artifact with altered appearance
-	var/chapel_block = FALSE // Artifact does not work inside chapels
 	var/list/activation_sounds = list()
 	var/list/instrument_sounds = list()
 	var/list/lightswitch_sounds = list('sound/misc/lightswitch.ogg')
@@ -252,8 +251,24 @@ var/datum/artifact_controller/artifact_controls
 			if(artifact.blend_mode == BLEND_SUBTRACT)
 				artifact.plane = PLANE_FLOOR
 
+	proc/may_activate(var/obj/artifact)
+		return TRUE
+
+	proc/pre_destroyed(var/obj/artifact)
+		return
+
 	proc/generate_name()
 		return "unknown object"
+
+	proc/Artifact_chapel_block(var/datum/component/component, var/area/old_area, var/area/new_area)
+		var/obj/O = component.parent
+		var/datum/artifact/artifact = O.artifact
+		var/is_chapel = istype(new_area, /area/station/chapel)
+		if(is_chapel && artifact.activated)
+			playsound(O.loc, 'sound/effects/bamf.ogg', 50, 1, pitch = 1.25)
+			O.ArtifactDeactivated()
+		if(!is_chapel && !artifact.activated && artifact.automatic_activation)
+			O.ArtifactActivated()
 
 
 /datum/artifact_origin/ancient
@@ -400,7 +415,6 @@ var/datum/artifact_controller/artifact_controls
 		/datum/artifact_fault/messager/what_dead_people_said = 5,
 		/datum/artifact_fault/messager/what_people_said = 5,
 		/datum/artifact_fault/messager/emoji = 5)
-	chapel_block = TRUE
 	activation_sounds = list('sound/machines/ArtifactWiz1.ogg')
 	instrument_sounds = list('sound/musical_instruments/artifact/Artifact_Wizard_1.ogg',
 		'sound/musical_instruments/artifact/Artifact_Wizard_2.ogg',
@@ -426,8 +440,25 @@ var/datum/artifact_controller/artifact_controls
 	var/list/object = list("jewel","trophy","favor","boon","token","crown","treasure","sacrament","oath")
 	var/list/aspect = list("wonder","splendor","power","plenty","mystery","glory","majesty","eminence","grace")
 
-	post_setup(obj/artifact)
+	post_setup(var/obj/artifact)
 		. = ..()
+		RegisterSignal(artifact, XSIG_MOVABLE_AREA_CHANGED, PROC_REF(Artifact_chapel_block))
+		src.post_setup_appearance(artifact)
+
+	pre_destroyed(var/obj/artifact)
+		. = ..()
+		UnregisterSignal(artifact, XSIG_MOVABLE_AREA_CHANGED)
+
+	may_activate(var/obj/artifact)
+		. = ..()
+		var/is_chapel = istype(get_area(artifact), /area/station/chapel)
+		if(is_chapel)
+			playsound(artifact.loc, 'sound/effects/bamf.ogg', 50, 1, pitch = 1.25)
+			var/turf/T = get_turf(artifact)
+			T.visible_message(SPAN_ALERT("<b>[artifact] attempts to activate but fails!</b>"))
+			return FALSE
+
+	proc/post_setup_appearance(obj/artifact)
 		var/datum/artifact/AD = artifact.artifact
 		var/rarityMod = AD.get_rarity_modifier()
 		if(prob(300*rarityMod))
@@ -475,7 +506,6 @@ var/datum/artifact_controller/artifact_controls
 /datum/artifact_origin/eldritch
 	type_name = "Eldritch"
 	name = "eldritch"
-	chapel_block = TRUE
 	activation_sounds = list('sound/machines/ArtifactEld1.ogg','sound/machines/ArtifactEld2.ogg')
 	instrument_sounds = list('sound/musical_instruments/artifact/Artifact_Eldritch_1.ogg',
 		'sound/musical_instruments/artifact/Artifact_Eldritch_2.ogg',
@@ -516,6 +546,23 @@ var/datum/artifact_controller/artifact_controls
 	var/list/horror_name_start = list("trog","yogg","ta","y","has","shub","az","cth","cha","ul","xel","og","flu","wrk")
 	var/list/horror_name_mid = list("sog","ran","gon","ni","a","hul","ttur","ay","o","lo","ncac","sin","fel","di")
 	var/list/horror_name_end = list("dyte","oth","tula","olac","tur","bburath","thoth","hu","dha","aoth","tath","goth","ter")
+
+	post_setup(var/obj/artifact)
+		. = ..()
+		RegisterSignal(artifact, XSIG_MOVABLE_AREA_CHANGED, PROC_REF(Artifact_chapel_block))
+
+	pre_destroyed(var/obj/artifact)
+		. = ..()
+		UnregisterSignal(artifact, XSIG_MOVABLE_AREA_CHANGED)
+
+	may_activate(var/obj/artifact)
+		. = ..()
+		var/is_chapel = istype(get_area(artifact), /area/station/chapel)
+		if(is_chapel)
+			playsound(artifact.loc, 'sound/effects/bamf.ogg', 50, 1, pitch = 1.25)
+			var/turf/T = get_turf(artifact)
+			T.visible_message(SPAN_ALERT("<b>[artifact] attempts to activate but fails!</b>"))
+			return FALSE
 
 	generate_name()
 		var/the_horror = src.horror_name()

--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -83,7 +83,6 @@
 	type_size = ARTIFACT_SIZE_TINY
 	rarity_weight = 350
 	validtypes = list("ancient","martian","wizard","precursor")
-	automatic_activation = 0
 	react_elec = list("equal",0,10)
 	react_xray = list(10,80,95,11,"SEGMENTED")
 	examine_hint = "It kinda looks like it's supposed to be inserted into something."

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -48,10 +48,6 @@ ABSTRACT_TYPE(/datum/artifact/)
 	var/deact_sound = null
 	/// What message the artifact gives when deactivated
 	var/deact_text = null
-	/// How likely this artifact is to appear to be from an origin that it isn't from
-	var/scramblechance = 10
-	/// used to set straight icon_states on activation instead of fx overlays
-	var/nofx = 0
 	/// special_addendum for ArtifactLogs() proc
 	var/log_addendum = null
 
@@ -122,6 +118,11 @@ ABSTRACT_TYPE(/datum/artifact/)
 		src.artitype.post_setup(holder)
 		OTHER_START_TRACKING_CAT(holder, TR_CAT_ARTIFACTS)
 
+	proc/pre_destroyed(var/obj/O)
+		if(!O)
+			return 0
+		return src.artitype.pre_destroyed(O)
+
 	disposing()
 		if(src.artitype)
 			OTHER_STOP_TRACKING_CAT(holder, TR_CAT_ARTIFACTS)
@@ -140,7 +141,7 @@ ABSTRACT_TYPE(/datum/artifact/)
 	proc/may_activate(var/obj/O)
 		if (!O)
 			return 0
-		return 1
+		return src.artitype.may_activate(O)
 
 	/// What the artifact does once when activated.
 	proc/effect_activate(var/obj/O)

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -62,12 +62,11 @@
 		qdel(src)
 		return
 	A.artitype = AO
-	A.scramblechance = AO.scramblechance
 	// Refers to the artifact datum's list of origins it's allowed to be from and selects one at random. This way we can avoid
 	// stuff that doesn't make sense like ancient robot plant seeds or eldritch healing devices
 
 	var/datum/artifact_origin/appearance = artifact_controls.get_origin_from_string(AO.name)
-	if (prob(A.scramblechance))
+	if (prob(AO.scramblechance))
 		appearance = null
 	// rare-ish chance of an artifact appearing to be a different origin, just to throw things off
 
@@ -121,13 +120,10 @@
 	A.fault_types |= AO.fault_types - A.fault_blacklist
 	A.internal_name = AO.generate_name()
 	A.used_names[AO.type_name] = A.internal_name
-	A.nofx = AO.nofx
 
 	ArtifactDevelopFault(10)
 
-	if(A.artitype.chapel_block)
-		src.RegisterSignal(src, XSIG_MOVABLE_AREA_CHANGED, PROC_REF(Artifact_chapel_block))
-	if (A.automatic_activation)
+	if(A.automatic_activation)
 		src.ArtifactActivated()
 
 	var/list/valid_triggers = A.validtriggers
@@ -156,20 +152,13 @@
 		return 1 // can't activate these ones at all by design
 	if (!A.may_activate(src))
 		return 1
-	if(A.artitype.chapel_block)
-		var/is_chapel = istype(get_area(src), /area/station/chapel)
-		if(is_chapel)
-			playsound(src.loc, 'sound/effects/bamf.ogg', 50, 1, pitch = 1.25)
-			var/turf/T = get_turf(src)
-			T.visible_message(SPAN_ALERT("<b>[src] attempts to activate but fails!</b>"))
-			return 1
 	if (A.activ_sound)
 		playsound(src.loc, A.activ_sound, 100, 1)
 	if (A.activ_text)
 		var/turf/T = get_turf(src)
 		if (T) T.visible_message("<b>[src] [A.activ_text]</b>") //ZeWaka: Fix for null.visible_message()
 	A.activated = 1
-	if (A.nofx)
+	if (A.artitype.nofx)
 		src.icon_state = src.icon_state + "fx"
 	else
 		A.show_fx(src)
@@ -197,7 +186,7 @@
 		var/turf/T = get_turf(src)
 		T.visible_message("<b>[src] [A.deact_text]</b>")
 	A.activated = 0
-	if (A.nofx)
+	if (A.artitype.nofx)
 		src.icon_state = src.icon_state - "fx"
 	else
 		A.hide_fx(src)
@@ -390,14 +379,6 @@
 	src.ArtifactHitWith(W, user)
 	return 1
 
-/obj/proc/Artifact_chapel_block(var/thing, var/area/old_area, var/area/new_area)
-	var/is_chapel = istype(new_area, /area/station/chapel)
-	if(is_chapel && src.artifact.activated)
-		playsound(src.loc, 'sound/effects/bamf.ogg', 50, 1, pitch = 1.25)
-		src.ArtifactDeactivated()
-	if(!is_chapel && !src.artifact.activated && src.artifact.automatic_activation)
-		src.ArtifactActivated()
-
 #define FAULT_RESULT_INVALID 2 // artifact can't do faults
 #define FAULT_RESULT_STOP	1		 // we gotta stop, artifact was destroyed or deactivated
 #define FAULT_RESULT_SUCCESS 0 // everything's cool!
@@ -582,8 +563,7 @@
 	src.remove_artifact_forms()
 
 	src.ArtifactDeactivated()
-	if(src.artifact.artitype.chapel_block)
-		UnregisterSignal(src, XSIG_MOVABLE_AREA_CHANGED)
+	src.artifact.pre_destroyed(src)
 
 	ArtifactLogs(usr, null, src, "destroyed", null, 0)
 


### PR DESCRIPTION
## About the PR
- Moves some artifact code that checked for artifact origins and moved them to the artifact origin itself. 
- Removed some variables that were in both the artifact datum and artifact origin, but were otherwise identical. 

## Why's this needed?
- Fewer artifact origin checks in non-origin related code.

## Testing
<img width="221" height="182" alt="Screenshot 2026-06-12 200234" src="https://github.com/user-attachments/assets/a3357575-1e0f-45bb-8c44-f4cc44754f18" />
<img width="325" height="243" alt="Screenshot 2026-06-12 101115" src="https://github.com/user-attachments/assets/2edb2311-2464-4ffb-8967-b2a5c0ef0ff6" />
