### PR TITLE
Sync glide_size for attached_objs

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -667,8 +667,7 @@ TYPEINFO(/obj/item/disk)
 		SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, A, direct)
 		src.last_move = get_dir(A, src.loc)
 		if (length(src.attached_objs))
-			for (var/atom/movable/M as anything in attached_objs)
-				M.set_loc(src.loc)
+			src.move_attached_objs()
 		if (islist(src.tracked_blood))
 			src.track_blood()
 		actions.interrupt(src, INTERRUPT_MOVE)
@@ -708,6 +707,12 @@ TYPEINFO(/obj/item/disk)
   * called via pulls and mob steps
 	*/
 /atom/movable/proc/OnMove(source = null)
+
+/// Moves attached objects with this atom, keeping their glide_size in sync.
+/atom/movable/proc/move_attached_objs()
+	for (var/atom/movable/M as anything in src.attached_objs)
+		M.glide_size = src.glide_size
+		M.set_loc(src.loc)
 
 /// Base pull proc, returns 1 if the various checks for pulling fail, so that it can be overriden to add extra functionality without rewriting all the conditions.
 /atom/movable/proc/pull(mob/user)
@@ -1096,8 +1101,7 @@ TYPEINFO(/obj/item/disk)
 		new_area.Entered(src, oldloc)
 
 	if (islist(src.attached_objs) && length(attached_objs))
-		for (var/atom/movable/M in src.attached_objs)
-			M.set_loc(src.loc)
+		src.move_attached_objs()
 	else
 		last_turf = null
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Sync `glide_size` for `attached_objs` so that they stay in sync while moving around
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Currently pulling attached objs come apart visually when moving, e.g. bed/sheet/iv stands. Some implementations like the surgery table avoid this by handling glide_size internally, this just implements it globally
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
* Tested locally
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Sovexe
(+)Objects that are attached to one another (e.g. roller beds and bed sheets) should no longer come apart visually while moving.
```
