### PR TITLE
Make the Mining Magnet delete inactive Flockdrones

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -167,6 +167,9 @@
 			for (var/mob/living/L in T)
 				if(ismobcritter(L) && L.is_npc)
 					qdel(L)
+			for (var/mob/living/critter/flock/drone/L in T)
+				if(L.dormant == 1)
+					qdel(L)
 			if(istype(T,/turf/unsimulated) && ( T.can_build || (station_repair.station_generator && (origin.z == Z_LEVEL_STATION))))
 				T.ReplaceWith(/turf/space, force=TRUE)
 			else


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Deletes any lingering, inactive Flockdrones from the Mining Magnet when the user pulls a fresh asteroid. Does not affect Flockdrones controlled by a player.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently there's a prefab that can be pulled by the Mining Magnet that contains several Flockdrones that are inactive. They're mindless and can't be interacted with beyond moving them around manually or attacking them.  Problem is, they're considered critters, and thus ignored by the Magnet's safeties, but *not* considered NPCs.

When the Magnet pulls an asteroid it's supposed to wipe all NPC critters (rockworms, Syndicates, zombies, etc.) from the Magnet area, but it ignores these Flockdrones and leads to them just taking up space and cluttering the Magnet. This PR adds a little clause to the Magnet's erasure proc to have it delete any inactive Flockdrones within the area.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
- Pulled the Flock prefab using the Mining Magnet
- Possessed one of the drones to set `dormant = 0` (to test what would happen if a proper drone wandered over)
- Activated the Mining Magnet

Magnet correctly deleted only the dormant ones.

- Tried the same process but manually set `dormant = 1`

This time it deleted me along with the others

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

```changelog
(u)Driftered
(+)Inactive Flockdrones are now properly removed from the Mining Magnet when a new asteroid is called.
```
[Game-Objects] [QoL]