### PR TITLE
Security Armory Stasis Guns instead of Tractor Beam

### DIFF
--- a/assets/maps/devtest_prefabs/pod_test.dmm
+++ b/assets/maps/devtest_prefabs/pod_test.dmm
@@ -51,6 +51,10 @@
 /obj/machinery/vehicle/miniputt/armed,
 /turf/space,
 /area/station/devzone)
+"in" = (
+/obj/machinery/vehicle/pod_smooth/heavy/security,
+/turf/space,
+/area/station/devzone)
 "ir" = (
 /obj/item/shipcomponent/secondary_system/shielding/heavy,
 /turf/unsimulated/floor,
@@ -188,6 +192,10 @@
 /area/station/devzone)
 "zR" = (
 /obj/item/shipcomponent/secondary_system/storage,
+/turf/unsimulated/floor,
+/area/station/devzone)
+"Ah" = (
+/obj/item/shipcomponent/mainweapon/stasis,
 /turf/unsimulated/floor,
 /area/station/devzone)
 "Bg" = (
@@ -654,7 +662,7 @@ jH
 jH
 jH
 hr
-vs
+Ah
 "}
 (17,1,1) = {"
 vs
@@ -666,7 +674,7 @@ jH
 jH
 jH
 jH
-jH
+in
 jH
 fR
 jH

--- a/assets/maps/devtest_prefabs/tank_test.dmm
+++ b/assets/maps/devtest_prefabs/tank_test.dmm
@@ -114,6 +114,10 @@
 /obj/item/shipcomponent/engine,
 /turf/simulated/floor,
 /area/station/devzone)
+"xh" = (
+/obj/item/shipcomponent/mainweapon/stasis,
+/turf/simulated/floor,
+/area/station/devzone)
 "yb" = (
 /obj/item/shipcomponent/mainweapon/maser,
 /turf/simulated/floor,
@@ -603,7 +607,7 @@ ha
 ha
 ha
 ha
-ha
+xh
 "}
 (17,1,1) = {"
 ha

--- a/code/modules/transport/pods/MainWeapon.dm
+++ b/code/modules/transport/pods/MainWeapon.dm
@@ -237,6 +237,15 @@
 	icon_state = "disruptor-l"
 	muzzle_flash = "muzzle_flash_plaser"
 
+/obj/item/shipcomponent/mainweapon/stasis
+	name = "Stasis Charger"
+	desc = "An energy projectile weapon that holds a target in place for a limited amount of time."
+	weapon_score = 0.6
+	firerate = 25
+	current_projectile = new/datum/projectile/energy_bolt/stasis
+	icon_state = "assult-laser"
+	muzzle_flash = "muzzle_flash_plaser"
+
 /obj/item/shipcomponent/mainweapon/precursor
 	name = "IRIDIUM Spheroid Projector"
 	desc = "****CLASSIFIED: THANOTECH APPLIED RESEARCH DIVISION, Y-LEVEL CLEARANCE REQUIRED****."

--- a/code/obj/storage/secure_crates.dm
+++ b/code/obj/storage/secure_crates.dm
@@ -78,6 +78,7 @@
 			name = "pod weapons crate"
 			spawn_contents = list(/obj/item/shipcomponent/mainweapon/disruptor_light = 2,\
 			/obj/item/shipcomponent/mainweapon/laser = 2,\
+			/obj/item/shipcomponent/mainweapon/stasis = 2,\
 			/obj/item/storage/box/missile_launcher)
 
 /obj/storage/secure/crate/plasma

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -14294,13 +14294,6 @@
 /obj/item/device/radio/intercom/security{
 	dir = 8
 	},
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = 10;
-	pixel_y = -2
-	},
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = 6
-	},
 /turf/simulated/floor/black,
 /area/station/hangar/sec)
 "fwD" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -4284,13 +4284,6 @@
 	pixel_x = -10;
 	pixel_y = 2
 	},
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = 6
-	},
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = 10;
-	pixel_y = -2
-	},
 /obj/machinery/light{
 	dir = 4
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -64206,14 +64206,6 @@
 	pixel_x = -10
 	},
 /obj/storage/crate,
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = -6;
-	pixel_y = -5
-	},
 /obj/item/shipcomponent/mainweapon/taser{
 	pixel_x = -6;
 	pixel_y = 2
@@ -70569,14 +70561,6 @@
 /area/station/routing/depot)
 "tTw" = (
 /obj/storage/crate,
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = -6;
-	pixel_y = -5
-	},
 /obj/item/shipcomponent/mainweapon/taser{
 	pixel_x = -6;
 	pixel_y = 2

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -15683,8 +15683,6 @@
 /obj/storage/crate,
 /obj/item/shipcomponent/mainweapon/taser,
 /obj/item/shipcomponent/mainweapon/taser,
-/obj/item/shipcomponent/secondary_system/tractor_beam,
-/obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/item/shipcomponent/mainweapon/phaser,
 /obj/item/shipcomponent/mainweapon/phaser,
 /obj/item/device/radio/intercom/security,

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -17547,14 +17547,6 @@
 "fvd" = (
 /obj/machinery/light/incandescent/warm,
 /obj/storage/crate,
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = -10;
-	pixel_y = -5
-	},
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = 7;
-	pixel_y = -5
-	},
 /obj/item/shipcomponent/mainweapon/taser{
 	pixel_x = 6;
 	pixel_y = 7
@@ -67517,14 +67509,6 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/storage/crate,
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = -10;
-	pixel_y = -5
-	},
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = 7;
-	pixel_y = -5
-	},
 /obj/item/shipcomponent/mainweapon/taser{
 	pixel_x = 6;
 	pixel_y = 7

--- a/maps/events/wrestlemap.dmm
+++ b/maps/events/wrestlemap.dmm
@@ -47048,8 +47048,6 @@
 /obj/storage/crate,
 /obj/item/shipcomponent/mainweapon/taser,
 /obj/item/shipcomponent/mainweapon/taser,
-/obj/item/shipcomponent/secondary_system/tractor_beam,
-/obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/machinery/light/emergency{
 	dir = 1
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -46205,8 +46205,6 @@
 /area/station/security/brig/solitary)
 "pYe" = (
 /obj/table/auto,
-/obj/item/shipcomponent/secondary_system/tractor_beam,
-/obj/item/shipcomponent/secondary_system/tractor_beam,
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "pZc" = (

--- a/maps/mushroom.dmm
+++ b/maps/mushroom.dmm
@@ -16570,13 +16570,6 @@
 	pixel_x = -10;
 	pixel_y = 2
 	},
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = 6
-	},
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = 10;
-	pixel_y = -2
-	},
 /obj/machinery/light/incandescent{
 	dir = 1
 	},

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -22102,12 +22102,6 @@
 /area/station/security/secwing)
 "jEi" = (
 /obj/table/reinforced/auto,
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = -6
-	},
-/obj/item/shipcomponent/secondary_system/tractor_beam{
-	pixel_x = 6
-	},
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = 2;
 	pixel_y = -3

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -34696,7 +34696,6 @@
 /obj/table/reinforced/auto,
 /obj/item/shipcomponent/mainweapon/taser,
 /obj/item/shipcomponent/mainweapon/bad_mining,
-/obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/reagent_containers/food/drinks/fueltank,
 /obj/item/weldingtool,

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -49680,7 +49680,6 @@
 /obj/table/reinforced/auto,
 /obj/item/shipcomponent/mainweapon/taser,
 /obj/item/shipcomponent/mainweapon/bad_mining,
-/obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/reagent_containers/food/drinks/fueltank{
 	pixel_x = 10

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -13399,7 +13399,6 @@
 	},
 /area/marsoutpost)
 "beE" = (
-/obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/lattice,
 /obj/decal/cleanable/machine_debris,
 /obj/storage/crate/bloody,
@@ -33769,7 +33768,6 @@
 	name = "Pod N a Box"
 	},
 /obj/item/shipcomponent/mainweapon/foamer,
-/obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/item/shipcomponent/sensor/mining,
 /obj/item/electronics/relay,
 /obj/item/electronics/bulb,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Removes tractor beam components from security podbays
* Adds new pod weapon: Stasis Charger. Fires the same stasis bolts as the Stasis Gun, at a slower fire rate than other pod weapons.
* The armory pod weapons crate receives two Stasis Charger weapons in addition to its other gear.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Tractor beam is near-impossible to break out of, but doesn't require standing still or aiming to lock someone down.
However, not having any ability to reduce jetpack user mobility leaves security in a tough situation.
This attempts to strike a balance by letting security choose between anti-vehicle and anti-personnel weapons when opening the armory.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested in devtest with updated pod/tank prefabs.


https://github.com/user-attachments/assets/b89b2812-1267-46e7-a766-51394b6ce095



<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*) Pod Tractor Beam secondary components have been removed from Security podbays.
(*) Armory Pod Weapons Crate gets 2 Stasis Charger pod weapons
```
