### PR TITLE
Custom injectors will now have the reagent's name specified in the injector name.

### DIFF
--- a/code/modules/chemistry/tools/emergency_injectors.dm
+++ b/code/modules/chemistry/tools/emergency_injectors.dm
@@ -75,6 +75,7 @@
 				src.can_fill = FALSE
 				src.empty = FALSE
 				W.reagents.trans_to(src, src.initial_volume)
+				src.name = "Emergency auto-injector ([src.reagents.get_master_reagent_name()])"
 				logTheThing(LOG_CHEMISTRY, user, "fills [src] with [W] [log_reagents(src)]")
 				user.visible_message(SPAN_ALERT("[user] transfer chemicals from [W] to [src]."),\
 				SPAN_ALERT("You transfer chemicals from [W] to [src]. [src]'s filling port closes."))


### PR DESCRIPTION

<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Custom injectors printed from the med-fab will now have proper names, depending on the master reagent inside them. 
Previously they would have the generic, "Emergency auto-injector" as their name while now they would have, "Emergency auto-inejctor ([reagent]).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I don't think there's some inherent rule to decide, as to which reagent should go inside which color injector?? so having the reagent's name labeled on the injector itself seems more informative, even to the actual doc's who would be picking these up from the pharmacist.  

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
- Red injector from the med-fab filled with epi. 
<img width="397" height="289" alt="dreamseeker_xj5NT1rxJH" src="https://github.com/user-attachments/assets/df968400-a4f0-4b08-a25d-88bd758e5f8e" />


- Orange injector filled with sulfuric acid (When the injector-filler was EMAG'ed)
<img width="422" height="310" alt="dreamseeker_6bbMSCB3r6" src="https://github.com/user-attachments/assets/c3e1c404-3c60-41c8-bc2d-1fab2249e5d5" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)SebaceousSasquatch
(+)Custom injectors now have the reagent's name specified on them too.
```

