### PR TITLE
Fix being unable to add wood finish to tables

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -243,7 +243,7 @@ TYPEINFO_NEW(/obj/table)
 			qdel(W)
 			return
 
-		else if (istype(W,/obj/item/sheet/wood))
+		else if (istype(W,/obj/item/sheet) && (W.material?.getMaterialFlags() & MATERIAL_WOOD))
 			if (istype(src, /obj/table/reinforced/bar)) //why must you be so confusing
 				return ..()
 			if (status != STATUS_STRONG || !istype(src, /obj/table/reinforced/auto))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes material sheets require to be made out of wood material instead of just being "sheet/wood" type when it comes to applying them to a reinforced table to make a fancier version.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugfix.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Sheet applies correctly to table.

fixes https://github.com/goonstation/goonstation/issues/26489
