### PR TITLE
Ghostdrone mentormousing

### DIFF
--- a/code/mob/living/critter/small_animal/mouse.dm
+++ b/code/mob/living/critter/small_animal/mouse.dm
@@ -393,6 +393,12 @@ ADMIN_INTERACT_PROCS(/mob/living/critter/small_animal/mouse, proc/glorp)
 			src.make_critter(/mob/living/critter/small_animal/mouse/weak)
 			return
 
+	new_static_image()
+		return
+
+	update_static_image()
+		return
+
 /datum/targetable/critter/mentordisappear
 	name = "Vanish"
 	desc = "Leave your body and return to ghost form"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mentor mice (and admin mice) no longer have a static silhouette applied to them when something with a staticky vision (like a ghostdrone) tries to look at them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mentor mice are a flavorful OOC way to help players, regardless of their current job/form. Ghostdrone players also need the help. Admin mice can now also hop into their pockets for devious shenanigans.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Became a ghostdrone, saw the mentor mouse, everyone else was static, could offer to the mentormouse to hop in.

```changelog
(u)Bartimeus973
(+)Ghostdrones can now see and pickup mentormice
```
