### PR TITLE
Chaplain can bless the TEG

### DIFF
--- a/_std/defines/faith.dm
+++ b/_std/defines/faith.dm
@@ -12,3 +12,6 @@
 
 // charms
 #define FAITH_CHARM_CREATION 300
+
+//teg bless
+#define FAITH_TEG_BLESS 500

--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -945,7 +945,7 @@ datum/pump_ui/circulator_ui
 	attackby(obj/item/W, mob/user)
 		if(istype(W, /obj/item/bible)) // god bless this spess
 			if(ON_COOLDOWN(src, "bless_teg", 3 SECONDS)) return
-			else if (!istype(src.active_form, /datum/teg_transformation/vampire) && user.traitHolder && user.traitHolder.hasTrait("training_chaplain"))
+			else if (!istype(src.active_form, /datum/teg_transformation/vampire) && user.traitHolder?.hasTrait("training_chaplain"))
 				playsound(src.loc, 'sound/impact_sounds/generic_punch_5.ogg', 50, 1)
 				if(src.grump && prob(80) && get_chaplain_faith(user) > FAITH_TEG_BLESS)
 					playsound(user.loc, 'sound/effects/faithbiblewhack.ogg', 50, 1)

--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -943,6 +943,19 @@ datum/pump_ui/circulator_ui
 		return (efficiency_scale * 0.01)
 
 	attackby(obj/item/W, mob/user)
+		if(istype(W, /obj/item/bible)) // god bless this spess
+			if(ON_COOLDOWN(src, "bless_teg", 3 SECONDS)) return
+			else if (!src.active_form && user.traitHolder && user.traitHolder.hasTrait("training_chaplain"))
+				playsound(src.loc, 'sound/impact_sounds/generic_punch_5.ogg', 50, 1)
+				if(src.grump && prob(80) && get_chaplain_faith(user) > FAITH_TEG_BLESS)
+					playsound(user.loc, 'sound/effects/faithbiblewhack.ogg', 50, 1)
+					user.visible_message(SPAN_ALERT("<B>[user] blesses [src]!</B>"))
+					src.grump -= rand(10, 50)
+					modify_chaplain_faith(user, -FAITH_TEG_BLESS)
+				else
+					playsound(src.loc, pick(sounds_enginegrump), 70, 0)
+					user.visible_message(SPAN_ALERT("<B>[src] makes an awful noise!</B>"))
+			return
 		// Weld > Crowbar > Rods > Weld
 		switch(semiconductor_state)
 			if(TEG_SEMI_STATE_INSTALLED)

--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -945,7 +945,7 @@ datum/pump_ui/circulator_ui
 	attackby(obj/item/W, mob/user)
 		if(istype(W, /obj/item/bible)) // god bless this spess
 			if(ON_COOLDOWN(src, "bless_teg", 3 SECONDS)) return
-			else if (!src.active_form && user.traitHolder && user.traitHolder.hasTrait("training_chaplain"))
+			else if (!istype(src.active_form, /datum/teg_transformation/vampire) && user.traitHolder && user.traitHolder.hasTrait("training_chaplain"))
 				playsound(src.loc, 'sound/impact_sounds/generic_punch_5.ogg', 50, 1)
 				if(src.grump && prob(80) && get_chaplain_faith(user) > FAITH_TEG_BLESS)
 					playsound(user.loc, 'sound/effects/faithbiblewhack.ogg', 50, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows chaplains to bless the TEG by smacking it with a bible, reducing a random amount of grump at the cost of 500 faith. If the TEG is in the alive portion of the vamp TEG event they just beat the shit out of it same as before. 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The TEG is a spiritual machine
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested on local, works. also made sure the vamp TEG behaviour is unchanged. 
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bamlord
(*)The Chaplain can now bless the TEG with their bible
```
