### PR TITLE
Cart recipes for QM Manufacturer

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -3738,6 +3738,36 @@ ABSTRACT_TYPE(/datum/manufacture/radio_upgrade)
 	name = "Unmarked Syndicate Crate"
 	item_outputs = list(/obj/storage/secure/crate/gear/syndicate)
 
+/******************** Carts *******************/
+
+/datum/manufacture/cart
+	name = "Cart"
+	item_requirements = list("metal" = 1)
+	item_outputs = list(/obj/storage/cart)
+	create = 1
+	time = 10 SECONDS
+	category = "Miscellaneous"
+
+/datum/manufacture/cart/forensic
+	name = "Forensics Cart"
+	item_outputs = list(/obj/storage/cart/forensic)
+
+/datum/manufacture/cart/mechanic
+	name = "Mechanics Cart"
+	item_outputs = list(/obj/storage/cart/mechcart)
+
+/datum/manufacture/cart/medical
+	name = "Medical Cart"
+	item_outputs = list(/obj/storage/cart/medcart)
+
+/datum/manufacture/cart/trash
+	name = "Trash Cart"
+	item_outputs = list(/obj/storage/cart/trash)
+
+/datum/manufacture/cart/hotdog
+	name = "Hotdog Cart"
+	item_outputs = list(/obj/storage/cart/hotdog)
+
 /******************** GUNS *******************/
 
 /datum/manufacture/alastor

--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -583,9 +583,14 @@ TYPEINFO(/obj/machinery/manufacturer/general/grody)
 		/datum/manufacture/crate/secure/engineering,
 		/datum/manufacture/crate/secure/medical,
 		/datum/manufacture/crate/secure/hydroponics,
+		/datum/manufacture/cart,
+		/datum/manufacture/cart/forensic,
+		/datum/manufacture/cart/mechanic,
+		/datum/manufacture/cart/medical,
+		/datum/manufacture/cart/trash,
 		)
 
-	hidden = list(/datum/manufacture/crate/class, /datum/manufacture/crate/secure/syndicate)
+	hidden = list(/datum/manufacture/crate/class, /datum/manufacture/crate/secure/syndicate, /datum/manufacture/cart/hotdog)
 
 /obj/machinery/manufacturer/zombie_survival
 	name = "\improper Uber-Extreme Survival Manufacturer"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the various carts to the cargo manufacturer. The hotdog cart is hidden however because I thought that would be funny.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Carts are found around the map and function very similarly to crates, with some very minor differences (Did you know crates can be attached at the end of a cargo cart? Now you do!), it makes sense that they'd be able to be found in the cargo fabricator and the comment next to the fabricator even says "prints crates and carts" which is currently a lie.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="926" height="525" alt="image" src="https://github.com/user-attachments/assets/d1ab15cf-9aed-4f92-82f6-a311dd720871" />
<img width="618" height="157" alt="image" src="https://github.com/user-attachments/assets/bf375445-447a-421a-9d84-e6490febdcfc" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Cargo can now print carts at their manufacturer
```
