### PR TITLE
Buttbots made out of a changeling's ass no longer snitch their real name

### DIFF
--- a/code/obj/item/organs/butt.dm
+++ b/code/obj/item/organs/butt.dm
@@ -187,7 +187,7 @@ TYPEINFO(/obj/item/clothing/head/butt)
 			var/obj/machinery/bot/buttbot/B = new /obj/machinery/bot/buttbot(src, W)
 			// Let's not rat out changelings through their butt name, as funny as it is
 			var/regex/R = regex("mutagenic")
-			if(R.Find(src.name))
+			if(findtext(src.name, "mutagenic")
 				B.name = "mutagenic buttbot"
 			else if (src.donor || src.donor_name)
 				B.name = "[src.donor_name ? "[src.donor_name]" : "[src.donor.real_name]"] buttbot"

--- a/code/obj/item/organs/butt.dm
+++ b/code/obj/item/organs/butt.dm
@@ -185,7 +185,11 @@ TYPEINFO(/obj/item/clothing/head/butt)
 	attackby(obj/item/W, mob/user)
 		if (istype(W, /obj/item/parts/robot_parts/arm))
 			var/obj/machinery/bot/buttbot/B = new /obj/machinery/bot/buttbot(src, W)
-			if (src.donor || src.donor_name)
+			// Let's not rat out changelings through their butt name, as funny as it is
+			var/regex/R = regex("mutagenic")
+			if(R.Find(src.name))
+				B.name = "mutagenic buttbot"
+			else if (src.donor || src.donor_name)
 				B.name = "[src.donor_name ? "[src.donor_name]" : "[src.donor.real_name]"] buttbot"
 			user.show_text("You add [W] to [src]. Fantastic.", "blue")
 			B.set_loc(get_turf(src))

--- a/code/obj/item/organs/butt.dm
+++ b/code/obj/item/organs/butt.dm
@@ -186,8 +186,7 @@ TYPEINFO(/obj/item/clothing/head/butt)
 		if (istype(W, /obj/item/parts/robot_parts/arm))
 			var/obj/machinery/bot/buttbot/B = new /obj/machinery/bot/buttbot(src, W)
 			// Let's not rat out changelings through their butt name, as funny as it is
-			var/regex/R = regex("mutagenic")
-			if(findtext(src.name, "mutagenic")
+			if(findtext(src.name, "mutagenic"))
 				B.name = "mutagenic buttbot"
 			else if (src.donor || src.donor_name)
 				B.name = "[src.donor_name ? "[src.donor_name]" : "[src.donor.real_name]"] buttbot"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that if a butt has "mutagenic" in it's name the resulting buttbot will simply be called "mutagenic buttbot" and not use the ex-owner's real name.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As funny as it is, it's definitely not intended to be able to just put a cyborg arm on the thing and immediatly know who's it was. The usual process of DNA matching should be the way to find it.
A roboticist with a robot arm shouldn't be a better investigator than the detective.

Fixes https://github.com/goonstation/goonstation/issues/25118

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Dropped my butt, made a buttbot, was named after me. Dropped another butt, named it "something mutagenic something butt" and the resulting buttbot was called "mutagenic buttbot".

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Bartimeus973
(+)Making buttbots out of a changeling's butt, such as one from a dead buttcrab, no longer doxes their real name.
```
