### PR TITLE
Any material can be turned into sheets using the sheet extruder

### DIFF
--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -17,7 +17,7 @@
 			return ..()
 		if (src.working || src.is_disabled())
 			return
-		if (!I.material || !HAS_ANY_FLAGS(I.material.getMaterialFlags(), MATERIAL_METAL | MATERIAL_CRYSTAL | MATERIAL_WOOD))
+		if (!I.material)
 			boutput(user, SPAN_ALERT("[I] doesn't go in there!"))
 			return
 		var/obj/item/material_piece/taken_piece = null


### PR DESCRIPTION
## About the PR
- Sheet extruder no longer checks for the type of material.

## Why's this needed?
- PR #26598 already makes creating sheets out of any material possible. This brings that change to the sheet extruder.
- Simplifies material sheets so that the conditions for which materials can and cannot be turned into sheets are less arbitrary.

## Testing
<img width="230" height="217" alt="Screenshot 2026-06-23 041853" src="https://github.com/user-attachments/assets/c20f4d1d-4632-44de-8a0b-c0b8381950b7" />

## Changelog
```changelog
(u)LorrMaster
(*)Any material may now be turned into sheets using the sheet extruder.
```
