### PR TITLE
Allow deconstructing in syndicate hideouts

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -22,6 +22,7 @@ ABSTRACT_TYPE(/area) // don't instantiate this directly dummies, use /area/space
   */
 TYPEINFO(/area)
 	var/valid_bounty_area = FALSE
+	var/allow_restricted_z_deconstruction = FALSE
 /area
 
 	/// TRUE if a dude is here (DOES NOT APPLY TO THE "SPACE" AREA)
@@ -3777,6 +3778,8 @@ ABSTRACT_TYPE(/area/station/catwalk)
 
 // end station areas //
 
+TYPEINFO(/area/salvager)
+	allow_restricted_z_deconstruction = TRUE
 // Salvager Spawn
 /area/salvager
 	name = "Salvager Vessel Magpie"
@@ -3851,6 +3854,8 @@ ABSTRACT_TYPE(/area/station/catwalk)
 	name = "medical bay"
 	icon_state = "purple"
 
+TYPEINFO(/area/syndicate_station/hideout)
+	allow_restricted_z_deconstruction = TRUE
 /area/syndicate_station/hideout
 	name = "Mysterious Hideout"
 	icon_state = "red"

--- a/code/datums/components/tool/deconstructing.dm
+++ b/code/datums/components/tool/deconstructing.dm
@@ -38,6 +38,7 @@ TYPEINFO(/datum/component/deconstructing)
 		if (O.deconstruct_flags == DECON_NONE)
 			return
 
+		var/area/object_area = get_area(O)
 		var/decon_complexity = O.build_deconstruction_buttons()
 		if (!decon_complexity || !O.can_deconstruct(user))
 			if (O.deconstruct_flags & DECON_NULL_ACCESS)
@@ -52,7 +53,7 @@ TYPEINFO(/datum/component/deconstructing)
 			boutput(user, SPAN_ALERT("You cannot deconstruct [target] without sufficient access to operate it."))
 		else if(length(get_all_mobs_in(O)))
 			boutput(user, SPAN_ALERT("You cannot deconstruct [target] while someone is inside it!"))
-		else if (isrestrictedz(O.z) && !isitem(target) && !istype(get_area(O), /area/salvager)) //let salvagers deconstruct on the magpie
+		else if (isrestrictedz(O.z) && !isitem(target) && !(object_area.get_typeinfo().allow_restricted_z_deconstruction)) //let salvagers deconstruct on the magpie
 			boutput(user, SPAN_ALERT("You cannot bring yourself to deconstruct [target] in this area."))
 		else if (O.decon_contexts && length(O.decon_contexts) <= 0) //ready!!!
 			boutput(user, "Deconstructing [O], please remain still...")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes restricted Z deconstruction permission checks to area typeinfo rather than specific /area/salvager check.
Adds the syndicate hideout to the list of areas that allow you to deconstruct in a restricted Z.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows people to deconstruct things they build in the syndicate hideout

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Can deconstruct in the main magpie areas in the local magpie prefab
<img width="213" height="140" alt="image" src="https://github.com/user-attachments/assets/7b4b3d36-f231-4bad-bccf-d7abf395a863" />
Cant deconstruct outside, as it is a different /salvager_space area not under /salvager
<img width="247" height="159" alt="image" src="https://github.com/user-attachments/assets/503a9395-f75a-4235-a82e-0b9da85efc41" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
