### PR TITLE
added a butt version of the door bucket prank

### DIFF
--- a/code/obj/item/organs/butt.dm
+++ b/code/obj/item/organs/butt.dm
@@ -255,26 +255,32 @@ TYPEINFO(/obj/item/clothing/head/butt)
 			src.visible_message(SPAN_ALERT("[src] falls unhindered from \the [targetDoor], farting sadly upon hitting the floor.")) //butts have emotions
 			playsound(src, (src.sound_fart ? src.sound_fart : pick(random_fart_sounds)), 50, TRUE)
 			return
-		else
-			logTheThing(LOG_COMBAT, AM, "Victim of butt-door-prank on [targetDoor]")
-			if(ishuman(AM))
-				var/mob/living/carbon/human/H = AM
-				if(isnull(H.head))
-					src.set_loc(get_turf(H))
-					H.equip_if_possible(src, SLOT_HEAD)
-					H.set_clothing_icon_dirty()
-					H.visible_message(SPAN_ALERT("[src] falls from \the [targetDoor], landing on [H]'s head with a gleeful fart! [pick("Butthead!", "Nerd!", "What a dork!")]"), \
-								SPAN_ALERT("[src] falls from \the [targetDoor], landing on your head with a gleeful fart!"))
-					playsound(H, (src.sound_fart ? src.sound_fart : pick(random_fart_sounds)), 50, TRUE)
-				else
-					src.set_loc(get_turf(H))
-					H.visible_message(SPAN_ALERT("[src] falls from \the [targetDoor], bouncing off [H]'s hat and landing on the floor with an indignant fart!"), \
+
+		logTheThing(LOG_COMBAT, AM, "Victim of butt-door-prank on [targetDoor]")
+
+		if(!ishuman(AM))
+			src.set_loc(get_turf(targetDoor))
+			targetDoor.visible_message(SPAN_ALERT("[src] falls from \the [targetDoor], bouncing off [AM] and landing on the floor with a disappointed fart."))
+			playsound(src, (src.sound_fart ? src.sound_fart : pick(random_fart_sounds)), 50, TRUE)
+			return
+
+		var/mob/living/carbon/human/H = AM
+
+		if(H.head)
+			src.set_loc(get_turf(H))
+			H.visible_message(SPAN_ALERT("[src] falls from \the [targetDoor], bouncing off [H]'s hat and landing on the floor with an indignant fart!"), \
 								SPAN_ALERT("[src] falls from \the [targetDoor], bouncing off your hat and landing on the floor with an indignant fart!"))
-					playsound(H, (src.sound_fart ? src.sound_fart : pick(random_fart_sounds)), 50, TRUE)
-			else
-				src.set_loc(get_turf(targetDoor))
-				targetDoor.visible_message(SPAN_ALERT("[src] falls from \the [targetDoor], bouncing off [AM] and landing on the floor with a disappointed fart."))
-				playsound(src, (src.sound_fart ? src.sound_fart : pick(random_fart_sounds)), 50, TRUE)
+			playsound(H, (src.sound_fart ? src.sound_fart : pick(random_fart_sounds)), 50, TRUE)
+			return
+
+
+		src.set_loc(get_turf(H))
+		H.equip_if_possible(src, SLOT_HEAD)
+		H.set_clothing_icon_dirty()
+		H.visible_message(SPAN_ALERT("[src] falls from \the [targetDoor], landing on [H]'s head with a gleeful fart! [pick("Butthead!", "Nerd!", "What a dork!")]"), \
+							SPAN_ALERT("[src] falls from \the [targetDoor], landing on your head with a gleeful fart!"))
+		playsound(H, (src.sound_fart ? src.sound_fart : pick(random_fart_sounds)), 50, TRUE)
+
 
 	afterattack(obj/target, mob/user, flag)
 		if(!istype(target, /obj/machinery/door/unpowered/wood))

--- a/code/obj/item/organs/butt.dm
+++ b/code/obj/item/organs/butt.dm
@@ -31,6 +31,16 @@ TYPEINFO(/obj/item/clothing/head/butt)
 	var/sound/sound_fart = null // this is the life I live, making it so you can change the fart sound of your butt (that you can wear on your head) so that you can make artifact butts with weird farts
 	default_material = "butt"
 	mat_changename = "butt"
+	var/static/list/random_fart_sounds = list( // some nice variety in our fart sounds for random butt shennanigans
+			'sound/voice/farts/poo2.ogg',
+			'sound/voice/farts/fart1.ogg',
+			'sound/voice/farts/fart2.ogg',
+			'sound/voice/farts/fart3.ogg',
+			'sound/voice/farts/fart4.ogg',
+			'sound/voice/farts/fart5.ogg',
+			'sound/voice/farts/fart6.ogg',
+			'sound/voice/farts/fart7.ogg'
+		)
 
 	disposing()
 		UnregisterSignal(src, COMSIG_ITEM_ASSEMBLY_APPLY)
@@ -216,6 +226,66 @@ TYPEINFO(/obj/item/clothing/head/butt)
 
 	proc/on_fart(var/mob/farted_on) // what is wrong with me
 		return
+
+	proc/setup_butt_prank(obj/machinery/door/targetDoor, mob/user) // balance a butt above a wooden door to prank the next person who opens it. based on the bucket prank code
+		if(locate(/obj/item/clothing/head/butt) in targetDoor)
+			boutput(user, "<b>There's already a butt prank set up!</b>")
+			return
+		logTheThing(LOG_COMBAT, user, "Set up a butt-door-prank on [targetDoor]")
+		RegisterSignal(targetDoor, COMSIG_DOOR_OPENED, PROC_REF(butt_prank))
+		user.u_equip(src)
+		src.set_loc(targetDoor)
+		user.visible_message(SPAN_ALERT("[user] props \the [src] above \the [targetDoor]!"), SPAN_ALERT("You prop \the [src] above \the [targetDoor]. The next person to come through will get a butt on their head!"))
+
+		var/image/I = image(src.icon, src, src.icon_state, targetDoor.layer+0.1)
+		I.color = src.color
+		I.transform = matrix(I.transform, 0.5, 0.5, MATRIX_SCALE)
+		I.transform = matrix(I.transform, (targetDoor.dir & (WEST | EAST) ? 0 : -16), (targetDoor.dir & (NORTH | SOUTH) ? 0 : -16), MATRIX_TRANSLATE)
+		targetDoor.UpdateOverlays(I, "buttprank")
+
+	proc/butt_prank(obj/machinery/door/targetDoor, atom/movable/AM)
+		//fall off the door, land on their head if you can
+		//note that AM can be null, and this is caught by !IN_RANGE
+
+		UnregisterSignal(targetDoor, COMSIG_DOOR_OPENED)
+		targetDoor.UpdateOverlays(null, "buttprank")
+
+		if(!IN_RANGE(AM, targetDoor, 1))
+			src.set_loc(get_turf(targetDoor))
+			src.visible_message(SPAN_ALERT("[src] falls unhindered from \the [targetDoor], farting sadly upon hitting the floor.")) //butts have emotions
+			playsound(src, (src.sound_fart ? src.sound_fart : pick(random_fart_sounds)), 50, TRUE)
+			return
+		else
+			logTheThing(LOG_COMBAT, AM, "Victim of butt-door-prank on [targetDoor]")
+			if(ishuman(AM))
+				var/mob/living/carbon/human/H = AM
+				if(isnull(H.head))
+					src.set_loc(get_turf(H))
+					H.equip_if_possible(src, SLOT_HEAD)
+					H.set_clothing_icon_dirty()
+					H.visible_message(SPAN_ALERT("[src] falls from \the [targetDoor], landing on [H]'s head with a gleeful fart! [pick("Butthead!", "Nerd!", "What a dork!")]"), \
+								SPAN_ALERT("[src] falls from \the [targetDoor], landing on your head with a gleeful fart!"))
+					playsound(H, (src.sound_fart ? src.sound_fart : pick(random_fart_sounds)), 50, TRUE)
+				else
+					src.set_loc(get_turf(H))
+					H.visible_message(SPAN_ALERT("[src] falls from \the [targetDoor], bouncing off [H]'s hat and landing on the floor with an indignant fart!"), \
+								SPAN_ALERT("[src] falls from \the [targetDoor], bouncing off your hat and landing on the floor with an indignant fart!"))
+					playsound(H, (src.sound_fart ? src.sound_fart : pick(random_fart_sounds)), 50, TRUE)
+			else
+				src.set_loc(get_turf(targetDoor))
+				targetDoor.visible_message(SPAN_ALERT("[src] falls from \the [targetDoor], bouncing off [AM] and landing on the floor with a disappointed fart."))
+				playsound(src, (src.sound_fart ? src.sound_fart : pick(random_fart_sounds)), 50, TRUE)
+
+	afterattack(obj/target, mob/user, flag)
+		if(!istype(target, /obj/machinery/door/unpowered/wood))
+			return ..()
+		if(locate(/obj/item/clothing/head/butt) in target)
+			boutput(user, "<b>There's already a butt prank set up!</b>")
+			return
+		boutput(user, "You start propping \the [src] above \the [target]...")
+		SETUP_GENERIC_ACTIONBAR(user, src, 3 SECONDS, PROC_REF(setup_butt_prank), list(target, user), src.icon, src.icon_state, \
+					src.visible_message(SPAN_ALERT("<B>[user] props \the [src] above \the [target]</B>")), \
+					INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION | INTERRUPT_MOVE)
 
 TYPEINFO(/obj/item/clothing/head/butt/cyberbutt)
 	mat_appearances_to_ignore = list("pharosium")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a butt version of the bucket door prank. Allows a player to prop a butt above a wooden door, which will fall on the next person to walk through, landing on their head. If the victim is out of range the butt will fall to the floor. If the victim is not human or is wearing a hat the butt will bounce off them and fall to the floor. Much farting is involved. 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because putting butts on people's heads is funny and we need more butt jokes
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested on human and monkey with and without hat, and critters like capy, walrus and roach. Also tested on synth and robutts.
<img width="264" height="266" alt="butt_prank_pr" src="https://github.com/user-attachments/assets/34b7fddb-842e-4f7b-abde-7caa4b34a461" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)j3kchad
(+)Added a door butt prank based on the door bucket prank
```
