### PR TITLE
Mender Refill Cartridge refilling and fab recipe

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2605,6 +2605,15 @@ ABSTRACT_TYPE(/datum/manufacture/aiModule)
 	time = 30 SECONDS
 	category = "Resource"
 
+/datum/manufacture/mender_refill_cartridge
+	name = "Mender Refill Cartridge"
+	item_requirements = list("metal" = 1,
+							"conductive" = 1)
+	item_outputs = list(/obj/item/reagent_containers/mender_refill_cartridge)
+	create = 1
+	time = 3 SECONDS
+	category = "Resource"
+
 /datum/manufacture/penlight
 	name = "Penlight"
 	item_requirements = list("metal" = 1,

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -692,14 +692,15 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/mender_refill_cartridge)
 	desc = "A container designed to be able to quickly refill medical auto-menders."
 	icon = 'icons/obj/chemical.dmi'
 	initial_volume = 200
-	initial_reagents = "nicotine"
 	// item_state = "ecigrefill"
 	icon_state = "mender-refill"
-	flags = TABLEPASS
+	flags = TABLEPASS | OPENCONTAINER
 	var/image/fluid_image
+	var/list/whitelist = list()
 
 	New()
 		. = ..()
+		src.whitelist = chem_whitelist
 
 		src.AddComponent( \
 			/datum/component/reagent_overlay, \
@@ -708,6 +709,16 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/mender_refill_cartridge)
 			reagent_overlay_states = 4, \
 			reagent_overlay_scaling = RC_REAGENT_OVERLAY_SCALING_LINEAR, \
 		)
+
+	on_reagent_change(add)
+		..()
+		if (src.reagents && (src.reagents.total_temperature > 330 || src.reagents.total_temperature < 270))
+			src.reagents.temperature_cap = 330
+			src.reagents.temperature_min = 270
+			src.reagents.temperature_reagents(change_min = 0, change_cap = 0)
+		if (add)
+			check_whitelist(src, src.whitelist)
+		src.UpdateIcon()
 
 	proc/do_refill(var/obj/item/reagent_containers/mender, var/mob/user)
 		if (src?.reagents.total_volume > 0)

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -470,17 +470,17 @@ TYPEINFO(/obj/item/reagent_containers/mender)
 		if (!tampered && islist(chem_whitelist) && length(chem_whitelist))
 			src.whitelist = chem_whitelist
 		if (src.reagents)
-			src.reagents.temperature_cap = 330
-			src.reagents.temperature_min = 270
+			src.reagents.temperature_cap = T20C
+			src.reagents.temperature_min = T0C
 			src.reagents.temperature_reagents(change_min = 0, change_cap = 0)
 		if(borg)
 			src.flags &= ~ACCEPTS_MOUSEDROP_REAGENTS
 
 	on_reagent_change(add)
 		..()
-		if (src.reagents && (src.reagents.total_temperature > 330 || src.reagents.total_temperature < 270))
-			src.reagents.temperature_cap = 330
-			src.reagents.temperature_min = 270
+		if (src.reagents && (src.reagents.total_temperature > T20C || src.reagents.total_temperature < T0C))
+			src.reagents.temperature_cap = T20C
+			src.reagents.temperature_min = T0C
 			src.reagents.temperature_reagents(change_min = 0, change_cap = 0)
 		if (!tampered && add)
 			check_whitelist(src, src.whitelist)
@@ -712,9 +712,9 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/mender_refill_cartridge)
 
 	on_reagent_change(add)
 		..()
-		if (src.reagents && (src.reagents.total_temperature > 330 || src.reagents.total_temperature < 270))
-			src.reagents.temperature_cap = 330
-			src.reagents.temperature_min = 270
+		if (src.reagents && (src.reagents.total_temperature > T20C || src.reagents.total_temperature < T0C))
+			src.reagents.temperature_cap = T20C
+			src.reagents.temperature_min = T0C
 			src.reagents.temperature_reagents(change_min = 0, change_cap = 0)
 		if (add)
 			check_whitelist(src, src.whitelist)

--- a/code/obj/machinery/manufacturer_subtypes.dm
+++ b/code/obj/machinery/manufacturer_subtypes.dm
@@ -227,6 +227,7 @@ TYPEINFO(/obj/machinery/manufacturer/general/grody)
 		/datum/manufacture/hypospray,
 		/datum/manufacture/patch,
 		/datum/manufacture/mender,
+		/datum/manufacture/mender_refill_cartridge,
 		/datum/manufacture/penlight,
 		/datum/manufacture/stethoscope,
 		/datum/manufacture/empty_autoinjector/orange,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows adding chems directly to mender refill cartridges, using the mender whitelist. Also adds a recipe to print empty cartridges to medical fabricators.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This lets medical staff (primarily pharmacists) create custom mender mixes that are easy to use/share. Notably useful for EG botany mailing synthflesh or omnizine over, and stuffing it in cartridges instead of leaving it on the floor due to not having any beakers.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Printed and refilled the cartridges with various whitelisted/non-whitelisted chemicals and it behaved appropriately. Also made sure the only way to remove chems from them was to refill a mender (aka no using them like budget beakers). The generic brute/burn refills worked properly as well.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Asterion0
(+)Mender refill cartridges can be refilled with whitelisted chemicals, and empty cartridges can now be printed at medical fabricators.
```
