### PR TITLE
Prevent meteors from destroying artifacts instead of damaging

### DIFF
--- a/code/obj/artifacts/artifacts.dm
+++ b/code/obj/artifacts/artifacts.dm
@@ -43,7 +43,6 @@
 
 	meteorhit(obj/O as obj)
 		src.ArtifactStimulus("force", 60)
-		..()
 
 	examine()
 		. = list("You have no idea what this thing is!")
@@ -165,7 +164,6 @@
 
 	meteorhit(obj/O as obj)
 		src.ArtifactStimulus("force", 60)
-		..()
 
 	ex_act(severity)
 		switch(severity)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR prevents the `meteorhit` proc within artifacts from calling its parent proc within `/atom`, which was causing the artifact to get qdel'd instead of following the normal process of taking damage, as the code seemed to intend.

Additionally, this prevents (at least some occurrences of) a runtime error that was getting triggered sporadically on round start:
`Cannot read null.activated` - `code/datums/controllers/artifact_controls.dm:270`
This was occurring due to a signal triggering the `Artifact_chapel_block` proc, even after the artifact itself ceased to exist, and could probably do with some further investigation outside of this PR.

This change will only impact interactions between meteors and artifacts.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It makes the interaction between artifacts and meteors consistent with the original intentions of the code, as well as removing a source of a runtime error.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Multiple rounds were started locally and it was validated that meteors could hit artifacts and no longer immediately qdel them.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Zeabus
(+)Artifacts will no longer get immediately obliterated by meteors.
```
