### PR TITLE
Fix control unit jumping to PC 6 when outputting

### DIFF
--- a/code/modules/mechanics/MechanicMC14500.dm
+++ b/code/modules/mechanics/MechanicMC14500.dm
@@ -252,14 +252,12 @@ function update_mem_lights(mem)
 					if (lastSignal)
 						lastSignal.signal = "[.]:[RR ? 1 : 0]"
 						SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_MSG,lastSignal)
-						program_counter = INSTRUCTIONS_PER_PROCESS
 						lastSignal = null
 						if (src.dbgmode)
 							boutput(world, "OUTe: [.]:[RR ? 1 : 0]")
 
 					else
 						SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL,"[.]:[RR ? 1 : 0]")
-						program_counter = INSTRUCTIONS_PER_PROCESS
 						if (src.dbgmode)
 							boutput(world, "OUT: [.]:[RR ? 1 : 0]")
 
@@ -277,14 +275,12 @@ function update_mem_lights(mem)
 					if (lastSignal)
 						lastSignal.signal = "[.]:[RR ? 0 : 1]"
 						SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_MSG,lastSignal)
-						program_counter = INSTRUCTIONS_PER_PROCESS
 						lastSignal = null
 						if (src.dbgmode)
 							boutput(world, "OUTe: [.]:[RR ? 0 : 1]")
 
 					else
 						SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL,"[.]:[RR ? 0 : 1]")
-						program_counter = INSTRUCTIONS_PER_PROCESS
 						if (src.dbgmode)
 							boutput(world, "OUT: [.]:[RR ? 0 : 1]")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes a few cases where the program counter was set when it shouldn't be

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently very difficult to construct programs when any instance of outputting a value resets the program counter to instruction 6.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

The problem can very easily be observed with the following ROM:

```
IEN 0 // align infinite loop
OEN 0 // enable output
NOP // align infinite loop
SKZ // all SKZ instructions are meant to skip an infinite loop
OR 0 // enable the infinite loop, only happens if this instruction is jumped to
SKZ
STO 8 // visible output from being inside the infinite loop
SKZ
JMP 0 // loop to OR 0
STO 0 // output "0:0"
```

Which compiles to `A0B000E050E088E0C080`.

This program *should* never stop outputting `0:0`. The first execution would enable output, skip over each instruction of the loop, and hit `STO 0`, at which point it will jump back to the beginning and do the same thing again.

Currently, the program counter is set to 6 whenever the control unit sends a signal (which is then incremented by 2). This leads to the instruction  which forces the program to execute the infinite loop, trapping it and preventing any more output. 

With this fix, the expected behavior occurs and the program continues to output `0:0` forever.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Walnut356
(+)Fixed Control Unit execution jumping to offset 6 when outputting a signal
```
