### PR TITLE
Movement Component outputs movement direction when stepping

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -4714,7 +4714,10 @@ ADMIN_INTERACT_PROCS(/obj/item/mechanics/trigger/button, proc/press)
 		if (!walk_check(S))
 			return
 		set_glide_size(S)
-		step(S, direction, (32 / move_lag) * world.tick_lag)
+		if (step(S, direction, (32 / move_lag) * world.tick_lag))
+			SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL,"[direction]")
+		else
+			SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL,"0")
 		UnregisterSignal(S, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_SET_LOC))
 
 	/// set our glide size in case it was changed


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Each time a movement component takes a step, it outputs the step direction. If it was unable to take a step (i.e. its movement was blocked), it outputs `0` (the same signal as its `stop` input)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's very difficult to make things with the movement component that aren't manually controlled because you can't be sure any movement commands actually worked. With this output, you can e.g. Dispatch Component to try to path around the obstacle, or intentionally follow along a perimeter wall. 

This doesn't include output for the `walk` command because 1. the `walk` function doesn't return a convenient "success" variable like `step` does so I'd have no idea how to implement that and 2. if you're using `walk`, the assumption can be made that regardless of whether the previous step was a success, you still want to keep moving in the same direction you were already moving in.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://imgur.com/q2PxvSe

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Walnut356
(+)When stepping, Movement Component now outputs a signal with the result of the step.
```
