### PR TITLE
Vampire bite kills if the victim is drained of all blood

### DIFF
--- a/code/modules/antagonists/vampire/abilities/blood_steal.dm
+++ b/code/modules/antagonists/vampire/abilities/blood_steal.dm
@@ -118,8 +118,6 @@
 		if (state == ACTIONSTATE_RUNNING)
 			if (HH.blood_volume <= 0)
 				boutput(M, SPAN_ALERT("[HH] doesn't have enough blood left to drink."))
-			else if (!H.can_take_blood_from(H, HH))
-				boutput(M, SPAN_ALERT("You have drank your fill [HH]'s blood. It tastes all bland and gross now."))
 			else
 				boutput(M, SPAN_ALERT("Your feast was interrupted."))
 

--- a/code/modules/antagonists/vampire/abilities/vampire_bite.dm
+++ b/code/modules/antagonists/vampire/abilities/vampire_bite.dm
@@ -1,21 +1,6 @@
 /datum/abilityHolder/vampire/var/list/blood_tally
 /datum/abilityHolder/vampire/var/const/max_take_per_mob = 250
 
-/datum/abilityHolder/vampire/proc/tally_bite(var/mob/living/carbon/human/target, var/blood_amt_taken)
-	if (!src.blood_tally)
-		src.blood_tally = list()
-
-	if (!(target in src.blood_tally))
-		src.blood_tally[target] = 0
-
-	src.blood_tally[target] += blood_amt_taken
-
-/datum/abilityHolder/vampire/proc/can_take_blood_from(var/mob/living/carbon/human/target)
-	.= 1
-	if (src.blood_tally)
-		if (target in src.blood_tally)
-			.= src.blood_tally[target] < max_take_per_mob
-
 
 /datum/abilityHolder/vampire/proc/can_bite(var/mob/living/carbon/human/target, is_pointblank = TRUE)
 	var/datum/abilityHolder/vampire/holder = src
@@ -59,9 +44,6 @@
 		boutput(M, SPAN_ALERT("Drink monkey blood?! That's disgusting!"))
 		return FALSE
 
-	if (!holder.can_take_blood_from(target))
-		return FALSE
-
 	if (isnpc(target))
 		boutput(M, SPAN_ALERT("The blood of this target would provide you with no sustenance."))
 		return FALSE
@@ -85,7 +67,6 @@
 		var/bitesize = 5 * mult
 		H.change_vampire_blood(bitesize, 1, victim = HH)
 		H.change_vampire_blood(bitesize, 0, victim = HH)
-		H.tally_bite(HH,bitesize)
 		if (HH.blood_volume < 20 * mult)
 			HH.blood_volume = 0
 		else
@@ -110,7 +91,6 @@
 
 				H.change_vampire_blood(bitesize, 0, victim = HH)
 				H.change_vampire_blood(bitesize, 1, victim = HH)
-				H.tally_bite(HH,bitesize)
 				if (prob(50))
 					boutput(M, SPAN_ALERT("This is the blood of a fellow vampire!"))
 			else
@@ -121,7 +101,6 @@
 			var/bitesize = 10 * mult
 			H.change_vampire_blood(bitesize, 1, victim = HH)
 			H.change_vampire_blood(bitesize, 0, victim = HH)
-			H.tally_bite(HH,bitesize)
 			if (HH.blood_volume < 20 * mult)
 				HH.blood_volume = 0
 			else
@@ -144,7 +123,7 @@
 						HH.changeStatus("knockdown", 1 SECOND)
 						HH.stuttering = min(HH.stuttering + 3, 10)
 
-	if (!can_take_blood_from(HH) && (mult >= 1) && isunconscious(HH))
+	if (HH.blood_volume <= 100 && (mult >= 1))
 		boutput(HH, SPAN_ALERT("You feel your soul slipping away..."))
 		HH.death(FALSE)
 
@@ -289,7 +268,7 @@
 						HH.changeStatus("knockdown", 1 SECOND)
 						HH.stuttering = min(HH.stuttering + 3, 10)
 
-	if (!can_take_blood_from(HH) && (mult >= 1) && isunconscious(HH))
+	if (HH.blood_volume <= 100 && (mult >= 1))
 		boutput(HH, SPAN_ALERT("You feel your soul slipping away..."))
 		HH.death(FALSE)
 
@@ -424,8 +403,6 @@
 		if (state == ACTIONSTATE_RUNNING)
 			if (HH.blood_volume < 0)
 				boutput(M, SPAN_ALERT("[HH] doesn't have enough blood left to drink."))
-			else if (!H.can_take_blood_from(H, HH))
-				boutput(M, SPAN_ALERT("You have drank your fill [HH]'s blood. It tastes all bland and gross now."))
 			else
 				boutput(M, SPAN_ALERT("Your feast was interrupted."))
 

--- a/code/modules/antagonists/vampire/abilities/vampire_bite.dm
+++ b/code/modules/antagonists/vampire/abilities/vampire_bite.dm
@@ -56,7 +56,7 @@
 	var/datum/abilityHolder/vampire/H = src
 
 
-	if (HH.blood_volume <= 0)
+	if (HH.blood_volume <= 0 && isdead(HH))
 		boutput(M, SPAN_ALERT("This human is completely void of blood... Wow!"))
 		return 0
 
@@ -207,7 +207,7 @@
 	var/datum/abilityHolder/vampiric_thrall/H = src
 
 
-	if (HH.blood_volume <= 0)
+	if (HH.blood_volume <= 0 && isdead(HH))
 		boutput(M, SPAN_ALERT("This human is completely void of blood... Wow!"))
 		return 0
 

--- a/code/modules/antagonists/vampire/abilities/vampire_bite.dm
+++ b/code/modules/antagonists/vampire/abilities/vampire_bite.dm
@@ -123,7 +123,7 @@
 						HH.changeStatus("knockdown", 1 SECOND)
 						HH.stuttering = min(HH.stuttering + 3, 10)
 
-	if (HH.blood_volume <= 100 && (mult >= 1))
+	if (HH.blood_volume <= 0 && (mult >= 1))
 		boutput(HH, SPAN_ALERT("You feel your soul slipping away..."))
 		HH.death(FALSE)
 
@@ -268,7 +268,7 @@
 						HH.changeStatus("knockdown", 1 SECOND)
 						HH.stuttering = min(HH.stuttering + 3, 10)
 
-	if (HH.blood_volume <= 100 && (mult >= 1))
+	if (HH.blood_volume <= 0 && (mult >= 1))
 		boutput(HH, SPAN_ALERT("You feel your soul slipping away..."))
 		HH.death(FALSE)
 

--- a/code/modules/antagonists/vampire/abilities/vampire_bite.dm
+++ b/code/modules/antagonists/vampire/abilities/vampire_bite.dm
@@ -1,7 +1,3 @@
-/datum/abilityHolder/vampire/var/list/blood_tally
-/datum/abilityHolder/vampire/var/const/max_take_per_mob = 250
-
-
 /datum/abilityHolder/vampire/proc/can_bite(var/mob/living/carbon/human/target, is_pointblank = TRUE)
 	var/datum/abilityHolder/vampire/holder = src
 	var/mob/living/M = holder.owner
@@ -135,23 +131,6 @@
 	HH.was_harmed(M, special = "vamp")
 	bleed(HH, 1, 3, get_turf(src.owner))
 
-/datum/abilityHolder/vampiric_thrall/var/list/blood_tally
-/datum/abilityHolder/vampiric_thrall/var/const/max_take_per_mob = 250
-
-/datum/abilityHolder/vampiric_thrall/proc/can_take_blood_from(var/mob/living/carbon/human/target)
-	.= 1
-	if (src.blood_tally)
-		if (target in src.blood_tally)
-			.= src.blood_tally[target] < max_take_per_mob
-
-/datum/abilityHolder/vampiric_thrall/proc/tally_bite(var/mob/living/carbon/human/target, var/blood_amt_taken)
-	if (!src.blood_tally)
-		src.blood_tally = list()
-
-	if (!(target in src.blood_tally))
-		src.blood_tally[target] = 0
-
-	src.blood_tally[target] += blood_amt_taken
 
 /datum/abilityHolder/vampiric_thrall/proc/can_bite(var/mob/living/carbon/human/target, is_pointblank = 1)
 	var/datum/abilityHolder/vampiric_thrall/holder = src
@@ -195,17 +174,11 @@
 		boutput(M, SPAN_ALERT("Drink monkey blood?! That's disgusting!"))
 		return 0
 
-	if (!holder.can_take_blood_from(target))
-		return 0
-
-
 	return 1
 
 /datum/abilityHolder/vampiric_thrall/proc/do_bite(var/mob/living/carbon/human/HH, var/mult = 1)
 	.= 1
 	var/mob/living/carbon/human/M = src.owner
-	var/datum/abilityHolder/vampiric_thrall/H = src
-
 
 	if (HH.blood_volume <= 0 && isdead(HH))
 		boutput(M, SPAN_ALERT("This human is completely void of blood... Wow!"))
@@ -218,7 +191,6 @@
 		var/bitesize = 5 * mult
 		M.change_vampire_blood(bitesize, 1, victim = HH)
 		M.change_vampire_blood(bitesize, 0, victim = HH)
-		H.tally_bite(HH,bitesize)
 		if (HH.blood_volume < 20 * mult)
 			HH.blood_volume = 0
 		else
@@ -242,7 +214,6 @@
 
 				M.change_vampire_blood(bitesize, 0, victim = HH)
 				M.change_vampire_blood(bitesize, 1, victim = HH)
-				H.tally_bite(HH,bitesize)
 				if (prob(50))
 					boutput(M, SPAN_ALERT("This is the blood of a fellow vampire!"))
 			else
@@ -253,7 +224,6 @@
 			var/bitesize = 10 * mult
 			M.change_vampire_blood(bitesize, 1, victim = HH)
 			M.change_vampire_blood(bitesize, 0, victim = HH)
-			H.tally_bite(HH,bitesize)
 			if (HH.blood_volume < 20 * mult)
 				HH.blood_volume = 0
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
See title, vampire or thrall direct bits will now instantly kill the victim if they are at 0 blood volume.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is a change from the previous system where each vampire's holder kept a list of all their victims and how much blood they've had drained, then it would instantly kill them when the value passed 250, but only if they were unconscious.
????
This change makes fully draining someone much more immediately lethal and prevents both the awkward situation of someone being completely devoid of blood but still taking ages to actually die, and the situation where someone could be instantly killed by the first vampire bite if they had been drained previously.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Staffie died as expected when drained.
Not dead staffie being drained with ranged blood steal:
<img width="306" height="422" alt="image" src="https://github.com/user-attachments/assets/76979cec-d1f8-4f4e-a7fc-255d31165dff" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Vampire bite now instantly kills the victim when they are fully drained of blood.
```
