### PR TITLE
Makes the Blood Fish actually fishable and adds behavior to it

### DIFF
--- a/code/modules/fishing/fish.dm
+++ b/code/modules/fishing/fish.dm
@@ -60,6 +60,7 @@ Alien/mutant/other fish:
 	Implemented:
 		Meat mutant
 		Eye fish
+		Blood fish
 		Void fish
 		Sun fish
 		Blobfish
@@ -71,8 +72,6 @@ Alien/mutant/other fish:
 		Origami fish
 		Cardboard fish
 		Starstonefish
-	Unimplemented:
-		Blood fish
 */
 
 // These catagories aren't used currently.
@@ -699,14 +698,26 @@ TYPEINFO(/obj/item/reagent_containers/food/fish/meat_mutant)
 
 	get_scent_color()
 		return "blood red"
-/*
+
+TYPEINFO(/obj/item/reagent_containers/food/fish/blood_fish)
+	appears_in_fish_collection = TRUE
 /obj/item/reagent_containers/food/fish/blood_fish
 	name = "blood fish"
 	desc = "A viscous, gory mass of congealed blood. You're really stretching the definition of fish here."
-	icon_state = "bass_old"
-	inhand_color = "#af2323"
+	icon_state = "blood_fish"
+	inhand_color = "#9c0000"
 	rarity = ITEM_RARITY_RARE
-*/
+	slice_product = /obj/item/reagent_containers/food/snacks/condiment/ketchup
+	slice_amount = 2
+	brew_result = list("blood"=20)
+
+	get_scent_color()
+		return "blood red"
+
+	make_reagents()
+		src.reagents.add_reagent("blood", 20)
+		return
+
 TYPEINFO(/obj/item/reagent_containers/food/fish/eye_mutant)
 	appears_in_fish_collection = TRUE
 /obj/item/reagent_containers/food/fish/eye_mutant

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -585,6 +585,7 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/mob/living/critter/blobman = 5,\
 	/mob/living/critter/blobman/meat = 5,\
 	/obj/item/reagent_containers/food/fish/eye_mutant = 15,\
+	/obj/item/reagent_containers/food/fish/blood_fish = 15,\
 	/obj/item/reagent_containers/food/fish/lingfish = 5,\
 	/obj/decal/cleanable/blood/gibs = 25,\
 	/obj/decal/cleanable/blood/gibs/core = 25)
@@ -613,6 +614,7 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	fishing_atom_type = /obj/machinery/clonepod
 	rod_tier_required = 2
 	fish_available = list(/obj/item/reagent_containers/food/fish/meat_mutant = 10,\
+	/obj/item/reagent_containers/food/fish/blood_fish = 5,\
 	/mob/living/critter/blobman = 5,\
 	/mob/living/critter/blobman/meat = 5,\
 	/obj/item/parts/human_parts/arm/left = 10,\
@@ -954,7 +956,8 @@ datum/fishing_spot/golden_toilet
 	fishing_atom_type = /obj/item/reagent_containers/applicator/condiment/bottle/ketchup
 	rod_tier_required = 3
 	fish_available = list(/obj/item/reagent_containers/food/snacks/condiment/ketchup = 50,\
-	/obj/item/reagent_containers/food/snacks/yuck = 20)
+	/obj/item/reagent_containers/food/snacks/yuck = 20,\
+	/obj/item/reagent_containers/food/fish/blood_fish = 1,) //but of course!
 
 /datum/fishing_spot/mustard
 	fishing_atom_type = /obj/item/reagent_containers/applicator/condiment/bottle/mustard
@@ -1000,6 +1003,7 @@ datum/fishing_spot/golden_toilet
 	fish_available = list(/obj/decal/cleanable/blood/gibs = 25,\
 	/obj/decal/cleanable/blood/gibs/core = 25,\
 	/obj/item/reagent_containers/food/fish/meat_mutant = 10,\
+	/obj/item/reagent_containers/food/fish/blood_fish = 5,\
 	/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat = 10,\
 	/obj/item/clothing/glasses/blindfold = 5,\
 	/obj/item/parts/human_parts/arm/mutant/monkey/left = 5,\


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR
Makes the aforementioned fish acquirable in game, and adds behavior to it.

## Why's this needed?
A sprite was done for it by j3kchad, and this is the second part of the implementation.

## Testing
The fish was successfully fished and sliced into the supposed product.

## Changelog 

```changelog
(u)TekoTheTeapot
(*)Makes the Blood Fish actually fishable and adds behavior to it
```
