### PR TITLE
Say Message Datum `(init)` Optimisation

### DIFF
--- a/code/modules/speech/say_message.dm
+++ b/code/modules/speech/say_message.dm
@@ -89,13 +89,7 @@
 	/// The CSS values for the maptext, stored as an associative list, i.e: "font-weight" = "bold".
 	var/list/maptext_css_values = null
 	/// The variables for the maptext object, stored as an associative list, i.e: "alpha" = "140".
-	var/list/maptext_variables = list(
-		"alpha" = 255,
-		"maptext_x" = -64,
-		"maptext_y" = 34,
-		"maptext_width" = 160,
-		"maptext_height" = 48,
-	)
+	var/list/maptext_variables = null
 	/// A list of colours for the maptext to oscillate through. Use the "start_colour" value to determine the colour to animate from to `maptext_css_values["color"]`.
 	var/list/maptext_animation_colours = null
 	/// A list of callback datums to be invoked, with the message itself as the first argument and the maptext image created by this message as the second argument.
@@ -121,6 +115,13 @@
 	src.flags |= flags
 	src.atom_listeners_override = atom_listeners_override
 	src.maptext_css_values = list()
+	src.maptext_variables = list(
+		"alpha" = 255,
+		"maptext_x" = -64,
+		"maptext_y" = 34,
+		"maptext_width" = 160,
+		"maptext_height" = 48,
+	)
 
 	// Determine identification variables and the say verb to use.
 	src.last_character = copytext(src.content, length(src.content))


### PR DESCRIPTION
## About The PR:
Moves a single list initialisation from `(init)` to `New()` on `/datum/say_message`, removing the `(init)` overhead and removing the list initialisation entirely from `Copy()`. This could have been a direct commit, but I wanted a PR so I could attach profiler statistics to the commit.


## Testing:
<img width="1596" height="886" alt="image" src="https://github.com/user-attachments/assets/245903b0-f098-4ac1-b3a7-fd0da9c15b4b" />

​
The overhead from this proc has been removed:
<img width="946" height="629" alt="image" src="https://github.com/user-attachments/assets/d328a9e5-1e93-41e8-a646-65b150d61514" />