### PR TITLE
Being prevented from teleporting by magboots now tells you why

### DIFF
--- a/code/modules/telescience/teleporter_old.dm
+++ b/code/modules/telescience/teleporter_old.dm
@@ -211,6 +211,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/teleport/portal_generator, proc/engage, proc
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.shoes?.magnetic)
+			H.show_text("You are anchored to the floor!")
 			return 1
 
 	if (ismob(destination.loc))

--- a/code/modules/telescience/teleporter_old.dm
+++ b/code/modules/telescience/teleporter_old.dm
@@ -211,7 +211,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/teleport/portal_generator, proc/engage, proc
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.shoes?.magnetic)
-			H.show_text("You are anchored to the floor!")
+			boutput(H, SPAN_ALERT("Your magnetic boots anchor you to the ground, preventing you from teleporting!"))
 			return 1
 
 	if (ismob(destination.loc))

--- a/code/obj/portal.dm
+++ b/code/obj/portal.dm
@@ -26,6 +26,7 @@
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.shoes?.magnetic)
+			H.show_text("You are anchored to the floor!")
 			return
 	SPAWN(0)
 		src.teleport(M)
@@ -36,6 +37,7 @@
 	if (ishuman(mover))
 		var/mob/living/carbon/human/H = mover
 		if(H.shoes?.magnetic)
+			H.show_text("You are anchored to the floor!")
 			return FALSE
 	. = ..()
 

--- a/code/obj/portal.dm
+++ b/code/obj/portal.dm
@@ -26,7 +26,7 @@
 	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.shoes?.magnetic)
-			H.show_text("You are anchored to the floor!")
+			boutput(H, SPAN_ALERT("Your magnetic boots anchor you to the ground, preventing you from teleporting!"))
 			return
 	SPAWN(0)
 		src.teleport(M)
@@ -37,7 +37,6 @@
 	if (ishuman(mover))
 		var/mob/living/carbon/human/H = mover
 		if(H.shoes?.magnetic)
-			H.show_text("You are anchored to the floor!")
 			return FALSE
 	. = ..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[A-Game-Objects] [C-QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If you try to step through a portal while wearing magboots, you are not allowed to go through. Previously, this would simply make the portal act like a wall without telling the player why. Now a message is output reminding them they are anchored.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's pretty easy to completely forget you have your magboots activated. I once got so confused why I couldn't go through a portal I prayed for help. The admin that responded also could not figure out why the portal wouldn't work. I think this shows that a small message is needed.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="559" height="57" alt="image" src="https://github.com/user-attachments/assets/562ea440-561e-4f99-ac42-decc94901b23" />
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

