### PR TITLE
Lesbian Flags As Fishing Bait

### DIFF
--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -26,7 +26,7 @@
 	New()
 		..()
 		RegisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE, PROC_REF(attackby_pre))  // Storage for a single lure item
-		src.create_storage(/datum/storage, can_hold = list(/obj/item/reagent_containers/food), max_wclass = W_CLASS_NORMAL, slots = 1)
+		src.create_storage(/datum/storage, can_hold = list(/obj/item/reagent_containers/food, /obj/item/flag/), max_wclass = W_CLASS_NORMAL, slots = 1)
 
 	disposing()
 		UnregisterSignal(src, COMSIG_ITEM_ATTACKBY_PRE)

--- a/code/modules/fishing/fishing_lootpools.dm
+++ b/code/modules/fishing/fishing_lootpools.dm
@@ -102,3 +102,14 @@
 /datum/fishing_lootpool/igneous_fish
 	minimum_rod_tier = 2
 	fish_available = list(/obj/item/reagent_containers/food/fish/igneous_fish = 10)
+
+///Pride themed fishing loot!
+/datum/fishing_lootpool/pride_loot
+	minimum_rod_tier = 2
+	required_lure = /obj/item/flag/
+	fish_available = list(/obj/item/reagent_containers/food/fish/red_herring = 5,\
+	/obj/item/reagent_containers/food/fish/rainbow_trout = 15,\
+	/obj/item/clothing/suit/flag/lesb = 8,\
+	/obj/item/clothing/under/pride/lesb = 7,\
+	/obj/item/clothing/head/lesbian_hat = 15
+	)

--- a/code/modules/fishing/fishing_spots.dm
+++ b/code/modules/fishing/fishing_spots.dm
@@ -121,6 +121,10 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/sardine = 20,
 	/obj/item/reagent_containers/food/fish/anchovy = 10)
 
+/datum/fishing_spot/sea/New()
+	..()
+	src.fishing_lootpools += new /datum/fishing_lootpool/pride_loot(src)
+
 /datum/fishing_spot/swamp
 	fishing_atom_type = /turf/unsimulated/floor/auto/swamp
 	rod_tier_required = 1
@@ -458,6 +462,10 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/mob/living/critter/small_animal/snake = 10,\
 	/mob/living/critter/small_animal/frog = 10)
 
+/datum/fishing_spot/river/New()
+	..()
+	src.fishing_lootpools += new /datum/fishing_lootpool/pride_loot(src)
+
 /datum/fishing_spot/plantpot
 	fishing_atom_type = /obj/machinery/plantpot
 	rod_tier_required = 1
@@ -576,6 +584,7 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 /datum/fishing_spot/drain/New()
 	..()
 	src.fishing_lootpools += new /datum/fishing_lootpool/real_goldfish(src)
+	src.fishing_lootpools += new /datum/fishing_lootpool/pride_loot(src)
 
 // Alien/mutant fishing spots
 /datum/fishing_spot/meatzone_acid
@@ -708,6 +717,10 @@ ABSTRACT_TYPE(/datum/fishing_spot)
 	/obj/item/reagent_containers/food/fish/shrimp = 15,\
 	/obj/item/reagent_containers/food/fish/sardine = 20,\
 	/obj/item/reagent_containers/food/fish/glassfish = 10)
+
+/datum/fishing_spot/biodome_lake/New()
+	..()
+	src.fishing_lootpools += new /datum/fishing_lootpool/pride_loot(src)
 
 //ainsley
 /datum/fishing_spot/nuclear_core_decal


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the ability for fishing rods to use lesbian flags as a form of fishing bait, to catch some semi-related items. Locations include Rivers, Oceans, Drains, and the Biodome Lake.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a fun and silly expansion for fishing using bait! Beyond just that, it's one of very few ways to get the lesbian hat, which is nice.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Fished a bunch in drains, rivers, spawned in cenotes/oceans, and all worked as they should. Fishing rods hold flags, food, and nothing else.
Flags being able to be in fishing rods:
<img width="721" height="172" alt="image" src="https://github.com/user-attachments/assets/1414a659-2d56-4585-8492-8a3536d3bd92" />
Various different fish obtained by fishing in a drain using an upgraded fishing rod:
<img width="376" height="355" alt="image" src="https://github.com/user-attachments/assets/b105d7ca-1e20-4fff-9d10-0be15ed7e327" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Asterion0
(+)Lesbian flags can be used as bait in fishing rods to fish up related items.
```
