### PR TITLE
contraband lockers are no longer reinforced

### DIFF
--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -443,7 +443,6 @@
 	close_sound = 'sound/misc/safe_close.ogg'
 	_max_health = LOCKER_HEALTH_STRONG
 	_health = LOCKER_HEALTH_STRONG
-	reinforced = TRUE
 	bolted = TRUE
 	spawn_contents = list(/obj/item/item_box/contraband)
 	radiation_protection = 20


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the reinforced flag from contraband lockers, making them able to be broken open with melee weapons and weaker guns

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If you know how, getting into a contraband locker is fairly easy. The easiest method is to put it where the diner shuttle spawns then call it to the station, which destroys the locker. This is a very obscure game mechanic, as are pretty much all the other ways to get in. However, if you do not know one of these methods, you are forced to use antag gear, which you might have already spent all your TC on and had it confiscated.
Since it's already pretty easy for a knowledgable antag to get their gear back, it should probably be easy for a less knowledgable player to do so as well.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Bashed a contraband locker open with a fire extinguisher.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)grasswitch
(*)Contraband lockers are now easier to break open. They were made by the lowest bidder, after all...
```
