### PR TITLE
Makes pineapple iced matcha slightly heal gen Z

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -4877,6 +4877,16 @@ datum
 			description = "Tangy, yet refreshingly earthy."
 			reagent_state = LIQUID
 
+			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
+				. = ..()
+				if (!M)
+					M = holder.my_atom
+				if(istype(M, /mob/living/carbon/human))
+					var/mob/living/carbon/human/H = M
+					if (H.bioHolder.age < 57 && H.bioHolder.age > 41)
+						H.take_toxin_damage(-1)
+
+
 		fooddrink/caffeinated/thaicoffee
 			name = "Thai iced coffee"
 			id = "thaiicedcoffee"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes pineapple matcha heal individuals between the ages of 57 and 41 by 1 TOX when ingested. These age ranges correlate to how old people of generation Z will be in 2053. This is meant to be a reference to how matcha is often associated with generation Z.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I don't like redundant chems. Pineapple iced matcha is currently identical to matcha tea even though it is very slightly more involved to make.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

I went into a test station drank a bunch of toxin, then flushed it when I had sufficient tox damage. I then drank pineapple matcha and didn't get healed. I set my age to 45 and tried again, this time it healed me. 
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)A.I.The Artificial Idiot
(+)Makes pineapple iced matcha heal people in the generation z age range by 1 TOX on ingest.
```
