### PR TITLE
[DEVTEST] Added the missing common manufacturers to devtest's manufacturing room

### DIFF
--- a/maps/utilities/devtest.dmm
+++ b/maps/utilities/devtest.dmm
@@ -315,6 +315,10 @@
 /obj/landmark/antagonist/blob,
 /turf/unsimulated/floor/blue,
 /area/station/devzone)
+"gk" = (
+/obj/machinery/manufacturer/general,
+/turf/simulated/floor,
+/area/station/devzone)
 "gF" = (
 /obj/machinery/teleport/portal_ring,
 /obj/item/hand_tele{
@@ -698,6 +702,10 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/devzone)
+"mI" = (
+/obj/machinery/manufacturer/science,
+/turf/simulated/floor,
+/area/station/devzone)
 "mQ" = (
 /obj/disposalpipe/segment/mail/bent/west,
 /turf/simulated/floor/plating/jen,
@@ -946,6 +954,10 @@
 /obj/item/grinder_upgrade,
 /turf/simulated/floor/blue/checker,
 /area/station/devzone)
+"qd" = (
+/obj/machinery/manufacturer/hangar,
+/turf/simulated/floor,
+/area/station/devzone)
 "qg" = (
 /obj/forcefield/energyshield/perma,
 /obj/landmark/magnet_shield,
@@ -1059,10 +1071,6 @@
 /obj/item/rocko,
 /obj/item/rcd/construction/chiefEngineer,
 /turf/unsimulated/floor/caution,
-/area/station/devzone)
-"sE" = (
-/obj/machinery/manufacturer/engineering,
-/turf/simulated/floor,
 /area/station/devzone)
 "sG" = (
 /obj/machinery/door/poddoor/pyro{
@@ -1234,6 +1242,10 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/devzone)
+"wm" = (
+/obj/machinery/manufacturer/gas,
+/turf/simulated/floor,
+/area/station/devzone)
 "wn" = (
 /obj/landmark/start/job/captain,
 /turf/simulated/floor,
@@ -1273,7 +1285,8 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/caution,
+/obj/machinery/manufacturer/engineering,
+/turf/simulated/floor,
 /area/station/devzone)
 "xp" = (
 /obj/surgery_tray,
@@ -1666,6 +1679,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/jen,
 /area/station/devzone)
 "Di" = (
@@ -2119,10 +2133,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor,
 /area/station/devzone)
-"Lm" = (
-/obj/machinery/manufacturer/robotics,
-/turf/simulated/floor,
-/area/station/devzone)
 "Ln" = (
 /obj/disposalpipe/switch_junction/left/east{
 	mail_tag = "medbay";
@@ -2436,7 +2446,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/reagent_dispensers/fueltank,
+/obj/machinery/manufacturer/robotics,
 /turf/simulated/floor,
 /area/station/devzone)
 "Ql" = (
@@ -2871,13 +2881,6 @@
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/devzone)
-"Xo" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/manufacturer/general,
-/turf/simulated/floor,
-/area/station/devzone)
 "Xx" = (
 /obj/forcefield/energyshield/perma{
 	dir = 6
@@ -2973,6 +2976,10 @@
 	name = "Exhaust Vent"
 	},
 /turf/simulated/floor/engine/vacuum,
+/area/station/devzone)
+"YO" = (
+/obj/machinery/manufacturer/personnel,
+/turf/simulated/floor,
 /area/station/devzone)
 "YU" = (
 /obj/machinery/conveyor/WE{
@@ -3974,7 +3981,7 @@ hL
 Cn
 Dh
 PX
-Xo
+Cv
 xi
 ng
 nG
@@ -4017,9 +4024,9 @@ Hk
 Hk
 Hk
 GS
+fs
 Yx
-sE
-ng
+wm
 ng
 DG
 Fg
@@ -4061,9 +4068,9 @@ Hk
 Hk
 Hk
 AA
+mI
 Yx
 zn
-ng
 ng
 nF
 Yx
@@ -4105,9 +4112,9 @@ Es
 iA
 Es
 hr
+YO
 Yx
-fs
-ng
+GZ
 ng
 UT
 Yx
@@ -4150,8 +4157,8 @@ Es
 Es
 Es
 LM
-GZ
-ng
+Yx
+qd
 ng
 Vl
 oL
@@ -4194,8 +4201,8 @@ lH
 Es
 Ea
 Xk
-Lm
-ng
+Yx
+gk
 ng
 Hy
 Yx


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a the missing manufacturers that can be found on all stations to dev test's manufacturing area.
Yes im aware the medbay has the medical manufacturers as well but i think its better for testing to have all of them at the same area

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Im doing a lot of changes to manufacturers (new categories for debloating) and want to test it waaaa
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="441" height="214" alt="image" src="https://github.com/user-attachments/assets/3b4535da-5f10-4cef-8282-bad7659101be" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

no log for devtest!!
