### PR TITLE
extends pre-round time by 2 minutes

### DIFF
--- a/_std/setup.dm
+++ b/_std/setup.dm
@@ -107,7 +107,7 @@ var/ZLOG_START_TIME
 #endif
 
 //Amount of 1 Second ticks to spend in the pregame lobby before roundstart. Has been 150 seconds for a couple years.
-#define PREGAME_LOBBY_TICKS 180	// raised from 120 to 180 to accomodate the v500 ads, then raised back down to 150 after Z5 was introduced.
+#define PREGAME_LOBBY_TICKS 300	// raised from 180 to 300 by popular demand
 
 //The value of mapvotes. A passive vote is one done through player preferences, an active vote is one where the player actively chooses a map
 #define MAPVOTE_PASSIVE_WEIGHT 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[QoL][Experimental][Input Wanted][Respawning]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR extends the initial round delay by 120 1-second ticks, making it 5 Minutes long in total. The mapvote still starts 60 seconds before roundstart, and the reminder happens at 30 seconds before roundstart still.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Several people have expressed their desire for a longer round timer in [this forum thread](https://forum.ss13.co/showthread.php?tid=25206), these benefits and drawbacks were mentioned:
### Pros (+) and Cons (-):
- **(+)** It gives people more time to talk in post-/preround chat
- **(+)** People can take longer breaks, allowing them to grab a drink or a snack
- **(+)** The join window for new rounds is increased, making it easier for people who want to join the next round to do so (even if hit by the fateful 30-second connection delay timer)
- **(-)** Possible waste of time/boredom to some players [only mentioned by two (?) people in the thread above] 
### Alternative Options/Additions:
- Timer decreases when more people ready up (**(+)** Less boredom, **(-)** People leave desk at 4 minutes remaining for 2 minutes, come back to see the timer at 30 seconds)
- Add a pre-round chat area for people to spawn in and talk to eachother OOC (**(+)** Easier chat readability, **(-)** I'd need help with implementation) 
-  Make it RP only
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Started the game, it took about 300 seconds from first load to roundstart, countdown worked properly. Roundend, too, worked properly.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chasu
(f)https://forum.ss13.co/showthread.php?tid=25277
(*)The timer before the start of the round has been extended by two minutes
```
