### PR TITLE
Migrated rcd charges & general manufacturer ammo to the ammo category

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -414,7 +414,7 @@
 	item_outputs = list(/obj/item/ammo/bullets/a38/stun)
 	create = 1
 	time = 20 SECONDS
-	category = MANUFACTURER::CATEGORY::RESOURCE
+	category = MANUFACTURER::CATEGORY::AMMO
 
 /datum/manufacture/bullet_22
 	name = ".22 Bullets"
@@ -423,7 +423,7 @@
 	item_outputs = list(/obj/item/ammo/bullets/bullet_22)
 	create = 1
 	time = 30 SECONDS
-	category = MANUFACTURER::CATEGORY::RESOURCE
+	category = MANUFACTURER::CATEGORY::AMMO
 
 /datum/manufacture/bullet_9mm_frangible
 	name = "9mm Frangible Rounds"
@@ -434,7 +434,7 @@
 	item_outputs = list(/obj/item/ammo/bullets/nine_mm_NATO)
 	create = 1
 	time = 15 SECONDS
-	category = MANUFACTURER::CATEGORY::RESOURCE
+	category = MANUFACTURER::CATEGORY::AMMO
 
 /datum/manufacture/bullet_12g_nail
 	name = "12 gauge nailshot"
@@ -443,7 +443,7 @@
 	item_outputs = list(/obj/item/ammo/bullets/nails)
 	create = 1
 	time = 30 SECONDS
-	category = MANUFACTURER::CATEGORY::RESOURCE
+	category = MANUFACTURER::CATEGORY::AMMO
 
 /datum/manufacture/bullet_smoke
 	name = "40mm Smoke Grenade"
@@ -452,7 +452,7 @@
 	item_outputs = list(/obj/item/ammo/bullets/smoke)
 	create = 1
 	time = 35 SECONDS
-	category = MANUFACTURER::CATEGORY::RESOURCE
+	category = MANUFACTURER::CATEGORY::AMMO
 
 /datum/manufacture/extinguisher
 	name = "Fire Extinguisher"
@@ -1056,7 +1056,7 @@
 	item_outputs = list(/obj/item/rcd_ammo)
 	create = 1
 	time = 10 SECONDS
-	category = MANUFACTURER::CATEGORY::RESOURCE
+	category = MANUFACTURER::CATEGORY::AMMO
 
 /datum/manufacture/RCDammomedium
 	name = "Medium Compressed Matter Cartridge"
@@ -1064,7 +1064,7 @@
 	item_outputs = list(/obj/item/rcd_ammo/medium)
 	create = 1
 	time = 20 SECONDS
-	category = MANUFACTURER::CATEGORY::RESOURCE
+	category = MANUFACTURER::CATEGORY::AMMO
 
 /datum/manufacture/RCDammolarge
 	name = "Large Compressed Matter Cartridge"
@@ -1072,7 +1072,7 @@
 	item_outputs = list(/obj/item/rcd_ammo/big)
 	create = 1
 	time = 30 SECONDS
-	category = MANUFACTURER::CATEGORY::RESOURCE
+	category = MANUFACTURER::CATEGORY::AMMO
 
 /datum/manufacture/sds
 	name = "Syndicate Destruction System"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Migrate rcd charges to the ammo category.
Migrate the ammo made in general manufacturer to the ammo category (9mm, .22, 40mm smoke)
Migrate the unused .38 stun & 22 gauge nailshot recpies to the ammo category (for parity)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
After the namespacing of manufacturing categories the unused ammo category is usable again, so why shouldnt ammo be there? 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
engineering manufacturer
<img width="921" height="580" alt="Engiemanuf" src="https://github.com/user-attachments/assets/6b6ecee1-eee1-4bd0-bc5e-ce21af5c3f3d" />

hacked general manufacturer
<img width="951" height="255" alt="genmanuf" src="https://github.com/user-attachments/assets/edcd6dfb-4d00-4c4a-8cb1-6ea1baf6a6c3" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ANNmagedon
(+)RCD Charges now show up as ammo in manufacturers
(+)Ammo found in hacked general manufacturers will now be correctly categorized
```
