### PR TITLE
XSIG Refactor

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -49,6 +49,7 @@
 #include "defines\clothingbooth.dm"
 #include "defines\combat.dm"
 #include "defines\component_defines\component_defines_atom.dm"
+#include "defines\component_defines\component_defines_complex.dm"
 #include "defines\component_defines\component_defines_datum.dm"
 #include "defines\component_defines\component_defines_global.dm"
 #include "defines\component_defines\component_defines_mechcomp.dm"

--- a/_std/defines/component_defines/_component_defines_integral.dm
+++ b/_std/defines/component_defines/_component_defines_integral.dm
@@ -7,7 +7,7 @@
 /// Arguments given here are packaged in a list and given to _SendSignal
 #define SEND_SIGNAL(target, sigtype, arguments...) ( !target?.comp_lookup || !target.comp_lookup[sigtype] ? 0 : target._SendSignal(sigtype, list(target, ##arguments)) )
 
-#define SEND_COMPLEX_SIGNAL(target, sigtype, arguments...) SEND_SIGNAL(target, sigtype[2], ##arguments)
+#define SEND_COMPLEX_SIGNAL(target, sigtype, arguments...) SEND_SIGNAL(target, (sigtype)::id, ##arguments)
 
 #define GLOBAL_SIGNAL (global.global_signal_holder ||= new()) // dummy datum that exclusively exists to hold onto global signals
 
@@ -26,7 +26,7 @@
 #define LoadComponent(arguments...) _LoadComponent(list(##arguments))
 
 /// Checks if a signal is "complex", i.e. it is handled by adding a special component and registering may have side effects and overhead
-#define IS_COMPLEX_SIGNAL(x) (length(x) == 2 && ispath(x[1], /datum/component/complexsignal))
+#define IS_COMPLEX_SIGNAL(x) ispath(x, /datum/xsig)
 
 /**
 	* Return this from `/datum/component/Initialize` or `datum/component/OnTransfer` to have the component be deleted if it's applied to an incorrect type.

--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -121,17 +121,6 @@
 	/// when an AM is revealed from under a floor tile (turf revealed from)
 	#define COMSIG_MOVABLE_FLOOR_REVEALED "mov_floor_revealed"
 
-	// ---- complex ----
-
-	/// when the outermost movable in the .loc chain changes (thing, old_outermost_movable, new_outermost_movable)
-	#define XSIG_OUTERMOST_MOVABLE_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_outermost_changed")
-	/// When the outermost movable in the .loc chain moves to a new area. (thing, old_area, new_area)
-	#define XSIG_MOVABLE_AREA_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_area_changed")
-	/// When the outermost movable in the .loc chain moves to a new turf. (thing, old_turf, new_turf)
-	#define XSIG_MOVABLE_TURF_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_turf_changed")
-	/// when the z-level of a movable changes (works in nested contents) (thing, old_z_level, new_z_level)
-	#define XSIG_MOVABLE_Z_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_z-level_changed")
-
 // ---- turf signals ----
 	/// when an atom inside the turfs contents changes opacity (turf, previous_opacity, thing)
 	#define COMSIG_TURF_CONTENTS_SET_OPACITY "turf_contents_set_opacity"

--- a/_std/defines/component_defines/component_defines_complex.dm
+++ b/_std/defines/component_defines/component_defines_complex.dm
@@ -1,0 +1,48 @@
+// Component defines for complex signals.
+
+
+// --- Outermost Movable Complex Signals ---
+
+	/// When the outermost movable in the `.loc` chain changes. (thing, old_outermost_movable, new_outermost_movable)
+	#define XSIG_OUTERMOST_MOVABLE_CHANGED /datum/xsig/outermost_movable/outermost_changed
+	/// When the outermost movable in the `.loc` chain moves to a new z-level. (thing, old_z_level, new_z_level)
+	#define XSIG_MOVABLE_Z_CHANGED /datum/xsig/outermost_movable/z_level_changed
+	/// When the outermost movable in the `.loc` chain moves to a new area. (thing, old_area, new_area)
+	#define XSIG_MOVABLE_AREA_CHANGED /datum/xsig/outermost_movable/area_changed
+	/// When the outermost movable in the `.loc` chain moves to a new turf. (thing, old_turf, new_turf)
+	#define XSIG_MOVABLE_TURF_CHANGED /datum/xsig/outermost_movable/turf_changed
+
+
+
+
+
+ALWAYS_ABSTRACT(/datum/xsig)
+/**
+ *	XSIG datums are non-instantiable paths that are used to store static data relating to the associated XSIG.
+ */
+/datum/xsig
+	/// XSIGs differ from ordinary signals in that when registered to a datum, they also register a component to that datum. This is the type path of that component.
+	var/datum/component/complexsignal/component = null
+	/// XSIGs also require a unique ID string which will act as an ordinary signal for the registered datum to listen for. This signal will be emitted by the XSIG component.
+	var/id = null
+
+/datum/xsig/outermost_movable
+	component = /datum/component/complexsignal/outermost_movable
+	/// Whether the component should listen for `COMSIG_MOVABLE_MOVED` signals on the outermost movable.
+	var/track_movable_moved = FALSE
+
+/datum/xsig/outermost_movable/outermost_changed
+	id = "mov_outermost_changed"
+	track_movable_moved = FALSE
+
+/datum/xsig/outermost_movable/z_level_changed
+	id = "mov_z_level_changed"
+	track_movable_moved = FALSE
+
+/datum/xsig/outermost_movable/area_changed
+	id = "mov_area_changed"
+	track_movable_moved = TRUE
+
+/datum/xsig/outermost_movable/turf_changed
+	id = "mov_turf_changed"
+	track_movable_moved = TRUE

--- a/_std/types.dm
+++ b/_std/types.dm
@@ -5,7 +5,8 @@
 #define ENSURE_TYPE(VAR) if(!istype(VAR)) VAR = null;
 
 #define ABSTRACT_TYPE(type) /_is_abstract ## type
-#define IS_ABSTRACT(type) text2path("/_is_abstract[type]")
+#define ALWAYS_ABSTRACT(type) type/var/final/_always_abstract = TRUE
+#define IS_ABSTRACT(type) (text2path("/_is_abstract[type]") || type:_always_abstract)
 /*
 usage:
 

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -202,7 +202,7 @@ var/datum/signal_holder/global_signal_holder
 /datum/proc/RegisterSignal(datum/target, signal_type, proctype, override = FALSE, ...)
 	if(QDELETED(src) || QDELETED(target))
 		return
-	if (islist(signal_type) && !IS_COMPLEX_SIGNAL(signal_type))
+	if (islist(signal_type))
 		var/static/list/known_failures = list()
 		var/list/signal_type_list = signal_type
 		var/message = "([target.type]) is registering [signal_type_list.Join(", ")] as a list, the older method. Change it to RegisterSignals."
@@ -216,10 +216,10 @@ var/datum/signal_holder/global_signal_holder
 	var/list/lookup = (target.comp_lookup ||= list())
 
 	if(IS_COMPLEX_SIGNAL(signal_type))
-		var/complexsignal_component_type = signal_type[1]
-		var/datum/component/complexsignal/comp = target.LoadComponent(complexsignal_component_type)
+		var/datum/xsig/xsignal = signal_type
+		var/datum/component/complexsignal/comp = target.LoadComponent(xsignal::component)
 		var/list/register_args = args.Copy()
-		register_args[2] = signal_type[2] // replacing sig_type_or_types
+		register_args[2] = xsignal // replacing sig_type_or_types
 		register_args[1] = src // comp.register's first argument is the LISTENER not the target
 		comp.register(arglist(register_args))
 		return // exit early since we're done
@@ -256,22 +256,22 @@ var/datum/signal_holder/global_signal_holder
   * * sig_typeor_types Signal string key or list of signal keys to stop listening to specifically
   */
 /datum/proc/UnregisterSignal(datum/target, sig_type_or_types)
-	if (!target || !src || src.qdeled)
+	if (!target || !src || src.qdeled || !signal_procs)
 		return
 	var/list/lookup = target.comp_lookup
-	if(!signal_procs || (!islist(sig_type_or_types) && (!signal_procs[target] || !lookup)))
-		// if sig_type_or_types is a list it's either a complex signal (in which case the conditions can fail but we still want to remove the signal)
-		// or it is a list which can potentially contain another complex signal in which case ditto
+	if(!IS_COMPLEX_SIGNAL(sig_type_or_types) && !islist(sig_type_or_types) && (!signal_procs[target] || !lookup))
+		// if sig_type_or_types is either a complex signal (in which case the conditions can fail but we still want to remove the signal)
+		// or a list which can potentially contain another complex signal in which case ditto
 		return
-	if(!islist(sig_type_or_types) || IS_COMPLEX_SIGNAL(sig_type_or_types))
+	if(!islist(sig_type_or_types))
 		sig_type_or_types = list(sig_type_or_types)
 	for(var/sig in sig_type_or_types)
 		if(IS_COMPLEX_SIGNAL(sig))
-			var/complexsignal_component_type = sig[1]
-			var/datum/component/complexsignal/comp = target.GetComponent(complexsignal_component_type)
+			var/datum/xsig/xsignal = sig
+			var/datum/component/complexsignal/comp = target.GetComponent(xsignal::component)
 			if(isnull(comp))
-				CRASH("Unregistering a complex signal [json_encode(sig)] without its component existing.")
-			comp.unregister(src, sig[2])
+				CRASH("Unregistering a complex signal [xsignal] without its component existing.")
+			comp.unregister(src, xsignal)
 			continue
 		if(!signal_procs[target]?[sig])
 			if(!istext(sig))

--- a/code/datums/components/complexsignal/complexsignal.dm
+++ b/code/datums/components/complexsignal/complexsignal.dm
@@ -19,29 +19,27 @@
 	/// Whether the component should qdel itself when the number of registered signals drops to zero
 	var/qdel_when_unneeded = TRUE
 
-/datum/component/complexsignal/proc/register(datum/listener, sig_type, proctype, override = FALSE, ...)
+/datum/component/complexsignal/proc/register(datum/listener, datum/xsig/xsignal, proctype, override = FALSE, ...)
 	SHOULD_NOT_OVERRIDE(TRUE)
-	src.registered_signals += sig_type
+	src.registered_signals += xsignal::id
 	. = src._register(arglist(args))
 
 /**
  * Override this to add code which happens when a complex signal is registered. If RegisterSignal is passed additional arguments those get passed
  * after `override`. Other arguments are the same as for .RegisterSignal.
- * Complex signal definitions are of the form list(component_path, string_id). The `sig_type` var will in this case contain only the `string_id` and
- * not the full two-element list.
  */
-/datum/component/complexsignal/proc/_register(datum/listener, sig_type, proctype, override = FALSE, ...)
-	listener.RegisterSignal(src, sig_type, proctype, override)
+/datum/component/complexsignal/proc/_register(datum/listener, datum/xsig/xsignal, proctype, override = FALSE, ...)
+	listener.RegisterSignal(src, xsignal::id, proctype, override)
 
-/datum/component/complexsignal/proc/unregister(datum/listener, sig_type)
+/datum/component/complexsignal/proc/unregister(datum/listener, datum/xsig/xsignal)
 	SHOULD_NOT_OVERRIDE(TRUE)
-	. = src._unregister(listener, sig_type)
-	src.registered_signals -= sig_type
+	. = src._unregister(listener, xsignal)
+	src.registered_signals -= xsignal::id
 	if(length(registered_signals) <= 0 && qdel_when_unneeded)
 		qdel(src)
 
 /**
  * Override to add code which happens on unregistering a signal.
  */
-/datum/component/complexsignal/proc/_unregister(datum/listener, sig_type)
-	listener.UnregisterSignal(src, sig_type)
+/datum/component/complexsignal/proc/_unregister(datum/listener, datum/xsig/xsignal)
+	listener.UnregisterSignal(src, xsignal::id)

--- a/code/datums/components/complexsignal/outermost_movable.dm
+++ b/code/datums/components/complexsignal/outermost_movable.dm
@@ -3,6 +3,8 @@
 	var/list/atom/movable/loc_chain = null
 	/// The number of concurrent requests for this component to listen for `COMSIG_MOVABLE_MOVED` signals on the outermost movable.
 	var/track_movable_moved_requests = 0
+	/// The previous turf of the outermost movable, tracked to prevent signals from firing twice.
+	var/turf/previous_turf = null
 
 /datum/component/complexsignal/outermost_movable/proc/get_outermost_movable()
 	RETURN_TYPE(/atom/movable)
@@ -52,8 +54,10 @@
 /datum/component/complexsignal/outermost_movable/proc/on_turf_change(atom/movable/thing, atom/previous_loc)
 	var/atom/movable/outermost_movable = src.get_outermost_movable()
 
-	var/turf/old_turf = get_turf(previous_loc)
+	var/turf/old_turf = src.previous_turf
 	var/turf/new_turf = get_turf(outermost_movable)
+	src.previous_turf = new_turf
+
 	if (old_turf != new_turf)
 		SEND_COMPLEX_SIGNAL(src, XSIG_MOVABLE_TURF_CHANGED, old_turf, new_turf)
 
@@ -72,6 +76,7 @@
 		return COMPONENT_INCOMPATIBLE
 	src.RegisterSignal(src.parent, COMSIG_MOVABLE_SET_LOC, PROC_REF(on_loc_change))
 	src.loc_chain = list(src.parent)
+	src.previous_turf = get_turf(src.parent)
 	src.on_loc_change()
 	. = ..()
 
@@ -80,6 +85,7 @@
 		src.UnregisterSignal(AM, COMSIG_MOVABLE_SET_LOC)
 		src.UnregisterSignal(AM, COMSIG_MOVABLE_MOVED)
 	src.loc_chain.len = 0
+	src.previous_turf = null
 	. = ..()
 
 /datum/component/complexsignal/outermost_movable/_register(datum/listener, datum/xsig/outermost_movable/xsignal, proctype, override = FALSE, ...)

--- a/code/datums/components/complexsignal/outermost_movable.dm
+++ b/code/datums/components/complexsignal/outermost_movable.dm
@@ -1,8 +1,8 @@
 /datum/component/complexsignal/outermost_movable
 	/// The stored loc chain of the parent AM, starting with the parent and containing every successive loc that is an AM.
 	var/list/atom/movable/loc_chain = null
-	/// Whether the component should listen for `COMSIG_MOVABLE_MOVED` signals on the outermost movable.
-	var/track_movable_moved = FALSE
+	/// The number of concurrent requests for this component to listen for `COMSIG_MOVABLE_MOVED` signals on the outermost movable.
+	var/track_movable_moved_requests = 0
 
 /datum/component/complexsignal/outermost_movable/proc/get_outermost_movable()
 	RETURN_TYPE(/atom/movable)
@@ -43,7 +43,7 @@
 	var/atom/movable/new_outermost = src.get_outermost_movable()
 	if (old_outermost != new_outermost)
 		SEND_COMPLEX_SIGNAL(src, XSIG_OUTERMOST_MOVABLE_CHANGED, old_outermost, new_outermost)
-		if (src.track_movable_moved)
+		if (src.track_movable_moved_requests)
 			src.UnregisterSignal(old_outermost, COMSIG_MOVABLE_MOVED)
 			src.RegisterSignal(new_outermost, COMSIG_MOVABLE_MOVED, PROC_REF(on_turf_change))
 
@@ -82,17 +82,16 @@
 	src.loc_chain.len = 0
 	. = ..()
 
-/datum/component/complexsignal/outermost_movable/_register(datum/listener, sig_type, proctype, override = FALSE, ...)
+/datum/component/complexsignal/outermost_movable/_register(datum/listener, datum/xsig/outermost_movable/xsignal, proctype, override = FALSE, ...)
 	. = ..()
-	if (!src.track_movable_moved && ((sig_type == XSIG_MOVABLE_TURF_CHANGED[2]) || (sig_type == XSIG_MOVABLE_AREA_CHANGED[2])))
-		var/atom/A = src.get_outermost_movable()
-		if (!(A.event_handler_flags & MOVE_NOCLIP))
-			src.RegisterSignal(A, COMSIG_MOVABLE_MOVED, PROC_REF(on_turf_change))
+	// If the complex signal tracks movement, increment the request counter.
+	// Then, if the request counter was 0, register the `COMSIG_MOVABLE_MOVED` signal.
+	if (xsignal::track_movable_moved && !(src.track_movable_moved_requests++))
+		src.RegisterSignal(src.get_outermost_movable(), COMSIG_MOVABLE_MOVED, PROC_REF(on_turf_change))
 
-		src.track_movable_moved = TRUE
-
-/datum/component/complexsignal/outermost_movable/_unregister(datum/listener, sig_type)
+/datum/component/complexsignal/outermost_movable/_unregister(datum/listener, datum/xsig/outermost_movable/xsignal)
 	. = ..()
-	if (((sig_type == XSIG_MOVABLE_TURF_CHANGED[2]) && !(XSIG_MOVABLE_AREA_CHANGED[2] in src.registered_signals)) || ((sig_type == XSIG_MOVABLE_AREA_CHANGED[2]) && !(XSIG_MOVABLE_TURF_CHANGED[2] in src.registered_signals)))
+	// If the complex signal tracks movement, decrement the request counter.
+	// Then, if the request counter is now 0, unregister the `COMSIG_MOVABLE_MOVED` signal.
+	if (xsignal::track_movable_moved && !(--src.track_movable_moved_requests))
 		src.UnregisterSignal(src.get_outermost_movable(), COMSIG_MOVABLE_MOVED)
-		src.track_movable_moved = FALSE

--- a/code/modules/clothingbooth/clothingbooth_datums.dm
+++ b/code/modules/clothingbooth/clothingbooth_datums.dm
@@ -107,10 +107,10 @@ ABSTRACT_TYPE(/datum/clothingbooth_grouping)
 	// Instantiate all the constituent `clothingbooth_item` types in `src.item_paths`, append them to `src.clothingbooth_items`
 	var/last_item_slot // For checking if all the slots are the same.
 	for (var/clothingbooth_item_type in src.item_paths)
-		var/datum/clothingbooth_item/current_item = new clothingbooth_item_type
 		// Concrete types only.
-		if (IS_ABSTRACT(current_item))
+		if (IS_ABSTRACT(clothingbooth_item_type))
 			continue
+		var/datum/clothingbooth_item/current_item = new clothingbooth_item_type
 		// Scream if something goes wrong.
 		if (src.clothingbooth_items[current_item.name])
 			CRASH("A clothingbooth_item with name [current_item.name] already exists within grouping [src.name]!")
@@ -119,9 +119,9 @@ ABSTRACT_TYPE(/datum/clothingbooth_grouping)
 		last_item_slot = current_item.slot
 		src.clothingbooth_items[current_item.name] = current_item
 	for (var/clothingbooth_grouping_tag in src.grouping_tags)
-		var/datum/clothingbooth_grouping_tag/current_tag = new clothingbooth_grouping_tag
-		if (IS_ABSTRACT(current_tag))
+		if (IS_ABSTRACT(clothingbooth_grouping_tag))
 			continue
+		var/datum/clothingbooth_grouping_tag/current_tag = new clothingbooth_grouping_tag
 		if (src.clothingbooth_grouping_tags[current_tag.name])
 			CRASH("A clothingbooth_grouping_tag with name [current_tag.name] already exists within grouping [src.name]!")
 		src.clothingbooth_grouping_tags[current_tag.name] = current_tag

--- a/code/modules/medical/genetics/combo_recipes.dm
+++ b/code/modules/medical/genetics/combo_recipes.dm
@@ -1,7 +1,7 @@
 ABSTRACT_TYPE(/datum/geneticsrecipe)
 /datum/geneticsrecipe
 	var/list/required_effects = list()
-	var/result = null
+	var/datum/bioEffect/result = null
 
 // Beneficial
 

--- a/code/modules/medical/genetics/combo_recipes.dm
+++ b/code/modules/medical/genetics/combo_recipes.dm
@@ -1,7 +1,7 @@
 ABSTRACT_TYPE(/datum/geneticsrecipe)
 /datum/geneticsrecipe
 	var/list/required_effects = list()
-	var/datum/bioEffect/result = null
+	var/result = null
 
 // Beneficial
 

--- a/code/modules/unit_tests/mutation_combo_valid_ids.dm
+++ b/code/modules/unit_tests/mutation_combo_valid_ids.dm
@@ -5,5 +5,5 @@
 			if(!(part in bioEffectList))
 				Fail("Combo recipe [G.type] has invalid required effect [part]")
 		var/datum/bioEffect/R = G.result
-		if (IS_ABSTRACT(R) || !(R::id in bioEffectList))
+		if (IS_ABSTRACT(R::type) || !(R::id in bioEffectList))
 			Fail("Combo recipe [G.type] has invalid result [R]")

--- a/code/modules/unit_tests/mutation_combo_valid_ids.dm
+++ b/code/modules/unit_tests/mutation_combo_valid_ids.dm
@@ -5,5 +5,5 @@
 			if(!(part in bioEffectList))
 				Fail("Combo recipe [G.type] has invalid required effect [part]")
 		var/datum/bioEffect/R = G.result
-		if (IS_ABSTRACT(R.type) || !(R::id in bioEffectList))
+		if (IS_ABSTRACT(R) || !(R::id in bioEffectList))
 			Fail("Combo recipe [G.type] has invalid result [R]")

--- a/code/modules/unit_tests/mutation_combo_valid_ids.dm
+++ b/code/modules/unit_tests/mutation_combo_valid_ids.dm
@@ -5,5 +5,5 @@
 			if(!(part in bioEffectList))
 				Fail("Combo recipe [G.type] has invalid required effect [part]")
 		var/datum/bioEffect/R = G.result
-		if (IS_ABSTRACT(R) || !(R::id in bioEffectList))
+		if (IS_ABSTRACT(R.type) || !(R::id in bioEffectList))
 			Fail("Combo recipe [G.type] has invalid result [R]")


### PR DESCRIPTION
## About The PR:
Refactors XSIGs from lists containing a component path and ID to static uninstantiable paths whose data may be accessed with `::`. This allows XSIGs to carry additional data beyond their component path and ID, as illustrated by the OMM XSIG now carrying a `track_movable_moved` variable, removing the need for some rather cursed logic in `outermost_movable.dm`.

Signal infrastructure has been updated to accommodate these changes.


## Why Is This Needed?
Faster than the old system, as there's no list to instantiate every time the define is used.
Making XSIG defines static paths rather than lists allows for them to be namespaced easily.


## Testing:
Tested using parallax and the OMM signals. Turf movement, area jumping, and z-level jumping all work as expected.