### PR TITLE
Simple TGUI confirmation proc

### DIFF
--- a/code/modules/admin/buildmodes/gravity.dm
+++ b/code/modules/admin/buildmodes/gravity.dm
@@ -31,9 +31,9 @@ Ctrl + Right Click on Buildmode Button	- Change Z-level gravity values<br>
 				boutput(usr, SPAN_ALERT("Invalid G-force setting '[gforce_to_set]'"))
 				return
 			gforce_to_set *= GFORCE_EARTH_GRAVITY
-			var/update_tethers = tgui_confirmation(usr, "Tell gravity tethers on same z-level to update?")
+			var/update_tethers = tgui_confirm(usr, "Tell gravity tethers on same z-level to update?")
 
-			if (tgui_confirmation(usr, "Set Z-level '[zlevel_to_alter]' to [gforce_to_set/GFORCE_EARTH_GRAVITY]G, and [update_tethers ? "" :"do not "]update tethers"))
+			if (tgui_confirm(usr, "Set Z-level '[zlevel_to_alter]' to [gforce_to_set/GFORCE_EARTH_GRAVITY]G, and [update_tethers ? "" :"do not "]update tethers"))
 				global.set_zlevel_gforce(zlevel_to_alter, gforce_to_set, update_tethers)
 		else
 			var/gforce_to_set = tgui_input_number(usr, "How much gravity should left-clicking set turf gravity to, in G-Force?", "Turf G-Force", src.gforce_value/GFORCE_EARTH_GRAVITY, 1000, 0, round_input=FALSE)
@@ -71,5 +71,5 @@ Ctrl + Right Click on Buildmode Button	- Change Z-level gravity values<br>
 			boutput(usr, SPAN_ALERT("Invalid G-force setting '[gforce_to_set]'"))
 			return
 
-		if (tgui_confirmation(usr, "Set Area '[A]' minimum gravity to [gforce_to_set]?"))
+		if (tgui_confirm(usr, "Set Area '[A]' minimum gravity to [gforce_to_set]?"))
 			A.set_gforce_minimum(gforce_to_set * 100)

--- a/code/modules/admin/buildmodes/gravity.dm
+++ b/code/modules/admin/buildmodes/gravity.dm
@@ -31,10 +31,9 @@ Ctrl + Right Click on Buildmode Button	- Change Z-level gravity values<br>
 				boutput(usr, SPAN_ALERT("Invalid G-force setting '[gforce_to_set]'"))
 				return
 			gforce_to_set *= GFORCE_EARTH_GRAVITY
-			var/update_tethers = tgui_alert(usr, "Tell gravity tethers on same z-level to update?", "Tether Update", list("Yes", "No")) == "Yes"
+			var/update_tethers = tgui_confirmation(usr, "Tell gravity tethers on same z-level to update?")
 
-			var/confirm = tgui_alert(usr, "Set Z-level '[zlevel_to_alter]' to [gforce_to_set/GFORCE_EARTH_GRAVITY]G, and [update_tethers ? "" :"do not "]update tethers", "Confirm", list("Confirm", "Cancel")) == "Confirm"
-			if (confirm)
+			if (tgui_confirmation(usr, "Set Z-level '[zlevel_to_alter]' to [gforce_to_set/GFORCE_EARTH_GRAVITY]G, and [update_tethers ? "" :"do not "]update tethers"))
 				global.set_zlevel_gforce(zlevel_to_alter, gforce_to_set, update_tethers)
 		else
 			var/gforce_to_set = tgui_input_number(usr, "How much gravity should left-clicking set turf gravity to, in G-Force?", "Turf G-Force", src.gforce_value/GFORCE_EARTH_GRAVITY, 1000, 0, round_input=FALSE)
@@ -72,6 +71,5 @@ Ctrl + Right Click on Buildmode Button	- Change Z-level gravity values<br>
 			boutput(usr, SPAN_ALERT("Invalid G-force setting '[gforce_to_set]'"))
 			return
 
-		var/confirm = tgui_alert(usr, "Set Area '[A]' minimum gravity to [gforce_to_set]?", "Confirm", list("Confirm", "Cancel")) == "Confirm"
-		if (confirm)
+		if (tgui_confirmation(usr, "Set Area '[A]' minimum gravity to [gforce_to_set]?"))
 			A.set_gforce_minimum(gforce_to_set * 100)

--- a/code/modules/tgui/tgui_alert.dm
+++ b/code/modules/tgui/tgui_alert.dm
@@ -58,9 +58,9 @@
 		qdel(alert)
 
 // |GOONSTATION-ADD| TGUI confirmation window proc to simplify alerts to confirm actions
-/proc/tgui_confirmation(mob/user, message)
-	var/input = tgui_alert(user, message, "Confirm Action",list("Confirm", "Cancel"))
-	return (input == "Confirm")
+/proc/tgui_confirm(mob/user, message)
+	var/input = tgui_alert(user, message, "Confirm Action",list("Yes", "No"))
+	return (input == "Yes")
 
 /**
  * # tgui_modal

--- a/code/modules/tgui/tgui_alert.dm
+++ b/code/modules/tgui/tgui_alert.dm
@@ -57,6 +57,11 @@
 		. = alert.choice
 		qdel(alert)
 
+// |GOONSTATION-ADD| TGUI confirmation window proc to simplify alerts to confirm actions
+/proc/tgui_confirmation(mob/user, message)
+	var/input = tgui_alert(user, message, "Confirm Action",list("Confirm", "Cancel"))
+	return (input == "Confirm")
+
 /**
  * # tgui_modal
  *


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a super simple tgui_confirmation proc that takes a user and message argument and shows the user a tgui_alert window with the options being "yes" and "no" and returning the boolean of if the user selected "yes"

Adds this to the gravity build mode for demonstrative purposes

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Code cleanliness mainly, makes the many times you want to make a confirmation window way shorter because you don't need to write out your own list of options or check that it matches your confirmation option.
Before and after:
<img width="1515" height="95" alt="image" src="https://github.com/user-attachments/assets/f44ce465-f894-4294-89ae-9510571d7abb" />
<img width="1393" height="83" alt="image" src="https://github.com/user-attachments/assets/286f1712-1e35-43ff-a31e-33fa5b91bfc7" />

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="486" height="196" alt="image" src="https://github.com/user-attachments/assets/354498ad-c178-44d6-99ce-9b092a5b5729" />
<img width="348" height="48" alt="image" src="https://github.com/user-attachments/assets/22ec0958-b616-4339-90f0-c39e8641e33f" />
<img width="499" height="196" alt="image" src="https://github.com/user-attachments/assets/80f2a2d8-0dca-4a97-b5ed-f0229cf1a7c8" />
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
