### PR TITLE
Reworks stimpacks to be usable on other mobs

### DIFF
--- a/code/modules/chemistry/tools/stimpack.dm
+++ b/code/modules/chemistry/tools/stimpack.dm
@@ -5,32 +5,83 @@
 
 /obj/item/stimpack
 	name = "Stimpack"
+	desc = "A single dose of incredibly strong stimulants."
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "stims"
 	throw_speed = 1
 	throw_range = 5
 	w_class = W_CLASS_TINY
 	object_flags = NO_GHOSTCRITTER
-	var/empty = 0
+	var/empty = FALSE
+	var/duration = 3 MINUTES
+
 	attack(mob/target, mob/user, def_zone, is_special = FALSE, params = null)
 		if(empty)
 			boutput(user, SPAN_ALERT("This stimpack is empty!"))
 			return
-		if(user != target)
-			boutput(user, SPAN_ALERT("You can only use this item on yourself."))
+		if(!isliving(target) || issilicon(target) || isintangible(target))
+			boutput(user, SPAN_ALERT("You can't use this item on that!"))
 			return
-		src.empty = 1
-		src.icon_state = "stims0"
-		boutput(user, SPAN_NOTICE("Ah! That's the stuff!"))
-		user.changeStatus("stimulants", 3 MINUTES)
-		return
+		if(user == target)
+			target.changeStatus("stimulants", src.duration)
+			src.empty = TRUE
+			src.icon_state = "stims0"
+			boutput(user, SPAN_NOTICE("Ah! That's the stuff!"))
+			return
+		else
+			actions.start(new/datum/action/bar/icon/stimulant(target, src, src.icon, src.icon_state), user)
+			return
 
-/obj/item/stimpack/large_dose
-	attack(mob/target, mob/user, def_zone, is_special = FALSE, params = null)
-		if(user != target)
-			boutput(user, SPAN_ALERT("You can only use this item on yourself."))
+	large_dose
+		duration = 15 MINUTES
+
+/datum/action/bar/icon/stimulant
+	duration = 3 SECONDS
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ATTACKED
+	var/mob/mob_owner
+	var/mob/target
+	var/obj/item/stimpack/S
+
+	New(var/mob/target, var/item, var/icon, var/icon_state)
+		..()
+		src.target = target
+		if (istype(item, /obj/item/stimpack))
+			S = item
+		else
+			logTheThing(LOG_DEBUG, src, "/datum/action/bar/icon/stimulant called with invalid type [item].")
 			return
-		boutput(user, SPAN_NOTICE("Ah! That's the stuff!"))
-		user.changeStatus("stimulants", 15 MINUTES)
-		qdel(src)
-		return
+		src.icon = icon
+		src.icon_state = icon_state
+
+
+	onStart()
+		if (!isliving(owner))
+			interrupt(INTERRUPT_ALWAYS)
+			return
+
+		src.mob_owner = owner
+		logTheThing(LOG_COMBAT, mob_owner, "starts trying to inject a stimpack into [constructTarget(target)].")
+
+		if(BOUNDS_DIST(owner, target) > 0 || !target || !owner || mob_owner.equipped() != S)
+			interrupt(INTERRUPT_ALWAYS)
+			return
+		..()
+
+	onUpdate()
+		..()
+		if(BOUNDS_DIST(owner, target) > 0 || !target || !owner || mob_owner.equipped() != S)
+			interrupt(INTERRUPT_ALWAYS)
+			return
+
+	onEnd()
+		..()
+		if(BOUNDS_DIST(owner, target) > 0 || !target || !owner || mob_owner.equipped() != S)
+			interrupt(INTERRUPT_ALWAYS)
+			return
+		if (!isnull(S) && !S.empty)
+			target.changeStatus("stimulants", S.duration)
+			S.empty = TRUE
+			S.icon_state = "stims0"
+			logTheThing(LOG_COMBAT, owner, "injects [constructTarget(target,"combat")] with stimulants at [log_loc(owner)].")
+			owner.visible_message(SPAN_ALERT("[owner.name] injects [target.name] with [S.name]!"))
+			boutput(target, SPAN_NOTICE("Ah! That's the stuff!"))

--- a/code/modules/chemistry/tools/stimpack.dm
+++ b/code/modules/chemistry/tools/stimpack.dm
@@ -23,10 +23,7 @@
 			boutput(user, SPAN_ALERT("You can't use this item on that!"))
 			return
 		if(user == target)
-			target.changeStatus("stimulants", src.duration)
-			src.empty = TRUE
-			src.icon_state = "stims0"
-			boutput(user, SPAN_NOTICE("Ah! That's the stuff!"))
+			stimulant_action(user, target)
 			return
 		else
 			actions.start(new/datum/action/bar/icon/stimulant(target, src, src.icon, src.icon_state), user)
@@ -34,6 +31,14 @@
 
 	large_dose
 		duration = 15 MINUTES
+
+	proc/stimulant_action(mob/user, mob/target)
+		target.changeStatus("stimulants", src.duration)
+		src.empty = TRUE
+		src.icon_state = "stims0"
+		logTheThing(LOG_COMBAT, user, "injects [constructTarget(target,"combat")] with stimulants at [log_loc(user)].")
+		user.visible_message(SPAN_ALERT("[user.name] injects [target.name] with [src.name]!"))
+		boutput(target, SPAN_NOTICE("Ah! That's the stuff!"))
 
 /datum/action/bar/icon/stimulant
 	duration = 3 SECONDS
@@ -79,9 +84,4 @@
 			interrupt(INTERRUPT_ALWAYS)
 			return
 		if (!isnull(S) && !S.empty)
-			target.changeStatus("stimulants", S.duration)
-			S.empty = TRUE
-			S.icon_state = "stims0"
-			logTheThing(LOG_COMBAT, owner, "injects [constructTarget(target,"combat")] with stimulants at [log_loc(owner)].")
-			owner.visible_message(SPAN_ALERT("[owner.name] injects [target.name] with [S.name]!"))
-			boutput(target, SPAN_NOTICE("Ah! That's the stuff!"))
+			S.stimulant_action(owner, target)

--- a/code/modules/chemistry/tools/stimpack.dm
+++ b/code/modules/chemistry/tools/stimpack.dm
@@ -23,7 +23,7 @@
 			boutput(user, SPAN_ALERT("You can't use this item on that!"))
 			return
 		if(user == target)
-			stimulant_action(user, target)
+			src.stimulant_action(user, target)
 			return
 		else
 			actions.start(new/datum/action/bar/icon/stimulant(target, src, src.icon, src.icon_state), user)

--- a/code/modules/chemistry/tools/stimpack.dm
+++ b/code/modules/chemistry/tools/stimpack.dm
@@ -19,7 +19,7 @@
 		if(empty)
 			boutput(user, SPAN_ALERT("This stimpack is empty!"))
 			return
-		if(!isliving(target) || issilicon(target) || isintangible(target))
+		if(!isliving(target) || issilicon(target) || isintangible(target) || isrobocritter(target))
 			boutput(user, SPAN_ALERT("You can't use this item on that!"))
 			return
 		if(user == target)

--- a/code/modules/chemistry/tools/stimpack.dm
+++ b/code/modules/chemistry/tools/stimpack.dm
@@ -37,7 +37,10 @@
 		src.empty = TRUE
 		src.icon_state = "stims0"
 		logTheThing(LOG_COMBAT, user, "injects [constructTarget(target,"combat")] with stimulants at [log_loc(user)].")
-		user.visible_message(SPAN_ALERT("[user.name] injects [target.name] with [src.name]!"))
+		if(user == target)
+			user.visible_message(SPAN_ALERT("[user.name] injects themselves with the [src.name]!"))
+		else
+			user.visible_message(SPAN_ALERT("[user.name] injects [target.name] with the [src.name]!"))
 		boutput(target, SPAN_NOTICE("Ah! That's the stuff!"))
 
 /datum/action/bar/icon/stimulant

--- a/code/modules/chemistry/tools/stimpack.dm
+++ b/code/modules/chemistry/tools/stimpack.dm
@@ -29,9 +29,6 @@
 			actions.start(new/datum/action/bar/icon/stimulant(target, src, src.icon, src.icon_state), user)
 			return
 
-	large_dose
-		duration = 15 MINUTES
-
 	proc/stimulant_action(mob/user, mob/target)
 		target.changeStatus("stimulants", src.duration)
 		src.empty = TRUE
@@ -42,6 +39,10 @@
 		else
 			user.visible_message(SPAN_ALERT("[user.name] injects [target.name] with the [src.name]!"))
 		boutput(target, SPAN_NOTICE("Ah! That's the stuff!"))
+
+
+/obj/item/stimpack/large_dose
+	duration = 15 MINUTES
 
 /datum/action/bar/icon/stimulant
 	duration = 3 SECONDS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reworks stimpacks so you can use them on other people/mobs/critters. Behaves like a syringe, i.e. using them on yourself is still instant but on others it uses a short 3 second action bar.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You can now stim your fellow syndie instead of needing to hand it over to them. Useful if they're in crit etc. Also opens up stimpacking critters if you can get them to stand still for long enough/avoid dying yourself. 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->


<img width="248" height="165" alt="Screenshot 2026-07-06 165458" src="https://github.com/user-attachments/assets/ad22db88-6332-4188-87e9-e332682622e9" />

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bamlord
(*)Stimpacks can now be used on other people/critters.
```
