### PR TITLE
Attempt to fix prestampped paper

### DIFF
--- a/code/modules/chemistry/tools/jars.dm
+++ b/code/modules/chemistry/tools/jars.dm
@@ -313,10 +313,17 @@ proc/load_intraround_jars()
 			src.form_fields = pickled.form_fields?.Copy()
 			src.field_counter = pickled.field_counter
 
-			for(var/i in 1 to 3)
-				if(prob(60))
-					var/list/stain_info = list(list("stamp-stain-[i].png", rand(0, sizex || 400), rand(0, sizey || 500), rand(360)))
-					LAZYLISTADD(src.stamps, stain_info)
+			if(prob(60))
+				var/list/stain_info = list(list("[resource("images/tgui/stamp_icons/stamp-stain-1.png")]", rand(0, sizex || 400), rand(0, sizey || 500), rand(360)))
+				LAZYLISTADD(src.stamps, stain_info)
+
+			if(prob(60))
+				var/list/stain_info = list(list("[resource("images/tgui/stamp_icons/stamp-stain-2.png")]", rand(0, sizex || 400), rand(0, sizey || 500), rand(360)))
+				LAZYLISTADD(src.stamps, stain_info)
+
+			if(prob(60))
+				var/list/stain_info = list(list("[resource("images/tgui/stamp_icons/stamp-stain-3.png")]", rand(0, sizex || 400), rand(0, sizey || 500), rand(360)))
+				LAZYLISTADD(src.stamps, stain_info)
 
 	attack_self(mob/user)
 		// show both the text and take a bite! consuming both information and food at the same time!

--- a/code/modules/events/minor/special_order.dm
+++ b/code/modules/events/minor/special_order.dm
@@ -51,7 +51,7 @@
 	New()
 		..()
 		info = replacetext(info, "%TARGET%", pick("X̶e̸e̶ ̵P̶'̸X'", "TOM", "Smith Smithington", "Mx. Grey"))
-		src.stamp(rand(50,160), rand(50,90), rand(-20,20), "stamp-gtc.png", "stamp-syndicate")
+		src.stamp(rand(50,160), rand(50,90), rand(-20,20), "[resource("images/tgui/stamp_icons/stamp-gtc.png")]", "stamp-syndicate")
 
 /obj/item/paper/requisition/pizza_party
 	info = {"We have quite the situation where all our pizza ovens are having a fit.  We a number of orders to fill and could really use your help, my manager said by any means necessary!  We have quotas to meet! We have <i>guarantee</i> to uphold!<BR>
@@ -69,7 +69,7 @@
 		target_name += " [pick_string_autokey("names/last.txt")]"
 		info = replacetext(info, "%TARGET%", target_name)
 		if(src.type == /obj/item/paper/requisition/pizza_party)
-			src.stamp(rand(50,160), rand(50,90), rand(-20,20), "stamp-gtc.png", "stamp-syndicate")
+			src.stamp(rand(50,160), rand(50,90), rand(-20,20), "[resource("images/tgui/stamp_icons/stamp-gtc.png")]", "stamp-syndicate")
 
 	nt
 		info = {"TO: Space Station 13<BR/>
@@ -87,7 +87,7 @@
 				target_name = pick_string_autokey("names/first_male.txt")
 			target_name += " [pick_string_autokey("names/last.txt")]"
 			info = replacetext(info, "%BDAY%", target_name)
-			src.stamp(rand(130,180), rand(160,190), rand(-40,40), "stamp-req-nt.png", "stamp-centcom")
+			src.stamp(rand(130,180), rand(160,190), rand(-40,40), "[resource("images/tgui/stamp_icons/stamp-req-nt.png")]", "stamp-centcom")
 
 
 /obj/item/paper/requisition/blood
@@ -104,9 +104,9 @@
 				info += "Alucard"
 			else
 				info += "V. D."
-		src.stamp(rand(50,160), rand(50,90), rand(-60,-20), "stamp-gtc.png", "stamp-syndicate")
-		src.stamp(rand(50,160), rand(190,290), rand(-40,40), "stamp-gtc.png", "stamp-syndicate")
-		src.stamp(rand(120,260), rand(50,390), rand(20,60), "stamp-gtc.png", "stamp-syndicate")
+		src.stamp(rand(50,160), rand(50,90), rand(-60,-20), "[resource("images/tgui/stamp_icons/stamp-gtc.png")]", "stamp-syndicate")
+		src.stamp(rand(50,160), rand(190,290), rand(-40,40), "[resource("images/tgui/stamp_icons/stamp-gtc.png")]", "stamp-syndicate")
+		src.stamp(rand(120,260), rand(50,390), rand(20,60), "[resource("images/tgui/stamp_icons/stamp-gtc.png")]", "stamp-syndicate")
 
 /obj/item/paper/requisition/surgery/organ_swap
 	info = {"TO: Space Station 13<BR/>
@@ -119,7 +119,7 @@
 	<i>All information included or obtained regarding the individual should be ignored and are all part of the training exercise.</i>"}
 	New()
 		..()
-		src.stamp(rand(90,160), rand(120,160), rand(-20,20), "stamp-classified.png", "stamp-syndicate")
+		src.stamp(rand(90,160), rand(120,160), rand(-20,20), "[resource("images/tgui/stamp_icons/stamp-classified.png")]", "stamp-syndicate")
 
 
 /obj/item/paper/requisition/food_order
@@ -133,7 +133,7 @@
 		..()
 
 		info = replacetext(info, "%FOOD_COMPANY%", pick(company))
-		src.stamp(rand(90,260), rand(150,390), rand(-20,20), "stamp-gtc.png", "stamp-syndicate")
+		src.stamp(rand(90,260), rand(150,390), rand(-20,20), "[resource("images/tgui/stamp_icons/stamp-gtc.png")]", "stamp-syndicate")
 
 //non-integrated special order system
 

--- a/code/modules/writing/papers.dm
+++ b/code/modules/writing/papers.dm
@@ -184,7 +184,7 @@
 
 	New()
 		. = ..()
-		src.stamp(200, 20, rand(-5,5), "stamp-qm.png", "stamp-qm")
+		src.stamp(200, 20, rand(-5,5), "[resource("images/tgui/stamp_icons/stamp-qm.png")]", "stamp-qm")
 
 /obj/item/paper/engine
 	name = "'Generator Startup Procedure'"


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Stamps on cargo special orders are broken only on the live servers, see #27104
While trying to figure out why, with help from #imcoder on discord, I determined the *likely* cause is that it's missing the CDN. Searching for the broken pattern in the rest of the code, I found two more instances of it outside the orders: `/obj/item/paper/martian_manifest` and `/obj/item/reagent_containers/food/snacks/pickle_holder/paper`. Changed those too.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Stamps showing up as broken images sucks

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="1155" height="843" alt="Screenshot 2026-07-06 114626" src="https://github.com/user-attachments/assets/d558410c-b926-4793-86c6-e251782a423a" />
<img width="675" height="889" alt="Screenshot 2026-07-06 121855" src="https://github.com/user-attachments/assets/ede8216d-a426-47f8-a7a5-311a06e9efe3" />

Due to the nature of the change, I can only really confirm that it doesn't break it locally, not that it fixes the problem on the live servers.
 
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->


