### PR TITLE
`RegisterSignal()` Cleanup

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -227,16 +227,16 @@ var/datum/signal_holder/global_signal_holder
 	target_procs[signal_type] = proctype
 	var/list/looked_up = lookup[signal_type]
 
-	// Nothing has registered here yet.
+	// If nothing has been registered here yet, register the reference.
 	if (isnull(looked_up))
 		lookup[signal_type] = src
-	// We're already registered here.
+	// If we're already registered here, return.
 	else if (looked_up == src)
 		return
-	// One other thing has registered here.
+	// If only one other thing has been registered here, replace the reference with a list.
 	else if (!length(looked_up))
 		lookup[signal_type] = list((looked_up) = TRUE, (src) = TRUE)
-	// Many other things have registered here
+	// If many other things have been registered here, add us to the list.
 	else
 		looked_up[src] = TRUE
 

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -200,49 +200,50 @@ var/datum/signal_holder/global_signal_holder
 	* * other arguments get passed to complexsignal/register in the case of a complex signal
   */
 /datum/proc/RegisterSignal(datum/target, signal_type, proctype, override = FALSE, ...)
-	if(QDELETED(src) || QDELETED(target))
+	if (QDELETED(src) || QDELETED(target))
 		return
-	if (islist(signal_type))
-		var/static/list/known_failures = list()
-		var/list/signal_type_list = signal_type
-		var/message = "([target.type]) is registering [signal_type_list.Join(", ")] as a list, the older method. Change it to RegisterSignals."
-		if (!(message in known_failures))
-			known_failures[message] = TRUE
-			logDiary("[target] [message]")
-		RegisterSignals(target, signal_type, proctype, override, args.Copy(5))
-		return
-	var/list/procs = (signal_procs ||= list())
-	var/list/target_procs = (procs[target] ||= list())
-	var/list/lookup = (target.comp_lookup ||= list())
 
-	if(IS_COMPLEX_SIGNAL(signal_type))
+	if (islist(signal_type))
+		var/list/signal_types = signal_type
+		global.stack_trace("([target.type]) is registering [signal_types.Join(", ")] as a list. Use RegisterSignals.")
+		src.RegisterSignals(target, signal_types, proctype, override, args.Copy(5))
+		return
+
+	if (IS_COMPLEX_SIGNAL(signal_type))
 		var/datum/xsig/xsignal = signal_type
 		var/datum/component/complexsignal/comp = target.LoadComponent(xsignal::component)
 		var/list/register_args = args.Copy()
-		register_args[2] = xsignal // replacing sig_type_or_types
-		register_args[1] = src // comp.register's first argument is the LISTENER not the target
+		register_args[1] = src // The first argument of `comp.register` is the listener, not the target.
 		comp.register(arglist(register_args))
-		return // exit early since we're done
+		return
 
-	if(!override && target_procs[signal_type])
-		stack_trace("[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [identify_object(target)] Proc: [proctype]")
+	var/list/procs = (src.signal_procs ||= list())
+	var/list/target_procs = (procs[target] ||= list())
+	var/list/lookup = (target.comp_lookup ||= list())
+
+	if (!override && target_procs[signal_type])
+		global.stack_trace("[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [global.identify_object(target)] Proc: [proctype]")
 
 	target_procs[signal_type] = proctype
 	var/list/looked_up = lookup[signal_type]
 
-	if(isnull(looked_up)) // Nothing has registered here yet
+	// Nothing has registered here yet.
+	if (isnull(looked_up))
 		lookup[signal_type] = src
-	else if(looked_up == src) // We already registered here
-		; // pass
-	else if(!length(looked_up)) // One other thing registered here
+	// We're already registered here.
+	else if (looked_up == src)
+		return
+	// One other thing has registered here.
+	else if (!length(looked_up))
 		lookup[signal_type] = list((looked_up) = TRUE, (src) = TRUE)
-	else // Many other things have registered here
+	// Many other things have registered here
+	else
 		looked_up[src] = TRUE
 
 /// Registers multiple signals to the same proc.
 /datum/proc/RegisterSignals(datum/target, list/signal_types, proctype, override = FALSE, ...)
-	for (var/signal_type in signal_types)
-		RegisterSignal(target, signal_type, proctype, args.Copy(5))
+	for (var/signal_type as anything in signal_types)
+		src.RegisterSignal(target, signal_type, proctype, override, args.Copy(5))
 
 /**
   * Stop listening to a given signal from target
@@ -253,54 +254,72 @@ var/datum/signal_holder/global_signal_holder
   *
   * Arguments:
   * * datum/target Datum to stop listening to signals from
-  * * sig_typeor_types Signal string key or list of signal keys to stop listening to specifically
+  * * signal_type Signal string key to stop listening to specifically
   */
-/datum/proc/UnregisterSignal(datum/target, sig_type_or_types)
-	if (!target || !src || src.qdeled || !signal_procs)
+/datum/proc/UnregisterSignal(datum/target, signal_type)
+	if (!src || src.qdeled || !src.signal_procs || !target)
 		return
-	var/list/lookup = target.comp_lookup
-	if(!IS_COMPLEX_SIGNAL(sig_type_or_types) && !islist(sig_type_or_types) && (!signal_procs[target] || !lookup))
-		// if sig_type_or_types is either a complex signal (in which case the conditions can fail but we still want to remove the signal)
-		// or a list which can potentially contain another complex signal in which case ditto
-		return
-	if(!islist(sig_type_or_types))
-		sig_type_or_types = list(sig_type_or_types)
-	for(var/sig in sig_type_or_types)
-		if(IS_COMPLEX_SIGNAL(sig))
-			var/datum/xsig/xsignal = sig
-			var/datum/component/complexsignal/comp = target.GetComponent(xsignal::component)
-			if(isnull(comp))
-				CRASH("Unregistering a complex signal [xsignal] without its component existing.")
-			comp.unregister(src, xsignal)
-			continue
-		if(!signal_procs[target]?[sig])
-			if(!istext(sig))
-				stack_trace("We're unregistering with something that isn't a valid signal \[[sig]\], you fucked up")
-			continue
-		switch(length(lookup[sig]))
-			if(2)
-				lookup[sig] = (lookup[sig]-src)[1]
-			if(1)
-				stack_trace("[identify_object(target)] somehow has single length list inside comp_lookup")
-				if(src in lookup[sig])
-					lookup -= sig
-					if(!length(lookup))
-						target.comp_lookup = null
-						break
-			if(0)
-				if(lookup[sig] != src)
-					continue
-				lookup -= sig
-				if(!length(lookup))
-					target.comp_lookup = null
-					break
-			else
-				lookup[sig] -= src
 
-	if(signal_procs?[target])
-		signal_procs[target] -= sig_type_or_types
-		if(!signal_procs[target].len)
-			signal_procs -= target
+	if (islist(signal_type))
+		src.UnregisterSignals(target, signal_type)
+		return
+
+	if (IS_COMPLEX_SIGNAL(signal_type))
+		var/datum/xsig/xsignal = signal_type
+		var/datum/component/complexsignal/comp = target.GetComponent(xsignal::component)
+		if (isnull(comp))
+			CRASH("Unregistering a complex signal [xsignal] without its component existing.")
+
+		comp.unregister(src, xsignal)
+		return
+
+	var/list/procs = src.signal_procs
+	var/list/target_procs = procs[target]
+	var/list/lookup = target.comp_lookup
+	if (!target_procs || !lookup)
+		return
+
+	if (!target_procs[signal_type])
+		if (!istext(signal_type))
+			global.stack_trace("Unregistering something that isn't a valid signal \[[signal_type]\].")
+
+		return
+
+	// Remove the signal type from `src.signal_procs[target]`.
+	target_procs -= signal_type
+	if (!length(target_procs))
+		procs -= target
+
+	var/list/looked_up = lookup[signal_type]
+	switch (length(looked_up))
+		// If only one other thing has been registered, replace the list with a reference to that other registree.
+		if (2)
+			lookup[signal_type] = (looked_up - src)[1]
+			return
+
+		// If we're the only thing registered and we're in a list, remove the signal type from the lookup. This should never occur.
+		if (1)
+			global.stack_trace("[identify_object(target)] somehow has single length list inside comp_lookup")
+			if (src in looked_up)
+				lookup -= signal_type
+
+		// If the looked up regristree is a reference and we're the reference, remove the signal type from the lookup.
+		if (0)
+			if (looked_up == src)
+				lookup -= signal_type
+
+		// If many other things have been registered here, remove us from the list.
+		else
+			looked_up -= src
+			return
+
+	if (!length(lookup))
+		target.comp_lookup = null
+
+/// Stop listening to multiple signals from a target.
+/datum/proc/UnregisterSignals(datum/target, list/signal_types)
+	for (var/signal_type as anything in signal_types)
+		src.UnregisterSignal(target, signal_type)
 
 /**
   * Called on a component when a component of the same type was added to the same parent

--- a/code/datums/components/_holdertargeting.dm
+++ b/code/datums/components/_holdertargeting.dm
@@ -18,7 +18,7 @@ TYPEINFO(/datum/component/holdertargeting)
 
 /datum/component/holdertargeting/proc/on_pickup(datum/source, mob/user)
 	if(istype(user, mobtype))
-		RegisterSignal(user, signals, proctype, TRUE)
+		RegisterSignals(user, signals, proctype, TRUE)
 		current_user = user
 	else
 		UnregisterSignal(user, signals)

--- a/code/datums/components/_loctargeting.dm
+++ b/code/datums/components/_loctargeting.dm
@@ -21,7 +21,7 @@ TYPEINFO(/datum/component/loctargeting)
 		src.on_added(source, old_loc)
 
 /datum/component/loctargeting/proc/on_added(atom/movable/source, atom/old_loc)
-	RegisterSignal(source.loc, signals, proctype, TRUE)
+	RegisterSignals(source.loc, signals, proctype, TRUE)
 
 /datum/component/loctargeting/proc/on_removed(atom/movable/source, atom/old_loc)
 	UnregisterSignal(old_loc, signals)

--- a/code/datums/components/_wearertargeting.dm
+++ b/code/datums/components/_wearertargeting.dm
@@ -25,7 +25,7 @@ TYPEINFO(/datum/component/wearertargeting)
 /datum/component/wearertargeting/proc/on_equip(datum/source, mob/equipper, slot)
 	SHOULD_CALL_PARENT(1)
 	if((slot in valid_slots) && istype(equipper, mobtype))
-		RegisterSignal(equipper, signals, proctype, TRUE)
+		RegisterSignals(equipper, signals, proctype, TRUE)
 		current_user = equipper
 	else
 		UnregisterSignal(equipper, signals)

--- a/code/datums/components/contraband.dm
+++ b/code/datums/components/contraband.dm
@@ -18,7 +18,7 @@ TYPEINFO(/datum/component/contraband)
 	RegisterSignal(AM, COMSIG_MOVABLE_CONTRABAND_CHANGED, PROC_REF(visible_contraband_changed))
 
 	if (isitem(AM))
-		RegisterSignal(AM, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_PICKUP), PROC_REF(equipped))
+		RegisterSignals(AM, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_PICKUP), PROC_REF(equipped))
 		RegisterSignals(AM, list(COMSIG_ITEM_UNEQUIPPED, COMSIG_ITEM_DROPPED), PROC_REF(removed))
 
 	src.visible_contraband_changed(AM)

--- a/code/datums/components/food_stuff.dm
+++ b/code/datums/components/food_stuff.dm
@@ -274,7 +274,7 @@ TYPEINFO(/datum/component/consume/food_effects)
 		return COMPONENT_INCOMPATIBLE
 	src.food_parent = parent
 	src.status_effects = _status_effects
-	RegisterSignal(parent, list(COMSIG_ITEM_CONSUMED_PARTIAL, COMSIG_ITEM_CONSUMED), PROC_REF(apply_food_effects))
+	RegisterSignals(parent, list(COMSIG_ITEM_CONSUMED_PARTIAL, COMSIG_ITEM_CONSUMED), PROC_REF(apply_food_effects))
 
 /datum/component/consume/food_effects/InheritComponent(datum/component/consume/food_effects/C, i_am_original, _new_status_effects)
 	if(C?.status_effects)

--- a/code/datums/components/itemblock/_itemblock.dm
+++ b/code/datums/components/itemblock/_itemblock.dm
@@ -24,7 +24,7 @@
 /datum/component/itemblock/proc/on_block_begin(obj/item/I, var/obj/item/grab/block/B)
 	SHOULD_CALL_PARENT(1)
 	if(istype(B.assailant, mobtype)) //make sure only things that we want are getting signals registered for them
-		RegisterSignal(B.assailant, signals, proctype, TRUE) //start listening for signals from the user
+		RegisterSignals(B.assailant, signals, proctype, TRUE) //start listening for signals from the user
 	else
 		UnregisterSignal(B.assailant, signals)
 	showTooltip = 1 //show any custom tooltip stuff

--- a/code/datums/components/itemblock/_unarmedblock.dm
+++ b/code/datums/components/itemblock/_unarmedblock.dm
@@ -34,7 +34,7 @@
 	if(affectedBlock)
 		on_block_end(source, affectedBlock)
 	affectedBlock = B
-	RegisterSignal(source, signals, proctype, TRUE)
+	RegisterSignals(source, signals, proctype, TRUE)
 
 //Must clean up anything you're doing to the block in here - this also gets called when the item is unequipped, so that we unmodify our block
 /datum/component/wearertargeting/unarmedblock/proc/on_block_end(var/mob/living/carbon/source, var/obj/item/grab/block/B)

--- a/code/datums/components/power_cell.dm
+++ b/code/datums/components/power_cell.dm
@@ -157,7 +157,7 @@ TYPEINFO(/datum/component/power_cell)
 /datum/component/power_cell/redirect/proc/connect(obj/item/parent, atom/target, mob/user, reach, params)
 	if(istype(target, target_type))
 		redirect_object = target
-		RegisterSignal(redirect_object, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_SET_LOC), PROC_REF(check_redirect))
+		RegisterSignals(redirect_object, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_SET_LOC), PROC_REF(check_redirect))
 		boutput(user,SPAN_SUCCESS("You connect [parent] to [target]."))
 
 /datum/component/power_cell/redirect/proc/update_redirect(atom/movable/target, previous_loc, direction)
@@ -167,7 +167,7 @@ TYPEINFO(/datum/component/power_cell)
 
 		if(!cell.internal && !parent_locked)
 			parent_locked = TRUE
-			RegisterSignal(cell.loc, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_SET_LOC), PROC_REF(check_redirect))
+			RegisterSignals(cell.loc, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_SET_LOC), PROC_REF(check_redirect))
 			RegisterSignal(cell.loc, COMSIG_ITEM_AFTERATTACK, PROC_REF(connect))
 
 		var/obj/O = parent


### PR DESCRIPTION
## About The PR:
As complex signals are now paths instead of lists, some logic in `RegisterSignal()` and `UnregisterSignal()` can be simplified. Also removes all instances of `RegisterSignal()` being passed a list, allowing it to explicitly error if passed one.

`UnregisterSignal()` has undergone more extensive refactoring, with it no longer being designed to be passed a list - lists are currently passed off to a `UnregisterSignals()` proc instead of erroring.


## Testing:
Tested using parallax and the OMM signals. Turf, area, and z-level signals are all added and removed as expected.