### PR TITLE
Remaps Sign Switches

### DIFF
--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -871,8 +871,6 @@ SET_UP_DIRECTIONALS(/obj/blind_switch/on, OFFSETS_LIGHTSWITCH)
 				src.initialize()
 
 	initialize()
-		if (!src.name || (src.name in list("N sign switch", "E sign switch", "S sign switch", "W sign switch")))
-			src.name = "sign switch"
 		if (!src.id)
 			var/area/sign_area = get_area(src)
 			src.id = sign_area.name
@@ -909,21 +907,8 @@ SET_UP_DIRECTIONALS(/obj/blind_switch/on, OFFSETS_LIGHTSWITCH)
 	attackby(obj/item/W, mob/user)
 		src.toggle_group()
 
-/obj/sign_switch/north
-	name = "N sign switch"
-	pixel_y = 24
+SET_UP_DIRECTIONALS(/obj/sign_switch, OFFSETS_LIGHTSWITCH)
 
-/obj/sign_switch/east
-	name = "E sign switch"
-	pixel_x = 24
-
-/obj/sign_switch/south
-	name = "S sign switch"
-	pixel_y = -24
-
-/obj/sign_switch/west
-	name = "W sign switch"
-	pixel_x = -24
 
 /obj/machinery/illuminated_sign
 	name = "illuminated sign"

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -65342,7 +65342,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/sign_switch/north{
+/obj/sign_switch/directional/north{
 	pixel_x = 10
 	},
 /obj/machinery/shower{

--- a/maps/mushroom.dmm
+++ b/maps/mushroom.dmm
@@ -5234,7 +5234,7 @@
 	dir = 8;
 	tag = "icon-showerhead (WEST)"
 	},
-/obj/sign_switch/west{
+/obj/sign_switch/directional/west{
 	id = "mushstall2"
 	},
 /turf/simulated/floor/sanitary,
@@ -8473,7 +8473,7 @@
 	dir = 8;
 	pixel_x = 6
 	},
-/obj/sign_switch/north{
+/obj/sign_switch/directional/north{
 	id = "mushstall3"
 	},
 /turf/simulated/floor/sanitary,
@@ -20494,7 +20494,7 @@
 	dir = 8;
 	pixel_x = 6
 	},
-/obj/sign_switch/south{
+/obj/sign_switch/directional/south{
 	id = "mushstall4"
 	},
 /turf/simulated/floor/sanitary,
@@ -32541,7 +32541,7 @@
 /obj/table/auto,
 /obj/item/clothing/head/plunger,
 /obj/item/paper_bin,
-/obj/sign_switch/east{
+/obj/sign_switch/directional/east{
 	id = "mushstall1"
 	},
 /turf/simulated/floor/sanitary,

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -28535,9 +28535,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/sign_switch/east{
-	id = "nadiradio";
-	dir = 4
+/obj/sign_switch/directional/east{
+	id = "nadiradio"
 	},
 /turf/simulated/floor/twotone/darkblue,
 /area/station/crew_quarters/radio/lab)
@@ -30011,9 +30010,8 @@
 /obj/disposalpipe/trunk/food{
 	dir = 8
 	},
-/obj/sign_switch/east{
-	id = "kitchenopen";
-	dir = 4
+/obj/sign_switch/directional/east{
+	id = "kitchenopen"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -16898,7 +16898,7 @@
 	pixel_x = 8
 	},
 /obj/landmark/latejoin_job/radio_show_host,
-/obj/sign_switch/south{
+/obj/sign_switch/directional/south{
 	id = "radio_onair";
 	pixel_x = -8
 	},
@@ -19515,7 +19515,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/sign_switch/south{
+/obj/sign_switch/directional/south{
 	id = "tv_onair";
 	pixel_x = 8
 	},

--- a/tools/UpdatePaths/Scripts/27110_signswitch_directionals.txt
+++ b/tools/UpdatePaths/Scripts/27110_signswitch_directionals.txt
@@ -1,0 +1,31 @@
+# Reminder:
+#	1: NORTH	2: SOUTH	4: EAST		8: WEST
+
+# Remove old directional subtypes.
+/obj/sign_switch/@SUBTYPES/north		: /obj/sign_switch/@SUBTYPES_1{@OLD; dir = 1}
+/obj/sign_switch/@SUBTYPES/south		: /obj/sign_switch/@SUBTYPES_1{@OLD; dir = 2}
+/obj/sign_switch/@SUBTYPES/east			: /obj/sign_switch/@SUBTYPES_1{@OLD; dir = 4}
+/obj/sign_switch/@SUBTYPES/west			: /obj/sign_switch/@SUBTYPES_1{@OLD; dir = 8}
+/obj/sign_switch/@SUBTYPES/directional	: /obj/sign_switch/@SUBTYPES_1{@OLD}
+
+# Name to direction.
+/obj/sign_switch/@SUBTYPES{name = "sign switch"}	: /obj/sign_switch/@SUBTYPES_1{@OLD; name = @SKIP}
+/obj/sign_switch/@SUBTYPES{name = "N sign switch"}	: /obj/sign_switch/@SUBTYPES_1{@OLD; name = @SKIP; dir = 1}
+/obj/sign_switch/@SUBTYPES{name = "S sign switch"}	: /obj/sign_switch/@SUBTYPES_1{@OLD; name = @SKIP; dir = 2}
+/obj/sign_switch/@SUBTYPES{name = "E sign switch"}	: /obj/sign_switch/@SUBTYPES_1{@OLD; name = @SKIP; dir = 4}
+/obj/sign_switch/@SUBTYPES{name = "W sign switch"}	: /obj/sign_switch/@SUBTYPES_1{@OLD; name = @SKIP; dir = 8}
+
+# Repath and clean up pixel offsets. Uses a temporary repath to avoid repathing the same paths multiple times.
+# NORTH
+/obj/sign_switch/@SUBTYPES{dir = @UNSET}	: /temporary_sign_switch_repath/@SUBTYPES/directional/north{@OLD; dir = @SKIP; pixel_y = @SKIP}
+/obj/sign_switch/@SUBTYPES{dir = 1}			: /temporary_sign_switch_repath/@SUBTYPES/directional/north{@OLD; dir = @SKIP; pixel_y = @SKIP}
+# SOUTH
+/obj/sign_switch/@SUBTYPES{dir = 0}			: /temporary_sign_switch_repath/@SUBTYPES/directional/south{@OLD; dir = @SKIP; pixel_y = @SKIP}
+/obj/sign_switch/@SUBTYPES{dir = 2}			: /temporary_sign_switch_repath/@SUBTYPES/directional/south{@OLD; dir = @SKIP; pixel_y = @SKIP}
+# EAST
+/obj/sign_switch/@SUBTYPES{dir = 4}			: /temporary_sign_switch_repath/@SUBTYPES/directional/east{@OLD; dir = @SKIP; pixel_x = @SKIP}
+# WEST
+/obj/sign_switch/@SUBTYPES{dir = 8}			: /temporary_sign_switch_repath/@SUBTYPES/directional/west{@OLD; dir = @SKIP; pixel_x = @SKIP}
+
+# Revert the temporary repath.
+/temporary_sign_switch_repath/@SUBTYPES : /obj/sign_switch/@SUBTYPES{@OLD}


### PR DESCRIPTION
## About The PR:
Remaps every sign switch to a directional variant that uses the directional offsets system.
PRing to run correctness checks before a merge.


## Why Is This Needed?
See #24226.


## Testing:
In all maps that I loaded both ingame and in StrongDMM, none had any observable differences. Due to the small number of replacements, `.dmm` files were also checked by hand.