### PR TITLE
Moves juggle code to mob/living and allows critters to use it

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -30,9 +30,9 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //------------ OPTIONS TO GO FAST ------------//
 
-//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
+#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
 
-//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
+#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
 
 //#define SKIP_FEA_SETUP // Skip setting up atmospheric system
 //#define SKIP_Z5_SETUP // Skip generation of mining level

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -30,9 +30,9 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //------------ OPTIONS TO GO FAST ------------//
 
-#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
+//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the tiny map Devtest, no other zlevels. Boots way faster
 
-#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
+//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // All of the below
 
 //#define SKIP_FEA_SETUP // Skip setting up atmospheric system
 //#define SKIP_Z5_SETUP // Skip generation of mining level

--- a/code/datums/abilities/generic.dm
+++ b/code/datums/abilities/generic.dm
@@ -288,11 +288,11 @@
 	var/empowered = FALSE
 
 	cast(atom/movable/target)
-		if (!ishuman(src.holder.owner))
+		if (!isliving(src.holder.owner))
 			return
 		if (!src.empowered && (target.anchored || target == src.holder.owner) || target.anchored == ANCHORED_ALWAYS)
 			boutput(src.holder.owner, SPAN_ALERT("Your juggling abilities aren't quite enough to juggle that."))
 			return
 		. = ..()
-		var/mob/living/carbon/human/human = src.holder.owner
-		human.add_juggle(target)
+		var/mob/living/juggler = src.holder.owner
+		juggler.add_juggle(target)

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -880,10 +880,14 @@ ABSTRACT_TYPE(/datum/trait/job)
 		owner.AddComponent(/datum/component/death_confetti)
 		owner.bioHolder?.AddEffect("accent_comic", innate = TRUE)
 		owner.bioHolder?.AddEffect("clumsy", innate = TRUE)
-		owner.can_juggle = TRUE
+		if (isliving(owner))
+			var/mob/living/carbon/human/H = owner
+			H.can_juggle = TRUE
 
 	onRemove(var/mob/owner)
-		owner.can_juggle = FALSE
+		if (isliving(owner))
+			var/mob/living/carbon/human/H = owner
+			H.can_juggle = FALSE
 
 /datum/trait/job/mime
 	name = "Mime Training"
@@ -893,10 +897,14 @@ ABSTRACT_TYPE(/datum/trait/job)
 	onAdd(var/mob/owner)
 		owner.bioHolder?.AddEffect("mute", innate = TRUE)
 		owner.bioHolder?.AddEffect("blankman", innate = TRUE)
-		owner.can_juggle = TRUE
+		if (isliving(owner))
+			var/mob/living/carbon/human/H = owner
+			H.can_juggle = TRUE
 
 	onRemove(var/mob/owner)
-		owner.can_juggle = FALSE
+		if (isliving(owner))
+			var/mob/living/carbon/human/H = owner
+			H.can_juggle = FALSE
 
 /datum/trait/job/miner
 	name = "Miner Training"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -880,6 +880,10 @@ ABSTRACT_TYPE(/datum/trait/job)
 		owner.AddComponent(/datum/component/death_confetti)
 		owner.bioHolder?.AddEffect("accent_comic", innate = TRUE)
 		owner.bioHolder?.AddEffect("clumsy", innate = TRUE)
+		owner.can_juggle = TRUE
+
+	onRemove(var/mob/owner)
+		owner.can_juggle = FALSE
 
 /datum/trait/job/mime
 	name = "Mime Training"
@@ -889,6 +893,10 @@ ABSTRACT_TYPE(/datum/trait/job)
 	onAdd(var/mob/owner)
 		owner.bioHolder?.AddEffect("mute", innate = TRUE)
 		owner.bioHolder?.AddEffect("blankman", innate = TRUE)
+		owner.can_juggle = TRUE
+
+	onRemove(var/mob/owner)
+		owner.can_juggle = FALSE
 
 /datum/trait/job/miner
 	name = "Miner Training"

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1585,7 +1585,14 @@ TYPEINFO(/mob/living)
 			src.add_juggle(AM)
 	..()
 
-
+/mob/living/relaymove(mob/user, direction, delay, running)
+	..()
+	if ((user in src.juggling) && !ON_COOLDOWN(user, "resist_juggle", 1 SECOND))
+		boutput(user, SPAN_ALERT("You attempt to wriggle free from the unending juggling."))
+		playsound(src.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1)
+		if (prob(15))
+			src.remove_juggle(user)
+			user.set_loc(src.loc)
 
 // can stumble or flip while drunk
 /mob/living/proc/can_drunk_act()

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -936,6 +936,8 @@ TYPEINFO(/mob/living)
 	return 0
 
 /mob/living/proc/empty_hands()
+	if (src.juggling())
+		src.drop_juggle()
 	. = 0
 
 /mob/living/proc/update_lying()
@@ -1574,6 +1576,13 @@ TYPEINFO(/mob/living)
 				src.was_harmed(thr.user, AM)
 	if (AM.throwforce > 5) //number
 		src.changeStatus("staggered", 5 SECONDS)
+	if(!isobj(AM) && !src.juggling()) // nabbed from mob's hitby
+		return
+	if (prob(src.juggling.len * 5))
+		src.drop_juggle()
+	else
+		SPAWN(0)
+			src.add_juggle(AM)
 	..()
 
 
@@ -1815,6 +1824,24 @@ TYPEINFO(/mob/living)
 				var/obj/storage/crate/crate = new
 				new /obj/item/disk/data/floppy/read_only/authentication(crate)
 				shippingmarket.receive_crate(crate)
+
+/mob/living/proc/juggle_emote()
+	if (!src.restrained())
+		if (src.can_juggle)
+			var/obj/item/thing = src.equipped()
+			if (!thing)
+				if (src.l_hand)
+					thing = src.l_hand
+				else if (src.r_hand)
+					thing = src.r_hand
+			if (thing && !thing.cant_drop)
+				if (src.juggling())
+					if (prob(src.juggling.len * 5)) // might drop stuff while already juggling things
+						src.drop_juggle()
+					else
+						src.add_juggle(thing)
+				else
+					src.add_juggle(thing)
 
 /mob/living/proc/juggling()
 	if (islist(src.juggling) && length(src.juggling))

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -122,6 +122,11 @@ TYPEINFO(/mob/living)
 
 	var/last_sleep = 0 //used for sleep_bubble
 
+	var/list/juggling = list()
+	var/can_juggle = 0
+	///A dummy object that juggled objects go in the vis_contents of, so they can be scaled visually without affecting their actual scale
+	var/obj/dummy/juggle_dummy = null
+
 	can_lie = TRUE
 
 	voice_type = "1"
@@ -200,12 +205,15 @@ TYPEINFO(/mob/living)
 
 	if(src.ai_active)
 		ai_mobs.Remove(src)
+
+	src.juggle_dummy = null
 	..()
 
 /mob/living/death(gibbed)
 	#define VALID_MOB(M) (!isVRghost(M) && !isghostcritter(M) && !inafterlife(M) && !M.hasStatus("in_afterlife"))
 	src.remove_ailments()
 	src.lastgasp(allow_dead = TRUE)
+	src.drop_juggle()
 	if (src.ai) src.ai.disable()
 	if (src.isFlying)
 		REMOVE_ATOM_PROPERTY(src, PROP_ATOM_FLOATING, src)
@@ -1807,3 +1815,99 @@ TYPEINFO(/mob/living)
 				var/obj/storage/crate/crate = new
 				new /obj/item/disk/data/floppy/read_only/authentication(crate)
 				shippingmarket.receive_crate(crate)
+
+/mob/living/proc/juggling()
+	if (islist(src.juggling) && length(src.juggling))
+		return TRUE
+	return FALSE
+
+/mob/living/proc/drop_juggle()
+	set waitfor = FALSE // remove if you want to see 3,500 SHOULD_NOT_SLEEP errors because anything that ever causes a person to die can't sleep anymore
+
+	if (!src.juggling())
+		return
+	src.visible_message(SPAN_ALERT("<b>[src]</b> drops everything [he_or_she(src)] [were_or_was(src)] juggling!"))
+	for (var/atom/movable/A in src.juggling)
+		src.remove_juggle(A)
+		if(istype(A, /obj/item/device/light)) //i hate this
+			var/obj/item/device/light/L = A
+			L.light?.attach(L)
+		if (istype(A, /obj/item/gun) && prob(80)) //prob(80)
+			var/obj/item/gun/gun = A
+			gun.shoot(get_turf(pick(view(10, src))), get_turf(src), src, 16, 16)
+		else if (prob(40)) //bombs might land funny
+			if (istype(A, /obj/item/chem_grenade) || istype(A, /obj/item/old_grenade))
+				var/obj/item/explosive = A
+				explosive.AttackSelf(src)
+			else if (istype(A, /obj/item/device/transfer_valve))
+				var/obj/item/device/transfer_valve/ttv = A
+				ttv.toggle_valve()
+				logTheThing(LOG_BOMBING, src, "accidentally [ttv.valve_open ? "opened" : "closed"] the valve on a TTV tank transfer valve by failing to juggle at [log_loc(src)].")
+				message_admins("[key_name(usr)] accidentally [ttv.valve_open ? "opened" : "closed"] the valve on a TTV tank transfer valve by failing to juggle at [log_loc(src)].")
+			else if (istype(A, /obj/item/assembly))
+				var/obj/item/assembly/dropped_assembly = A
+				if(!dropped_assembly.secured)
+					// You're not evading death that easily, clown
+					dropped_assembly.secured = TRUE
+					dropped_assembly.add_fingerprint(src)
+					dropped_assembly.UpdateIcon()
+					dropped_assembly.last_armer = src
+				dropped_assembly.AttackSelf(src)
+		A.set_loc(get_turf(src)) //I give up trying to make this work with src.loc
+		if (prob(25))
+			A.throw_at(get_step(src, pick(alldirs)), 1, 1)
+	src.drop_from_slot(src.r_hand)
+	src.drop_from_slot(src.l_hand)
+	src.update_body()
+	logTheThing(LOG_STATION, src, "drops the items they were juggling")
+
+/mob/living/proc/remove_juggle(atom/movable/thing)
+	UnregisterSignal(thing, COMSIG_MOVABLE_SET_LOC)
+	thing.layer = initial(thing.layer)
+	src.juggle_dummy.vis_contents -= thing
+	animate_spin(thing, parallel = FALSE, looping = 0)
+	thing.pixel_x = initial(thing.pixel_x)
+	thing.pixel_y = initial(thing.pixel_y)
+	thing.layer = initial(thing.layer)
+	src.juggling -= thing
+
+/mob/living/proc/add_juggle(atom/movable/thing)
+	if (!thing || src.stat)
+		return
+	if (istype(thing, /obj/item/grab))
+		return
+	src.u_equip(thing)
+	if (thing.loc != src)
+		thing.set_loc(src)
+	if (src.juggling())
+		var/items = ""
+		var/count = 0
+		for (var/atom/movable/juggled in src.juggling)
+			count++
+			if (length(src.juggling) > 1 && count == src.juggling.len)
+				items += " and [juggled]"
+			else
+				items += ", [juggled]"
+		items = copytext(items, 3)
+		src.visible_message("<b>[src]</b> adds [thing] to the [items] [he_or_she(src)] [were_or_was(src)] already juggling!")
+	else
+		src.visible_message("<b>[src]</b> starts juggling [thing]!")
+	src.juggling += thing
+	if(isnull(src.juggle_dummy))
+		src.juggle_dummy = new(null)
+		src.juggle_dummy.name = null
+		src.juggle_dummy.mouse_opacity = FALSE
+		src.juggle_dummy.Scale(2/3, 2/3)
+		src.juggle_dummy.layer = src.layer + 0.1
+		src.juggle_dummy.appearance_flags |= RESET_COLOR | RESET_ALPHA
+		src.vis_contents += src.juggle_dummy
+	src.juggle_dummy.vis_contents += thing
+	thing.layer = src.layer + 0.1
+	animate_juggle(thing)
+	RegisterSignal(thing, COMSIG_MOVABLE_SET_LOC, PROC_REF(remove_juggle)) //there are so many ways juggled things can be stolen I'm just doing this
+	JOB_XP(src, "Clown", 1)
+	if (isitem(thing))
+		var/obj/item/i = thing
+		i.on_spin_emote(src)
+	src.update_body()
+	logTheThing(LOG_STATION, src, "starts juggling [thing].")

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -936,9 +936,9 @@ TYPEINFO(/mob/living)
 	return 0
 
 /mob/living/proc/empty_hands()
+	. = 0
 	if (src.juggling())
 		src.drop_juggle()
-	. = 0
 
 /mob/living/proc/update_lying()
 	if (src.lying != src.lying_old)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -132,11 +132,6 @@
 	var/static/image/spider_image = image('icons/mob/human.dmi', "layer" = EFFECTS_LAYER_UNDER_1-1)
 	var/static/image/makeup_image = image('icons/mob/human.dmi') // yeah this is just getting stupider
 
-	var/list/juggling = list()
-	var/can_juggle = 0
-	///A dummy object that juggled objects go in the vis_contents of, so they can be scaled visually without affecting their actual scale
-	var/obj/dummy/juggle_dummy = null
-
 	// preloaded sounds moved up to /mob/living
 
 	var/list/sound_list_scream = null
@@ -558,8 +553,6 @@
 	QDEL_NULL(src.cloner_defects)
 	QDEL_NULL(src.inventory)
 
-	src.juggle_dummy = null
-
 	..()
 
 	//blah, this might not be effective for ref clearing but ghost observers inside me NEED this list to be populated in base mob/disposing
@@ -614,8 +607,6 @@
 	src.jitteriness = 0
 
 	src.update_health_monitor_icon()
-
-	src.drop_juggle()
 
 #ifdef DATALOGGER
 	game_stats.Increment("deaths")
@@ -2584,102 +2575,6 @@ Tries to put an item in an available backpack, belt storage, pocket, or hand slo
 	if (wearing_football_gear())
 		src.tackle(AM)
 	..()
-
-/mob/living/carbon/human/proc/juggling()
-	if (islist(src.juggling) && length(src.juggling))
-		return TRUE
-	return FALSE
-
-/mob/living/carbon/human/proc/drop_juggle()
-	set waitfor = FALSE // remove if you want to see 3,500 SHOULD_NOT_SLEEP errors because anything that ever causes a person to die can't sleep anymore
-
-	if (!src.juggling())
-		return
-	src.visible_message(SPAN_ALERT("<b>[src]</b> drops everything [he_or_she(src)] [were_or_was(src)] juggling!"))
-	for (var/atom/movable/A in src.juggling)
-		src.remove_juggle(A)
-		if(istype(A, /obj/item/device/light)) //i hate this
-			var/obj/item/device/light/L = A
-			L.light?.attach(L)
-		if (istype(A, /obj/item/gun) && prob(80)) //prob(80)
-			var/obj/item/gun/gun = A
-			gun.shoot(get_turf(pick(view(10, src))), get_turf(src), src, 16, 16)
-		else if (prob(40)) //bombs might land funny
-			if (istype(A, /obj/item/chem_grenade) || istype(A, /obj/item/old_grenade))
-				var/obj/item/explosive = A
-				explosive.AttackSelf(src)
-			else if (istype(A, /obj/item/device/transfer_valve))
-				var/obj/item/device/transfer_valve/ttv = A
-				ttv.toggle_valve()
-				logTheThing(LOG_BOMBING, src, "accidentally [ttv.valve_open ? "opened" : "closed"] the valve on a TTV tank transfer valve by failing to juggle at [log_loc(src)].")
-				message_admins("[key_name(usr)] accidentally [ttv.valve_open ? "opened" : "closed"] the valve on a TTV tank transfer valve by failing to juggle at [log_loc(src)].")
-			else if (istype(A, /obj/item/assembly))
-				var/obj/item/assembly/dropped_assembly = A
-				if(!dropped_assembly.secured)
-					// You're not evading death that easily, clown
-					dropped_assembly.secured = TRUE
-					dropped_assembly.add_fingerprint(src)
-					dropped_assembly.UpdateIcon()
-					dropped_assembly.last_armer = src
-				dropped_assembly.AttackSelf(src)
-		A.set_loc(get_turf(src)) //I give up trying to make this work with src.loc
-		if (prob(25))
-			A.throw_at(get_step(src, pick(alldirs)), 1, 1)
-	src.drop_from_slot(src.r_hand)
-	src.drop_from_slot(src.l_hand)
-	src.update_body()
-	logTheThing(LOG_STATION, src, "drops the items they were juggling")
-
-/mob/living/carbon/human/proc/remove_juggle(atom/movable/thing)
-	UnregisterSignal(thing, COMSIG_MOVABLE_SET_LOC)
-	thing.layer = initial(thing.layer)
-	src.juggle_dummy.vis_contents -= thing
-	animate_spin(thing, parallel = FALSE, looping = 0)
-	thing.pixel_x = initial(thing.pixel_x)
-	thing.pixel_y = initial(thing.pixel_y)
-	thing.layer = initial(thing.layer)
-	src.juggling -= thing
-
-/mob/living/carbon/human/proc/add_juggle(atom/movable/thing)
-	if (!thing || src.stat)
-		return
-	if (istype(thing, /obj/item/grab))
-		return
-	src.u_equip(thing)
-	if (thing.loc != src)
-		thing.set_loc(src)
-	if (src.juggling())
-		var/items = ""
-		var/count = 0
-		for (var/atom/movable/juggled in src.juggling)
-			count++
-			if (length(src.juggling) > 1 && count == src.juggling.len)
-				items += " and [juggled]"
-			else
-				items += ", [juggled]"
-		items = copytext(items, 3)
-		src.visible_message("<b>[src]</b> adds [thing] to the [items] [he_or_she(src)] [were_or_was(src)] already juggling!")
-	else
-		src.visible_message("<b>[src]</b> starts juggling [thing]!")
-	src.juggling += thing
-	if(isnull(src.juggle_dummy))
-		src.juggle_dummy = new(null)
-		src.juggle_dummy.name = null
-		src.juggle_dummy.mouse_opacity = FALSE
-		src.juggle_dummy.Scale(2/3, 2/3)
-		src.juggle_dummy.layer = src.layer + 0.1
-		src.juggle_dummy.appearance_flags |= RESET_COLOR | RESET_ALPHA
-		src.vis_contents += src.juggle_dummy
-	src.juggle_dummy.vis_contents += thing
-	thing.layer = src.layer + 0.1
-	animate_juggle(thing)
-	RegisterSignal(thing, COMSIG_MOVABLE_SET_LOC, PROC_REF(remove_juggle)) //there are so many ways juggled things can be stolen I'm just doing this
-	JOB_XP(src, "Clown", 1)
-	if (isitem(thing))
-		var/obj/item/i = thing
-		i.on_spin_emote(src)
-	src.update_body()
-	logTheThing(LOG_STATION, src, "starts juggling [thing].")
 
 /mob/living/carbon/human/relaymove(mob/user, direction, delay, running)
 	if ((user in src.juggling) && !ON_COOLDOWN(user, "resist_juggle", 1 SECOND))

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2916,14 +2916,13 @@ Tries to put an item in an available backpack, belt storage, pocket, or hand slo
 		return FALSE
 
 /mob/living/carbon/human/empty_hands()
+	..()
 	var/h = src.hand
 	src.hand = 0
 	drop_item()
 	src.hand = 1
 	drop_item()
 	src.hand = h
-	if (src.juggling())
-		src.drop_juggle()
 
 /mob/living/carbon/human/special_movedelay_mod(delay,space_movement,aquatic_movement)
 	.= delay

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2576,14 +2576,6 @@ Tries to put an item in an available backpack, belt storage, pocket, or hand slo
 		src.tackle(AM)
 	..()
 
-/mob/living/carbon/human/relaymove(mob/user, direction, delay, running)
-	if ((user in src.juggling) && !ON_COOLDOWN(user, "resist_juggle", 1 SECOND))
-		boutput(user, SPAN_ALERT("You attempt to wriggle free from the unending juggling."))
-		playsound(src.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1)
-		if (prob(15))
-			src.remove_juggle(user)
-			user.set_loc(src.loc)
-
 /mob/living/carbon/human/return_air(direct = FALSE)
 	if (!direct)
 		return src.loc?.return_air()

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -650,29 +650,12 @@
 				else
 					src.show_text("You just don't feel kawaii enough to uguu right now!", "red")
 					return
-
 			if ("juggle")
-				if (!src.restrained())
-					if (src.emote_check(voluntary, 25))
-						m_type = 1
-						if (src.traitHolder?.hasTrait("training_clown") || src.traitHolder?.hasTrait("training_mime") || src.can_juggle)
-							var/obj/item/thing = src.equipped()
-							if (!thing)
-								if (src.l_hand)
-									thing = src.l_hand
-								else if (src.r_hand)
-									thing = src.r_hand
-							if (thing && !thing.cant_drop)
-								if (src.juggling())
-									if (prob(src.juggling.len * 5)) // might drop stuff while already juggling things
-										src.drop_juggle()
-									else
-										src.add_juggle(thing)
-								else
-									src.add_juggle(thing)
-							else
-								message = "<B>[src]</B> wiggles [his_or_her(src)] fingers a bit.[prob(10) ? " Weird." : null]"
-								maptext_out = "<I>wiggles [his_or_her(src)] fingers a bit.</I>"
+				if (src.emote_check(voluntary, 25))
+					src.juggle_emote()
+					m_type = 1
+					message = "<B>[src]</B> wiggles [his_or_her(src)] fingers a bit.[prob(10) ? " Weird." : null]"
+					maptext_out = "<I>wiggles [his_or_her(src)] fingers a bit.</I>"
 			if ("twirl", "spin")
 				if (!src.restrained())
 					if (src.emote_check(voluntary, 25))

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -917,13 +917,6 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 		logTheThing(LOG_COMBAT, src, "is struck by [AM] [AM.is_open_container() ? "[log_reagents(AM)]" : ""] at [log_loc(src)] (likely thrown by [thr?.user ? constructName(thr.user) : "a non-mob"]).")
 	if(thr?.user)
 		src.was_harmed(thr.user, AM)
-	if(!isobj(AM) && !src.juggling()) // nabbed from mob's hitby
-		return
-	if (prob(src.juggling.len * 5))
-		src.drop_juggle()
-	else
-		SPAWN(0)
-			src.add_juggle(AM)
 
 /mob/living/critter/TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 	if (src.nodamage || QDELETED(src))
@@ -1093,8 +1086,6 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 			I.set_loc(src.loc)
 			I.layer = initial(I.layer)
 			u_equip(I)
-	if (src.juggling())
-		src.drop_juggle()
 
 /mob/living/critter/proc/drop_equipment()
 	for (var/datum/equipmentHolder/EH in equipment)
@@ -1204,28 +1195,11 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 						animate_spin(src, pick("L", "R"), 1, 0)
 				src.drop_juggle()
 			if ("juggle")
-				if (!src.restrained())
-					if (src.emote_check(voluntary, 25))
-						m_type = 1
-						if (src.can_juggle)
-							var/obj/item/thing = src.equipped()
-							if (!thing)
-								if (src.l_hand)
-									thing = src.l_hand
-								else if (src.r_hand)
-									thing = src.r_hand
-							if (thing && !thing.cant_drop)
-								if (src.juggling())
-									if (prob(src.juggling.len * 5)) // might drop stuff while already juggling things
-										src.drop_juggle()
-									else
-										src.add_juggle(thing)
-								else
-									src.add_juggle(thing)
-							else
-								message = "<B>[src]</B> wiggles [his_or_her(src)] fingers a bit.[prob(10) ? " Weird." : null]"
-								maptext_out = "<I>wiggles [his_or_her(src)] fingers a bit.</I>"
-
+				if (src.emote_check(voluntary, 25))
+					src.juggle_emote()
+					m_type = 1
+					message = "<B>[src]</B> wiggles [his_or_her(src)] fingers a bit.[prob(10) ? " Weird." : null]"
+					maptext_out = "<I>wiggles [his_or_her(src)] fingers a bit.</I>"
 	if (!message)
 		return
 

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1077,6 +1077,7 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 			u_equip(I)
 
 /mob/living/critter/empty_hands()
+	..()
 	for (var/datum/handHolder/HH in hands)
 		if (HH.item)
 			if (!HH.item.qdeled && !HH.item.disposed && istype(HH.item, /obj/item/grab))

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -917,6 +917,13 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 		logTheThing(LOG_COMBAT, src, "is struck by [AM] [AM.is_open_container() ? "[log_reagents(AM)]" : ""] at [log_loc(src)] (likely thrown by [thr?.user ? constructName(thr.user) : "a non-mob"]).")
 	if(thr?.user)
 		src.was_harmed(thr.user, AM)
+	if(!isobj(AM) && !src.juggling()) // nabbed from mob's hitby
+		return
+	if (prob(src.juggling.len * 5))
+		src.drop_juggle()
+	else
+		SPAWN(0)
+			src.add_juggle(AM)
 
 /mob/living/critter/TakeDamage(zone, brute, burn, tox, damage_type, disallow_limb_loss)
 	if (src.nodamage || QDELETED(src))
@@ -1086,6 +1093,8 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 			I.set_loc(src.loc)
 			I.layer = initial(I.layer)
 			u_equip(I)
+	if (src.juggling())
+		src.drop_juggle()
 
 /mob/living/critter/proc/drop_equipment()
 	for (var/datum/equipmentHolder/EH in equipment)
@@ -1193,6 +1202,7 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 					else
 						message = "<b>[src]</B> does a flip!"
 						animate_spin(src, pick("L", "R"), 1, 0)
+				src.drop_juggle()
 
 	if (!message)
 		return

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1203,6 +1203,28 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 						message = "<b>[src]</B> does a flip!"
 						animate_spin(src, pick("L", "R"), 1, 0)
 				src.drop_juggle()
+			if ("juggle")
+				if (!src.restrained())
+					if (src.emote_check(voluntary, 25))
+						m_type = 1
+						if (src.can_juggle)
+							var/obj/item/thing = src.equipped()
+							if (!thing)
+								if (src.l_hand)
+									thing = src.l_hand
+								else if (src.r_hand)
+									thing = src.r_hand
+							if (thing && !thing.cant_drop)
+								if (src.juggling())
+									if (prob(src.juggling.len * 5)) // might drop stuff while already juggling things
+										src.drop_juggle()
+									else
+										src.add_juggle(thing)
+								else
+									src.add_juggle(thing)
+							else
+								message = "<B>[src]</B> wiggles [his_or_her(src)] fingers a bit.[prob(10) ? " Weird." : null]"
+								maptext_out = "<I>wiggles [his_or_her(src)] fingers a bit.</I>"
 
 	if (!message)
 		return

--- a/code/mob/living/critter/martian.dm
+++ b/code/mob/living/critter/martian.dm
@@ -24,6 +24,7 @@ TYPEINFO(/mob/living/critter/martian)
 	can_grab = TRUE
 	can_disarm = TRUE
 	can_help = TRUE
+	can_juggle = TRUE
 	health_brute = 50
 	health_brute_vuln = 0.5
 	health_burn = 50

--- a/code/mob/living/critter/small_animal/mouse.dm
+++ b/code/mob/living/critter/small_animal/mouse.dm
@@ -280,6 +280,7 @@ ADMIN_INTERACT_PROCS(/mob/living/critter/small_animal/mouse, proc/glorp)
 	player_can_spawn_with_pet = FALSE
 	has_genes = FALSE
 	shiny_chance = 0
+	can_juggle = TRUE
 
 	New()
 		..()
@@ -459,6 +460,7 @@ TYPEINFO(/mob/living/critter/small_animal/mouse/weak/mentor/admin)
 	player_can_spawn_with_pet = FALSE
 	say_language = LANGUAGE_ENGLISH
 	shiny_chance = 1365 //Odds with the shiny charm, because of how charming these guys are before they run you over with a truck!
+	can_juggle = TRUE
 
 	New()
 		. = ..()

--- a/code/mob/living/critter/spider.dm
+++ b/code/mob/living/critter/spider.dm
@@ -436,6 +436,7 @@
 	venom2 = "rainbow fluid"
 	good_grip = 1
 	encase_in_web = 2
+	can_juggle = 1
 	stepsound = "clownstep"
 	death_text = "%src% explodes into technicolor gore!"
 	add_abilities = list(/datum/targetable/critter/clownspider_trample,

--- a/code/mob/living/critter/spider.dm
+++ b/code/mob/living/critter/spider.dm
@@ -32,6 +32,7 @@
 	can_throw = 1
 	can_grab = 1
 	can_disarm = 1
+	can_juggle = 1
 	var/good_grip = 1
 
 	butcherable = BUTCHER_ALLOWED

--- a/code/mob/living/life/breath.dm
+++ b/code/mob/living/life/breath.dm
@@ -116,6 +116,9 @@
 				var/obj/fluid/F = new // used for underwater breathing check
 				F.reagents = owner.loc.reagents
 				underwater = F
+		else if (istype(owner.loc, /mob/living/critter))
+			src.update_breath_hud(status_updates)
+			return
 
 		//if (istype(loc, /obj/machinery/clonepod)) return
 

--- a/code/modules/ranch/chicken.dm
+++ b/code/modules/ranch/chicken.dm
@@ -525,6 +525,7 @@ All other chickens in this file are non-secret. Please be respectful.
 	favorite_flag = "honk"
 	negative_happiness = TRUE
 	base_evolution_type = /datum/ranch/evolution/chicken/feed_threshold/honk
+	can_juggle = TRUE
 
 	New()
 		. = ..()
@@ -1898,6 +1899,7 @@ All other chickens in this file are non-secret. Please be respectful.
 	favorite_flag = "nicotine"
 	attack_ability_type = /datum/targetable/critter/mime_cage
 	happy_pet_message = "looks happy."
+	can_juggle = TRUE
 
 	grow_up()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Juggling code was placed under the human type despite not strictly needing it to be a human to use, so I moved all relevant vars and code to mob/living and mirrored any proc calls in human procs (hitby, empty hands and "flip" emote) to the equivalent critter proc.

This also gives spiders, queen clownspiders, martians and clown/mime chickens can_juggle = TRUE so they can juggle naturally. Martians have telekinesis and tentacles, after all.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Juggling is funny, it never needed to be for humans only _and_ I'm planning on adding a juggle throw to a critter I'm working on, so this would be needed for that.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested typing *juggle with critters with different amount of hands, seems to work even queen clownspiders. Tested using the juggle ability on critters without can_juggle which worked. Tested if humans can still juggle and drop juggles properly which they can. I'm expecting an oversight bug to crop up somewhere but it seems to work fine right now.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CalliopeSoups
(+)Queen clownspiders, martians and more can juggle now, beware.
```
