### PR TITLE
Emagging atmospheric analyzer

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -151,6 +151,7 @@
 #include "defines\uplink.dm"
 #include "defines\vehicles.dm"
 #include "defines\viewport.dm"
+#include "defines\volume.dm"
 #include "defines\watermap.dm"
 #include "defines\weapons.dm"
 #include "defines\worldgen.dm"

--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -108,6 +108,7 @@
 #include "defines\obj.dm"
 #include "defines\pod_door_access_levels.dm"
 #include "defines\preferences.dm"
+#include "defines\pressure.dm"
 #include "defines\process.dm"
 #include "defines\projectiles.dm"
 #include "defines\ranch.dm"

--- a/_std/defines/pressure.dm
+++ b/_std/defines/pressure.dm
@@ -1,0 +1,5 @@
+/// Converts a pressure in kPa to psi.
+#define TO_PSI(K) (K * 0.145038)
+
+/// Converts a pressure in psi to kPa.
+#define TO_KPA(P) (P / 0.145038)

--- a/_std/defines/pressure.dm
+++ b/_std/defines/pressure.dm
@@ -1,5 +1,2 @@
 /// Converts a pressure in kPa to psi.
 #define TO_PSI(K) (K * 0.145038)
-
-/// Converts a pressure in psi to kPa.
-#define TO_KPA(P) (P / 0.145038)

--- a/_std/defines/volume.dm
+++ b/_std/defines/volume.dm
@@ -1,5 +1,2 @@
 /// Converts a volume in liters to gallons.
 #define TO_GALLONS(L) (L * 0.264172)
-
-/// Converts a volume in gallons to liters.
-#define TO_LITERS(G) (G / 0.264172)

--- a/_std/defines/volume.dm
+++ b/_std/defines/volume.dm
@@ -1,0 +1,5 @@
+/// Converts a volume in liters to gallons.
+#define TO_GALLONS(L) (L * 0.264172)
+
+/// Converts a volume in gallons to liters.
+#define TO_LITERS(G) (G / 0.264172)

--- a/code/modules/scanners/atmospheric.dm
+++ b/code/modules/scanners/atmospheric.dm
@@ -55,10 +55,10 @@
 			[SPAN_NOTICE("Atmospheric analysis of <b>[A]</b>")]<br>\
 			<br>\
 			Pressure: [round(pressure, 0.1)] kPa<br>\
-			Temperature: [emagged_analyzer ? "[round(((check_me.temperature - 273.15) * 9 / 5) + 32, 0.1)] °F" : "[round(check_me.temperature)] K"]<br>"
+			Temperature: [emagged_analyzer ? "[round(((check_me.temperature - 273.15) * 9 / 5) + 32)] °F" : "[round(check_me.temperature)] K"]<br>"
 			//realistically bubbles should have a constantly changing volume based on their pressure but it doesn't really matter so let's just not report it
 			if (!istype(A, /obj/bubble))
-				data += "Volume: [check_me.volume] L<br>"
+				data += "Volume: [emagged_analyzer ? "[round(check_me.volume * 0.264172)] gal" : "[check_me.volume] L"]<br>"
 			data +=	"[SIMPLE_CONCENTRATION_REPORT(check_me, "<br>")]"
 
 	else

--- a/code/modules/scanners/atmospheric.dm
+++ b/code/modules/scanners/atmospheric.dm
@@ -55,7 +55,7 @@
 			[SPAN_NOTICE("Atmospheric analysis of <b>[A]</b>")]<br>\
 			<br>\
 			Pressure: [round(pressure, 0.1)] kPa<br>\
-			Temperature: [emagged_analyzer ? "[round(((check_me.temperature - 273.15) * 9 / 5) + 32)] °F" : "[round(check_me.temperature)] K"]<br>"
+			Temperature: [emagged_analyzer ? "[round(TO_FAHRENHEIT(check_me.temperature))] °F" : "[round(check_me.temperature)] K"]<br>"
 			//realistically bubbles should have a constantly changing volume based on their pressure but it doesn't really matter so let's just not report it
 			if (!istype(A, /obj/bubble))
 				data += "Volume: [emagged_analyzer ? "[round(check_me.volume * 0.264172)] gal" : "[check_me.volume] L"]<br>"
@@ -95,7 +95,7 @@ TYPEINFO(/obj/item/device/analyzer/atmospheric)
 	var/hudarrow_color = "#0df0f0"
 	///We keep track of the airgroup so we can acquire a new breach after the old one is patched, even if the user is standing on space at the time
 	var/datum/air_group/tracking_airgroup = null
-	var/emagged = 0
+	var/emagged = FALSE
 
 	// Distance upgrade action code
 	pixelaction(atom/target, params, mob/user, reach)
@@ -207,20 +207,20 @@ TYPEINFO(/obj/item/device/analyzer/atmospheric)
 			if (user)
 				boutput(user, SPAN_NOTICE("You have de-standardized the results provided by the analyzer."))
 			logTheThing(LOG_COMBAT, user, "emagged [src] at [log_loc(src)].")
-			emagged = 1
-			return 1
+			emagged = TRUE
+			return TRUE
 		else
 			if (user)
-				boutput(user, "The analyzer is already unstandardized.")
-			return 0
+				boutput(user, "The analyzer is already de-standardized.")
+			return FALSE
 
 	demag(var/mob/user)
 		if (!src.emagged)
-			return 0
-		emagged = 0
+			return FALSE
+		emagged = FALSE
 		if (user)
 			boutput(user, SPAN_NOTICE("You reconfigure the analyzer to provide standardized readings."))
-		return 1
+		return TRUE
 
 /obj/item/device/analyzer/atmospheric/upgraded //for borgs because JESUS FUCK
 	analyzer_upgrade = 1

--- a/code/modules/scanners/atmospheric.dm
+++ b/code/modules/scanners/atmospheric.dm
@@ -95,6 +95,7 @@ TYPEINFO(/obj/item/device/analyzer/atmospheric)
 	var/hudarrow_color = "#0df0f0"
 	///We keep track of the airgroup so we can acquire a new breach after the old one is patched, even if the user is standing on space at the time
 	var/datum/air_group/tracking_airgroup = null
+	var/emagged = 0
 
 	// Distance upgrade action code
 	pixelaction(atom/target, params, mob/user, reach)
@@ -200,6 +201,26 @@ TYPEINFO(/obj/item/device/analyzer/atmospheric)
 				SPAWN(0)
 					det.detonate()
 		return
+
+	emag_act(var/mob/user, var/obj/item/card/emag/E)
+		if (!src.emagged)
+			if (user)
+				boutput(user, SPAN_NOTICE("You have de-standardized the results provided by the analyzer."))
+			logTheThing(LOG_COMBAT, user, "emagged [src] at [log_loc(src)].")
+			emagged = 1
+			return 1
+		else
+			if (user)
+				boutput(user, "The analyzer is already unstandardized.")
+			return 0
+
+	demag(var/mob/user)
+		if (!src.emagged)
+			return 0
+		emagged = 0
+		if (user)
+			boutput(user, SPAN_NOTICE("You reconfigure the analyzer to provide standardized readings."))
+		return 1
 
 /obj/item/device/analyzer/atmospheric/upgraded //for borgs because JESUS FUCK
 	analyzer_upgrade = 1

--- a/code/modules/scanners/atmospheric.dm
+++ b/code/modules/scanners/atmospheric.dm
@@ -3,7 +3,7 @@
 // handheld atmos scanner & upgrade chip
 
 // Made this a global proc instead of 10 or so instances of duplicate code spread across the codebase (Convair880).
-/proc/scan_atmospheric(var/atom/A as turf|obj, var/pda_readout = 0, var/simple_output = 0, var/visible = 0, var/alert_output = 0)
+/proc/scan_atmospheric(var/atom/A as turf|obj, var/pda_readout = 0, var/simple_output = 0, var/visible = 0, var/alert_output = 0, var/emagged_analyzer = 0)
 	if (istype(A, /obj/ability_button))
 		return
 	if (!A)
@@ -55,7 +55,7 @@
 			[SPAN_NOTICE("Atmospheric analysis of <b>[A]</b>")]<br>\
 			<br>\
 			Pressure: [round(pressure, 0.1)] kPa<br>\
-			Temperature: [round(check_me.temperature)] K<br>"
+			Temperature: [emagged_analyzer ? "[round(((check_me.temperature - 273.15) * 9 / 5) + 32, 0.1)] °F" : "[round(check_me.temperature)] K"]<br>"
 			//realistically bubbles should have a constantly changing volume based on their pressure but it doesn't really matter so let's just not report it
 			if (!istype(A, /obj/bubble))
 				data += "Volume: [check_me.volume] L<br>"
@@ -102,7 +102,7 @@ TYPEINFO(/obj/item/device/analyzer/atmospheric)
 		var/turf/T = get_turf(target)
 		if ((analyzer_upgrade == 1) && (BOUNDS_DIST(user, T) > 0))
 			user.visible_message(SPAN_NOTICE("<b>[user]</b> takes a distant atmospheric reading of [T]."))
-			boutput(user, scan_atmospheric(T, visible = 1))
+			boutput(user, scan_atmospheric(T, visible = 1, emagged_analyzer = emagged))
 			src.add_fingerprint(user)
 			return
 
@@ -183,7 +183,7 @@ TYPEINFO(/obj/item/device/analyzer/atmospheric)
 
 		if (istype(A, /obj) || isturf(A))
 			user.visible_message(SPAN_NOTICE("<b>[user]</b> takes an atmospheric reading of [A]."))
-			boutput(user, scan_atmospheric(A, visible = 1))
+			boutput(user, scan_atmospheric(A, visible = 1, emagged_analyzer = emagged))
 		src.add_fingerprint(user)
 		return
 

--- a/code/modules/scanners/atmospheric.dm
+++ b/code/modules/scanners/atmospheric.dm
@@ -54,7 +54,7 @@
 			data = "--------------------------------<br>\
 			[SPAN_NOTICE("Atmospheric analysis of <b>[A]</b>")]<br>\
 			<br>\
-			Pressure: [round(pressure, 0.1)] kPa<br>\
+			Pressure: [emagged_analyzer ? "[round(TO_PSI(pressure), 0.1)] psi" : "[round(pressure, 0.1)] kPa"]<br>\
 			Temperature: [emagged_analyzer ? "[round(TO_FAHRENHEIT(check_me.temperature))] °F" : "[round(check_me.temperature)] K"]<br>"
 			//realistically bubbles should have a constantly changing volume based on their pressure but it doesn't really matter so let's just not report it
 			if (!istype(A, /obj/bubble))

--- a/code/modules/scanners/atmospheric.dm
+++ b/code/modules/scanners/atmospheric.dm
@@ -58,7 +58,7 @@
 			Temperature: [emagged_analyzer ? "[round(TO_FAHRENHEIT(check_me.temperature))] °F" : "[round(check_me.temperature)] K"]<br>"
 			//realistically bubbles should have a constantly changing volume based on their pressure but it doesn't really matter so let's just not report it
 			if (!istype(A, /obj/bubble))
-				data += "Volume: [emagged_analyzer ? "[round(check_me.volume * 0.264172)] gal" : "[check_me.volume] L"]<br>"
+				data += "Volume: [emagged_analyzer ? "[round(TO_GALLONS(check_me.volume))] gal" : "[check_me.volume] L"]<br>"
 			data +=	"[SIMPLE_CONCENTRATION_REPORT(check_me, "<br>")]"
 
 	else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allow players to use EMAG card into atmospheric analyzer to change the displayed temperature and volumen measure units from metric to imperial.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it can be a fun and a not specially harmfull way for antagonists to mess with certain departments and pull off some creative gimmicks.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
In the devtest map scanned both floor tiles and a plasma cannister with a upgraded non-emagged atmospheric analyzer, confirming that readings are displayed as currently (Kelvin for temperatura and Liters for volume). Then emagged the the analyzer and repeated the scan, confirming that the displayed units have changed.

<img width="451" height="308" alt="image" src="https://github.com/user-attachments/assets/a6c0ab61-9bd7-466a-ba4f-65492c7f9fea" />

I also spawned as Atmospherish Technician, usign the PDA Atmospheric Scan and verifying that it still displays the original units
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Astarthoc
(+)You can now emag atmospheric analyzers, causing them to display temperature and volume usint imperial units instead of metric.
```
