### PR TITLE
Clownspider implanter

### DIFF
--- a/code/datums/syndicate_buylist/buylist_job.dm
+++ b/code/datums/syndicate_buylist/buylist_job.dm
@@ -64,6 +64,7 @@
 	vr_allowed = FALSE
 	job = list(ALL_CLOWNS)
 	can_buy = UPLINK_TRAITOR
+	max_buy = 3
 
 /datum/syndicate_buylist/traitor/chambomb
 	name = "Chameleon Bomb Case"

--- a/code/datums/syndicate_buylist/buylist_job.dm
+++ b/code/datums/syndicate_buylist/buylist_job.dm
@@ -56,6 +56,15 @@
 	job = list(ALL_CLOWNS)
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
+/datum/syndicate_buylist/traitor/clownspider_implant
+	name = "Clownspider Implant"
+	items = list(/obj/item/implanter/clownspider)
+	cost = 2
+	desc = "Strike me down and I shall become funnier than you could possibly imagine. Whoever is implanted with this will explode into a bunch of clownspiders on death and be considered friendly to clownspiders. CAUTION: Spider bites may result in contraction of known disease \"Clowning Around\"."
+	vr_allowed = FALSE
+	job = list(ALL_CLOWNS)
+	can_buy = UPLINK_TRAITOR
+
 /datum/syndicate_buylist/traitor/chambomb
 	name = "Chameleon Bomb Case"
 	items = list(/obj/item/storage/box/chameleonbomb)

--- a/code/modules/medical/implants/implanter.dm
+++ b/code/modules/medical/implants/implanter.dm
@@ -217,6 +217,16 @@
 		src.imp = new /obj/item/implant/revenge/wasp(src)
 		..()
 
+/obj/item/implanter/clownspider
+	name = "funny-looking implanter"
+	icon_state = "implanter1-g"
+	sneaky = TRUE
+	HELP_MESSAGE_OVERRIDE({"When someone dies while implanted with this, they will explode into a cloud of angry clownspiders. Suiciding will cause no cloud of wasps to appear. This implant will also make clownspiders friendly to the user."})
+
+	New()
+		src.imp = new /obj/item/implant/revenge/wasp/clownspider(src)
+		..()
+
 /obj/item/implanter/marionette
 	icon_state = "implanter1-g"
 	sneaky = TRUE

--- a/code/modules/medical/implants/revenge.dm
+++ b/code/modules/medical/implants/revenge.dm
@@ -158,3 +158,10 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		SPAWN(1)
 			src.owner?.gib()
 		. = ..()
+
+/obj/item/implant/revenge/wasp/clownspider
+	name = "funny implant"
+	big_message = " squeaks a little."
+	small_message = "emits a loud honk, uh oh!"
+	wasp_type = /mob/living/critter/spider/clown
+	faction = FACTION_CLOWN


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a clownspider implanter to the clown uplink for 2TC causing the target to explode into 8 small clownspiders on death.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've given several clowns this already with admin tools and its rather funny as while they dont do that much damage immediately (they inject you with histamine), they are likely to infect you with clowning around.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="713" height="217" alt="image" src="https://github.com/user-attachments/assets/d24fa588-e3e8-4137-a120-05442dadc202" />
<img width="593" height="347" alt="image" src="https://github.com/user-attachments/assets/54c25632-e9ce-41d8-bccb-5c85e9d29dd0" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Clown Traitors can now purchase a "clownspider implanter", causing them to explode into several clownspiders on death
```
