### PR TITLE
Removes access requirements from airlocks which have been forced open by EMPs

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1197,6 +1197,7 @@ TYPEINFO(/obj/machinery/door/airlock)
 	if (prob(20) && (src.density && src.cant_emag != 1 && src.isblocked() != 1))
 		src.open()
 		src.operating = -1
+		src.deconstruct_flags |= DECON_NO_ACCESS
 	if(prob(40))
 		if(src.secondsElectrified == 0)
 			src.secondsElectrified = -1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[ENGINEERING] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Airlocks which have been forced open by EMPs have the DECON_NO_ACCESS deconstruction flag added to them, so they can be deconstructed by anybody with a deconstruction device and the relevant tools.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Same as the reasoning behind emags removing airlock access requirements - if it can't be used in any meaningful way, what's the point of preventing people from deconstructing it?
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="2560" height="1440" alt="Screenshot (825)" src="https://github.com/user-attachments/assets/8909d662-bcc6-4a5e-8065-5e18cead672a" />
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)nova2053
(+)Airlocks which have been forced open by EMPs no longer require access to deconstruct.
```
