### PR TITLE
Fix objective-specific items

### DIFF
--- a/code/modules/antagonists/__antagonist.dm
+++ b/code/modules/antagonists/__antagonist.dm
@@ -157,6 +157,11 @@ ABSTRACT_TYPE(/datum/antagonist)
 			if (!src.owner.assigned_role)
 				message_admins("Antagonist datum of type [src.type] failed to properly late setup after 60 seconds. Report this to a coder.")
 
+		if (do_objectives)
+			src.assign_objectives()
+			if (!src.silent)
+				src.announce_objectives()
+
 		src.did_equip = do_equip
 		if (do_equip)
 			src.give_equipment()
@@ -176,11 +181,6 @@ ABSTRACT_TYPE(/datum/antagonist)
 		if (!src.silent)
 			src.announce()
 			src.do_popup()
-
-		if (do_objectives)
-			src.assign_objectives()
-			if (!src.silent)
-				src.announce_objectives()
 
 		if (do_relocate)
 			src.relocate()

--- a/code/obj/item/pinpointer.dm
+++ b/code/obj/item/pinpointer.dm
@@ -292,8 +292,7 @@ TYPEINFO(/obj/item/pinpointer/idtracker)
 					if(ckey(I.registered) == ckey(A.targetname))
 						targets[I] = I
 				LAGCHECK(LAG_LOW)
-			target = null
-			target = input(user, "Which ID do you wish to track?", "Target Locator", null) in targets
+			target = tgui_input_list(user, "Which ID do you wish to track?", "Target Locator", targets)
 			if(!target)
 				boutput(user, SPAN_NOTICE("You activate the target locator. No available targets!"))
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Causes antagonist objectives to be applied _before_ giving equipment such as uplinks.
This allows objective items to properly apply and thus Traitors with Assassinate objectives and Headrevs (who get assassinate objectives for all command members) to purchase ID pinpointers for their targets.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Syndicate buylist entries can be locked to specific objectives, currently this is only the ID pinpointer available to anyone with an assassinate target (including Headrevs)

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Note I had to manually edit my assassinate objective here to target me as they refuse to have a target that is themselves (e.g. command headrevs will not have a suicide objective, though other headrevs will get objectives to kill them)

<img width="735" height="335" alt="image" src="https://github.com/user-attachments/assets/5abab06a-7129-4d16-9c6e-2a57ebb32ac8" />
<img width="487" height="352" alt="image" src="https://github.com/user-attachments/assets/536d21f4-7837-4bc6-8a60-ede497f3e88f" />
<img width="174" height="129" alt="image" src="https://github.com/user-attachments/assets/d6ad2105-13b1-4231-a2e5-5d684b388286" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Fixed objective-specific uplink items not appearing in uplinks. Note this now allows traitors/headrevs with kill objectives (Headrevs get kill objectives for ALL command) to buy ID pinpointers.
```
