### PR TITLE
traitor botanists can now buy wasp implanters

### DIFF
--- a/code/datums/syndicate_buylist/buylist_job.dm
+++ b/code/datums/syndicate_buylist/buylist_job.dm
@@ -187,7 +187,7 @@
 /datum/syndicate_buylist/traitor/wasp_implanter
 	name = "Wasp Implanter"
 	items = list(/obj/item/implanter/wasp)
-	cost = 6
+	cost = 2
 	desc = "Enemies being a buzzkill? This implant will release a swarm of angry wasps upon your death, and make them really feel the sting! More implants mean more wasps, and while you are implanted wasps will be friendly to you."
 	vr_allowed = FALSE
 	job = list("Botanist", "Apiculturist")

--- a/code/datums/syndicate_buylist/buylist_job.dm
+++ b/code/datums/syndicate_buylist/buylist_job.dm
@@ -192,6 +192,7 @@
 	vr_allowed = FALSE
 	job = list("Botanist", "Apiculturist")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
+	max_buy = 3
 
 /datum/syndicate_buylist/traitor/fakegrenade
 	name = "Fake Cleaner Grenades"

--- a/code/datums/syndicate_buylist/buylist_job.dm
+++ b/code/datums/syndicate_buylist/buylist_job.dm
@@ -188,10 +188,10 @@
 	name = "Wasp Implanter"
 	items = list(/obj/item/implanter/wasp)
 	cost = 2
-	desc = "Enemies being a buzzkill? This implant will release a swarm of angry wasps upon your death, and make them really feel the sting! More implants mean more wasps, and while you are implanted wasps will be friendly to you."
+	desc = "Enemies being a buzzkill? This implant will release a swarm of angry wasps upon your death, and make them really feel the sting! More implants mean more wasps. If a target is implanted, wasps will be friendly to them as if they are a botanist or apiculturalist."
 	vr_allowed = FALSE
 	job = list("Botanist", "Apiculturist")
-	can_buy = UPLINK_TRAITOR
+	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 
 /datum/syndicate_buylist/traitor/fakegrenade
 	name = "Fake Cleaner Grenades"

--- a/code/datums/syndicate_buylist/buylist_job.dm
+++ b/code/datums/syndicate_buylist/buylist_job.dm
@@ -184,6 +184,15 @@
 			return
 		..()
 
+/datum/syndicate_buylist/traitor/wasp_implanter
+	name = "Wasp Implanter"
+	items = list(/obj/item/implanter/wasp)
+	cost = 6
+	desc = "Enemies being a buzzkill? This implant will release a swarm of angry wasps upon your death, and make them really feel the sting! More implants mean more wasps, and while you are implanted wasps will be friendly to you."
+	vr_allowed = FALSE
+	job = list("Botanist", "Apiculturist")
+	can_buy = UPLINK_TRAITOR
+
 /datum/syndicate_buylist/traitor/fakegrenade
 	name = "Fake Cleaner Grenades"
 	items = list(/obj/item/storage/box/f_grenade_kit)

--- a/code/modules/medical/implants/revenge.dm
+++ b/code/modules/medical/implants/revenge.dm
@@ -136,12 +136,6 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		..()
 		if (istype(M) && src.faction)
 			LAZYLISTADDUNIQUE(M.faction, src.faction)
-		if (M == I)
-			M.mind.store_memory("Your implanted [src] will release wasps upon unintentional death.", 0, 0)
-			boutput(M, "The implanted [src] will release wasps upon unintentional death. (Suiciding will likely fail to trigger it, but succumbing while in crit will trigger it.)")
-		else if (istype(I))
-			boutput(I, "The implanted [src] will release wasps upon [M]'s unintentional death.")
-
 
 	on_remove(mob/M)
 		..()
@@ -164,4 +158,3 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		SPAWN(1)
 			src.owner?.gib()
 		. = ..()
-

--- a/code/modules/medical/implants/revenge.dm
+++ b/code/modules/medical/implants/revenge.dm
@@ -136,6 +136,12 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		..()
 		if (istype(M) && src.faction)
 			LAZYLISTADDUNIQUE(M.faction, src.faction)
+		if (M == I)
+			M.mind.store_memory("Your implanted [src] will release wasps upon unintentional death.", 0, 0)
+			boutput(M, "The implanted [src] will release wasps upon unintentional death. (Suiciding will likely fail to trigger it, but succumbing while in crit will trigger it.)")
+		else if (istype(I))
+			boutput(I, "The implanted [src] will release wasps upon [M]'s unintentional death.")
+
 
 	on_remove(mob/M)
 		..()
@@ -158,3 +164,4 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		SPAWN(1)
 			src.owner?.gib()
 		. = ..()
+


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Traitor botanists and apiculturalists can now buy wasp implanters with their uplink for 2TC. 

The existing wasp implant only spawned in traitor crates alongside wasp crossbows or wasp grenades and did not have a cost. A new cost of 2 was chosen for the implant giving a traitor who spends all 12 coins a total of 48 wasps released on death.  A buy limit of 3 has been added. 

Also adds an info message on implant about inten to match the microbomb. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently wasp implanters are only available in surplus crates. They fit thematically and synergize with the wasp crossbow and wasp grenades that are already available to botanists.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->


<img width="400" height="400" alt="listing_2" src="https://github.com/user-attachments/assets/513d6f58-a56c-49ab-a165-3a618d2fbaf8" />


<img width="400" height="400" alt="description_2" src="https://github.com/user-attachments/assets/bb122a45-74ae-44a9-b288-d312b977636d" />

<img width="400" height="350" alt="working_1" src="https://github.com/user-attachments/assets/3fa95ba6-8e5e-46e4-b8ce-6f71906451aa" />



<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->


