### PR TITLE
Adds a can_juggle check to mob/living/hitby

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1576,7 +1576,7 @@ TYPEINFO(/mob/living)
 				src.was_harmed(thr.user, AM)
 	if (AM.throwforce > 5) //number
 		src.changeStatus("staggered", 5 SECONDS)
-	if(!isobj(AM) && !src.juggling()) // nabbed from mob's hitby
+	if((!isobj(AM) && !src.juggling()) || !src.can_juggle) // nabbed from mob's hitby
 		return
 	if (prob(src.juggling.len * 5))
 		src.drop_juggle()

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1576,7 +1576,7 @@ TYPEINFO(/mob/living)
 				src.was_harmed(thr.user, AM)
 	if (AM.throwforce > 5) //number
 		src.changeStatus("staggered", 5 SECONDS)
-	if((!src.can_juggle || !isobj(AM) || !src.juggling())) // nabbed from mob's hitby
+	if((!src.can_juggle || !isitem(AM) || !src.juggling())) // nabbed from mob's hitby
 		return
 	if (prob(src.juggling.len * 5))
 		src.drop_juggle()

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1576,7 +1576,7 @@ TYPEINFO(/mob/living)
 				src.was_harmed(thr.user, AM)
 	if (AM.throwforce > 5) //number
 		src.changeStatus("staggered", 5 SECONDS)
-	if((!isobj(AM) && !src.juggling()) || !src.can_juggle) // nabbed from mob's hitby
+	if((!src.can_juggle || !isobj(AM) || !src.juggling())) // nabbed from mob's hitby
 		return
 	if (prob(src.juggling.len * 5))
 		src.drop_juggle()
@@ -1938,7 +1938,7 @@ TYPEINFO(/mob/living)
 	src.juggle_dummy.vis_contents += thing
 	thing.layer = src.layer + 0.1
 	animate_juggle(thing)
-	RegisterSignal(thing, COMSIG_MOVABLE_SET_LOC, PROC_REF(remove_juggle)) //there are so many ways juggled things can be stolen I'm just doing this
+	RegisterSignal(thing, COMSIG_MOVABLE_SET_LOC, PROC_REF(remove_juggle), override = TRUE) //there are so many ways juggled things can be stolen I'm just doing this
 	JOB_XP(src, "Clown", 1)
 	if (isitem(thing))
 		var/obj/item/i = thing


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

I forgot to put a check to see if you can juggle when someone throws an item at you. This also makes override TRUE in the registersignal at line 1941, as it was throwing a crash that didn't seem important, seems to work fine.

Additionally this changes an isobj check to isitem to avoid people juggling massive objects thrown at them, as funny as that is.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #27144.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested it by giving shitty bill clown training and throwing things at him, also throwing things at things without can_juggle.
