### PR TITLE
Makes standard cyborg arms cost 0 points in character creation

### DIFF
--- a/code/datums/part_customization.dm
+++ b/code/datums/part_customization.dm
@@ -148,13 +148,11 @@ ABSTRACT_TYPE(/datum/part_customization/human/limb)
 				id = "arm_robo_standard_left"
 				slot = "l_arm"
 				part_type = /obj/item/parts/robot_parts/arm/left/standard
-				trait_cost = 1
 
 			robo_standard_right
 				id = "arm_robo_standard_right"
 				slot = "r_arm"
 				part_type = /obj/item/parts/robot_parts/arm/right/standard
-				trait_cost = 1
 
 			plant_left
 				id = "arm_plant_left"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduces the cost of standard borg arms from 1 trait point to 0 in character selection.
Note: This PR does not affect cyborg legs, since they remove the drawbacks of going barefoot + standard legs can break legcuffs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Standard borg arms no longer confer mechanical benefits over light arms after their cuffbreaking ability was moved to sturdy arms. It makes sense to have their point cost standardized down to 0, same as the light version.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Opened character setup, selected standard arms, they cost 0 points as expected

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)rdcb
(*)Standard cyborg arms now cost 0 points in character creation.
```
