### PR TITLE
Fixes Mentor Mice not hearing themselves and other ethereal critters

### DIFF
--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -562,6 +562,7 @@ var/list/antag_respawn_critter_types =  list(/mob/living/critter/small_animal/fl
 
 	C.mind.assigned_role = "Animal"
 	C.say_language = LANGUAGE_ANIMAL
+	C.ensure_listen_tree().AddKnownLanguage(LANGUAGE_ANIMAL)
 	C.literate = 0
 	C.original_name = selfmob.real_name
 	C.is_npc = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where mentor mice couldn't hear ethereal critters, themselves or other mentor mice due to speaking in the animal language, but not "understanding" it
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes a bug, allows mentors to communicate if multiple mentors for whatever reason are trying to help the same person
Despite someone commenting its fixed, it very much is not, maybe the person who commented was in admin mode where they can hear everything
#26284
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Opened game, removed admin tree, then spoke in mentor mouse, and it worked
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
