### PR TITLE
Hideout chutes always repressurize as if in normal atmosphere

### DIFF
--- a/code/datums/components/extradimensional_storage/extradimensional_prefabs/disposal_unit.dm
+++ b/code/datums/components/extradimensional_storage/extradimensional_prefabs/disposal_unit.dm
@@ -6,6 +6,19 @@
 	_max_health = 250
 	SYNDICATE_STEALTH_DESCRIPTION("You can't see the bottom.", null)
 
+/obj/machinery/disposal/extradimensional/absorb_gas(var/datum/gas_mixture/mix)
+	if(mix)
+		return ..(mix)
+
+	//Always absorb atmosphere at the standard rate
+	var/datum/gas_mixture/air_mix = new
+	air_mix.oxygen = MOLES_O2STANDARD
+	air_mix.nitrogen = MOLES_O2STANDARD
+	air_mix.fuel_burnt = 0
+	air_mix.temperature = T20C
+	. = ..(air_mix)
+	qdel(air_mix)
+
 /obj/machinery/disposal/extradimensional/flush()
 	src.flushing = 1
 	FLICK("[icon_style]-flush", src)

--- a/code/modules/disposals/disposal_chute.dm
+++ b/code/modules/disposals/disposal_chute.dm
@@ -520,28 +520,23 @@ ADMIN_INTERACT_PROCS(/obj/machinery/disposal, proc/flush, proc/eject)
 		if(flush && MIXTURE_PRESSURE(air_contents) >= 2*ONE_ATMOSPHERE)	// flush can happen even without power
 			SPAWN(0) //Quit holding up the process you fucker
 				flush()
+		src.absorb_gas()
+		return
 
-		if(status & NOPOWER)			// won't charge if no power
-			return
+	proc/absorb_gas(var/datum/gas_mixture/env)
+		if(!src.loc) return // Nullspaced, no point in trying.
+		if(src.status & NOPOWER) return // Won't charge without power
+		if(src.mode != DISPOSAL_CHUTE_CHARGING)	return // if off or ready, no need to charge
 
-		if (!loc) return
-
-		if(mode != DISPOSAL_CHUTE_CHARGING)		// if off or ready, no need to charge
-			return
-
-		var/atom/L = loc						// recharging from loc turf
-		var/datum/gas_mixture/env = L.return_air()
-		if (!air_contents)
-			air_contents = new /datum/gas_mixture
+		env ||= src.loc.return_air()
+		src.air_contents ||= new /datum/gas_mixture
 		var/pressure_delta = (3.5 * ONE_ATMOSPHERE) - MIXTURE_PRESSURE(air_contents) // purposefully trying to overshoot the target of 2 atmospheres to make it faster
 
 		if(env.temperature > 0)
 			var/transfer_moles = src.repressure_speed * pressure_delta*air_contents.volume/(env.temperature * R_IDEAL_GAS_EQUATION)
-
 			//Actually transfer the gas
 			var/datum/gas_mixture/removed = env.remove(transfer_moles)
 			air_contents.merge(removed)
-
 
 		// if full enough, switch to ready mode
 		if(MIXTURE_PRESSURE(air_contents) >= 2.5*ONE_ATMOSPHERE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the disposal chute repressurization part of process into its own proc that can specify gas mixture to absorb
If not passed a mixture arg, it gets the mixture of its loc same as current behaviour.
Extradimensional chutes if not passed a mixture arg will pass a normal atmosphere mixture to its parent proc, causing the chute to always repressurize as if in a normal atmosphere. This will also mean you do not pump any _bad_ gasses between the chutes

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently if you blow a hole in your hideout everyone inside is stuck forever unless you manage to repressurize the room. This should never happen.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Left/Right - Hideout/Normal Chute
Top/Bottom - Airless/Airfull Turf (Unsimulated)
Flushed these chutes and they behaved as expected, with all but the top right repressurizing at the normal rate.
<img width="860" height="358" alt="image" src="https://github.com/user-attachments/assets/7e4ef346-f9b8-447a-93dd-d38d739907ad" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Syndicate hideout chutes (both entrance and exit) now always repressurize as if in a normal atmosphere, even if there is no atmosphere around them.
```
