### PR TITLE
Artisan Trait less likely to choose Synthrubber

### DIFF
--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -2328,7 +2328,6 @@ ABSTRACT_TYPE(/datum/material/rubber)
 				0.30, 0.00, 0.00, 0.00,\
 				0.00, 0.00, 0.00, 1.00,\
 				0.25, 0.00, 0.00, 0.00)
-	artisan_trait_weight = MATERIAL_ARTISAN_COMMON
 
 	New()
 		..()


### PR DESCRIPTION
## About the PR
- Turns synthrubber from a common to uncommon material for the artisan trait.

## Why's this needed?
- Each synthrubber color is its own material, making synthrubber very likely to be picked over everything else.

## Testing
- It compiled.

## Changelog
```changelog
(u)LorrMaster
(+)Artisan trait is less likely to choose synthrubber materials.
```