### PR TITLE
Multiple morgue-crematorium link options in morgue area contents check

### DIFF
--- a/code/modules/unit_tests/_map_correctness/area_contents_check/medical/morgue.dm
+++ b/code/modules/unit_tests/_map_correctness/area_contents_check/medical/morgue.dm
@@ -11,7 +11,6 @@
 	expected_contents = list(
 		// General
 		CONTENTS_GT(/obj/machinery/traymachine/morgue, 2),
-		CONTENTS_EQ(/obj/disposaloutlet, 1),
 		CONTENTS_EQ(/mob/living/critter/small_animal/opossum/morty, 1),
 		// Surgical Equipment
 		CONTENTS_GT(/obj/machinery/optable, 0),
@@ -34,6 +33,11 @@
 		CONTENTS_OR(
 			list(CONTENTS_GT(/obj/item/storage/box/body_bag, 0)),
 			list(CONTENTS_GT(/obj/item/body_bag, 2)),
+		),
+		// Morgue-crematorium linkage of some sort (omitted on Nadir)
+		CONTENTS_OR(
+			list(CONTENTS_EQ(/obj/disposaloutlet, 1)),
+			list(CONTENTS_EQ(/obj/machinery/disposal/morgue, 1)),
 		),
 	)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[INTERNAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the Morgue area contents check to permit either a disposal outlet or a morgue-type disposal chute.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It may be desirable to have the ability to send bodies from the Morgue to the Crematorium for safe body disposal, so this check allows for that to happen in a two-chute linkage.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Will show in CI.
