### PR TITLE
Jamming the AI blocks their announcements+shuttle calls

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2507,6 +2507,10 @@ proc/get_mobs_trackable_by_AI()
 		if(tgui_alert(src.get_message_mob(), "Your message was shortened to: \"[message]\", continue anyway?", "Too wordy!", list("Yes", "No")) != "Yes")
 			return
 
+	if(check_for_radio_jammers(src))
+		src.show_text("Your mainframe's communications array is currently being jammed!", "red")
+		return
+
 	command_announcement(html_encode(message), "Station Announcement by [src.name] (AI)", 'sound/misc/announcement_1.ogg', alert_origin=ALERT_COMMAND)
 
 	last_announcement = world.time

--- a/code/obj/item/device/radios/radio_jammer.dm
+++ b/code/obj/item/device/radios/radio_jammer.dm
@@ -47,7 +47,7 @@ TYPEINFO(/obj/item/radiojammer)
 		return
 	var/obj/item/assembly/parent_assembly = src.loc
 	//automatic heartbeat signals: we still want to know when we're jamming them but we probably don't care most of the time
-	var/icon_state = signal.data["command"] == "heartbeat" ? "signal_jammed_heartbeat" : "signal_jammed"
+	var/icon_state = signal?.data["command"] == "heartbeat" ? "signal_jammed_heartbeat" : "signal_jammed"
 	src.UpdateOverlays(image(src.icon, icon_state), "jammed_light")
 	if(istype(parent_assembly))
 		parent_assembly.UpdateOverlays(image('icons/obj/items/assemblies.dmi', icon_state), "jammed_light")

--- a/code/obj/machinery/computer/communications.dm
+++ b/code/obj/machinery/computer/communications.dm
@@ -13,6 +13,10 @@
 		src.show_text("Your mainframe was unable to relay this command that far away!", "red")
 		return
 
+	if(check_for_radio_jammers(src))
+		src.show_text("Your mainframe's communications array is currently being jammed!", "red")
+		return
+
 	if (emergency_shuttle.online)
 		boutput(usr, SPAN_ALERT("The emergency shuttle is currently in flight!"))
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents the AI from making announcements or calling the emergency shuttle if they are currently being signal jammed.

Also adds a little check to stop the signal jammer item runtiming if there was no signal datum attached to the jammer check

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently signal jamming the AI is pretty pointless as they can just announce "Help john mcsyndie signal jammed me and is kidnapping me!". Shuttle calling was included in this blocking as they could use this as an alternative announcement button when they realise their announcement isnt working. This makes the AI player have to use a shell to go call for help, but a clever traitor can prepare for this by destroying all the AI's shells.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested making announcements/calling the shuttle before being jammed, could.
Activated a jammer adjacent to my core, tried again, got the error message.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)The AI can no longer make station announcements or call the shuttle if their core is being signal jammed.
```
