### PR TITLE
Mailtag mapping helpers now work on chutes

### DIFF
--- a/code/modules/mapping/helpers/mailtag_spawn.dm
+++ b/code/modules/mapping/helpers/mailtag_spawn.dm
@@ -9,18 +9,25 @@
 
 ABSTRACT_TYPE(/obj/mapping_helper/mailtag)
 /obj/mapping_helper/mailtag
-	name = "junction mailtag spawn"
-	desc = "Configures a mail junction with its mail tag, then destroys itself."
+	name = "mailtag spawn"
+	desc = "Configures a mail chute or junction with its mail tag, then destroys itself."
 	icon = 'icons/effects/mapeditor.dmi'
 	icon_state = "mail_tag"
 	var/mail_tag = null
 
 	setup()
+		if(!src.mail_tag)
+			CRASH("Unconfigured mailtag spawn!\nCoordinates: [src.x] x, [src.y] y, [src.z] z")
 		for (var/obj/disposalpipe/switch_junction/sj in src.loc)
-			if(src.mail_tag)
-				if(!sj.mail_tag) sj.mail_tag = list()
-				sj.mail_tag += src.mail_tag
-				break
+			if(!sj.mail_tag) sj.mail_tag = list()
+			sj.mail_tag += src.mail_tag
+			break
+		for (var/obj/machinery/disposal/mail/mc in src.loc)
+			mc.name = "mail chute ([src.mail_tag])"
+			mc.mail_tag = src.mail_tag
+			SPAWN(1 SECOND)
+				mc.post_radio_status()
+			break
 
 	// Mailtag types
 	// All subtypes should exist across:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[INTERNAL][MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The mailtag mapping helper now has a setup() condition for mail chutes, configuring their name and tag in a similar fashion to how autoname chutes configure themselves.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Reduces varediting for special cases in maps, and may eventually permit complete elimination of typed mail chutes.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Replaced Cog2's chemistry mailchute with an unedited one and the Chemistry mailtag helper, and it worked as expected.
