### PR TITLE
ACTUALLY fix oshan for the mechlab test

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -12934,26 +12934,20 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/storage/cart/mechcart,
-/obj/item/rods/steel{
-	amount = 50
-	},
+/obj/storage/cart/mechcart/tools,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
 /area/station/engine/elect)
 "bnk" = (
 /obj/machinery/light/incandescent/warm,
-/obj/storage/cart/mechcart,
-/obj/item/rods/steel{
-	amount = 50
-	},
+/obj/machinery/vending/mechanics,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
 /area/station/engine/elect)
 "bnm" = (
-/obj/machinery/vending/standard,
+/obj/machinery/manufacturer/mechanic,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -25160,7 +25154,7 @@
 /area/station/maintenance/north)
 "dNf" = (
 /obj/item/device/radio/intercom/engineering,
-/obj/machinery/vending/mechanics,
+/obj/machinery/vending/standard,
 /turf/simulated/floor,
 /area/station/engine/elect)
 "dNn" = (
@@ -39219,6 +39213,10 @@
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
+"ppN" = (
+/obj/storage/cart/mechcart/breach,
+/turf/simulated/floor,
+/area/station/engine/eva)
 "ppQ" = (
 /obj/machinery/light/incandescent/netural,
 /obj/table/reinforced/auto,
@@ -39275,6 +39273,12 @@
 	pixel_y = 4
 	},
 /obj/item/clothing/ears/earmuffs,
+/obj/item/rods/steel{
+	amount = 50
+	},
+/obj/item/rods/steel{
+	amount = 50
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/eva)
 "prZ" = (
@@ -40422,6 +40426,12 @@
 /obj/landmark/pest,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"qsa" = (
+/obj/storage/cart/mechcart/breach,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/engine/eva)
 "qsD" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -48293,7 +48303,6 @@
 /area/research_outpost)
 "wKy" = (
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/manufacturer/mechanic,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -105041,8 +105050,8 @@ sYB
 lIm
 bfW
 mVB
-osH
-bfW
+qsa
+ppN
 blB
 bnj
 bnT


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Soooooo, at my previous pr both the map check was wrong (empty mech cart instead of tools mech cart).
This pr puts breach carts where the old empty carts were, 
put the metal rods (that were at the empty carts) at the table of the storage room, like in every other map,
Put a tool cart in the mechlab and move the fabricator & dispenser a bit to be more like before the faulty changes
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#27184 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I spawned in and checked the carts
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ANNmagedon
(+)Fixed Oshan lacking the standard tools & breach engineering carts.
```
