### PR TITLE
Add extended check for antag monkes in sudden sapience event

### DIFF
--- a/code/modules/events/sudden_sapience_disease.dm
+++ b/code/modules/events/sudden_sapience_disease.dm
@@ -12,7 +12,8 @@
 			var/turf/monkearea = get_turf(monke)
 			if (istype(monkearea.loc, /area/station/medical/dome) || istype(monke, /mob/living/carbon/human/npc/monkey/angry) || monke.mind?.current.client)
 				continue // remove monkey pen apes so you don't get one of those 95% of the time
-
+			else if (istypes(monke, src.antag_npcs) && master_mode == "extended")
+				continue
 			if (isalive(monke) && get_z(monke) == Z_LEVEL_STATION)
 				found_npcs += monke
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a quick check in the sudden sapience event so it doesn't add mobs in antag_npcs to the possible monke list.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

No antags in extended!

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested on a regular round and extended.

