### PR TITLE
Fixed clairon to match the mechlab tests

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -19756,8 +19756,10 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/vending/mechanics,
 /obj/machinery/firealarm/directional/north,
+/obj/storage/secure/closet/engineering/mechanic,
+/obj/item/electronics/soldering,
+/obj/item/clothing/gloves/yellow,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "jaD" = (
@@ -27211,6 +27213,7 @@
 /area/station/security/main)
 "ohZ" = (
 /obj/machinery/light_switch/directional/south,
+/obj/machinery/vending/mechanics,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "oia" = (
@@ -28657,6 +28660,9 @@
 	dir = 4
 	},
 /obj/noticeboard/persistent/mechanics/directional/north,
+/obj/storage/secure/closet/engineering/mechanic,
+/obj/item/electronics/soldering,
+/obj/item/clothing/gloves/yellow,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "pis" = (
@@ -34223,36 +34229,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/disposal/mail/small{
-	dir = 1;
-	mail_tag = "mechanics";
-	mailgroup = "mechanic";
-	message = "1";
-	name = "mail chute-'Mechanics'";
-	pixel_y = 32
-	},
+/obj/machinery/disposal/mail/small/autoname/mechanics/north,
 /obj/disposalpipe/trunk/mail{
 	dir = 8
 	},
-/obj/storage/cart/mechcart,
-/obj/item/electronics/scanner,
-/obj/item/electronics/scanner,
-/obj/item/disk/data/cartridge/diagnostics{
-	pixel_x = 9;
-	pixel_y = -2
-	},
-/obj/item/disk/data/cartridge/diagnostics{
-	pixel_x = 11;
-	pixel_y = 4
-	},
-/obj/item/disk/data/cartridge/diagnostics{
-	pixel_x = 10;
-	pixel_y = 12
-	},
-/obj/item/electronics/soldering,
-/obj/item/electronics/soldering,
-/obj/item/device/t_scanner,
-/obj/item/device/t_scanner,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "sZH" = (
@@ -38231,11 +38211,19 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_north,
-/obj/storage/secure/closet/engineering/mechanic,
-/obj/item/clothing/gloves/yellow,
-/obj/item/clothing/gloves/yellow,
-/obj/item/electronics/soldering,
-/obj/item/electronics/soldering,
+/obj/storage/cart/mechcart/tools,
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 10;
+	pixel_y = 12
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 11;
+	pixel_y = 4
+	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "vBC" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Made mechanics use an autoname chute.
Reshuffled the mechlab a bit to allow 2 mechanics lockers.
Replaced the old manually stuffed mech cart with a tools mech cart.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#27184 again
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="821" height="398" alt="image" src="https://github.com/user-attachments/assets/1784749c-d801-4499-b9bc-6713dcdd072b" />
Also validated the mail chute sends and receives correctly (mailed a blueprint to and from genetics!
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ANNmagedon
(+)Standardized Clairon's mech-lab's engineering cart.
```
