### PR TITLE
disable gluing things to disks and cartridges

### DIFF
--- a/code/datums/components/glue_ready.dm
+++ b/code/datums/components/glue_ready.dm
@@ -81,6 +81,9 @@ TYPEINFO(/datum/component/glue_ready)
 		return FALSE
 	if(istype(glued_to, /obj/machinery/door) || istype(glued_to, /obj/mesh/grille))
 		return FALSE
+	if(istype(glued_to, /obj/item/disk/data))
+		boutput(user, SPAN_ALERT("Gluing on \the [thing_glued] will make \the [glued_to] unusable! You'd better not!")) /* Stop people gluing shit (read: signal jammers or fibre wires) to a disk or cartridge and inserting it into a pda/console*/
+		return FALSE
 	if(istype(glued_to, /mob/dead) || istype(glued_to, /mob/living/intangible) )
 		if(user)
 			boutput(user, SPAN_ALERT("Your hand with [thing_glued] passes straight through \the [glued_to]."))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Stops being able to glue things to cartridges or disks altogether. Only affects tiny items that would pass the size check for gluing in the first place. This however includes active signal jammers, fiber wire, circular saw, body bags, some grenade pouches and razors.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
To stop people gluing an big stack of tiny items to a pda cart and hiding them by inserting it into their pda, especially signal jammers. Right now you can glue all of the above listed items all to the one cart at the same time and hide the lot in your pda. Same with gluing to disks and inserting into the cloning disk rack/any console that takes disks. 


## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

before: hide all the things. You can stack more than this, I think the limit would only be how much glue you can find
<img width="359" height="115" alt="all the shit" src="https://github.com/user-attachments/assets/8afcca66-cfbe-40f5-b098-5c1d1740d8de" />

<img width="359" height="132" alt="shiton a disk" src="https://github.com/user-attachments/assets/fbff7e3d-3ee5-4899-b4b4-9d339468544e" />


after: stop them in their tracks
<img width="664" height="111" alt="unglueable_1" src="https://github.com/user-attachments/assets/6039f0cd-f15e-4d11-9512-d277348b794e" />

Tested with the signal jammer and various other items. 

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
