### PR TITLE
Properly integrated headset uplinks

### DIFF
--- a/code/obj/item/device/radios/_radio.dm
+++ b/code/obj/item/device/radios/_radio.dm
@@ -154,6 +154,8 @@ TYPEINFO(/obj/item/device/radio)
 	src.ensure_speech_tree().process(message)
 
 /obj/item/device/radio/attackby(obj/item/W, mob/user)
+	if(src.traitorradio && !src.traitorradio.locked && !isscrewingtool(W))
+		return src.traitorradio.Attackby(W, user)
 	src.add_dialog(user)
 	if (!isscrewingtool(W))
 		return
@@ -175,6 +177,10 @@ TYPEINFO(/obj/item/device/radio)
 	src.toggle_speaker(FALSE)
 
 /obj/item/device/radio/ui_interact(mob/user, datum/tgui/ui)
+	if(src.traitorradio && !src.traitorradio.locked)
+		src.traitorradio.ui_interact(user)
+		return
+
 	if (src.bricked)
 		user.show_text(src.bricked_msg, "red")
 		return
@@ -185,10 +191,7 @@ TYPEINFO(/obj/item/device/radio)
 
 	ui = tgui_process.try_update_ui(user, src, ui)
 	if (!ui)
-		if(src.traitorradio && !src.traitorradio.locked)
-			ui = new(user, src.traitorradio, "Uplink")
-		else
-			ui = new(user, src, "Radio")
+		ui = new(user, src, "Radio")
 		ui.open()
 
 /obj/item/device/radio/ui_state(mob/user)

--- a/code/obj/item/device/radios/_radio.dm
+++ b/code/obj/item/device/radios/_radio.dm
@@ -154,7 +154,7 @@ TYPEINFO(/obj/item/device/radio)
 	src.ensure_speech_tree().process(message)
 
 /obj/item/device/radio/attackby(obj/item/W, mob/user)
-	if(src.traitorradio && !src.traitorradio.locked && !isscrewingtool(W))
+	if(src.traitorradio && !src.traitorradio.locked && istype(W, /obj/item/uplink_telecrystal))
 		return src.traitorradio.Attackby(W, user)
 	src.add_dialog(user)
 	if (!isscrewingtool(W))

--- a/code/obj/item/device/radios/_radio.dm
+++ b/code/obj/item/device/radios/_radio.dm
@@ -185,7 +185,10 @@ TYPEINFO(/obj/item/device/radio)
 
 	ui = tgui_process.try_update_ui(user, src, ui)
 	if (!ui)
-		ui = new(user, src, "Radio")
+		if(src.traitorradio && !src.traitorradio.locked)
+			ui = new(user, src.traitorradio, "Uplink")
+		else
+			ui = new(user, src, "Radio")
 		ui.open()
 
 /obj/item/device/radio/ui_state(mob/user)
@@ -232,26 +235,18 @@ TYPEINFO(/obj/item/device/radio)
 		if ("set-frequency")
 			if (src.locked_frequency)
 				return FALSE
-			src.set_frequency(sanitize_frequency(params["value"]))
+
+			var/frequency_to_set = sanitize_frequency(params["value"])
 
 			// The "finish" param indicates that a user has inputted a number or finished dragging the frequency dial.
 			// This makes it more difficult to bruteforce the uplink.
-			if (params["finish"] && !isnull(src.traitorradio) && src.traitor_frequency && src.frequency == src.traitor_frequency)
-				ui.close()
-				src.remove_dialog(usr)
-				usr.Browse(null, WINDOW_OPTIONS)
-				global.onclose(usr, "radio")
-
-				// Transform the regular radio into a disguised Syndicate uplink.
-				var/obj/item/uplink/integrated/radio/T = src.traitorradio
-				var/obj/item/device/radio/R = src
-				R.set_loc(T)
-				usr.u_equip(R)
-				usr.put_in_hand_or_drop(T)
-				R.set_loc(T)
-				T.locked = 0
-				T.AttackSelf(usr)
+			if (params["finish"] && !isnull(src.traitorradio) && src.traitor_frequency && frequency_to_set == src.traitor_frequency)
+				tgui_process.close_uis(src)
+				src.traitorradio.locked = FALSE
+				src.ui_interact(usr)
 				return
+
+			src.set_frequency(frequency_to_set)
 
 			return TRUE
 

--- a/code/obj/item/uplinks/integrated_uplinks.dm
+++ b/code/obj/item/uplinks/integrated_uplinks.dm
@@ -256,12 +256,15 @@
 				R.traitorradio = src
 				if (src.lock_code_autogenerate == 1)
 					R.traitor_frequency = src.generate_code()
+					src.locked = TRUE
 				R.protected_radio = TRUE
-				src.name = R.name
-				src.icon = R.icon
-				src.icon_state = R.icon_state
 				src.origradio = R
 		return
+
+	lock(mob/user)
+		. = ..()
+		if(!.) return //Failed to lock, don't continue.
+		src.origradio?.ui_interact(user)
 
 	traitor
 		purchase_flags = UPLINK_TRAITOR

--- a/code/obj/item/uplinks/integrated_uplinks.dm
+++ b/code/obj/item/uplinks/integrated_uplinks.dm
@@ -263,19 +263,6 @@
 				src.origradio = R
 		return
 
-	lock(mob/user)
-		. = ..()
-		if(!.) return //Failed to lock, don't continue.
-		if (!isnull(src.origradio) && istype(src.origradio, /obj/item/device/radio))
-			var/obj/item/device/radio/T = src.origradio
-			src.set_loc(T)
-			T.set_loc(user)
-			user.u_equip(src)
-			user.put_in_hand_or_drop(T)
-			src.set_loc(T)
-			T.set_frequency(initial(T.frequency))
-			T.AttackSelf(user)
-
 	traitor
 		purchase_flags = UPLINK_TRAITOR
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reworks the integrated headset uplink to actually be integrated into your headset, instead of replacing your headset with the uplink item when unlocked.
- UI interacting with a headset with an unlocked uplink will open the uplink's UI instead of the headset's.
- Changing your headset's frequency to the uplink code to unlock it will not set your headset to that frequency, meaning you can't use that frequency but can maintain access to the general radio while your uplink is unlocked.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Brings the headset uplink in line with the PDA uplink by allowing you to wear it and use it while your uplink is unlocked
Hopefully brings more people to using the headset uplink as its power is equivalent to the PDA uplink (you don't need to have either in your hand to buy stuff), thus making it harder for people to metagame "oh yeah uplinks are in your PDA".

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="1082" height="860" alt="image" src="https://github.com/user-attachments/assets/5de7b988-af12-4f49-a20c-c3e9323503b6" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Headset integrated uplinks are now actually integrated into the headset, rather than swapping the uplink/headset items on lock/unlock. Selecting the unlock frequency on an uplink headset will only unlock the uplink, and not set the frequency.
```
