### PR TITLE
EMP burst interdiction

### DIFF
--- a/code/modules/events/emp_storm.dm
+++ b/code/modules/events/emp_storm.dm
@@ -63,7 +63,10 @@
 			for_by_tcl(IX, /obj/machinery/interdictor)
 				if (IX.expend_interdict(150,T))
 					interdicted = TRUE
-					if(prob(20)) IX.stop_interdicting() //interdictor may sometimes "trip" from the pulse
+					if(prob(40)) //interdictor may sometimes "trip" from the pulse
+						playsound(get_turf(IX), 'sound/effects/electric_shock.ogg', 25, TRUE)
+						IX.visible_message(SPAN_ALERT("<B>[IX]</B> shorts out and shuts down!"))
+						IX.stop_interdicting()
 					return
 
 			playsound(T, pick(sound_list), 25, TRUE)

--- a/code/modules/events/emp_storm.dm
+++ b/code/modules/events/emp_storm.dm
@@ -58,12 +58,18 @@
 
 	proc/emp_burst(var/turf/T)
 		if (T)
+			var/interdicted = FALSE
+
+			for_by_tcl(IX, /obj/machinery/interdictor)
+				if (IX.expend_interdict(150,T))
+					interdicted = TRUE
+					if(prob(20)) IX.stop_interdicting() //interdictor may sometimes "trip" from the pulse
+					return
+
 			playsound(T, pick(sound_list), 25, TRUE)
 
 			var/reach_rand = rand(6,14) // they don't all need to be max screensize EMPs
 			var/reach = "[reach_rand]x[reach_rand]"
-
-			T.hotspot_expose(700,125)
 
 			var/obj/overlay/pulse = new/obj/overlay(T)
 			pulse.icon = 'icons/effects/effects.dmi'
@@ -73,11 +79,13 @@
 			SPAWN(2 SECONDS)
 				if (pulse) qdel(pulse)
 
-			for (var/turf/tile in range(reach, T))
-				for (var/atom/O in tile.contents)
-					var/area/t = get_area(O)
-					if(t?.sanctuary) continue
-					O.emp_act()
+			if(!interdicted)
+				T.hotspot_expose(700,125)
+				for (var/turf/tile in range(reach, T))
+					for (var/atom/O in tile.contents)
+						var/area/t = get_area(O)
+						if(t?.sanctuary) continue
+						O.emp_act()
 
 /datum/particleSystem/emp_warning
 	New(var/atom/location = null)

--- a/code/modules/events/emp_storm.dm
+++ b/code/modules/events/emp_storm.dm
@@ -67,7 +67,7 @@
 						playsound(get_turf(IX), 'sound/effects/electric_shock.ogg', 25, TRUE)
 						IX.visible_message(SPAN_ALERT("<B>[IX]</B> shorts out and shuts down!"))
 						IX.stop_interdicting()
-					return
+					break
 
 			playsound(T, pick(sound_list), 25, TRUE)
 

--- a/code/modules/events/emp_storm.dm
+++ b/code/modules/events/emp_storm.dm
@@ -65,6 +65,7 @@
 					interdicted = TRUE
 					if(prob(40)) //interdictor may sometimes "trip" from the pulse
 						playsound(get_turf(IX), 'sound/effects/electric_shock.ogg', 25, TRUE)
+						animate_little_spark(IX)
 						IX.visible_message(SPAN_ALERT("<B>[IX]</B> shorts out and shuts down!"))
 						IX.stop_interdicting()
 					break

--- a/code/modules/events/emp_storm.dm
+++ b/code/modules/events/emp_storm.dm
@@ -83,13 +83,15 @@
 			SPAWN(2 SECONDS)
 				if (pulse) qdel(pulse)
 
-			if(!interdicted)
-				T.hotspot_expose(700,125)
-				for (var/turf/tile in range(reach, T))
-					for (var/atom/O in tile.contents)
-						var/area/t = get_area(O)
-						if(t?.sanctuary) continue
-						O.emp_act()
+			if(interdicted)
+				return //visual effects fire off, but the damage doesn't
+
+			T.hotspot_expose(700,125)
+			for (var/turf/tile in range(reach, T))
+				for (var/atom/O in tile.contents)
+					var/area/t = get_area(O)
+					if(t?.sanctuary) continue
+					O.emp_act()
 
 /datum/particleSystem/emp_warning
 	New(var/atom/location = null)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Update the EMP burst anomaly from events to be interdictable. A successful interdiction requires 150 cell units, and has a 40% chance to "short out" the interdictor, knocking it offline temporarily (it will automatically reactivate when it's above 70% charge, which can be immediately).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

EMP bursts are within the range of phenomena interdictors should deal with.

Fixes #27224 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Interdicted successfully on local, and un-interdicted bursts fired off as they ought to.


## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

```changelog
(u)Kubius
(*)Interdictors can intercept EMP anomalies from EMP storms.
```