### PR TITLE
Spatial Interdictor: high-power white hole suppression and charge mechanic adjustment

### DIFF
--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -967,7 +967,7 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 
 		if(triggered_by_event)
 			//spatial interdictor: attempt to suppress white hole uncollapse, with great difficulty.
-			//50 operational cycles will entirely inhibit uncollapse; base cost of 200 cell units a cycle, +20 per stabilization (up to 1200 at max)
+			//50 operational cycles will entirely inhibit uncollapse; base cost of 200 cell units a cycle, +20 per stabilization (up to ~1200 at max)
 			//approx 35k cell units consumed overall
 			var/interdict_cost = 200
 			for_by_tcl(IX, /obj/machinery/interdictor)

--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -122,6 +122,7 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 	var/grow_duration = 0
 	var/active_duration = 0
 	var/activity_modifier = 1.0 // multiplies how many objects spawn each "tick"
+	var/interdiction_hp = 100 // it's possible to fully suppress them - but not easy
 	var/datum/light/light = null
 
 	var/static/list/spawn_probs = list(
@@ -965,15 +966,20 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 			qdel(src)
 
 		if(triggered_by_event)
-			//spatial interdictor: can't stop the white hole, but it can mitigate it
-			//consumes 500 units of charge (250,000 joules) to reduce white hole duration
+			//spatial interdictor: attempt to suppress white hole uncollapse, with great difficulty. consumes 500 units of charge per cycle
+			//100 cycles (50,000 cell units, just over 3 full supercells worth) will entirely inhibit uncollapse
 			for_by_tcl(IX, /obj/machinery/interdictor)
 				if (IX.expend_interdict(500, src))
-					if(prob(20))
+					if(src.interdiction_hp >= 100)
 						playsound(IX,'sound/machines/alarm_a.ogg',20,FALSE,5,-1.5)
 						IX.visible_message(SPAN_ALERT("<b>[IX] emits an anti-gravitational anomaly warning!</b>"))
 					if(state != "active")
 						grow_duration += 4 SECOND
+						interdiction_hp -= 1
+						if(interdiction_hp <= 0)
+							time_since_start = (grow_duration + active_duration) * 2
+							state = "dying"
+							break
 					else
 						active_duration -= 1 SECOND
 

--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -967,11 +967,11 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 
 		if(triggered_by_event)
 			//spatial interdictor: attempt to suppress white hole uncollapse, with great difficulty.
-			//50 operational cycles will entirely inhibit uncollapse; base cost of 200 cell units a cycle, +20 per stabilization (up to ~1200 at max)
-			//approx 35k cell units consumed overall
+			//50 operational cycles will entirely inhibit uncollapse; base cost of 200 cell units a cycle, +25 per stabilization (up to ~1400 at max)
+			//approx 41k cell units consumed overall
 			var/interdict_cost = 200
 			for_by_tcl(IX, /obj/machinery/interdictor)
-				interdict_cost = 200 + ((50 - interdiction_hp) * 20)
+				interdict_cost = 200 + ((50 - interdiction_hp) * 25)
 				if (IX.expend_interdict(interdict_cost, src))
 					if(src.interdiction_hp >= 50)
 						playsound(IX,'sound/machines/alarm_a.ogg',20,FALSE,5,-1.5)

--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -122,7 +122,7 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 	var/grow_duration = 0
 	var/active_duration = 0
 	var/activity_modifier = 1.0 // multiplies how many objects spawn each "tick"
-	var/interdiction_hp = 100 // it's possible to fully suppress them - but not easy
+	var/interdiction_hp = 50 // it's possible to fully suppress them - but not easy
 	var/datum/light/light = null
 
 	var/static/list/spawn_probs = list(
@@ -966,11 +966,14 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 			qdel(src)
 
 		if(triggered_by_event)
-			//spatial interdictor: attempt to suppress white hole uncollapse, with great difficulty. consumes 500 units of charge per cycle
-			//100 cycles (50,000 cell units, just over 3 full supercells worth) will entirely inhibit uncollapse
+			//spatial interdictor: attempt to suppress white hole uncollapse, with great difficulty.
+			//50 operational cycles will entirely inhibit uncollapse; base cost of 100 cell units a cycle, +20 per stabilization (up to 1100 at max)
+			//approx 30k cell units consumed overall
+			var/interdict_cost = 100
 			for_by_tcl(IX, /obj/machinery/interdictor)
-				if (IX.expend_interdict(500, src))
-					if(src.interdiction_hp >= 100)
+				interdict_cost = 100 + ((50 - interdiction_hp) * 20)
+				if (IX.expend_interdict(interdict_cost, src))
+					if(src.interdiction_hp >= 50)
 						playsound(IX,'sound/machines/alarm_a.ogg',20,FALSE,5,-1.5)
 						IX.visible_message(SPAN_ALERT("<b>[IX] emits an anti-gravitational anomaly warning!</b>"))
 					if(state != "active")
@@ -1012,28 +1015,29 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 			state = "dying"
 			playsound(src, 'sound/machines/singulo_start.ogg', 90, FALSE, 5, -2)
 
-		// push or throw things away from the white hole
-		for (var/atom/movable/X in range(7,src))
-			if (istype(X, /obj/structure/girder) && prob(40)) //mess up girders too
-				X.ex_act(3)
-			if (X.event_handler_flags & IMMUNE_SINGULARITY || X.anchored)
-				continue
+		if(state != "dying")
+			// push or throw things away from the white hole
+			for (var/atom/movable/X in range(7,src))
+				if (istype(X, /obj/structure/girder) && prob(40)) //mess up girders too
+					X.ex_act(3)
+				if (X.event_handler_flags & IMMUNE_SINGULARITY || X.anchored)
+					continue
 
-			if(prob(30))
-				continue
-			else if(prob(50))
-				step_away(X, src)
-			else
-				X.throw_at( \
-					locate_throw_target(X), \
-					rand(1, 6), \
-					randfloat(1, 3), \
-					bonus_throwforce = 50 / (1 + GET_DIST(X, src)) \
-				)
+				if(prob(30))
+					continue
+				else if(prob(50))
+					step_away(X, src)
+				else
+					X.throw_at( \
+						locate_throw_target(X), \
+						rand(1, 6), \
+						randfloat(1, 3), \
+						bonus_throwforce = 50 / (1 + GET_DIST(X, src)) \
+					)
 
-		for (var/turf/simulated/wall/wall in range(1, src)) //make it a little harder to wall them off
-			wall.ex_act(3)
-			break //just smack one wall at a time
+			for (var/turf/simulated/wall/wall in range(1, src)) //make it a little harder to wall them off
+				wall.ex_act(3)
+				break //just smack one wall at a time
 
 		var/time_interval = 3 SECONDS
 		var/spew_count = round(randfloat(1, 15 * src.activity_modifier))

--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -967,11 +967,11 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 
 		if(triggered_by_event)
 			//spatial interdictor: attempt to suppress white hole uncollapse, with great difficulty.
-			//50 operational cycles will entirely inhibit uncollapse; base cost of 100 cell units a cycle, +20 per stabilization (up to 1100 at max)
-			//approx 30k cell units consumed overall
-			var/interdict_cost = 100
+			//50 operational cycles will entirely inhibit uncollapse; base cost of 200 cell units a cycle, +20 per stabilization (up to 1200 at max)
+			//approx 35k cell units consumed overall
+			var/interdict_cost = 200
 			for_by_tcl(IX, /obj/machinery/interdictor)
-				interdict_cost = 100 + ((50 - interdiction_hp) * 20)
+				interdict_cost = 200 + ((50 - interdiction_hp) * 20)
 				if (IX.expend_interdict(interdict_cost, src))
 					if(src.interdiction_hp >= 50)
 						playsound(IX,'sound/machines/alarm_a.ogg',20,FALSE,5,-1.5)

--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -982,8 +982,8 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 						IX.visible_message(SPAN_ALERT("<b>[IX] emits an anti-gravitational anomaly warning!</b>"))
 					if(state != "active")
 						grow_duration += 4 SECOND
-						interdiction_hp -= 1
-						if(interdiction_hp <= 0)
+						src.interdiction_hp--
+						if(src.interdiction_hp <= 0)
 							time_since_start = (grow_duration + active_duration) * 2
 							state = "dying"
 							break

--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -974,18 +974,18 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 			//approx 41k cell units consumed overall
 			var/interdict_cost = 200
 			for_by_tcl(IX, /obj/machinery/interdictor)
-				interdict_cost = 200 + ((50 - interdiction_hp) * 25)
+				interdict_cost = 200 + ((50 - src.interdiction_hp) * 25)
 				if (IX.expend_interdict(interdict_cost, src))
 					interdicted_this_cycle = TRUE
 					if(src.interdiction_hp >= 50)
 						playsound(IX,'sound/machines/alarm_a.ogg',20,FALSE,5,-1.5)
 						IX.visible_message(SPAN_ALERT("<b>[IX] emits an anti-gravitational anomaly warning!</b>"))
-					if(state != "active")
+					if(src.state != "active")
 						grow_duration += 4 SECOND
 						src.interdiction_hp--
 						if(src.interdiction_hp <= 0)
 							time_since_start = (grow_duration + active_duration) * 2
-							state = "dying"
+							src.state = "dying"
 							break
 					else
 						active_duration -= 1 SECOND

--- a/code/modules/events/white_hole.dm
+++ b/code/modules/events/white_hole.dm
@@ -962,6 +962,9 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 	proc/process()
 		var/time_since_start = TIME - start_time
 
+		//Track interdiction this cycle for visual "force feedback"
+		var/interdicted_this_cycle = FALSE
+
 		if(state == "dying")
 			qdel(src)
 
@@ -973,6 +976,7 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 			for_by_tcl(IX, /obj/machinery/interdictor)
 				interdict_cost = 200 + ((50 - interdiction_hp) * 25)
 				if (IX.expend_interdict(interdict_cost, src))
+					interdicted_this_cycle = TRUE
 					if(src.interdiction_hp >= 50)
 						playsound(IX,'sound/machines/alarm_a.ogg',20,FALSE,5,-1.5)
 						IX.visible_message(SPAN_ALERT("<b>[IX] emits an anti-gravitational anomaly warning!</b>"))
@@ -988,6 +992,9 @@ ADMIN_INTERACT_PROCS(/obj/whitehole, proc/admin_activate)
 
 		if(time_since_start < grow_duration)
 			var/scale = 32 / 160 + (160 - 32) / 160 * clamp(((time_since_start + 3 SECONDS) - grow_duration / 3) / (grow_duration * 2 / 3), 0, 1)
+			if(interdicted_this_cycle) //visually depict the "pinch" on a white hole being interdicted
+				var/scale_adjustor = 0.025 * clamp(src.interdiction_hp,1,40)
+				scale = clamp(scale*scale_adjustor, 0, 1)
 			animate(src, transform = matrix(scale, MATRIX_SCALE), time = 3 SECONDS, loop = 0, easing = LINEAR_EASING)
 
 		if(time_since_start < grow_duration / 3)

--- a/code/obj/machinery/interdictor.dm
+++ b/code/obj/machinery/interdictor.dm
@@ -258,7 +258,8 @@
 			radstorm_interdict(src)
 			src.resisted = FALSE
 		if(intcap.charge < intcap.maxcharge && powered())
-			var/amount_to_add = min(round(intcap.maxcharge - intcap.charge, 10), src.chargerate)
+			var/ratelimit = min(max(src.chargerate,src.active_cost*0.8),src.chargerate_max)
+			var/amount_to_add = min(round(intcap.maxcharge - intcap.charge, 10), ratelimit)
 			if(amount_to_add)
 				var/added = intcap.give(amount_to_add)
 				if(!src.canInterdict) //only plays continually during charging phase

--- a/code/obj/machinery/interdictor.dm
+++ b/code/obj/machinery/interdictor.dm
@@ -258,8 +258,9 @@
 			radstorm_interdict(src)
 			src.resisted = FALSE
 		if(intcap.charge < intcap.maxcharge && powered())
-			var/ratelimit = min(max(src.chargerate,src.active_cost*0.8),src.chargerate_max)
-			var/amount_to_add = min(round(intcap.maxcharge - intcap.charge, 10), ratelimit)
+			var/ratetarget = max(src.chargerate,src.active_cost*0.8) //Pick from configured rate target, or load compensation (whichever is higher)
+			ratetarget = min(ratetarget,src.chargerate_max) //then clamp with the maximum allowable charge rate
+			var/amount_to_add = min(round(intcap.maxcharge - intcap.charge, 10), ratetarget)
 			if(amount_to_add)
 				var/added = intcap.give(amount_to_add)
 				if(!src.canInterdict) //only plays continually during charging phase


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Instead of a fixed cost of 500 cell units per cycle that only forestalls growth or speeds collapse, white holes now have new interdiction mechanics that permit full suppression if it can receive 50 interdiction cycles in total.
- Cost to interdict white holes starts out at 200 cell units per cycle; each successful cycle of suppression increases this by 25 units, up to about 1,400 units a cycle when the white hole has nearly been full suppressed (cumulatively, about 41,000 units used). A single standard "supercell" can only hold 15,000 units, so grid support is typically necessary, as well as multiple interdictors if you don't have a high-efficiency interdictor.
- To support this and other high-draw cases, spatial interdictors will now exceed their configured baseline grid draw when under heavy load, reimbursing themselves for 80% of power usage or the maximum rate of 500 cell units per process (whichever is lower). Interdictors may still be configured to use this maximum rate at all times, if desired, and this will slightly improve performance in high-load circumstances if the grid is well-supplied.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Improves interdictors' ability to repay the work put into preparation and active response.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested on a local, white hole behaves as intended.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(*)Interdictors can now fully suppress white holes with great difficulty (likely requiring multiple interdictors or an exceptional cell), with their grid draw functionality enhanced to support this.
```
