### PR TITLE
Using mop on catwalks mops the floor underneath

### DIFF
--- a/code/obj/mesh.dm
+++ b/code/obj/mesh.dm
@@ -527,7 +527,7 @@ TYPEINFO_NEW(/obj/mesh/catwalk)
 		src.loc.Attackby(user.equipped(), user)
 		return
 	if (istype(I,/obj/item/mop))
-		I:afterattack(get_turf(src), user)
+		I.AfterAttack(get_turf(src), user)
 		return
 	if(user.a_intent != "harm") // Don't do anything if you're not on harm intent, act like a normal floor.
 		return

--- a/code/obj/mesh.dm
+++ b/code/obj/mesh.dm
@@ -526,6 +526,9 @@ TYPEINFO_NEW(/obj/mesh/catwalk)
 	if (istype(I, /obj/item/cable_coil))
 		src.loc.Attackby(user.equipped(), user)
 		return
+	if (istype(I,/obj/item/mop))
+		I:afterattack(get_turf(src), user)
+		return
 	if(user.a_intent != "harm") // Don't do anything if you're not on harm intent, act like a normal floor.
 		return
 	..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When an /obj/item/mop is used on a catwalk, the after-attack (starting mopping) will be called for targeting the floor beneath said catwalk.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes mopping areas with decorative catwalks significantly less of a pain.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Mopped the catwalk.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(+)Mopping a catwalk will now automatically pass the click through to the floor underneath.
```
