### PR TITLE
Deprecate Donut 2

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -26,7 +26,6 @@ var/global/list/mapNames = list(
 #endif
 
 	"Cogmap 2" =			list("id" = "COGMAP2",		"settings" = "cogmap2",			"playerPickable" = TRUE, 	"MinPlayersAllowed" = 40),
-	"Donut 2" =				list("id" = "DONUT2",		"settings" = "donut2",			"playerPickable" = TRUE,	"MaxPlayersAllowed" = 80),
 	"Donut 3" =				list("id" = "DONUT3",		"settings" = "donut3",			"playerPickable" = TRUE, 	"MinPlayersAllowed" = 40),
 	"Kondaru" =				list("id" = "KONDARU",		"settings" = "kondaru",			"playerPickable" = TRUE,	"MaxPlayersAllowed" = 80),
 	"Clarion" =				list("id" = "CLARION",		"settings" = "clarion",			"playerPickable" = TRUE,	"MaxPlayersAllowed" = 60),
@@ -37,6 +36,7 @@ var/global/list/mapNames = list(
 	"Crash" = 				list("id" = "CRASH",		"settings" = "crash",			"playerPickable" = FALSE),
 	"Atlas" =				list("id" = "ATLAS",		"settings" = "atlas",			"playerPickable" = FALSE,	"MaxPlayersAllowed" = 30),
 	"Mushroom" =			list("id" = "MUSHROOM",		"settings" = "mushroom",		"playerPickable" = FALSE),
+	"Donut 2" =				list("id" = "DONUT2",		"settings" = "donut2",			"playerPickable" = FALSE,	"MaxPlayersAllowed" = 80),
 	"Density2" = 			list("id" = "DENSITY2",		"settings" = "density2",		"playerPickable" = FALSE,	"MaxPlayersAllowed" = 20),
 	"blank" =				list("id" = "BLANK",		"settings" = "", 				"playerPickable" = FALSE),
 	"blank_underwater" =	list("id" = "BLANK_UNDERWATER", "settings" = "", 			"playerPickable" = FALSE),


### PR DESCRIPTION
## About the PR
Removes Donut 2 from the standard map vote list. Doesn't remove the map though, and there's already an alternate way to vote for it.

I fully expect this one to be debated a lot, but getting the debate going is worth the effort. 

## Why's this needed?
Donut 2's gimmick of having science off-station and multiple power grids fundamentally breaks several aspects of the game, especially involving DWAINE and packets. 

## Testing
Map votes don't work in testing environments so I can't really test it, but it compiles, the alternate method already works on live, and it's set up the same as Mushroom. 

## Changelog

```changelog
(u)Keiya
(*)Donut 2 is no longer in the standard rotation. But...?
```
