### PR TITLE
Adds an if statement to ore wiggling

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -25,8 +25,9 @@
 
 	New()
 		..()
-		src.pixel_x = rand(0 - wiggle, wiggle)
-		src.pixel_y = rand(0 - wiggle, wiggle)
+		if(wiggle)
+			src.pixel_x = rand(0 - wiggle, wiggle)
+			src.pixel_y = rand(0 - wiggle, wiggle)
 		setup_material()
 		if(src.material?.getName())
 			initial_material_name = src.material.getName()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just makes it so if you remove wiggle from something like ore and then giving it a custom offset that offset won't then be overriden/altered by the wiggle proc on spawn
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being able to place ores however you like in pretty shapes is quite nice for mapping more natural areas
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested a few things I knew had it and custom placed ones that didn't, both worked as expected.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

