### PR TITLE
Allows digging in simmed dojo sand

### DIFF
--- a/code/z_adventurezones/gannets_dojozone.dm
+++ b/code/z_adventurezones/gannets_dojozone.dm
@@ -815,6 +815,7 @@ TYPEINFO_NEW(/turf/unsimulated/wall/auto/paper)
 	name = "zen garden"
 	icon = 'icons/turf/dojo.dmi'
 	icon_state = "sand"
+	can_dig = TRUE
 
 	horizontal
 		icon_state = "sand_horiz"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets you dig in the (simmed) dojo sand tileset. That's it.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've got an oshan zen garden and maints rework coming up which heavily uses the tiles, a few chapels and misc station areas on other maps also use them. More spots to dig in and bury bodies is in my mind a good thing. Keeping it to just simmed ones since digging code is Funky and prone to eating things it probably shouldn't
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I dug. 
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->


