### PR TITLE
Re-enables nicotwaine OD

### DIFF
--- a/code/modules/chemistry/Reagents-Drugs.dm
+++ b/code/modules/chemistry/Reagents-Drugs.dm
@@ -866,7 +866,7 @@ datum
 			do_overdose(var/severity, var/mob/M, var/mult = 1)
 				..()
 				..()
-				/*var/effect = ..(severity, M)
+				var/effect = ..(severity, M)
 				if (severity == 1)
 					if (effect <= 2)
 						M.visible_message(SPAN_ALERT("<b>[M.name]</b> looks really nervous!"))
@@ -909,7 +909,7 @@ datum
 						M.changeStatus("knockdown", 50 * mult)
 						M.make_jittery(60)
 						M.take_toxin_damage(5)
-						M.take_oxygen_deprivation(20)*/
+						M.take_oxygen_deprivation(20)
 
 		drug/psilocybin
 			name = "psilocybin"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Did you know the nicotwaine OD effect was commented out for years? No? Neither did I. I noticed it during a codedive and decided to go ahead and reimplement it. For all intents and purposes this could be a very bad idea in it's current state but the numbers can always be tweaked and I'd be happy to change them if it was desired.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's weird that a nicotine OD which is much easier to induce (1 eepy pen for normal, 2 for severe) and notably more debilitating than 330u of something that is supposed to be a riskier, more potent version of it. 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Both OD severities do what they're supposed to. 1 (70+) kills in you a few minutes while severity 2 (140+) has a kill time of give or take 45 seconds? While extreme it's also an incredibly obvious effects, exclusive to botany and has a very high threshold.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)CelineTheYeen
(+)Nicotwaine has an overdose effect again.
```
