### PR TITLE
Made sure all maps have at least 3 networks diagnostics cartirages at mechlab

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -39167,8 +39167,19 @@
 /obj/item/clothing/gloves/yellow,
 /obj/item/device/multitool,
 /obj/item/device/multitool,
-/obj/item/disk/data/cartridge/diagnostics,
 /obj/item/storage/wall/random,
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 11;
+	pixel_y = 4
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 10;
+	pixel_y = 12
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -12663,6 +12663,18 @@
 "bAF" = (
 /obj/table/auto,
 /obj/item/electronics/soldering,
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 11;
+	pixel_y = 4
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 10;
+	pixel_y = 12
+	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bAG" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -11427,6 +11427,18 @@
 /obj/item/device/radio/intercom/engineering{
 	dir = 4
 	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 11;
+	pixel_y = 4
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 10;
+	pixel_y = 12
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},

--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -36822,6 +36822,18 @@
 /obj/machinery/status_display{
 	pixel_y = 30
 	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 11;
+	pixel_y = 4
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 10;
+	pixel_y = 12
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 5
 	},

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -7932,6 +7932,18 @@
 /obj/machinery/light/incandescent/warm,
 /obj/item/deconstructor,
 /obj/item/electronics/scanner,
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 2;
+	pixel_y = -16
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 11;
+	pixel_y = -15
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = -6;
+	pixel_y = -15
+	},
 /turf/simulated/floor/yellow/checker{
 	dir = 4
 	},

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -49898,8 +49898,16 @@
 /obj/item/electronics/scanner,
 /obj/item/deconstructor,
 /obj/item/disk/data/cartridge/diagnostics{
-	pixel_x = -6;
-	pixel_y = 10
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 10;
+	pixel_y = 12
+	},
+/obj/item/disk/data/cartridge/diagnostics{
+	pixel_x = 11;
+	pixel_y = 4
 	},
 /turf/simulated/floor/caution/west{
 	dir = 5


### PR DESCRIPTION
… mechlab

<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Make sure all rotation maps have at least 3 networks diagnostics cartridges at mechlab
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#27184 needs to pass
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I opened each map and checked the placement looks "sane"
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ANNmagedon
(+)Standardized all mechanic's labs to have 3 networks diagnostics cartridges 
```
