### PR TITLE
Fix for radioactive outlines turning to incorrect colors

### DIFF
--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -167,6 +167,10 @@ TYPEINFO(/datum/component/radioactive)
 			if(!ON_COOLDOWN(M,"radiation_exposure", 0.5 SECONDS) && !isintangible(M)) //shorter than item tick time, so you can get multiple doses but there's a limit
 				M.take_radiation_dose(rad_dose * (src.effect_range - GET_DIST(M, PA) + 1) / (max(src.effect_range, 1)) * 0.8) //lnear, not inverse square because it plays nicer in game
 
+		if(owner.color)
+			// If the owner has been given a new color, keep it null so that the radiation outline stays green/blue
+			src._backup_color = owner.color
+			owner.color = null
 		var/update_filters = FALSE
 		if(src.radStrength > src.decay_target && prob(33))
 			src.radStrength = max(src.decay_target, src.radStrength - (1 * mult))

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -85,9 +85,7 @@ TYPEINFO(/datum/component/radioactive)
 			(rgb_rads[3] * perc_rads) + (rgb_neutron[3] * perc_neutron))
 		var/rad_color = rgb(rgb_comb[1], rgb_comb[2], rgb_comb[3], 255)
 		if(PA.color)
-			src._backup_color = PA.color
-			PA.add_filter("radiation_color_\ref[src]", 98, color_matrix_filter(normalize_color_to_matrix(PA.color ? PA.color : "#FFF")))
-			PA.color = null
+			src.filterize_color(PA)
 		if (isturf(PA))
 			PA.add_simple_light("radiation_light_\ref[src]", rgb2num(rad_color))
 		else if(src.our_light)
@@ -108,6 +106,12 @@ TYPEINFO(/datum/component/radioactive)
 				PA.add_filter("n_radiation_outline_\ref[src]", 99, outline_filter(size=outline_size_n, color="#2e3ae4", flags=OUTLINE_SQUARE))
 			if(src.radStrength)
 				PA.add_filter("radiation_outline_\ref[src]", 100, outline_filter(size=outline_size, color="#18e022", flags=OUTLINE_SQUARE))
+
+	/// Converts the owner's color to a filter so that the radioactive outline stays unaffected by the color change
+	proc/filterize_color(atom/owner)
+		src._backup_color = owner.color
+		owner.add_filter("radiation_color_\ref[src]", 98, color_matrix_filter(normalize_color_to_matrix(owner.color ? owner.color : "#FFF")))
+		owner.color = null
 
 	proc/process()
 		if(QDELETED(parent) || !parent.datum_components)
@@ -168,9 +172,7 @@ TYPEINFO(/datum/component/radioactive)
 				M.take_radiation_dose(rad_dose * (src.effect_range - GET_DIST(M, PA) + 1) / (max(src.effect_range, 1)) * 0.8) //lnear, not inverse square because it plays nicer in game
 
 		if(owner.color)
-			// If the owner has been given a new color, keep it null so that the radiation outline stays green/blue
-			src._backup_color = owner.color
-			owner.color = null
+			src.filterize_color(owner) // If the owner has been given a new color, keep it null so that the radiation outline stays green/blue
 		var/update_filters = FALSE
 		if(src.radStrength > src.decay_target && prob(33))
 			src.radStrength = max(src.decay_target, src.radStrength - (1 * mult))

--- a/code/modules/materials/Mat_ProcsDefines.dm
+++ b/code/modules/materials/Mat_ProcsDefines.dm
@@ -148,6 +148,10 @@ var/global/list/material_cache
 		if(mat1.shouldApplyColor())
 			src.alpha = mat1.getAlpha()
 			src.color = mat1.getColor()
+	var/datum/component/radioactive/rad_comp = src.GetComponent(/datum/component/radioactive)
+	if(rad_comp)
+		rad_comp._backup_color = src.color
+		src.color = null
 
 /// Applies material icon_state override to an /image based on this atom's material (or the material provided)
 /atom/proc/setMaterialAppearanceForImage(image/img, datum/material/mat=null)

--- a/code/modules/materials/Mat_ProcsDefines.dm
+++ b/code/modules/materials/Mat_ProcsDefines.dm
@@ -148,10 +148,9 @@ var/global/list/material_cache
 		if(mat1.shouldApplyColor())
 			src.alpha = mat1.getAlpha()
 			src.color = mat1.getColor()
-	var/datum/component/radioactive/rad_comp = src.GetComponent(/datum/component/radioactive)
-	if(rad_comp)
-		rad_comp._backup_color = src.color
-		src.color = null
+	if(src.color)
+		var/datum/component/radioactive/rad_comp = src.GetComponent(/datum/component/radioactive)
+		rad_comp?.filterize_color(rad_comp.parent)
 
 /// Applies material icon_state override to an /image based on this atom's material (or the material provided)
 /atom/proc/setMaterialAppearanceForImage(image/img, datum/material/mat=null)


### PR DESCRIPTION
## About the PR
- The radioactive component will now check the parent's color during rad updates and turn it into a filter if it has changed.
- Updating the material appearance of an atom will do the same check.

## Why's this needed?
- The radiation component turns the parent's color into a filter so that the radioactive outline color isn't also affected. However, changing the color afterwards will not update the filter. This PR tries to fix that by checking for the component after setting the material appearance as well as having the component itself occasionally check to see if it has been given a color.

## Testing
- Tested on objects that I found turning into incorrect colors. Gas canisters, fire extinguishers, flashlights, and air scrubbers.
<img width="318" height="317" alt="Screenshot 2026-07-24 034111" src="https://github.com/user-attachments/assets/57c066ae-f338-4c07-a808-20afc64f0197" />
