### PR TITLE
RP Revs Improvements

### DIFF
--- a/_std/macros/antagchecks.dm
+++ b/_std/macros/antagchecks.dm
@@ -46,3 +46,10 @@
 #define iskudzuman(x) (istype(x, /mob/living/carbon/human) && x:mutantrace && istype(x:mutantrace, /datum/mutantrace/kudzu))
 #define issawfly(x) (istype(x, /mob/living/critter/robotic/sawfly))
 #define iszombie(x) (istype(x, /mob/living/critter/zombie) || istype(x, /mob/living/carbon/human) && x:mutantrace && istype(x:mutantrace, /datum/mutantrace/zombie))
+
+// Should any revs spawned follow roleplay behaviour?
+#ifdef RP_MODE
+#define ROLEPLAY_REVOLUTIONARIES (!istype_exact(ticker.mode, /datum/game_mode/revolution))
+#else
+#define ROLEPLAY_REVOLUTIONARIES (istype(ticker.mode, /datum/game_mode/revolution/extended))
+#endif

--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -18,9 +18,9 @@
 	/// The time to wait till we send out the tracker time
 	var/trackertime = 0
 	/// lower bound on time before intercept arrives (in tenths of seconds)
-	var/const/trackertime_min = 27 MINUTES
+	var/trackertime_min = 27 MINUTES
 	/// upper bound on time before intercept arrives (in tenths of seconds)
-	var/const/trackertime_max = 30 MINUTES
+	var/trackertime_max = 30 MINUTES
 	/// Has the tracker been sent out yet
 	var/trackertimed = FALSE
 	var/const/min_revheads = 3
@@ -33,10 +33,12 @@
 	do_antag_random_spawns = 0
 	escape_possible = 0
 
-/datum/game_mode/revolution/extended //Does not end prematurely
-	name = "Revolution (no time limit)"
+/datum/game_mode/revolution/extended //Has sev
+	name = "Revolution (Roleplay)"
 	config_tag = "revolution_extended"
 	regular = FALSE
+	trackertime_min = 60 MINUTES
+	trackertime_max = 75 MINUTES
 
 /datum/game_mode/revolution/announce()
 	boutput(world, "<B>The current game mode is - Revolution!</B>")
@@ -107,7 +109,7 @@
 #ifndef ME_AND_MY_40_ALT_ACCOUNTS
 /datum/game_mode/revolution/process()
 	..()
-	if (!istype(ticker.mode, /datum/game_mode/revolution/extended) && ticker.round_elapsed_ticks >= round_limit && !gibwave_started)
+	if (!ROLEPLAY_REVOLUTIONARIES && ticker.round_elapsed_ticks >= round_limit && !gibwave_started)
 		gibwave_started = TRUE
 		start_gibwave()
 	if (ticker.round_elapsed_ticks > win_check_freq)
@@ -129,7 +131,9 @@
 	return
 
 /datum/game_mode/revolution/check_finished()
-	if(finished != 0)
+	if(ROLEPLAY_REVOLUTIONARIES) //Allow an admin or the shuttle call to determine the end instead of automatically ending.
+		return 0
+	else if(finished != 0)
 		return 1
 	else
 		return 0

--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -33,7 +33,8 @@
 	do_antag_random_spawns = 0
 	escape_possible = 0
 
-/datum/game_mode/revolution/extended //Has sev
+//Has several changes to accomodate the RP experience. See ROLEPLAY_REVOLUTIONARIES define for changes.
+/datum/game_mode/revolution/extended
 	name = "Revolution (Roleplay)"
 	config_tag = "revolution_extended"
 	regular = FALSE

--- a/code/modules/antagonists/revolutionary/head_revolutionary.dm
+++ b/code/modules/antagonists/revolutionary/head_revolutionary.dm
@@ -117,6 +117,12 @@
 			logTheThing(LOG_DEBUG, H, "Head revolutionary standalone uplink created: [uplink_source.name]. Location given: [loc_string]. Frequency: [uplink.lock_code]")
 			src.owner.store_memory("<b>Uplink frequency:</b> [uplink.lock_code].")
 
+		if(ROLEPLAY_REVOLUTIONARIES)
+			var/obj/item/device/radio/headset/headset = H.ears
+			if(headset && istype(headset))
+				headset.install_radio_upgrade(new /obj/item/device/radio_upgrade/syndicatechannel)
+				boutput(H, SPAN_NOTICE(SPAN_BOLD("The syndicate has granted \the [headset] on your head access to the syndicate channel to speak with your fellow revolutionaries.")))
+
 	add_to_image_groups()
 		. = ..()
 		var/datum/client_image_group/image_group = get_image_group(ROLE_REVOLUTIONARY)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
## Important Note:
These changes are to improve how revolution plays on RP when admin-spawned. There are currently no plans to enable the revolution mode on the roleplay servers.

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Introduces a ROLEPLAY_REVOLUTIONARIES define which determines whether revs are given special RP equipment/behaviour. (RP Revs behaviour is applied in the mode, or on RP when the classic revolution mode is not active.)
- Renames "Revolution (no time limit)" to "Revolution (Roleplay)"
- Increases the tracker timer in Revolution (Roleplay) from 27-30 Minutes to 60-75 Minutes (an admin can trigger these early at any time through the event controller)
- Revolution (Roleplay) will not automatically end when one side wins, allowing an admin to send a spawnwave or continue to play out the scenario (though they can end the round at any time)
- Roleplay Head Revolutionaries receive a syndicate radio upgrade in their headset. Allowing communication and coordination on escalation/demands between the head revolutionaries.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
RP revs isnt particularly engaging even when admin-spawned. This aims to introduce behaviour on the roleplay servers to perhaps make these rare occasions an admin spawns them more enjoyable.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested spawning as a headrev in extended with no RP mode define, did not get syndicate channel, spawned as headrev in RP mode, got syndicate channel
<img width="531" height="388" alt="image" src="https://github.com/user-attachments/assets/6a800dd4-dba9-439a-9b74-a7faa3cfd0db" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Head Revolutionaries on the roleplay servers will now receive the syndicate radio channel if the classic revolution mode is not active. The RP Revolution mode will also not end when one side wins to allow whichever admin spawned the revs to determine how to continue/end the round from there.
```
