### PR TITLE
Editable access spawners

### DIFF
--- a/code/modules/mapping/helpers/access_spawn.dm
+++ b/code/modules/mapping/helpers/access_spawn.dm
@@ -3,13 +3,19 @@
 	desc = "Sets access of machines on the same turf as it to its access, then destroys itself."
 	icon = 'icons/effects/mapeditor.dmi'
 	icon_state = "access_spawn"
+	/// List of types this helper affects, anything else is ignored.
+	var/affected_types = list(/obj/machinery)
+	/// Completely override any existing accesses on the target or just add to it?
+	var/override_access = FALSE
 
 	setup()
-		for (var/obj/machinery/M in src.loc)
-			if (!M.req_access)
-				M.req_access = src.req_access
+		for (var/obj/O in src.loc)
+			if(!istypes(O, src.affected_types))
+				continue
+			if (!O.req_access || src.override_access)
+				O.req_access = src.req_access
 			else
-				M.req_access += src.req_access
+				O.req_access += src.req_access
 			//todo : autoname doors	here too. var editing is illegal!
 
 #define SPECIAL "#ffa135"
@@ -298,10 +304,13 @@
 /obj/mapping_helper/access/admin_override //special admin override access spawner
 	name = "admin override access spawn"
 	color = SPECIAL
+	affected_types = list(/obj)
 	admin_access_override = ADMIN_ACCESS_OVERRIDE_BYPASS
 
 	setup()
 		for (var/obj/O in src.loc)
+			if(!istypes(O, src.affected_types))
+				continue
 			O.admin_access_override = src.admin_access_override
 
 /obj/mapping_helper/access/admin_override/admin_only //Deny access to any non-admins
@@ -312,9 +321,12 @@
 /obj/mapping_helper/access/public
 	name = "public access spawn"
 	color = SPECIAL
+	affected_types = list(/obj)
 
 	setup()
 		for (var/obj/O in src.loc)
+			if(!istypes(O, src.affected_types))
+				continue
 			O.req_access = null
 
 //////////////////////owlzone access///////


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds two new editable variables to accesshelpers:
- affected_types: A list of /obj types this helper affects, defaults to /obj/machinery as current, with the exception of admin and public access spawners, which default to /obj as current.
- override_access: Instead of adding this helper's access to affected objects, completely replace it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows editing of non-machinery object access by mappers without needing to affect _all_ objects on a tile or directly varedit req_access to a list of the magic access numbers.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spawned several airlocks and lockers with combinations of these helpers and everything worked as expected
<img width="460" height="295" alt="image" src="https://github.com/user-attachments/assets/ebcee70e-ff6c-4214-bab2-c3a7b91e4e28" />
