### PR TITLE
Sawflys keep material and forensics when deploying/undeploying

### DIFF
--- a/code/mob/living/critter/sawfly.dm
+++ b/code/mob/living/critter/sawfly.dm
@@ -87,6 +87,7 @@ This file is the critter itself, and all the custom procs it needs in order to f
 			return
 		else
 			var/obj/item/old_grenade/sawfly/N = new /obj/item/old_grenade/sawfly(get_turf(src))
+			N.forensic_holder = src.forensic_holder
 			if(src.material)
 				N.setMaterial(src.material)
 			// pass our name and health

--- a/code/mob/living/critter/sawfly.dm
+++ b/code/mob/living/critter/sawfly.dm
@@ -87,6 +87,8 @@ This file is the critter itself, and all the custom procs it needs in order to f
 			return
 		else
 			var/obj/item/old_grenade/sawfly/N = new /obj/item/old_grenade/sawfly(get_turf(src))
+			if(src.material)
+				N.setMaterial(src.material)
 			// pass our name and health
 			N.name = "Compact [name]"
 			N.desc = "A self-deploying antipersonnel robot. This one has seen some use."

--- a/code/obj/sawflymisc.dm
+++ b/code/obj/sawflymisc.dm
@@ -53,6 +53,11 @@ TYPEINFO(/obj/item/old_grenade/sawfly)
 
 		qdel(src)
 
+	setMaterial(datum/material/mat1, appearance, setname, mutable, use_descriptors)
+		. = ..()
+		if(heldfly && (heldfly.material != mat1))
+			heldfly.setMaterial(mat1, appearance, FALSE, mutable, TRUE)
+
 TYPEINFO(/obj/item/old_grenade/sawfly/firsttime)
 	manufactured_type = /obj/item/old_grenade/sawfly/firsttime //For subtype, prevents remote clutter if you're making an army
 /obj/item/old_grenade/sawfly/firsttime //super important- traitor uplinks and sawfly pouches use this specific version

--- a/code/obj/sawflymisc.dm
+++ b/code/obj/sawflymisc.dm
@@ -64,6 +64,7 @@ TYPEINFO(/obj/item/old_grenade/sawfly/firsttime)
 	New()
 
 		heldfly = new /mob/living/critter/robotic/sawfly(src.loc)
+		heldfly.forensic_holder = src.forensic_holder
 		heldfly.ourgrenade = src
 		heldfly.set_loc(src)
 		..()


### PR DESCRIPTION
## About the PR
- Sawfly material and forensics is now kept when deployed/undeployed.

## Why's this needed?
- This should be the expected behavior for sawflies.

## Testing
<img width="307" height="265" alt="Screenshot 2026-07-26 032644" src="https://github.com/user-attachments/assets/8931f5cb-7091-4a3d-83e8-47c20fa4a51c" />
<img width="338" height="337" alt="Screenshot 2026-07-26 032653" src="https://github.com/user-attachments/assets/690af932-8ded-4f02-a0ab-cca337580db5" />


## Changelog
```changelog
(u)LorrMaster
(+)Sawflies now keep their material when deployed/undeployed.
```
