### PR TITLE
Adds Gemstones to the list of Rock Plant mutations

### DIFF
--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -760,6 +760,12 @@ ABSTRACT_TYPE(/datum/plantmutation)
 	crop = /obj/item/raw_material/uqill
 	chance = 5
 
+/datum/plantmutation/rocks/gemstone
+	name_prefix = "Gemstone "
+	dont_rename_crop = TRUE
+	crop = /obj/item/raw_material/gemstone
+	chance = 5
+
 // trees. :effort:
 
 /datum/plantmutation/tree/money

--- a/code/modules/hydroponics/plants_alien.dm
+++ b/code/modules/hydroponics/plants_alien.dm
@@ -154,7 +154,7 @@ ABSTRACT_TYPE(/datum/plant/artifact)
 	harvests = 8
 	endurance = 40
 	force_seed_on_harvest = 1
-	mutations = list(/datum/plantmutation/rocks/syreline,/datum/plantmutation/rocks/bohrum,/datum/plantmutation/rocks/mauxite,/datum/plantmutation/rocks/uqill)
+	mutations = list(/datum/plantmutation/rocks/syreline,/datum/plantmutation/rocks/bohrum,/datum/plantmutation/rocks/mauxite,/datum/plantmutation/rocks/uqill,/datum/plantmutation/rocks/gemstone)
 
 /datum/plant/artifact/litelotus
 	name = "Light Lotus"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds gemstones as an ore that rock plants can produce, it has the same rarity (5) as uqill. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fun way to get gemstones, don't really ever see a lot in the rockbox in the first place.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="293" height="156" alt="Screenshot 2026-07-26 111601" src="https://github.com/user-attachments/assets/5aff7f9b-a9f0-42cc-bf6e-475cba366194" />

<img width="385" height="571" alt="Screenshot 2026-07-26 112855" src="https://github.com/user-attachments/assets/2d8966aa-ad60-4882-b486-aa9dee3d5721" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bork
(*)Rock plants now have a chance to mutate into gemstone plants.
```
