### PR TITLE
Artifact cells no longer self-charge while deactivated

### DIFF
--- a/code/obj/artifacts/artifact_items/power_cell.dm
+++ b/code/obj/artifacts/artifact_items/power_cell.dm
@@ -2,12 +2,14 @@
 	name = "artifact power cell"
 	icon = 'icons/obj/artifacts/artifactsitemS.dmi'
 	maxcharge = 1
-	var/chargeCap = 10000
-	genrate = 50
+	genrate = 0
 	specialicon = 1
 	artifact = 1
 	mat_changename = 0
 	mat_changedesc = 0
+
+	var/chargeCap = 10000
+	var/activation_genrate = 50
 	var/effectProbModifier = 0
 	var/noise = null
 	var/leakChem = null
@@ -60,12 +62,14 @@
 	ArtifactActivated()
 		. = ..()
 		src.maxcharge = src.chargeCap
+		src.genrate = src.activation_genrate
 		processing_items |= src				// in case someone decides to make big cells work like small cells
 
 	ArtifactDeactivated()
 		. = ..()
+		src.genrate = 0
+		src.charge = 0
 		src.maxcharge = 1
-		src.charge = 1
 
 	reagent_act(reagent_id,volume)
 		if (..())

--- a/code/obj/artifacts/artifact_objects/wish_granter.dm
+++ b/code/obj/artifacts/artifact_objects/wish_granter.dm
@@ -99,3 +99,7 @@
 							R.cell.genrate = 100
 							R.cell.maxcharge = 1000000
 							R.cell.charge = R.cell.maxcharge
+							if(istype(R.cell, /obj/item/cell/artifact))
+								var/obj/item/cell/artifact/artcell = R.cell
+								artcell.chargeCap = 1000000
+								artcell.activation_genrate = 100


### PR DESCRIPTION
## About the PR
- Artifact cells no longer regenerate charge automatically while deactivated.
- Deactivating an artifact cell drops its charge to 0 instead of 1.

## Why's this needed?
- Fixes related to #27002

## Testing
<img width="267" height="238" alt="Screenshot 2026-07-26 202538" src="https://github.com/user-attachments/assets/047f6f2b-daf0-45a6-b9c8-dcc8c28fe3e7" />
