### PR TITLE
Fixes nukie commander uplink instruction manuals

### DIFF
--- a/code/datums/syndicate_buylist/buylist_commander.dm
+++ b/code/datums/syndicate_buylist/buylist_commander.dm
@@ -8,7 +8,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 
 /datum/syndicate_buylist/commander/reinforcement
 	name = "Reinforcements"
-	items = list(/obj/item/remote/reinforcement_beacon, /obj/item/paper/reinforcement_info)
+	items = list(/obj/item/storage/box/nuke_ops/reinforcement)
 	cost = 2
 	desc = "Request a (probably) top-of-the-line Syndicate gunbot to help assist your team."
 	category = "Main"
@@ -29,14 +29,14 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/commander)
 
 /datum/syndicate_buylist/commander/designator
 	name = "Laser Designator"
-	items = list(/obj/item/device/laser_designator/syndicate, /obj/item/paper/designator_info)
+	items = list(/obj/item/storage/box/nuke_ops/designator)
 	cost = 3
 	desc = "A handheld, monocular laser designator that allows you to call in heavy fire support from the Cairngorm. Comes with 2 charges."
 	category = "Main"
 
 /datum/syndicate_buylist/commander/deployment_pods
 	name = "Rapid Deployment Remote"
-	items = list(/obj/item/device/deployment_remote, /obj/item/paper/deployment_info)
+	items = list(/obj/item/storage/box/nuke_ops/deployment_remote)
 	cost = 2
 	desc = "A handheld remote allowing you, your team, and the nuclear device to be sent in anywhere at a moment's notice!"
 	category = "Main"

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -455,3 +455,22 @@
 	name = "demolition grenade box"
 	icon_state = "flashbang"
 	spawn_contents = list(/obj/item/chem_grenade/fcleaner = 5)
+
+// Boxes for nuke ops commander uplink
+
+/obj/item/storage/box/nuke_ops
+	name = "specialist nuclear equipment case" // generic
+	icon_state = "hard_case"
+	slots = 3
+
+/obj/item/storage/box/nuke_ops/reinforcement
+	name = "reinforcement beacon case"
+	spawn_contents = list(/obj/item/remote/reinforcement_beacon, /obj/item/paper/reinforcement_info)
+
+/obj/item/storage/box/nuke_ops/designator
+	name = "laser designator case"
+	spawn_contents = list(/obj/item/device/laser_designator/syndicate, /obj/item/paper/designator_info)
+
+/obj/item/storage/box/nuke_ops/deployment_remote
+	name = "deployment remote case"
+	spawn_contents = list(/obj/item/device/deployment_remote, /obj/item/paper/deployment_info)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Several nukie commander uplink items are meant to spawn papers with info on how they work, but currently they don't spawn. As far as I can tell, it's because uplinks don't spawn multiple distinct items from one regular purchase. This PR fixes them by spawning the items in little storage cases which is how traitor purchases with multiple items typically work. 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugfix and the papers are helpful.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
works on local!
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
