### PR TITLE
Fix for log piles being rotated

### DIFF
--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -330,6 +330,7 @@ ABSTRACT_TYPE(/obj/item/material_piece/rubber)
 			..()
 
 	_update_stack_appearance()
+		src.transform = initial(src.transform) // Logs are rotated after being felled. Stacking should unrotate them.
 		switch(src.amount)
 			if(1)
 				src.icon_state = "log1"

--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -317,6 +317,7 @@ ABSTRACT_TYPE(/obj/item/material_piece/rubber)
 	max_stack = 10
 	uses_default_material_appearance = FALSE
 	mat_changename = FALSE
+	var/is_rotated = FALSE // Logs are rotated after being felled. Need to unrotate them after stacking.
 
 	attackby(obj/item/W, mob/user)
 		if ((istool(W, TOOL_CUTTING | TOOL_SAWING)))
@@ -330,7 +331,10 @@ ABSTRACT_TYPE(/obj/item/material_piece/rubber)
 			..()
 
 	_update_stack_appearance()
-		src.transform = initial(src.transform) // Logs are rotated after being felled. Stacking should unrotate them.
+		..()
+		if(src.is_rotated)
+			src.Turn(-90)
+			src.is_rotated = FALSE
 		switch(src.amount)
 			if(1)
 				src.icon_state = "log1"
@@ -347,6 +351,7 @@ ABSTRACT_TYPE(/obj/item/material_piece/rubber)
 	icon_state = "log_thin1"
 
 	_update_stack_appearance()
+		..()
 		switch(src.amount)
 			if(1)
 				src.icon_state = "log_thin1"

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -81,6 +81,7 @@
 					for (var/i in 0 to 2)
 						var/obj/item/material_piece/organic/wood/log = new(locate(our_turf.x + i, our_turf.y, our_turf.z))
 						log.Turn(90)
+						log.is_rotated = TRUE
 					qdel(src)
 					return
 				src.falling = TRUE


### PR DESCRIPTION
## About the PR
- Logs that have been rotated after being felled are unrotated when stacked.

## Why's this needed?
- The log piles should not be rotated like the individual logs.

## Testing 
<img width="497" height="383" alt="Screenshot 2026-07-28 221130" src="https://github.com/user-attachments/assets/1139c0a1-ef7a-4025-9e5c-4d7d0d029cce" />
