### PR TITLE
Silicon lockdown timer

### DIFF
--- a/code/datums/hud/robot.dm
+++ b/code/datums/hud/robot.dm
@@ -177,7 +177,8 @@
 			if (!master.module || !show_items)
 				update_equipment()
 				return
-			if (master.hasStatus("lockdown_robot"))
+			var/datum/statusEffect/lockdown/lockdown_effect = master.hasStatus("lockdown_robot")
+			if (lockdown_effect && !lockdown_effect.fake)
 				boutput(master, SPAN_ALERT("Your equipment is locked down!"))
 				update_equipment()
 				return

--- a/code/datums/hud/silicon.dm
+++ b/code/datums/hud/silicon.dm
@@ -16,28 +16,34 @@
 
 	proc/update_health()
 		var/datum/statusEffect/killswitch/killswitch_status
-		if (isrobot(silicon))
-			var/mob/living/silicon/robot/robot = silicon
-			if (robot.mainframe)
-				killswitch_status = robot.mainframe.hasStatus("killswitch_ai")
-			else
-				killswitch_status = silicon.hasStatus("killswitch_robot")
-		else if (isshell(silicon))
-			var/mob/living/silicon/hivebot/eyebot/eyebot = silicon
-			if (eyebot.mainframe)
-				killswitch_status = eyebot.mainframe.hasStatus("killswitch_ai")
-		else if (isAI(silicon))
-			killswitch_status = silicon.hasStatus("killswitch_ai")
+		killswitch_status = silicon.hasStatus("killswitch_robot") || silicon.hasStatus("killswitch_ai") || silicon.mainframe?.hasStatus("killswitch_ai")
+		var/datum/statusEffect/lockdown/lockdown_status
+		lockdown_status = silicon.hasStatus("lockdown_robot") || silicon.hasStatus("lockdown_ai") || silicon.mainframe?.hasStatus("lockdown_ai")
 
 		if (killswitch_status)
-			var/timeleft = round((killswitch_status.duration)/10, 1)
-			timeleft = "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
-
-			killswitch.invisibility = INVIS_NONE
-			if(killswitch_status.owner_is_immune())
-				killswitch.maptext = "<span class='vga vt c ol' style='color: green;'>KILLSWITCH TIMER: [timeleft]\n You are immune!</span>"
-			else
-				killswitch.maptext = "<span class='vga vt c ol' style='color: red;'>KILLSWITCH TIMER\n<span style='font-size: 24px;'>[timeleft]</span></span>"
+			src.handle_killswitch_timer(killswitch_status)
+		else if (lockdown_status)
+			src.handle_lockdown_timer(lockdown_status)
 		else
 			killswitch.invisibility = INVIS_ALWAYS
 			killswitch.maptext = ""
+
+	proc/handle_killswitch_timer(var/datum/statusEffect/killswitch/killswitch_status)
+		var/timeleft = round((killswitch_status.duration)/10, 1)
+		timeleft = "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
+
+		killswitch.invisibility = INVIS_NONE
+		if(killswitch_status.owner_is_immune())
+			killswitch.maptext = "<span class='vga vt c ol' style='color: green;'>KILLSWITCH TIMER: [timeleft]\n You are immune!</span>"
+		else
+			killswitch.maptext = "<span class='vga vt c ol' style='color: red;'>KILLSWITCH TIMER\n<span style='font-size: 24px;'>[timeleft]</span></span>"
+
+	proc/handle_lockdown_timer(var/datum/statusEffect/lockdown/lockdown_status)
+		var/timeleft = round((lockdown_status.duration)/10, 1)
+		timeleft = "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
+
+		killswitch.invisibility = INVIS_NONE
+		if(lockdown_status.fake)
+			killswitch.maptext = "<span class='vga vt c ol' style='color: green;'>LOCKDOWN TIMER: [timeleft]\n You are immune!</span>"
+		else
+			killswitch.maptext = "<span class='vga vt c ol' style='color: yellow;'>LOCKDOWN TIMER\n<span style='font-size: 24px;'>[timeleft]</span></span>"

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -794,18 +794,26 @@ var/global/list/module_editors = list()
 	icon_state = "handcuffed"
 	unique = TRUE
 	effect_quality = STATUS_QUALITY_NEGATIVE
+	/// Is the owner of this lockdown immune to its effects and currently faking the signal of it to the robotics console
+	var/fake = FALSE
 
 	onAdd(optional)
 		. = ..()
 		if (ismob(src.owner))
 			var/mob/M = src.owner
-			M.show_text(SPAN_ALERT("<b>Equipment lockdown engaged!</b>"))
+			if(src.fake)
+				M.show_text(SPAN_ALERT(SPAN_BOLD("Equipment lockdown signal received and overriden.")))
+			else
+				M.show_text(SPAN_ALERT(SPAN_BOLD("Equipment lockdown engaged!")))
 
 	onRemove()
 		. = ..()
-		if (ismob(src.owner))
+		if (ismob(src.owner) && !src.fake)
 			var/mob/M = src.owner
-			M.show_text(SPAN_ALERT("<b>Equipment lockdown disengaged!</b>"))
+			if(src.fake)
+				M.show_text(SPAN_ALERT(SPAN_BOLD("Attempted lockdown signal timer expired.")))
+			else
+				M.show_text(SPAN_ALERT(SPAN_BOLD("Equipment lockdown disengaged!")))
 
 /datum/statusEffect/killswitch
 	id = "killswitch"

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -3746,8 +3746,12 @@ TYPEINFO(/mob/living/silicon/robot)
 		. = ..()
 
 	onAdd(optional)
-		. = ..()
 		src.robot = src.owner
+		if(src.robot.syndicate || src.robot.emagged)
+			src.fake = TRUE
+		. = ..()
+		if(src.fake)
+			return
 		src.robot.uneq_all()
 		for (var/obj/item/roboupgrade/R in src.robot.contents)
 			if (R.activated)
@@ -3757,6 +3761,8 @@ TYPEINFO(/mob/living/silicon/robot)
 
 	onUpdate(timePassed)
 		. = ..()
+		if(src.fake)
+			return
 		src.robot.uneq_all()
 		for (var/obj/item/roboupgrade/R in src.robot.contents)
 			if (R.activated)

--- a/code/modules/robotics/robot/upgrade/parent.dm
+++ b/code/modules/robotics/robot/upgrade/parent.dm
@@ -24,7 +24,8 @@ ABSTRACT_TYPE(/obj/item/roboupgrade)
 /obj/item/roboupgrade/proc/upgrade_activate(mob/living/silicon/robot/user)
 	if (!user)
 		return ROBOT_UPGRADE_FAIL_DISABLED
-	if(user.hasStatus("upgrade_disabled") || user.hasStatus("lockdown_robot") || user.hasStatus("no_cell_robot"))
+	var/datum/statusEffect/lockdown/lockdown_effect = user.hasStatus("lockdown_robot")
+	if(user.hasStatus("upgrade_disabled") || (lockdown_effect && !lockdown_effect.fake) || user.hasStatus("no_cell_robot"))
 		boutput(user, SPAN_ALERT("Your modules are currently disabled!"))
 		return ROBOT_UPGRADE_FAIL_DISABLED
 	if(user.hasStatus("low_power_robot") ||  user.hasStatus("no_power_robot"))

--- a/code/obj/machinery/computer/robotics.dm
+++ b/code/obj/machinery/computer/robotics.dm
@@ -142,12 +142,11 @@
 				var/mob/living/silicon/robot/robot = locate(params["mob_ref"])
 				if (QDELETED(robot))
 					return
+				var/fake_text = ""
 				if (robot.emagged || robot.syndicate)
-					if (robot.client)
-						boutput(robot, SPAN_NOTICE("<b>Equipment lockdown signal blocked!</b>"))
-						return
+					fake_text = "fake "
 				robot.setStatus("lockdown_robot", ROBOT_LOCKDOWN_DURATION)
-				logTheThing(LOG_COMBAT, usr, "has activated [constructTarget(robot,"combat")]'s equipment lockdown.")
+				logTheThing(LOG_COMBAT, usr, "has activated [constructTarget(robot,"combat")]'s [fake_text]equipment lockdown.")
 				return TRUE
 			if ("stop_silicon_lock")
 				if (!src.can_lockdown)
@@ -155,8 +154,11 @@
 				var/mob/living/silicon/robot/robot = locate(params["mob_ref"])
 				if (QDELETED(robot))
 					return
+				var/fake_text = ""
+				if (robot.emagged || robot.syndicate)
+					fake_text = "fake "
 				robot.delStatus("lockdown_robot")
-				logTheThing(LOG_COMBAT, usr, "has deactivated [constructTarget(robot, "combat")]'s equipment lock.")
+				logTheThing(LOG_COMBAT, usr, "has deactivated [constructTarget(robot, "combat")]'s [fake_text]equipment lock.")
 				return TRUE
 			if ("killswitch_ghostdrone")
 				var/mob/living/silicon/ghostdrone/drone = locate(params["mob_ref"])

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2483,14 +2483,16 @@ proc/can_act(var/mob/M, var/include_cuffs = 1)
 
 /// Returns true if the given mob is incapacitated
 proc/is_incapacitated(mob/M)
+	var/datum/statusEffect/lockdown/lockdown_effect = M.hasStatus("lockdown_robot") || M.hasStatus("lockdown_ai")
+	if(!istype(lockdown_effect) || lockdown_effect?.fake)
+		lockdown_effect = null
 	return (M &&(\
 		M.hasStatus("stunned") || \
 		M.hasStatus("knockdown") || \
 		M.hasStatus("unconscious") || \
 		M.hasStatus("paralysis") || \
 		M.hasStatus("pinned") || \
-		M.hasStatus("lockdown_robot") || \
-		M.hasStatus("lockdown_ai") || \
+		lockdown_effect || \
 		M.hasStatus("no_power_robot") || \
 		M.hasStatus("no_cell_robot") || \
 		M.stat)) && !M.client?.holder?.ghost_interaction


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a killswitch-style lockdown timer for all silicons, the killswitch timer will override the lockdown timer if both are active.
Syndicate/emagged cyborgs can have lockdowns applied to them, but are fake and have no effects, the same as the killswitch.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Improved visibility as to why you cannot use your equipment and allows syndie/emagged borgs to fake it due to having a big obvious popup on their screen rather than just never having the status effect applied to them, which resulted in being able to test syndieborgs by attempting to lock them down.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Killswitch timers still render the same as they do currently
<img width="297" height="141" alt="image" src="https://github.com/user-attachments/assets/bdcb4f48-8377-4820-b53c-b2e6df0dc2ef" />
<img width="981" height="566" alt="image" src="https://github.com/user-attachments/assets/906f025e-5b7d-47ab-bf8f-50a963c47781" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Silicons now receive a killswitch like timer at the top of their screen for the duration of any equipment lockdowns. Active killswitches will override this timer.
(*)Syndicate and Emagged cyborgs can be "locked down" by the robotics console, but are immune to the effects of the lockdown.
```
