### PR TITLE
QM Console null trader bluescreen fix

### DIFF
--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -294,21 +294,19 @@
 				src.generate_mail()
 		#endif
 
-		SPAWN(5 SECONDS)
-			// 20% chance to shuffle out generic traders for a new one
-			// Do this after a short delay so QMs can finish any last-second deals
-			var/removed_count = 0
-			for (var/datum/trader/generic/GT in src.active_traders)
-				if (prob(20))
-					src.active_traders -= GT
-					removed_count++
+		// 20% chance to shuffle out generic traders for a new one
+		var/removed_count = 0
+		for (var/datum/trader/generic/GT in src.active_traders)
+			if (prob(20))
+				src.active_traders -= GT
+				removed_count++
 
-			while(removed_count > 0)
-				removed_count--
-				src.active_traders += new /datum/trader/generic(src)
+		while(removed_count > 0)
+			removed_count--
+			src.active_traders += new /datum/trader/generic(src)
 
-			update_shipping_data()
-			update_buy_prices()
+		update_shipping_data()
+		update_buy_prices()
 
 	proc/generate_mail()
 		var/alive_players = 0
@@ -745,11 +743,13 @@
 			computer.update_static_data_for_all_viewers()
 		for_by_tcl(barcoder, /obj/item/portable_barcoder)
 			barcoder.update_destinations()
-		src.update_supply_console_data()
+		src.update_supply_console_data(TRUE)
 
-	proc/update_supply_console_data()
+	proc/update_supply_console_data(var/market_reset = FALSE)
 		for_by_tcl(computer, /obj/machinery/computer/supplycomp)
 			computer.update_static_data_for_all_viewers()
+			if(market_reset) //Return to the trader main menu to avoid trying to view a trader that has left
+				computer.set_tgui_shared_state("viewtrader", -1)
 
 // Debugging and admin verbs (mostly coder)
 

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -73,6 +73,14 @@
 	for (var/datum/tgui/window as anything in open_uis)
 		window.send_full_update()
 
+/// |GOONSTATION-ADD| Sets the given shared state key to the given value
+/datum/proc/set_tgui_shared_state(var/key, var/value)
+	if(!key)
+		return
+	LAZYLISTINIT(src.tgui_shared_states)
+	src.tgui_shared_states[key] = value
+	tgui_process.update_uis(src)
+
 /**
  * public
  *


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements a set_tgui_shared_state(key, value) proc on /datum for easy DM-side editing of shared states.
Traders now reset with the market, rather than 5 seconds later. This was the case to give a little leeway with QMs finishing deals which made sense with the old slow UI but now the UI updates immediately on market shift (thus the traders need to be ready) and theres timers all over cargo (accurate in the UI + market timer signs in cargo) so if you miss it thats on you.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being in a trader screen on a market reset currently just changes the trader you're viewing to whatever trader is in the same index as the old one, resulting in a bluescreen if the amount of traders lessened to the point no trader was in that index, and resetting to the trader main menu just makes more sense than a random new trader.
Fixes #27311

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Selected trader 6, forced a market shift, was sent to the main trader menu in which there was only 3 traders in the new shift.


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Cargo traders now reset with the market, instead of 5 seconds after.
```
