### PR TITLE
Stop cloner artifact clones having offline indicators

### DIFF
--- a/code/obj/artifacts/artifact_objects/cloner.dm
+++ b/code/obj/artifacts/artifact_objects/cloner.dm
@@ -75,8 +75,8 @@
 
 		if(swapSouls && H.mind)
 			clone.is_npc = FALSE
-			H.mind.transfer_to(clone)
 			H.is_npc = TRUE
+			H.mind.transfer_to(clone)
 		APPLY_ATOM_PROPERTY(clone, PROP_MOB_SUPPRESS_LAYDOWN_SOUND, "cloner art")
 		clone.changeStatus("unconscious", imprison_time) // so they don't ruin the surprise
 		O.ArtifactFaultUsed(H)

--- a/code/procs/mobprocs/offline_indicator.dm
+++ b/code/procs/mobprocs/offline_indicator.dm
@@ -135,6 +135,7 @@ var/image/remote_indicator_off = image('icons/mob/overhead_icons32x48.dmi', "rem
 
 	SPAWN(1 MINUTE)
 		if (INVALID_OFFLINE)
+			src?.clear_offline_indicator()
 			return
 		// check if they're still logged out after a while and update the overlay
 		if (!src.client && logout_check == src.logout_at)
@@ -142,6 +143,7 @@ var/image/remote_indicator_off = image('icons/mob/overhead_icons32x48.dmi', "rem
 
 		SPAWN(4 MINUTES)
 			if (INVALID_OFFLINE)
+				src?.clear_offline_indicator()
 				return
 			// check if they're STILL logged out and update the overlay again
 			if (!src.client && logout_check == src.logout_at)

--- a/code/procs/mobprocs/offline_indicator.dm
+++ b/code/procs/mobprocs/offline_indicator.dm
@@ -135,7 +135,7 @@ var/image/remote_indicator_off = image('icons/mob/overhead_icons32x48.dmi', "rem
 
 	SPAWN(1 MINUTE)
 		if (INVALID_OFFLINE)
-			src?.clear_offline_indicator()
+			src.clear_offline_indicator()
 			return
 		// check if they're still logged out after a while and update the overlay
 		if (!src.client && logout_check == src.logout_at)
@@ -143,7 +143,7 @@ var/image/remote_indicator_off = image('icons/mob/overhead_icons32x48.dmi', "rem
 
 		SPAWN(4 MINUTES)
 			if (INVALID_OFFLINE)
-				src?.clear_offline_indicator()
+				src.clear_offline_indicator()
 				return
 			// check if they're STILL logged out and update the overlay again
 			if (!src.client && logout_check == src.logout_at)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents evil cloner offline indicator markers from appearing by marking the mob you are transferring from as an NPC before doing the mind transfer instead of after. This gets caught in the existing npc check condition when creating ofline indicators.

Also cleans up lingering offline indicator overlays if the conditions change between adding the indicator and the subsequent SPAWN checks.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Causes an obvious tell for an evil clone.
Fixes #27332

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested locally and confirmed the offline indicator code returned early due to is_npc being TRUE via breakpoint. Before this change, the indicator was still being created.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

