### PR TITLE
Fixed podwars corpse grinder

### DIFF
--- a/code/modules/medical/cloning/grinder.dm
+++ b/code/modules/medical/cloning/grinder.dm
@@ -539,6 +539,12 @@ TYPEINFO(/obj/machinery/clonegrinder)
 	grind_level = GRIND_BODIES
 	upgraded = TRUE
 
+/obj/machinery/clonegrinder/podwars
+	desc = "A high efficiency corpse grinder. It even grinds up whatever the corpse has on it! Use with caution!";
+	grind_level = GRIND_GEAR
+	name = "Corpse Grinder 5000"
+	
+
 #undef GRIND_NOTHING
 #undef GRIND_BODIES
 #undef GRIND_GEAR

--- a/maps/pod_wars.dmm
+++ b/maps/pod_wars.dmm
@@ -3574,11 +3574,7 @@
 	},
 /area/pod_wars/spacejunk/nancy)
 "nf" = (
-/obj/machinery/clonegrinder{
-	desc = "A high efficiency corpse grinder. It even grinds up whatever the corpse has on it! Use with caution!";
-	emagged = 1;
-	name = "Corpse Grinder 5000"
-	},
+/obj/machinery/clonegrinder/podwars,
 /obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/redwhite,
 /area/pod_wars/team2/medbay)
@@ -6510,11 +6506,7 @@
 	},
 /area/pod_wars/spacejunk/uvb67/crew)
 "xS" = (
-/obj/machinery/clonegrinder{
-	desc = "A high efficiency corpse grinder. It even grinds up whatever the corpse has on it! Use with caution!";
-	emagged = 1;
-	name = "Corpse Grinder 5000"
-	},
+/obj/machinery/clonegrinder/podwars,
 /obj/item_dispenser/bandage{
 	pixel_y = 0;
 	pixel_x = -28


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Rn the pod-wars corpse grinder is a var edited cloning grinder, the edited vars don't exist since the grinder was change. this pr adds the "Pre emagged" version the pod-wars map need, with the right variables.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
you cant run pod-wars due to nonexistent var
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Loaded podwars, grinded a corpse with gear, gear and corpse are gone
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ANNmagedon
(+)Fixed the pod-wars' corpse grinder.
```
