### PR TITLE
Reorganize medical manufacturer

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1595,71 +1595,31 @@
 	item_outputs = list(/obj/item/reagent_containers/emergency_injector/empty)
 	create = 1
 	time = 3 SECONDS
-	category = MANUFACTURER::CATEGORY::TOOL
+	category = MANUFACTURER::CATEGORY::MEDICINE
 
 /datum/manufacture/empty_autoinjector/orange
-	name = "Empty Auto-Injector"
-	item_requirements = list("metal" = 1)
 	item_outputs = list(/obj/item/reagent_containers/emergency_injector/empty/orange)
-	create = 1
-	time = 3 SECONDS
-	category = MANUFACTURER::CATEGORY::TOOL
 
 /datum/manufacture/empty_autoinjector/red
-	name = "Empty Auto-Injector"
-	item_requirements = list("metal" = 1)
 	item_outputs = list(/obj/item/reagent_containers/emergency_injector/empty/red)
-	create = 1
-	time = 3 SECONDS
-	category = MANUFACTURER::CATEGORY::TOOL
 
 /datum/manufacture/empty_autoinjector/blue
-	name = "Empty Auto-Injector"
-	item_requirements = list("metal" = 1)
 	item_outputs = list(/obj/item/reagent_containers/emergency_injector/empty/blue)
-	create = 1
-	time = 3 SECONDS
-	category = MANUFACTURER::CATEGORY::TOOL
 
 /datum/manufacture/empty_autoinjector/green
-	name = "Empty Auto-Injector"
-	item_requirements = list("metal" = 1)
 	item_outputs = list(/obj/item/reagent_containers/emergency_injector/empty/green)
-	create = 1
-	time = 3 SECONDS
-	category = MANUFACTURER::CATEGORY::TOOL
 
 /datum/manufacture/empty_autoinjector/yellow
-	name = "Empty Auto-Injector"
-	item_requirements = list("metal" = 1)
 	item_outputs = list(/obj/item/reagent_containers/emergency_injector/empty/yellow)
-	create = 1
-	time = 3 SECONDS
-	category = MANUFACTURER::CATEGORY::TOOL
 
 /datum/manufacture/empty_autoinjector/purple
-	name = "Empty Auto-Injector"
-	item_requirements = list("metal" = 1)
 	item_outputs = list(/obj/item/reagent_containers/emergency_injector/empty/purple)
-	create = 1
-	time = 3 SECONDS
-	category = MANUFACTURER::CATEGORY::TOOL
 
 /datum/manufacture/empty_autoinjector/black
-	name = "Empty Auto-Injector"
-	item_requirements = list("metal" = 1)
 	item_outputs = list(/obj/item/reagent_containers/emergency_injector/empty/black)
-	create = 1
-	time = 3 SECONDS
-	category = MANUFACTURER::CATEGORY::TOOL
 
 /datum/manufacture/empty_autoinjector/white
-	name = "Empty Auto-Injector"
-	item_requirements = list("metal" = 1)
 	item_outputs = list(/obj/item/reagent_containers/emergency_injector/empty/white)
-	create = 1
-	time = 3 SECONDS
-	category = MANUFACTURER::CATEGORY::TOOL
 
 /datum/manufacture/gene_booth_frame
 	name = "Genetics Booth Deployer"
@@ -2645,7 +2605,7 @@ ABSTRACT_TYPE(/datum/manufacture/aiModule)
 	item_outputs = list(/obj/item/reagent_containers/mender)
 	create = 2
 	time = 30 SECONDS
-	category = MANUFACTURER::CATEGORY::RESOURCE
+	category = MANUFACTURER::CATEGORY::TOOL
 
 /datum/manufacture/mender_refill_cartridge
 	name = "Mender Refill Cartridge"
@@ -2654,7 +2614,7 @@ ABSTRACT_TYPE(/datum/manufacture/aiModule)
 	item_outputs = list(/obj/item/reagent_containers/mender_refill_cartridge)
 	create = 1
 	time = 3 SECONDS
-	category = MANUFACTURER::CATEGORY::RESOURCE
+	category = MANUFACTURER::CATEGORY::MEDICINE
 
 /datum/manufacture/penlight
 	name = "Penlight"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Move the empty auto-injectors & empty refill cartridges to the oh so lonely medicine category
Move the automender to tools category
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The medical manufacturer is kind of very unorganized with a confusing & bloated tools category
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
scrolling through the manufacturer, slowly

https://github.com/user-attachments/assets/fa54743f-17cd-405a-8a5b-4cc8901041a5

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ANNmagedon
(+)Empty auto injectors & mender cartridges have been moved to the medicine category in the medical manufacturer. 
(+)Automander (x2) have been moved to the tools category in the medical manufacturer.
```
