### PR TITLE
Security records on PDA now show the rank/job

### DIFF
--- a/code/obj/item/device/pda2/record_progs.dm
+++ b/code/obj/item/device/pda2/record_progs.dm
@@ -39,6 +39,7 @@
 					dat += "Sex: [src.active1["sex"]]<br>"
 					dat += "Pronouns: [src.active1["pronouns"]]<br>"
 					dat += "Age: [src.active1["age"]]<br>"
+					dat += "Rank: [src.active1["rank"]]<br>"
 					dat += "Fingerprint (R): [src.active1["fingerprint_right"]]<br>"
 					dat += "Fingerprint (L): [src.active1["fingerprint_left"]]<br>"
 					dat += "DNA: [src.active1["dna"]]<br>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It just makes sense + QoL.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Spawned in, opened records on my PDA, job is there.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Chatauscours
(+)Security records on the PDA now list the job
```
