### PR TITLE
Stealth storage special description only shows to syndies

### DIFF
--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -323,6 +323,8 @@
 	var/cloaked = 0
 	w_class = W_CLASS_SMALL
 	max_wclass = W_CLASS_NORMAL
+	tooltip_flags = REBUILD_USER
+	SYNDICATE_STEALTH_DESCRIPTION("It looks heavy, somehow.", null)
 
 	New()
 		..()
@@ -342,8 +344,7 @@
 				return
 			src.name = W.name
 			src.real_name = W.name
-			src.desc = "[W.desc] It looks heavy, somehow."
-			src.real_desc = "[W.desc] It looks heavy, somehow."
+			src.desc = W.desc
 			src.icon = W.icon
 			src.icon_state = W.icon_state
 			src.item_state = W.item_state


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the "It looks heavy, somehow." extra description added to stealth storages to a syndicate stealth description, making it only  visible if you are a syndie or spy thief.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stealth is in the name, they're meant to be stealthy, having a part in the description that tells anyone "this is a stealth storage" gives anyone an excuse to check it even if you've no other reason to suspect they may have one making the item entirely dependent on if security wants to be nice to you.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="319" height="270" alt="image" src="https://github.com/user-attachments/assets/41990f65-f592-4880-9bc5-d9788bdb7956" />

<img width="325" height="280" alt="image" src="https://github.com/user-attachments/assets/8fc16f6a-a2ee-4e33-a78d-8f6c4489b12e" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)The "It looks heavy, somehow" description on disguised stealth storages now only shows to syndicate operatives.
```
