### PR TITLE
Add robotics monitoring console map check to robotics area

### DIFF
--- a/code/modules/unit_tests/_map_correctness/area_contents_check/medical/robotics.dm
+++ b/code/modules/unit_tests/_map_correctness/area_contents_check/medical/robotics.dm
@@ -11,6 +11,7 @@
 		CONTENTS_GT(/obj/machinery/sink, 0),
 		// Robotics Equipment
 		CONTENTS_GT(/obj/machinery/computer/robot_module_rewriter, 0),
+		CONTENTS_GT(/obj/machinery/computer/robotics/lab, 0),
 		CONTENTS_GT(/obj/machinery/manufacturer/robotics, 0),
 		CONTENTS_GT(/obj/machinery/portable_reclaimer, 0),
 		CONTENTS_EQ(/obj/submachine/cargopad/robotics, 1),


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add robotics monitoring console to map correctness checks

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Computer should be in robotics on all maps for parity

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Map checks should pass on this PR