### PR TITLE
Parallax Layers Now Use `pixel_w/z` To Scroll

### DIFF
--- a/_std/parallax.dm
+++ b/_std/parallax.dm
@@ -52,21 +52,6 @@ var/list/planet_parallax_render_source_groups = list()
 
 /// Realigns the parallax layer so that the centremost tessellated tile occupies the position of the tessellated tile closest to the player.
 #define UPDATE_TESSELLATION_ALIGNMENT(parallax_layer) if (parallax_layer.parallax_render_source.tessellate) { \
-	var/pixel_x_offset = 0; \
-	var/pixel_y_offset = 0; \
-	if (parallax_layer.transform.c + parallax_layer.animation_pixel_x_offset > 0) { \
-		pixel_x_offset -= parallax_layer.parallax_render_source.icon_width; \
-	} \
-	else if (parallax_layer.transform.c + parallax_layer.animation_pixel_x_offset < -(parallax_layer.parallax_render_source.icon_width)) { \
-		pixel_x_offset += parallax_layer.parallax_render_source.icon_width; \
-	} \
-	if (parallax_layer.transform.f + parallax_layer.animation_pixel_y_offset > 0) { \
-		pixel_y_offset -= parallax_layer.parallax_render_source.icon_height; \
-	} \
-	else if (parallax_layer.transform.f + parallax_layer.animation_pixel_y_offset < -(parallax_layer.parallax_render_source.icon_height)) { \
-		pixel_y_offset += parallax_layer.parallax_render_source.icon_height; \
-	} \
-	if (pixel_x_offset || pixel_y_offset) { \
-		parallax_layer.transform = parallax_layer.transform.Translate(pixel_x_offset, pixel_y_offset); \
-	} \
+	parallax_layer.pixel_w = ((parallax_layer.pixel_w % parallax_layer.parallax_render_source.icon_width) + parallax_layer.parallax_render_source.icon_width) % parallax_layer.parallax_render_source.icon_width; \
+	parallax_layer.pixel_z = ((parallax_layer.pixel_z % parallax_layer.parallax_render_source.icon_height) + parallax_layer.parallax_render_source.icon_height) % parallax_layer.parallax_render_source.icon_height; \
 }

--- a/code/modules/parallax/parallax_controller.dm
+++ b/code/modules/parallax/parallax_controller.dm
@@ -1,19 +1,24 @@
 /datum/parallax_controller
 	/// The client that this parallax controller belongs to.
-	var/client/owner
-	/// An associative list of the parallax render sources and their corresponding layers displayed on the client's screen.
-	var/list/atom/movable/screen/parallax_render_source/parallax_render_sources
-	/// The various parallax layers displayed on the client's screen that will require to be updated when the client's mob moves.
-	var/list/atom/movable/screen/parallax_layer/parallax_layers
+	var/client/owner = null
+	/// The screen object that all parallax layers are rendered on.
+	var/atom/movable/screen/parallax_anchor/anchor = null
+	/// An associative list of the parallax render sources and their corresponding layers displayed on the parallax anchor.
+	var/list/atom/movable/screen/parallax_render_source/parallax_render_sources = null
+	/// The various parallax layers displayed on the parallax anchor that will require to be updated when the client's mob moves.
+	var/list/atom/movable/screen/parallax_layer/parallax_layers = null
 	/// A list of all the render source groups that the client is currently a member of.
-	var/list/datum/parallax_render_source_group/render_source_groups
+	var/list/datum/parallax_render_source_group/render_source_groups = null
 	/// The outermost atom/movable in the client's mob's .loc chain.
-	var/atom/movable/outermost_movable
+	var/atom/movable/outermost_movable = null
 
 /datum/parallax_controller/New(client/new_owner)
 	. = ..()
 
 	src.owner = new_owner
+	src.anchor = new /atom/movable/screen/parallax_anchor()
+	src.owner.screen += src.anchor
+
 	src.parallax_render_sources = list()
 	src.parallax_layers = list()
 	src.render_source_groups = list()
@@ -32,6 +37,9 @@
 	for (var/datum/parallax_render_source_group/render_source_group as anything in src.render_source_groups)
 		render_source_group.members -= src.owner
 
+	src.owner.screen -= src.anchor
+	QDEL_NULL(src.anchor)
+
 	src.owner.parallax_controller = null
 	src.owner = null
 
@@ -46,26 +54,21 @@
 	var/x_pixel_change = (old_turf.x - new_turf.x) * world.icon_size
 	var/y_pixel_change = (old_turf.y - new_turf.y) * world.icon_size
 
-	var/animation_time = 0
-	if (src.outermost_movable.glide_size)
-		// The time it takes for an atom/movable to move one tile.
-		animation_time = (world.icon_size / src.outermost_movable.glide_size) * world.tick_lag
+	// The time it takes for an atom/movable to move one tile.
+	var/animation_time = src.outermost_movable.glide_size && ((world.icon_size / src.outermost_movable.glide_size) * world.tick_lag)
 
 	for (var/atom/movable/screen/parallax_layer/parallax_layer as anything in src.parallax_layers)
 		// Multiply the pixel change by the parallax value to determine the number of pixels the layer should move by.
 		// Update the position of the parallax layer on the client's screen, and animate the movement, using a time value derived from the client's mob's speed.
-		// Round to 1s to not blur sprites
+		// Round to one pixel so to not blur sprites.
 		animate(
 			parallax_layer,
 			animation_time,
-			transform = matrix(
-				1, 0, round(x_pixel_change * parallax_layer.parallax_render_source.parallax_value, 1),
-				0, 1, round(y_pixel_change * parallax_layer.parallax_render_source.parallax_value, 1)
-			),
-			flags = ANIMATION_PARALLEL | ANIMATION_RELATIVE
+			pixel_w = round(x_pixel_change * parallax_layer.parallax_render_source.parallax_value, 1),
+			pixel_z = round(y_pixel_change * parallax_layer.parallax_render_source.parallax_value, 1),
+			flags = ANIMATION_PARALLEL | ANIMATION_RELATIVE,
 		)
 
-		// Check whether the layer should be realigned on the client's screen.
 		UPDATE_TESSELLATION_ALIGNMENT(parallax_layer)
 
 /// Updates the parallax render sources and layers displayed to a client by a z-level.
@@ -115,17 +118,15 @@
 		if (parallax_layer.parallax_render_source.parallax_value)
 			src.parallax_layers += parallax_layer
 
-		src.owner.screen += render_source
-		src.owner.screen += parallax_layer
+		src.anchor.vis_contents += render_source
+		src.anchor.vis_contents += parallax_layer
 
 /// Creates a new parallax layer for every provided parallax layer render source.
 /datum/parallax_controller/proc/recalculate_parallax_layer(atom/movable/screen/parallax_render_source/render_source)
-	if(render_source in src.parallax_render_sources)
-		var/atom/movable/screen/parallax_layer/parallax_layer = src.parallax_render_sources[render_source]
-
+	var/atom/movable/screen/parallax_layer/parallax_layer = src.parallax_render_sources[render_source]
+	if (parallax_layer)
 		parallax_layer.offset_layer()
 		parallax_layer.scroll_layer()
-		UPDATE_TESSELLATION_ALIGNMENT(parallax_layer)
 
 /// Removes the parallax layers corresponding to the provided parallax layer render sources.
 /datum/parallax_controller/proc/remove_parallax_layer(list/parallax_layer_render_sources)
@@ -137,8 +138,8 @@
 		src.parallax_render_sources -= render_source
 		src.parallax_layers -= parallax_layer
 
-		src.owner.screen -= render_source
-		src.owner.screen -= parallax_layer
+		src.anchor.vis_contents -= render_source
+		src.anchor.vis_contents -= parallax_layer
 
 /datum/parallax_controller/proc/update_outermost_movable(datum/component/component, atom/movable/old_outermost, atom/movable/new_outermost)
 	src.outermost_movable = new_outermost
@@ -162,7 +163,15 @@
 	src.UnregisterSignal(M, XSIG_MOVABLE_Z_CHANGED)
 	src.UnregisterSignal(M, XSIG_OUTERMOST_MOVABLE_CHANGED)
 
-/client/var/datum/parallax_controller/parallax_controller
+
+/atom/movable/screen/parallax_anchor
+	plane = PLANE_PARALLAX
+	appearance_flags = KEEP_TOGETHER | TILE_BOUND
+	screen_loc = "CENTER,CENTER"
+	mouse_opacity = 0
+
+
+/client/var/datum/parallax_controller/parallax_controller = null
 
 /client/New()
 	. = ..()

--- a/code/modules/parallax/parallax_layer.dm
+++ b/code/modules/parallax/parallax_layer.dm
@@ -1,24 +1,12 @@
 /atom/movable/screen/parallax_layer
 	plane = PLANE_PARALLAX
-	appearance_flags = KEEP_TOGETHER | TILE_BOUND
-	screen_loc = "CENTER,CENTER"
+	appearance_flags = TILE_BOUND
 	mouse_opacity = 0
 
 	/// The client that this parallax layer belongs to.
-	var/client/owner
-
+	var/client/owner = null
 	/// The parallax render source that this layer should use, containing data on appearance, parallax value, scroll speed, and so forth.
-	var/atom/movable/screen/parallax_render_source/parallax_render_source
-
-	/// The initial x pixel offset required to centre the layer on the client's screen.
-	var/initial_pixel_x_offset = 0
-	/// The initial y pixel offset required to centre the layer on the client's screen.
-	var/initial_pixel_y_offset = 0
-
-	/// The x pixel offset required for a scrolling layer to remain within the boundaries of a client's screen.
-	var/animation_pixel_x_offset = 0
-	/// The y pixel offset required for a scrolling layer to remain within the boundaries of a client's screen.
-	var/animation_pixel_y_offset = 0
+	var/atom/movable/screen/parallax_render_source/parallax_render_source = null
 
 /atom/movable/screen/parallax_layer/New(turf/newLoc, new_owner, parallax_render_source)
 	. = ..()
@@ -34,45 +22,49 @@
 	src.offset_layer()
 	src.scroll_layer()
 
-/// Offsets the parallax layer using a transformation to either appear in the centre of the client's screen, or appear centred when the client is at the initial x and y coordinates.
+/// Offsets the parallax layer to appear centred when the client is at the initial x and y coordinates.
 /atom/movable/screen/parallax_layer/proc/offset_layer()
-	src.initial_pixel_x_offset = round((src.parallax_render_source.icon_width / 2) * -1, 1)
-	src.initial_pixel_y_offset = round((src.parallax_render_source.icon_height / 2) * -1, 1)
+	var/turf/T = get_turf(src.owner.eye)
+	var/x_offset = round((src.parallax_render_source.initial_x_coordinate - T.x) * world.icon_size * src.parallax_render_source.parallax_value, 1)
+	var/y_offset = round((src.parallax_render_source.initial_y_coordinate - T.y) * world.icon_size * src.parallax_render_source.parallax_value, 1)
 
-	var/turf/current_turf = get_turf(src.owner.eye)
+	// Offset the parallax layer so that it will be centred on the client's screen when they are at the initial x and y coordinates.
 	if (!src.parallax_render_source.tessellate)
-		// Offset the parallax layer so that it will be centred on the client's screen when they are at the initial x and y coordinates.
-		src.initial_pixel_x_offset += round((src.parallax_render_source.initial_x_coordinate - current_turf.x) * world.icon_size * src.parallax_render_source.parallax_value, 1)
-		src.initial_pixel_y_offset += round((src.parallax_render_source.initial_y_coordinate - current_turf.y) * world.icon_size * src.parallax_render_source.parallax_value, 1)
+		src.pixel_x = x_offset - round(src.parallax_render_source.icon_width / 2, 1)
+		src.pixel_y = y_offset - round(src.parallax_render_source.icon_height / 2, 1)
 
-		src.transform = matrix(1, 0, src.initial_pixel_x_offset, 0, 1, src.initial_pixel_y_offset)
-
+	// Offset the parallax layer as to maintain a consistant offset between `offset_layer()` calls, as opposed to resetting the layer to the middle of the client's screen.
 	else
-		// Offset the parallax layer as to maintain a consistant offset between `offset_layer()` calls, as opposed to resetting the layer to the middle of the client's screen.
-		var/pixel_x_offset = round((src.parallax_render_source.initial_x_coordinate - current_turf.x) * world.icon_size * src.parallax_render_source.parallax_value, 1) % src.parallax_render_source.icon_width
-		var/pixel_y_offset = round((src.parallax_render_source.initial_y_coordinate - current_turf.y) * world.icon_size * src.parallax_render_source.parallax_value, 1) % src.parallax_render_source.icon_height
+		src.pixel_x = world.icon_size - src.parallax_render_source.icon_width
+		src.pixel_y = world.icon_size - src.parallax_render_source.icon_height
 
-		src.transform = matrix(1, 0, src.initial_pixel_x_offset + pixel_x_offset, 0, 1, src.initial_pixel_y_offset + pixel_y_offset)
-
-	UPDATE_TESSELLATION_ALIGNMENT(src)
+		src.pixel_w = x_offset
+		src.pixel_z = y_offset
+		UPDATE_TESSELLATION_ALIGNMENT(src)
 
 /// Animates the parallax layer so that it appears to be infinitely moving in one direction, using the `scroll_speed`, `parallax_value`, and `scroll_angle` variables.
 /atom/movable/screen/parallax_layer/proc/scroll_layer()
 	if (!src.parallax_render_source.tessellate || (!src.parallax_render_source.scroll_speed && !src.parallax_render_source.scroll_angle))
 		return
+
 	animate(src)
+
 	var/x = src.parallax_render_source.scroll_speed * src.parallax_render_source.parallax_value * sin(src.parallax_render_source.scroll_angle)
 	if (x)
-		var/x_direction = x / abs(x)
-		var/animation_time_x = (abs(src.parallax_render_source.icon_width / x) / 2) SECONDS
-		src.animation_pixel_x_offset = src.parallax_render_source.icon_width * x_direction / -2
-		animate(src, 0, -1, transform = matrix(1, 0, src.animation_pixel_x_offset, 0, 1, 0), flags = ANIMATION_PARALLEL | ANIMATION_RELATIVE)
-		animate(time = animation_time_x, transform = matrix(1, 0, src.parallax_render_source.icon_width * x_direction, 0, 1, 0), flags = ANIMATION_RELATIVE)
+		var/half_width = src.parallax_render_source.icon_width / 2
+		var/x_direction = sign(x)
+		var/x_time = round((half_width / abs(x)) SECONDS, 1)
+		var/x_offset = round(half_width, 1)
+
+		animate(src, 0, -1, pixel_x = x_offset * -x_direction, flags = ANIMATION_PARALLEL | ANIMATION_RELATIVE)
+		animate(time = x_time, pixel_x = src.parallax_render_source.icon_width * x_direction, flags = ANIMATION_RELATIVE)
 
 	var/y = src.parallax_render_source.scroll_speed * src.parallax_render_source.parallax_value * cos(src.parallax_render_source.scroll_angle)
 	if (y)
-		var/y_direction = y / abs(y)
-		var/animation_time_y = (abs(src.parallax_render_source.icon_height / y) / 2) SECONDS
-		src.animation_pixel_y_offset = src.parallax_render_source.icon_height * y_direction / -2
-		animate(src, 0, -1, transform = matrix(1, 0, 0, 0, 1, src.animation_pixel_y_offset), flags = ANIMATION_PARALLEL | ANIMATION_RELATIVE)
-		animate(time = animation_time_y, transform = matrix(1, 0, 0, 0, 1, src.parallax_render_source.icon_height * y_direction), flags = ANIMATION_RELATIVE)
+		var/half_height = src.parallax_render_source.icon_height / 2
+		var/y_direction = sign(y)
+		var/y_time = round((half_height / abs(y)) SECONDS, 1)
+		var/y_offset = round(half_height, 1)
+
+		animate(src, 0, -1, pixel_y = y_offset * -y_direction, flags = ANIMATION_PARALLEL | ANIMATION_RELATIVE)
+		animate(time = y_time, pixel_y = src.parallax_render_source.icon_height * y_direction, flags = ANIMATION_RELATIVE)

--- a/code/modules/parallax/parallax_layer.dm
+++ b/code/modules/parallax/parallax_layer.dm
@@ -51,20 +51,18 @@
 
 	var/x = src.parallax_render_source.scroll_speed * src.parallax_render_source.parallax_value * sin(src.parallax_render_source.scroll_angle)
 	if (x)
-		var/half_width = src.parallax_render_source.icon_width / 2
 		var/x_direction = sign(x)
-		var/x_time = round((half_width / abs(x)) SECONDS, 1)
-		var/x_offset = round(half_width, 1)
+		var/x_offset = src.parallax_render_source.icon_width / 2
+		var/x_time = (x_offset / abs(x)) SECONDS
 
-		animate(src, 0, -1, pixel_x = x_offset * -x_direction, flags = ANIMATION_PARALLEL | ANIMATION_RELATIVE)
-		animate(time = x_time, pixel_x = src.parallax_render_source.icon_width * x_direction, flags = ANIMATION_RELATIVE)
+		animate(src, 0, -1, transform = matrix(1, 0, x_offset * -x_direction, 0, 1, 0), flags = ANIMATION_PARALLEL | ANIMATION_RELATIVE)
+		animate(time = x_time, transform = matrix(1, 0, src.parallax_render_source.icon_width * x_direction, 0, 1, 0), flags = ANIMATION_RELATIVE)
 
 	var/y = src.parallax_render_source.scroll_speed * src.parallax_render_source.parallax_value * cos(src.parallax_render_source.scroll_angle)
 	if (y)
-		var/half_height = src.parallax_render_source.icon_height / 2
 		var/y_direction = sign(y)
-		var/y_time = round((half_height / abs(y)) SECONDS, 1)
-		var/y_offset = round(half_height, 1)
+		var/y_offset = src.parallax_render_source.icon_height / 2
+		var/y_time = (y_offset / abs(y)) SECONDS
 
-		animate(src, 0, -1, pixel_y = y_offset * -y_direction, flags = ANIMATION_PARALLEL | ANIMATION_RELATIVE)
-		animate(time = y_time, pixel_y = src.parallax_render_source.icon_height * y_direction, flags = ANIMATION_RELATIVE)
+		animate(src, 0, -1, transform = matrix(1, 0, 0, 0, 1, y_offset * -y_direction), flags = ANIMATION_PARALLEL | ANIMATION_RELATIVE)
+		animate(time = y_time, transform = matrix(1, 0, 0, 0, 1, src.parallax_render_source.icon_height * y_direction), flags = ANIMATION_RELATIVE)

--- a/code/modules/parallax/parallax_render_sources/parallax_render_source_parent.dm
+++ b/code/modules/parallax/parallax_render_sources/parallax_render_source_parent.dm
@@ -6,7 +6,6 @@
 /atom/movable/screen/parallax_render_source
 	plane = PLANE_PARALLAX
 	appearance_flags = KEEP_TOGETHER | TILE_BOUND
-	screen_loc = "CENTER,CENTER"
 
 	name = null
 	desc = null


### PR DESCRIPTION
## About The PR:
Parallax layers have been refactored to use pixel offsets to scroll instead of matrix transforms. This allows for positioning to be done using the `x/y` offsets and scrolling to be done using the `w/z` offsets; this vastly simplifies the maths required to keep the scrolling offsets within certain bounds. This also means that `x/y` or `transform` can be independently animated for passive scrolling (snow, clouds, etc), causing less interference and jittering.


## Why Is This Needed?
Parallax, for some reason, has become increasingly jittery over the past months. I have no idea why. Locally, the new system is noticeably less jittery.


## Testing:
To testmerge, but everything worked as expected locally.

Below is a comparison of `update_parallax_layers()` before (in red) and after (in yellow) the changes. The results were obtained by setting up Atlas with the four tessellating Debris Field parallax layers and using the build mode tool to throw my character across the z-level such that I looped.

<img width="1600" height="890" alt="image" src="https://github.com/user-attachments/assets/0d48e265-0a9e-40c4-a7d6-6b0f947b5774" />