### PR TITLE
Makes security + HoS boots no longer make more footstep noises than normal when walking instead of running

### DIFF
--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -628,6 +628,7 @@ TYPEINFO(/obj/item/clothing/shoes/cowboy/boom)
 
 	emag_act(mob/user, obj/item/card/emag/E)
 		if(src.step_sound != "clownstep")
+			src.step_lots = 1
 			src.step_sound = "clownstep"
 			src.step_priority = /obj/item/clothing/shoes/clown_shoes::step_priority
 			boutput(user, SPAN_NOTICE("You scramble the speakers installed in [src]"))

--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -576,7 +576,6 @@ TYPEINFO(/obj/item/clothing/shoes/cowboy/boom)
 	protective_temperature = 1250
 	step_sound = "step_military"
 	step_priority = STEP_PRIORITY_LOW
-	step_lots = 1
 	kick_bonus = 2
 
 	setupProperties()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the "step_lots = 1" from military boots (and, by extension, HoS boots) to make it so that they no longer make more footstep noises when walking than when running
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Making more footsteps when you're moving slower doesn't make much sense, and multiple people in the Goonstation Discord expressed discontent with it. Clown shoes are unchanged because they're clowns, they're SUPPOSED to sound ridiculous.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spawned in each of the affected shoe types and wore them while walking; footstep sounds were played at a normal rate
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
