### PR TITLE
Rotate the Clarion Ice dispenser

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -5001,8 +5001,9 @@
 	},
 /obj/table/wood/auto/desk,
 /obj/item_dispenser/icedispenser{
-	dir = 4;
-	pixel_y = 23
+	dir = 8;
+	pixel_y = 23;
+	pixel_x = 20
 	},
 /obj/item/gun/russianrevolver,
 /obj/machinery/partyalarm{


### PR DESCRIPTION
[MAP]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Rotates the clarion ice dispenser so it faces the other way.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #27371 