### PR TITLE
Sleepy pen special description only shows to syndies

### DIFF
--- a/code/modules/chemistry/tools/sleepy_pen.dm
+++ b/code/modules/chemistry/tools/sleepy_pen.dm
@@ -4,6 +4,7 @@
 	hide_attack = TRUE
 	move_triggered = TRUE
 	can_dip = FALSE
+	tooltip_flags = REBUILD_USER
 	SYNDICATE_STEALTH_DESCRIPTION("It has a rather sharp point.", null)
 
 	New()

--- a/code/modules/chemistry/tools/sleepy_pen.dm
+++ b/code/modules/chemistry/tools/sleepy_pen.dm
@@ -4,14 +4,13 @@
 	hide_attack = TRUE
 	move_triggered = TRUE
 	can_dip = FALSE
+	SYNDICATE_STEALTH_DESCRIPTION("It has a rather sharp point.", null)
 
 	New()
 		..()
 		if (prob(50))
-			desc = "The humble National Notary 'Arundel' model pen. It's a normal black ink pen. With a sharp point."
-		else
 			name = "fancy pen"
-			desc = "One of those really fancy National Notary pens. Looks like the 'Grand Duchess' model with the marblewood handle. And a sharp point."
+			desc = /obj/item/pen/fancy::desc
 			icon_state = "pen_fancy"
 			item_state = "pen_fancy"
 			font_color = "blue"

--- a/code/modules/chemistry/tools/sleepy_pen.dm
+++ b/code/modules/chemistry/tools/sleepy_pen.dm
@@ -5,7 +5,7 @@
 	move_triggered = TRUE
 	can_dip = FALSE
 	tooltip_flags = REBUILD_USER
-	SYNDICATE_STEALTH_DESCRIPTION("It has a rather sharp point.", null)
+	SYNDICATE_STEALTH_DESCRIPTION("It has a rather sharp point.")
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the "With a sharp point" text from the sleepy pen's description to a syndies-only description

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stealth items should not have dead giveaways in their descriptions.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="312" height="203" alt="image" src="https://github.com/user-attachments/assets/29082056-560f-4954-8352-804c82671963" />
<img width="313" height="213" alt="image" src="https://github.com/user-attachments/assets/45d1f090-37c2-4d07-a4b1-b598b0701c76" />
<img width="308" height="211" alt="image" src="https://github.com/user-attachments/assets/7de0d80f-affb-4075-9156-8d606bf8696c" />
<img width="322" height="230" alt="image" src="https://github.com/user-attachments/assets/d6647f1d-8f8e-48e0-96bb-c3df6cfc9632" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Sleepy pens now only show their "sharp point" description text to syndies.
```
