### PR TITLE
More XSIGs For Hashmaps

### DIFF
--- a/_std/defines/component_defines/component_defines_complex.dm
+++ b/_std/defines/component_defines/component_defines_complex.dm
@@ -9,8 +9,16 @@
 	#define XSIG_MOVABLE_Z_CHANGED /datum/xsig/outermost_movable/z_level_changed
 	/// When the outermost movable in the `.loc` chain moves to a new area. (thing, old_area, new_area)
 	#define XSIG_MOVABLE_AREA_CHANGED /datum/xsig/outermost_movable/area_changed
+
+
 	/// When the outermost movable in the `.loc` chain moves to a new turf. (thing, old_turf, new_turf)
 	#define XSIG_MOVABLE_TURF_CHANGED /datum/xsig/outermost_movable/turf_changed
+	/// When the outermost movable in the `.loc` chain moves to a new turf, provided both the old and new turfs exist. (thing, old_turf, new_turf)
+	#define XSIG_MOVABLE_TURF_CHANGED_SAFE /datum/xsig/outermost_movable/turf_changed/safe
+	/// When the outermost movable in the `.loc` chain moves from a turf to nullspace. (thing, old_turf)
+	#define XSIG_MOVABLE_TURF_TO_NULLSPACE /datum/xsig/outermost_movable/turf_changed/to_null
+	/// When the outermost movable in the `.loc` chain moves from nullspace to a turf. (thing, new_turf)
+	#define XSIG_MOVABLE_NULLSPACE_TO_TURF /datum/xsig/outermost_movable/turf_changed/to_turf
 
 
 
@@ -46,3 +54,12 @@ ALWAYS_ABSTRACT(/datum/xsig)
 /datum/xsig/outermost_movable/turf_changed
 	id = "mov_turf_changed"
 	track_movable_moved = TRUE
+
+/datum/xsig/outermost_movable/turf_changed/safe
+	id = "mov_turf_changed_safe"
+
+/datum/xsig/outermost_movable/turf_changed/to_null
+	id = "mov_turf_to_nullspace"
+
+/datum/xsig/outermost_movable/turf_changed/to_turf
+	id = "mov_nullspace_to_turf"

--- a/code/datums/components/complexsignal/outermost_movable.dm
+++ b/code/datums/components/complexsignal/outermost_movable.dm
@@ -61,6 +61,14 @@
 	if (old_turf != new_turf)
 		SEND_COMPLEX_SIGNAL(src, XSIG_MOVABLE_TURF_CHANGED, old_turf, new_turf)
 
+		if (old_turf)
+			if (new_turf)
+				SEND_COMPLEX_SIGNAL(src, XSIG_MOVABLE_TURF_CHANGED_SAFE, old_turf, new_turf)
+			else
+				SEND_COMPLEX_SIGNAL(src, XSIG_MOVABLE_TURF_TO_NULLSPACE, old_turf)
+		else
+			SEND_COMPLEX_SIGNAL(src, XSIG_MOVABLE_NULLSPACE_TO_TURF, new_turf)
+
 		var/area/old_area = get_area(previous_loc)
 		var/area/new_area = get_area(outermost_movable)
 		if (old_area != new_area)

--- a/code/modules/parallax/parallax_controller.dm
+++ b/code/modules/parallax/parallax_controller.dm
@@ -47,9 +47,6 @@
 
 /// Updates the position of the parallax layer relative to the client's eye, taking into account the distance moved and the parallax value.
 /datum/parallax_controller/proc/update_parallax_layers(datum/component/component, turf/old_turf, turf/new_turf)
-	if (!isturf(old_turf) || !isturf(new_turf))
-		return
-
 	// Calculate the number of tiles the client's eye has moved, in pixels.
 	var/x_pixel_change = (old_turf.x - new_turf.x) * world.icon_size
 	var/y_pixel_change = (old_turf.y - new_turf.y) * world.icon_size
@@ -145,7 +142,7 @@
 	src.outermost_movable = new_outermost
 
 /datum/parallax_controller/proc/register_signals(client/C, mob/M)
-	src.RegisterSignal(M, XSIG_MOVABLE_TURF_CHANGED, PROC_REF(update_parallax_layers))
+	src.RegisterSignal(M, XSIG_MOVABLE_TURF_CHANGED_SAFE, PROC_REF(update_parallax_layers))
 	src.RegisterSignal(M, XSIG_MOVABLE_AREA_CHANGED, PROC_REF(update_area_parallax_layers))
 	src.RegisterSignal(M, XSIG_MOVABLE_Z_CHANGED, PROC_REF(update_z_level_parallax_layers))
 	src.RegisterSignal(M, XSIG_OUTERMOST_MOVABLE_CHANGED, PROC_REF(update_outermost_movable))
@@ -158,7 +155,7 @@
 	if (!M?.GetComponent(/datum/component/complexsignal/outermost_movable))
 		return
 
-	src.UnregisterSignal(M, XSIG_MOVABLE_TURF_CHANGED)
+	src.UnregisterSignal(M, XSIG_MOVABLE_TURF_CHANGED_SAFE)
 	src.UnregisterSignal(M, XSIG_MOVABLE_AREA_CHANGED)
 	src.UnregisterSignal(M, XSIG_MOVABLE_Z_CHANGED)
 	src.UnregisterSignal(M, XSIG_OUTERMOST_MOVABLE_CHANGED)

--- a/code/modules/spatial_hashing/_spatial_hashmap_parent.dm
+++ b/code/modules/spatial_hashing/_spatial_hashmap_parent.dm
@@ -251,7 +251,9 @@ ABSTRACT_TYPE(/datum/spatial_hashmap)
 	// Increment a tracked atom's signal subscription count.
 	if (!src.tracked_atoms_with_subcount[tracked_atom])
 		src.tracked_atoms_with_subcount[tracked_atom] = 1
-		src.RegisterSignal(tracked_atom, XSIG_MOVABLE_TURF_CHANGED, PROC_REF(update_entry))
+		src.RegisterSignal(tracked_atom, XSIG_MOVABLE_TURF_CHANGED_SAFE, PROC_REF(update_entry))
+		src.RegisterSignal(tracked_atom, XSIG_MOVABLE_TURF_TO_NULLSPACE, PROC_REF(remove_entry))
+		src.RegisterSignal(tracked_atom, XSIG_MOVABLE_NULLSPACE_TO_TURF, PROC_REF(add_entry))
 	else
 		src.tracked_atoms_with_subcount[tracked_atom] += 1
 
@@ -262,12 +264,10 @@ ABSTRACT_TYPE(/datum/spatial_hashmap)
 
 	// Provided the tracked atom isn't in nullspace, add it to the hashmap data structure.
 	var/turf/T = get_turf(tracked_atom)
-	if (T)
+	if (T?.z && (T.z <= src.z_order))
 		var/x = ceil(T.x / src.cell_size)
 		var/y = ceil(T.y / src.cell_size)
-		var/z = T.z
-		if (z && (z <= src.z_order))
-			src.hashmap[z][y][x] += entry
+		src.hashmap[T.z][y][x] += entry
 
 /**
  *	Removes an entry from the hashmap.
@@ -281,7 +281,9 @@ ABSTRACT_TYPE(/datum/spatial_hashmap)
 	src.tracked_atoms_with_subcount[tracked_atom] -= 1
 	if (!src.tracked_atoms_with_subcount[tracked_atom])
 		src.tracked_atoms_with_subcount -= tracked_atom
-		src.UnregisterSignal(tracked_atom, XSIG_MOVABLE_TURF_CHANGED)
+		src.UnregisterSignal(tracked_atom, XSIG_MOVABLE_TURF_CHANGED_SAFE)
+		src.UnregisterSignal(tracked_atom, XSIG_MOVABLE_TURF_TO_NULLSPACE)
+		src.UnregisterSignal(tracked_atom, XSIG_MOVABLE_NULLSPACE_TO_TURF)
 
 	// Dissociate the hashmap entry with the tracked atom and vice versa.
 	src.atoms_by_entry -= entry
@@ -291,12 +293,10 @@ ABSTRACT_TYPE(/datum/spatial_hashmap)
 
 	// Provided the tracked atom isn't in nullspace, remove it from the hashmap data structure.
 	var/turf/T = get_turf(tracked_atom)
-	if (T)
+	if (T?.z && (T.z <= src.z_order))
 		var/x = ceil(T.x / src.cell_size)
 		var/y = ceil(T.y / src.cell_size)
-		var/z = T.z
-		if (z && (z <= src.z_order))
-			src.hashmap[z][y][x] -= entry
+		src.hashmap[T.z][y][x] -= entry
 
 /**
  *	Updates the tracked atom being used to represent the physical position of a hashmap entry.
@@ -310,29 +310,45 @@ ABSTRACT_TYPE(/datum/spatial_hashmap)
  *	Internal use only.
  */
 /datum/spatial_hashmap/proc/update_entry(datum/component/complexsignal/outermost_movable/component, turf/old_turf, turf/new_turf)
-	if (old_turf && new_turf)
-		var/old_x = ceil(old_turf.x / src.cell_size)
-		var/new_x = ceil(new_turf.x / src.cell_size)
-		var/old_y = ceil(old_turf.y / src.cell_size)
-		var/new_y = ceil(new_turf.y / src.cell_size)
+	PRIVATE_PROC(TRUE)
+	var/old_x = ceil(old_turf.x / src.cell_size)
+	var/new_x = ceil(new_turf.x / src.cell_size)
+	var/old_y = ceil(old_turf.y / src.cell_size)
+	var/new_y = ceil(new_turf.y / src.cell_size)
 
-		if ((old_x == new_x) && (old_y == new_y) && (old_turf.z == new_turf.z))
-			return
+	if ((old_x == new_x) && (old_y == new_y) && (old_turf.z == new_turf.z))
+		return
 
-		if (old_turf.z && (old_turf.z <= src.z_order))
-			src.hashmap[old_turf.z][old_y][old_x] -= src.entries_by_atom[component.parent]
-		if (new_turf.z && (new_turf.z <= src.z_order))
-			src.hashmap[new_turf.z][new_y][new_x] += src.entries_by_atom[component.parent]
-
-	else if (old_turf?.z && (old_turf.z <= src.z_order))
-		var/old_x = ceil(old_turf.x / src.cell_size)
-		var/old_y = ceil(old_turf.y / src.cell_size)
+	if (old_turf.z && (old_turf.z <= src.z_order))
 		src.hashmap[old_turf.z][old_y][old_x] -= src.entries_by_atom[component.parent]
-
-	else if (new_turf?.z && (new_turf.z <= src.z_order))
-		var/new_x = ceil(new_turf.x / src.cell_size)
-		var/new_y = ceil(new_turf.y / src.cell_size)
+	if (new_turf.z && (new_turf.z <= src.z_order))
 		src.hashmap[new_turf.z][new_y][new_x] += src.entries_by_atom[component.parent]
+
+/**
+ *	Removes a hashmap entry, as if the entry's position was updated to nullspace.
+ *	Internal use only.
+ */
+/datum/spatial_hashmap/proc/remove_entry(datum/component/complexsignal/outermost_movable/component, turf/old_turf)
+	PRIVATE_PROC(TRUE)
+	if (!old_turf.z || (old_turf.z > src.z_order))
+		return
+
+	var/old_x = ceil(old_turf.x / src.cell_size)
+	var/old_y = ceil(old_turf.y / src.cell_size)
+	src.hashmap[old_turf.z][old_y][old_x] -= src.entries_by_atom[component.parent]
+
+/**
+ *	Adds a hashmap entry, as if the entry's position was updated from nullspace.
+ *	Internal use only.
+ */
+/datum/spatial_hashmap/proc/add_entry(datum/component/complexsignal/outermost_movable/component, turf/new_turf)
+	PRIVATE_PROC(TRUE)
+	if (!new_turf.z || (new_turf.z > src.z_order))
+		return
+
+	var/new_x = ceil(new_turf.x / src.cell_size)
+	var/new_y = ceil(new_turf.y / src.cell_size)
+	src.hashmap[new_turf.z][new_y][new_x] += src.entries_by_atom[component.parent]
 
 /**
  *	Updates the z-order of the hashmap.

--- a/code/modules/spatial_hashing/manual.dm
+++ b/code/modules/spatial_hashing/manual.dm
@@ -13,11 +13,10 @@
 	src.RegisterSignal(entry, COMSIG_PARENT_PRE_DISPOSING, PROC_REF(unregister_hashmap_entry))
 	src.atoms_by_entry[entry] = T
 
-	var/x = ceil(T.x / src.cell_size)
-	var/y = ceil(T.y / src.cell_size)
-	var/z = T.z
-	if (z && (z <= src.z_order))
-		src.hashmap[z][y][x] += entry
+	if (T.z && (T.z <= src.z_order))
+		var/x = ceil(T.x / src.cell_size)
+		var/y = ceil(T.y / src.cell_size)
+		src.hashmap[T.z][y][x] += entry
 
 /datum/spatial_hashmap/manual/unregister_hashmap_entry(datum/entry)
 	var/turf/T = src.atoms_by_entry[entry]
@@ -27,9 +26,8 @@
 	src.UnregisterSignal(entry, COMSIG_PARENT_PRE_DISPOSING)
 	src.atoms_by_entry -= entry
 
-	var/x = ceil(T.x / src.cell_size)
-	var/y = ceil(T.y / src.cell_size)
-	var/z = T.z
-	if (z && (z <= src.z_order))
-		src.hashmap[z][y][x] -= entry
+	if (T?.z && (T.z <= src.z_order))
+		var/x = ceil(T.x / src.cell_size)
+		var/y = ceil(T.y / src.cell_size)
+		src.hashmap[T.z][y][x] -= entry
 


### PR DESCRIPTION
## About The PR:
Atomises the XSIG changes from #25599, which implements three new `XSIG_MOVABLE_TURF_CHANGED` XSIG variants; one for `/turf -> /turf`, one for `/turf -> null`, and one for `null -> /turf`. Hashmaps have been slightly refactored to use these new signals, as has parallax.


## Why Is This Needed?
Minor performance boost, cutting down on safety checks and branching.


## Testing:
Testing from 25599 applies here. Also tested locally using the hashmap debug overlays. To be testmerged.