### PR TITLE
Clean up map config settings and add map size defines

### DIFF
--- a/_std/defines/gang.dm
+++ b/_std/defines/gang.dm
@@ -170,13 +170,11 @@
 #define GANG_TAG_INFLUENCE_LOCKER 4
 /// Radius of the circle that gang tags can see inside (can't be sprayed inside)
 #define GANG_TAG_SIGHT_RANGE_LOCKER 0
-// keep in mind, smaller maps will still have fewer players & less gangs
 
-// overriding gang tag sizes, 15-8 seems fair for most highpop maps
-#ifdef MAPSIZE_SMALL
+#ifdef MAPSIZE_SMALL // keep in mind, smaller maps will still have fewer players & less gangs
 	#define GANG_TAG_INFLUENCE 10
 	#define GANG_TAG_SIGHT_RANGE 5
-#elif defined(MAPSIZE_LARGE)
+#elif defined(MAPSIZE_LARGE) // overriding gang tag sizes, 15-8 seems fair for most highpop maps
 	#define GANG_TAG_INFLUENCE 15
 	#define GANG_TAG_SIGHT_RANGE 8
 #elif defined(MAPSIZE_XLARGE)

--- a/_std/defines/gang.dm
+++ b/_std/defines/gang.dm
@@ -173,19 +173,15 @@
 // keep in mind, smaller maps will still have fewer players & less gangs
 
 // overriding gang tag sizes, 15-8 seems fair for most highpop maps
-#ifdef MAP_OVERRIDE_COGMAP2
-	#define GANG_TAG_INFLUENCE 15
-	#define GANG_TAG_SIGHT_RANGE 8
-
-#elif defined(MAP_OVERRIDE_DONUT3)
-	#define GANG_TAG_INFLUENCE 15
-	#define GANG_TAG_SIGHT_RANGE 8
-#elif defined(MAP_OVERRIDE_OZYMANDIAS) //jesus christ. this is HUGE.
-	#define GANG_TAG_INFLUENCE 20
-	#define GANG_TAG_SIGHT_RANGE 12
-#elif defined(MAP_OVERRIDE_ATLAS)
+#ifdef MAPSIZE_SMALL
 	#define GANG_TAG_INFLUENCE 10
 	#define GANG_TAG_SIGHT_RANGE 5
+#elif defined(MAPSIZE_LARGE)
+	#define GANG_TAG_INFLUENCE 15
+	#define GANG_TAG_SIGHT_RANGE 8
+#elif defined(MAPSIZE_XLARGE)
+	#define GANG_TAG_INFLUENCE 20
+	#define GANG_TAG_SIGHT_RANGE 12
 #else
 	#define GANG_TAG_INFLUENCE 12
 	#define GANG_TAG_SIGHT_RANGE 6

--- a/_std/mapDefines.dm
+++ b/_std/mapDefines.dm
@@ -1,9 +1,13 @@
+// special modes
+#if defined(MAP_OVERRIDE_DEVTEST)
 
-#if defined(MAP_OVERRIDE_CONSTRUCTION)
+#elif defined(MAP_OVERRIDE_CONSTRUCTION)
 
-//#elif defined(MAP_OVERRIDE_POD_WARS)
+#elif defined(MAP_OVERRIDE_POD_WARS)
 
-//#elif defined(MAP_OVERRIDE_EVENT)
+#elif defined(MAP_OVERRIDE_EVENT)
+
+#elif defined(MAP_OVERRIDE_WRESTLEMAP)
 
 #elif defined(SPACE_PREFAB_RUNTIME_CHECKING)
 #define CI_RUNTIME_CHECKING 1
@@ -21,26 +25,20 @@
 #define CHECK_MORE_RUNTIMES 1
 #define RANDOM_ROOM_CHECKING 1
 
-#elif defined(MAP_OVERRIDE_PAMGOC)
-
-#define REVERSED_MAP
-
-//#elif defined(MAP_OVERRIDE_WRESTLEMAP)
-
-// rotation
+// rotation maps
 #elif defined(MAP_OVERRIDE_COGMAP)
 
 #elif defined(MAP_OVERRIDE_COGMAP2)
+#define MAPSIZE_LARGE 1
 
 #elif defined(MAP_OVERRIDE_DONUT2)
 
 #elif defined(MAP_OVERRIDE_DONUT3)
+#define MAPSIZE_LARGE 1
 
-// #elif defined(MAP_OVERRIDE_KONDARU)
+#elif defined(MAP_OVERRIDE_KONDARU)
 
 #elif defined(MAP_OVERRIDE_CLARION)
-
-#elif defined(MAP_OVERRIDE_ATLAS)
 
 #elif defined(MAP_OVERRIDE_OSHAN)
 #define UNDERWATER_MAP 1
@@ -52,25 +50,21 @@
 #elif defined(MAP_OVERRIDE_NEON)
 #define UNDERWATER_MAP 1
 #define HOTSPOTS_ENABLED 1
+#define MAPSIZE_SMALL 1
 
-// Non rotation
-#elif defined(MAP_OVERRIDE_DESTINY)
+// non rotation maps
+#elif defined(MAP_OVERRIDE_ATLAS)
+#define MAPSIZE_SMALL 1
 
-#elif defined(MAP_OVERRIDE_HORIZON)
-
-//#elif defined(MAP_OVERRIDE_CRASH)
+#elif defined(MAP_OVERRIDE_CRASH)
 
 #elif defined(MAP_OVERRIDE_MUSHROOM)
 
-#elif defined(MAP_OVERRIDE_TRUNKMAP)
+#elif defined(MAP_OVERRIDE_DENSITY2)
+#define MAPSIZE_SMALL 1
 
-/*#elif defined(MAP_OVERRIDE_DENSITY)
-
-#elif defined(MAP_OVERRIDE_OZYMANDIAS)
-
-#elif defined(MAP_OVERRIDE_FLEET)*/
+#elif defined(MAP_OVERRIDE_PROBSTATION)
 
 #else // the "default" map
-//#define UNDERWATER_MAP 1
 
 #endif

--- a/code/map.dm
+++ b/code/map.dm
@@ -15,7 +15,6 @@ var/global/list/mapNames = list(
 	//"Construction" =		list("id" = "CONSTRUCTION", "settings" = "construction"),
 	"pod_wars" =			list("id" = "POD_WARS",		"settings" = "pod_wars",		"playerPickable" = FALSE),
 	"Event" =				list("id" = "EVENT",		"settings" = "clarion",			"playerPickable" = FALSE),
-	// "1 pamgoC" =			list("id" = "PAMGOC",		"settings" = "pamgoc",			"playerPickable" = FALSE),
 	"Wrestlemap" =			list("id" = "WRESTLEMAP",	"settings" = "wrestlemap",		"playerPickable" = FALSE),
 	"Probstation" =			list("id" = "PROBSTATION",	"settings" = "probstation",		"playerPickable" = FALSE),
 

--- a/maps/config/map.dm
+++ b/maps/config/map.dm
@@ -17,9 +17,15 @@
 #elif defined(RANDOM_ROOM_RUNTIME_CHECKING)
 #include "blank.dm"
 
+#elif defined(GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW)
+#include "gottagofast.dm"
+
 // Secret Modes
 #elif defined(SECRET_MAP_OVERRIDE)
 //noop
+
+#elif defined(MAP_OVERRIDE_DEVTEST)
+#include "devtest.dm"
 
 // special modes
 #elif defined(MAP_OVERRIDE_CONSTRUCTION)
@@ -30,9 +36,6 @@
 
 #elif defined(MAP_OVERRIDE_EVENT)
 #include "event.dm"
-
-#elif defined(MAP_OVERRIDE_PAMGOC)
-#include "pamgoc.dm"
 
 #elif defined(MAP_OVERRIDE_WRESTLEMAP)
 #include "wrestlemap.dm"
@@ -53,9 +56,6 @@
 #elif defined(MAP_OVERRIDE_KONDARU)
 #include "kondaru.dm"
 
-#elif defined(MAP_OVERRIDE_ATLAS)
-#include "atlas.dm"
-
 #elif defined(MAP_OVERRIDE_CLARION)
 #include "clarion.dm"
 
@@ -65,16 +65,12 @@
 #elif defined(MAP_OVERRIDE_NADIR)
 #include "nadir.dm"
 
+#elif defined(MAP_OVERRIDE_NEON)
+#include "neon.dm"
+
 // non rotation maps
-
-#elif defined(MAP_OVERRIDE_DESTINY)
-#include "destiny.dm"
-
-#elif defined(MAP_OVERRIDE_DENSITY2)
-#include "density2.dm"
-
-#elif defined(MAP_OVERRIDE_HORIZON)
-#include "horizon.dm"
+#elif defined(MAP_OVERRIDE_ATLAS)
+#include "atlas.dm"
 
 #elif defined(MAP_OVERRIDE_CRASH)
 #include "crash.dm"
@@ -82,32 +78,11 @@
 #elif defined(MAP_OVERRIDE_MUSHROOM)
 #include "mushroom.dm"
 
-#elif defined(MAP_OVERRIDE_TRUNKMAP)
-#include "trunkmap.dm"
-
-#elif defined(MAP_OVERRIDE_DENSITY)
-#include "density.dm"
-
 #elif defined(MAP_OVERRIDE_DENSITY2)
 #include "density2.dm"
 
 #elif defined(MAP_OVERRIDE_PROBSTATION)
 #include "probstation.dm"
-
-#elif defined(MAP_OVERRIDE_OZYMANDIAS)
-#include "ozymandias.dm"
-
-#elif defined(MAP_OVERRIDE_FLEET)
-#include "fleet.dm"
-
-#elif defined(MAP_OVERRIDE_DEVTEST)
-#include "devtest.dm"
-
-#elif defined(MAP_OVERRIDE_NEON)
-#include "neon.dm"
-
-#elif defined(GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW)
-#include "gottagofast.dm"
 
 //Entry below is the "default" map
 #else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Prunes archived maps from various map config files and ensures every current map has an entry.

Adds 3 defines for map size: SMALL, LARGE, and XLARGE.  XLARGE size was originally for Ozymandius, will be used for Decarabia.
Use those defines for adjusting gang tag sizes instead of individual map overides in gang.dm.

Neon is now marked as a small map, so it will have slightly smaller gang tag influence and sight ranges. All other maps should have the same gang influence and sight ranges.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Abstract per-map settings from gang code. General cleanup of files.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
Builds should still work