### PR TITLE
Doubled bagpipes cooldown

### DIFF
--- a/code/modules/items/instruments/instruments.dm
+++ b/code/modules/items/instruments/instruments.dm
@@ -380,7 +380,7 @@
 	volume = 60
 	desc_sound = list("patriotic", "rowdy", "wee", "grand", "free", "Glaswegian", "sizzling", "carnal", "hedonistic")
 	pick_random_note = 1
-	note_time = 15 SECONDS
+	note_time = 20 SECONDS
 
 	New()
 		..()

--- a/code/modules/items/instruments/instruments.dm
+++ b/code/modules/items/instruments/instruments.dm
@@ -380,6 +380,7 @@
 	volume = 60
 	desc_sound = list("patriotic", "rowdy", "wee", "grand", "free", "Glaswegian", "sizzling", "carnal", "hedonistic")
 	pick_random_note = 1
+	note_time = 15 SECONDS
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Doubles the bagpipes cooldown to 20s
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bagpipes are sometimes used by groups of people to spam it loudly to just discourage people from even playing and its seriously insufferable. 1 bagpipe usage is all pleasant and could improve the vibes but spamming them throws some people (ie me 😭 ) into sensory overload
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Played bagpipes spammed c, took a bit longer to play
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

(i rather not put a changlong to not be blamed)