### PR TITLE
Elecbox now stop working for itself after 5 seconds

### DIFF
--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -4056,6 +4056,11 @@ TYPEINFO(/obj/machinery/networked/test_apparatus)
 					src.electrify_contents()
 					message_host("command=ack")
 					src.UpdateIcon()
+					SPAWN(5 SECONDS)
+						src.visible_message("<b>[src.name]</b> finishes working and shuts down.")
+						playsound(src, 'sound/machines/chime.ogg', 50, TRUE)
+						active = 0
+						src.UpdateIcon()
 				else
 					message_host("command=nack")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
Unlike the X-ray machine, which automatically finishes its operation once it has interacted with the artifact, the elecbox continues running, forcing players to stop it manually. This PR removes that extra step and makes working in Artlab more convenient.

I kept the option to manually turn off the elecbox in case someone wants to stop the process before the 5-second timer completes, but it can be removed if deemed unnecessary.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
In my experience, many scientists choose to use a multitool instead of the elecbox because it is one of the more cumbersome testers to use. I think this change will encourage players to use the elecbox more often.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spawned in dev test map and took an artifact into the elecbox, activated it and checked that it stops after 5 seconds or working, as X-Ray machine does.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Astarthoc 
(+)The elecbox now automatically stops 5 seconds after being activated, removing the need to stop it manually.
```
