### PR TITLE
Remove a surplus medbay camera

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -27191,9 +27191,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "ojB" = (
-/obj/machinery/camera/directional/west{
-	pixel_y = 5
-	},
 /obj/machinery/light_switch/directional/west,
 /obj/storage/cart/medcart/crash,
 /turf/simulated/floor/bluewhite{


### PR DESCRIPTION
[MAP]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Two cameras were right next to each other in medbay. This PR removes one of them, specifically the top one, as the bottom one visually connects to the wall better. yeah thats my whole rationale. thats it. i expect 200 words at least to convince me to remove the other one instead. i have spoken.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #27407

## Testing
<img width="1236" height="832" alt="image" src="https://github.com/user-attachments/assets/ffa1c323-764f-4930-97b5-b9a2a7ce2421" />