### PR TITLE
Exclude Nadir's Pasiphae wreck from stowaway eligibility

### DIFF
--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2641,7 +2641,7 @@ var/atom/movable/abstract_say_source/deadchat/deadchat_announcer = new()
 		if (istype(container, /obj/storage/secure) || istype(container, /obj/storage/crate/loot))
 			continue
 		// listening posts everywhere, martian ship (in station Z-level on Oshan), pasiphae on nadir (starts depowered and part acid flooded)
-		var/storagearea = get_area(container)
+		var/area/storagearea = get_area(container)
 		if (istype(storagearea, /area/listeningpost) || istype(storagearea, /area/evilreaver) || istype(storagearea, /area/pasiphae))
 			continue
 

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2641,7 +2641,7 @@ var/atom/movable/abstract_say_source/deadchat/deadchat_announcer = new()
 		if (istype(container, /obj/storage/secure) || istype(container, /obj/storage/crate/loot))
 			continue
 		// listening posts everywhere, martian ship (in station Z-level on Oshan), pasiphae on nadir (starts depowered and part acid flooded)
-		if (istypes(get_area(container), list(/area/listeningpost, /area/evilreaver, /area/pasiphae))
+		if (istypes(get_area(container), list(/area/listeningpost, /area/evilreaver, /area/pasiphae)))
 			continue
 
 		if (breathable)

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2641,8 +2641,7 @@ var/atom/movable/abstract_say_source/deadchat/deadchat_announcer = new()
 		if (istype(container, /obj/storage/secure) || istype(container, /obj/storage/crate/loot))
 			continue
 		// listening posts everywhere, martian ship (in station Z-level on Oshan), pasiphae on nadir (starts depowered and part acid flooded)
-		var/area/storagearea = get_area(container)
-		if (istype(storagearea, /area/listeningpost) || istype(storagearea, /area/evilreaver) || istype(storagearea, /area/pasiphae))
+		if (istypes(get_area(container), list(/area/listeningpost, /area/evilreaver, /area/pasiphae))
 			continue
 
 		if (breathable)

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2640,8 +2640,9 @@ var/atom/movable/abstract_say_source/deadchat/deadchat_announcer = new()
 			continue
 		if (istype(container, /obj/storage/secure) || istype(container, /obj/storage/crate/loot))
 			continue
-		// listening posts everywhere or martian ship (in station Z-level on Oshan)
-		if (istype(get_area(container), /area/listeningpost) || istype(get_area(container), /area/evilreaver))
+		// listening posts everywhere, martian ship (in station Z-level on Oshan), pasiphae on nadir (starts depowered and part acid flooded)
+		var/storagearea = get_area(container)
+		if (istype(storagearea, /area/listeningpost) || istype(storagearea, /area/evilreaver) || istype(storagearea, /area/pasiphae))
 			continue
 
 		if (breathable)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Extends Stowaway's area ineligibility to the wreck of the Pasiphae, owing to its partially acid-flooded nature and lack of roundstart power.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #27231

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

It compiled.