### PR TITLE
Arcfiends can use Discharge ability to recharge items

### DIFF
--- a/code/modules/antagonists/arcfiend/abilities/discharge.dm
+++ b/code/modules/antagonists/arcfiend/abilities/discharge.dm
@@ -1,7 +1,7 @@
 /// Melee attack. Shocks a targeted mob, or can be used on an airlock to temporarily cut its power.
 /datum/targetable/arcfiend/discharge
 	name = "Discharge"
-	desc = "Run a powerful current through a target in melee range. Mobs will be shocked and knocked back a short distance, airlocks will be briefly depowered, and machines will overload."
+	desc = "Run a powerful current through a target in melee range. Mobs will be shocked and knocked back a short distance, airlocks will be briefly depowered, and machines will overload. Items with batteries can be recharged."
 	icon_state = "discharge"
 	cooldown = 15 SECONDS
 	target_anything = TRUE

--- a/code/modules/antagonists/arcfiend/abilities/discharge.dm
+++ b/code/modules/antagonists/arcfiend/abilities/discharge.dm
@@ -50,6 +50,23 @@
 			else
 				boutput(src.holder.owner, SPAN_ALERT("\The [machine] couldn't be overloaded!"))
 				return CAST_ATTEMPT_FAIL_NO_COOLDOWN
+		else if (isitem(target))
+			var/datum/component/cell_holder/power_cell = target.GetComponent(/datum/component/cell_holder)
+			if (!istype(power_cell))
+				boutput(src.holder.owner, SPAN_ALERT("\The [target] doesn't hold a charge!"))
+				return CAST_ATTEMPT_FAIL_NO_COOLDOWN
+			var/chargeable = SEND_SIGNAL(target, COMSIG_CELL_CAN_CHARGE)
+			if (chargeable & CELL_UNCHARGEABLE)
+				boutput(src.holder.owner, SPAN_ALERT("\The [target] couldn't be charged!"))
+				return CAST_ATTEMPT_FAIL_NO_COOLDOWN
+			var/list/ret = list()
+			if(SEND_SIGNAL(target, COMSIG_CELL_CHECK_CHARGE, ret) & CELL_RETURNED_LIST)
+				var/amount_to_charge = ret["max_charge"] - ret["charge"]
+				if (src.pointCost + amount_to_charge > src.holder.points)
+					amount_to_charge = src.holder.points - src.pointCost
+				if (amount_to_charge > 0)
+					src.holder.deductPoints(amount_to_charge)
+					SEND_SIGNAL(target, COMSIG_CELL_CHARGE, amount_to_charge)
 		else
 			return CAST_ATTEMPT_FAIL_NO_COOLDOWN
 		var/datum/effects/system/spark_spread/S = new /datum/effects/system/spark_spread

--- a/code/modules/antagonists/arcfiend/abilities/discharge.dm
+++ b/code/modules/antagonists/arcfiend/abilities/discharge.dm
@@ -7,6 +7,7 @@
 	target_anything = TRUE
 	targeted = TRUE
 	pointCost = 25
+	target_in_inventory = TRUE
 	///how far to knock mobs away from ourselves
 	var/target_dist = 4
 	///how fast to throw affected mobs away


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Allows arcfiends to charge items with portable power cells (i.e. tasers, cargo teles) with their Discharge ability.

In addition to the base discharge abiilty cost, this uses one point per unit of charge on the item. I.e. to fully and instantly recharge a base stun baton cell, it would cost 225 points.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Thematically appropriate for a power gremlin to be able to recharge things. More uses for arcfiend power and a slight Arcfiend buff.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested recharging a stun baton in-hand and on ground, item was charged with cost and put on cooldown.

Tested recharging a non-chargeable Egun Jr., failed to charge as expected with output text and ability not put on cooldown.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Arcfiend's Discharge ability can recharge items wtih batteries, like stun batons and tasers.
```
