### PR TITLE
Makes Horror Form slightly delayed and much more grisly

### DIFF
--- a/code/modules/antagonists/changeling/abilities/abomination.dm
+++ b/code/modules/antagonists/changeling/abilities/abomination.dm
@@ -114,6 +114,13 @@
 		if (!H.lying)
 			H.changeStatus("knockdown", 5 SECONDS)
 			H.force_laydown_standup()
+		if (H.pulled_by)
+			boutput(H.pulled_by, SPAN_ALERT("[src.owner] writhes free of your grip!"))
+			H.pulled_by.remove_pulling()
+		if (length(H.grabbed_by))
+			for (var/obj/item/grab/G in H.grabbed_by) // not necessary to check for blocks here -- the knockdown gets rid of them already
+				boutput(G.assailant, SPAN_ALERT("[src.owner] writhes free of your grip!"))
+				qdel(G)
 		// the goal of piling on all these effects is to make it VERY obvious what's happening
 		// the animations and jittering here have the nice effect of making the convulsing look super inhuman
 		H.make_jittery(1000)

--- a/code/modules/antagonists/changeling/abilities/abomination.dm
+++ b/code/modules/antagonists/changeling/abilities/abomination.dm
@@ -15,7 +15,6 @@
 			return 1
 
 		var/mob/living/carbon/human/H = holder.owner
-		var/datum/abilityHolder/changeling/C = H.get_ability_holder(/datum/abilityHolder/changeling)
 		if (isabomination(H))
 			if (tgui_alert(H,"Are we sure?","Exit Horror Form?",list("Yes","No")) != "Yes")
 				return 1
@@ -24,30 +23,18 @@
 			boutput(H, "We cannot transform in this form.")
 			return 1
 		else
+			if (actions.hasAction(holder.owner, /datum/action/bar/private/icon/changelingHorrorForm))
+				boutput(holder.owner, SPAN_ALERT("We are already transforming!"))
+				return 1
 			if (holder.points < 15)
 				boutput(holder.owner, SPAN_ALERT("We're not strong enough to maintain the form."))
 				return 1
 			if (tgui_alert(H,"Are we sure?","Enter Horror Form?",list("Yes","No")) != "Yes")
 				return 1
-			H.set_mutantrace(/datum/mutantrace/abomination)
-			setalive(H)
-			H.real_name = "Shambling Abomination"
-			H.UpdateName()
-			H.update_face()
-			H.update_body()
-			H.update_clothing()
-			H.abilityHolder.transferOwnership(H)
-			C.in_fakedeath = 0
-			REMOVE_ATOM_PROPERTY(H, PROP_MOB_CANTMOVE, "regen_stasis")
 
-			H.remove_stuns()
-			H.delStatus("disorient")
-			H.delStatus("pinned")
-			H.force_laydown_standup()
+			actions.start(new/datum/action/bar/private/icon/changelingHorrorForm(holder), H)
 
-			H.abilityHolder.updateButtons()
-
-			logTheThing(LOG_COMBAT, H, "enters horror form as a changeling, [log_loc(H)].")
+			logTheThing(LOG_COMBAT, H, "begins entering horror form as a changeling, [log_loc(H)].")
 			return 0
 
 /mob/proc/revert_from_horror_form()
@@ -96,3 +83,88 @@
 			O.apply_sonic_stun(0, 0, 0, 10, 70, rand(0, 2))
 
 		return 0
+
+/datum/action/bar/private/icon/changelingHorrorForm
+	duration = 3 SECONDS
+	interrupt_flags = INTERRUPT_NONE
+	bar_icon_state = "bar-changeling"
+	border_icon_state = "border-changeling"
+	color_active = "#d73715"
+	color_success = "#3fb54f"
+	color_failure = "#8d1422"
+	var/datum/abilityHolder/changeling/C
+
+	New(Holder)
+		..()
+		C = Holder
+
+	onStart()
+		..()
+		src.owner.visible_message(SPAN_ALERT("[src.owner] starts contorting horribly!"))
+
+	onUpdate()
+		..()
+		if (QDELETED(C) || !ishuman(src.owner))
+			src.interrupt(INTERRUPT_ALWAYS)
+			return
+		var/mob/living/carbon/human/H = src.owner
+		if (isdead(H))
+			src.interrupt(INTERRUPT_ALWAYS)
+			return
+		if (!H.lying)
+			H.changeStatus("knockdown", 5 SECONDS)
+			H.force_laydown_standup()
+		// the goal of piling on all these effects is to make it VERY obvious what's happening
+		// the animations and jittering here have the nice effect of making the convulsing look super inhuman
+		H.make_jittery(1000)
+		violent_standup_twitch(H)
+		bleed(H, 0, 5)
+		var/list/spooks = list(
+			'sound/impact_sounds/Slimy_Splat_1.ogg',
+			'sound/impact_sounds/Flesh_Break_1.ogg',
+			'sound/impact_sounds/Flesh_Crush_1.ogg',
+			'sound/impact_sounds/Flesh_Tear_1.ogg',
+			'sound/impact_sounds/Flesh_Tear_2.ogg'
+		)
+		for (var/i in 0 to 2)
+			var/spook = pick(spooks)
+			spooks.Remove(spook)
+			playsound(H, spook, rand(30, 50), TRUE)
+
+	onEnd()
+		..()
+		var/mob/living/carbon/human/H = src.owner
+		logTheThing(LOG_COMBAT, H, "enters horror form as a changeling, [log_loc(H)].")
+		H.visible_message(SPAN_ALERT(SPAN_BOLD("[H]'s body splits apart into a [pick("ravening", "gibbering", "shrieking")] \
+		mass of limbs and teeth! [pick("HOLY FUCK!!!", "OH HELL NO!!!", "NO NO NO NO NO", "UHHHHHHHHHHHH")]")))
+
+		// step 1: clear stuns, set to conscious
+		// this has to be done *before* setting the mutantrace or it won't process the standup call 'til the next life tick
+		H.lying = FALSE
+		H.remove_stuns()
+		H.delStatus("disorient")
+		H.delStatus("pinned")
+		H.jitteriness = 0
+		H.force_laydown_standup()
+		setalive(H)
+
+		// step 2: set mutantrace and update appearance
+		H.set_mutantrace(/datum/mutantrace/abomination)
+		H.real_name = "Shambling Abomination"
+		H.UpdateName()
+		H.update_face()
+		H.update_body()
+		H.update_clothing()
+
+		// step 3: handle ability holder stuff, kick us out of fakedeath
+		// the ability set swaps over automatically, so we just need to update the buttons
+		H.abilityHolder.transferOwnership(H)
+		H.abilityHolder.updateButtons()
+		C.in_fakedeath = FALSE
+		REMOVE_ATOM_PROPERTY(H, PROP_MOB_CANTMOVE, "regen_stasis")
+
+		// finally: make it extra scary with a big burst of gore
+		// dir is set to south so that it shows off the full sprite
+		gibs(get_turf(H), null, H.bioHolder.Uid, H.bioHolder.bloodType)
+		H.set_dir(SOUTH)
+		H.emote("scream")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Activating Horror Form no longer instantly and silently sets the user's mutantrace (among other things). Instead, it has a 3-second windup period with a lot of freaky animations and sounds that culminate in a shower of gibs.

Implementation details:
* The windup is handled by a private action; the changeling can see the progress bar, but nobody else can.
* It can't be interrupted by any means other than the changeling dying.
* The changeling is knocked to the ground during the transformation, but stands back up instantly after it completes.
* Grabs and pulls are broken and can't be reapplied during the transformation, on account of the whole "horrific inhuman contortions" thing.
* Transforming inside of a locker/disposal unit/Port-A-Brig/whatever will make the sounds and create the gibs on that turf, but not eject them from it (this mirrors current functionality but can be changed if desired).
* Like the current version, it can be used in (and cancels) regenerative stasis.
* Reverting back to human form is unaffected.

Potential balance ramifications: 3 seconds isn't much time to react, but it's higher than the 0 seconds that people currently get. Also crew might potentially slip on the gibs or something.

<details><summary>video demo ft. amusing duck</summary>

https://github.com/user-attachments/assets/f26b0824-3cac-476d-951f-0e1d6412280d
</details>

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Despite being their big scary loud ability, turning into a shambler just snaps you into your new state immediately with no buildup or fanfare. It's very whelming! It isn't dramatic at all. This tries to fix that, so that it has more weight behind it and feels more exciting for everyone involved.

It should be noted that this is a minor nerf to shamblers. I personally think this is good! Horror Form is already super strong, and imposing a little bit of timing and strategy on activating their murder mode both isn't going to make it unusable by any stretch and also makes it a more meaningful decision than just slapping the button and immediately gobbling up whoever you're standing next to. [Leah was cool with this when it was brought up in the Discord,](https://discord.com/channels/182249960895545344/890223118482800790/1534543255453171793) but I figure it's still worth highlighting here.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spun up a local instance on a few different maps and transformed in different locations. Force-killed myself using the player options panel mid-transformation, and had it cancel correctly.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ceres et al.
(*)Activating Horror Form as a changeling now has a brief (uninterruptible) windup period that's very loud and messy.
```
