### PR TITLE
Repairing machinery no longer breaks the omnitool

### DIFF
--- a/code/datums/components/equipment_fault.dm
+++ b/code/datums/components/equipment_fault.dm
@@ -175,7 +175,6 @@ TYPEINFO(/datum/component/equipment_fault)
 	desc = "You shouldn't be reading this, bug."
 	icon_state = "wrench"
 	var/omni_mode
-	var/omni_path
 	var/success_text
 	var/success_sound
 
@@ -187,7 +186,7 @@ TYPEINFO(/datum/component/equipment_fault)
 	proc/omnitool_swap(atom/target, mob/user, obj/item/tool/omnitool/omni)
 		if (!omni.has_mode(src.omni_mode))
 			return FALSE
-		omni.change_mode(omni_mode, user, omni_path)
+		omni.change_mode_id(omni_mode, user)
 		user.show_text("You flip [omni] to [name] mode.", "blue")
 		sleep(0.5 SECONDS)
 		return TRUE
@@ -206,7 +205,6 @@ TYPEINFO(/datum/component/equipment_fault)
 		desc = "Wrenching required to repair."
 		icon_state = "wrench"
 		omni_mode = OMNITOOL::MODE_WRENCH
-		omni_path = /obj/item/wrench
 		success_text = "You wrench %target%'s bolts. Nice and snug."
 		success_sound = 'sound/items/Ratchet.ogg'
 
@@ -223,7 +221,6 @@ TYPEINFO(/datum/component/equipment_fault)
 		desc = "Cutting required to repair."
 		icon_state = "cut"
 		omni_mode = OMNITOOL::MODE_WIRECUTTER
-		omni_path = /obj/item/wirecutters
 		success_text = "You cut some vestigial wires from %target%."
 		success_sound = 'sound/items/Wirecutter.ogg'
 
@@ -239,7 +236,6 @@ TYPEINFO(/datum/component/equipment_fault)
 		desc = "Welding required to repair."
 		icon_state = "weld"
 		omni_mode = OMNITOOL::MODE_WELDER
-		omni_path = /obj/item/weldingtool
 		success_text = "You weld %target% carefully."
 		success_sound = null // sound handled in try_weld
 
@@ -259,7 +255,6 @@ TYPEINFO(/datum/component/equipment_fault)
 		desc = "Prying required to repair. Try a crowbar."
 		icon_state = "bar"
 		omni_mode = OMNITOOL::MODE_CROWBAR
-		omni_path = /obj/item/crowbar
 		success_text = "You pry things back into place on %target% with all your might."
 		success_sound = 'sound/items/Crowbar.ogg'
 
@@ -275,7 +270,6 @@ TYPEINFO(/datum/component/equipment_fault)
 		desc = "Screwing required to repair."
 		icon_state = "screw"
 		omni_mode = OMNITOOL::MODE_SCREWDRIVER
-		omni_path = /obj/item/screwdriver
 		success_text = "You screw in some of the screws on %target%."
 		success_sound = 'sound/items/Screwdriver.ogg'
 
@@ -292,7 +286,6 @@ TYPEINFO(/datum/component/equipment_fault)
 		desc = "Pulsing required to repair. Try a multitool."
 		icon_state = "pulse"
 		omni_mode = OMNITOOL::MODE_MULTITOOL
-		omni_path = /obj/item/device/multitool
 		success_text = "You pulse %target%. In a general sense."
 		success_sound = 'sound/items/penclick.ogg'
 


### PR DESCRIPTION
## About the PR
- Fixes a bug where repairing machinery breaks the omnitool.

## Why's this needed?
Fixes #27397
Fixes #27411
Fixes #27418

## Testing
<img width="387" height="563" alt="Screenshot 2026-08-06 225419" src="https://github.com/user-attachments/assets/4151875c-00ef-4d10-a623-aeab7c69a0b6" />

