### PR TITLE
Clowns spawn with 1k in them

### DIFF
--- a/code/datums/controllers/custom_job_savefile.dm
+++ b/code/datums/controllers/custom_job_savefile.dm
@@ -67,6 +67,9 @@
 			F["[i]_items_in_belt"] >> converter.items_in_belt
 			if(isnull(converter.items_in_belt))
 				converter.items_in_belt = list()
+			F["[i]_items_in_mob"] >> converter.items_in_mob
+			if(isnull(converter.items_in_mob))
+				converter.items_in_mob = list()
 			F["[i]_announce_on_join"] >> converter.world_announce_priority //Backup to keep old job saves the same
 			F["[i]_world_announce_priority"] >> converter.world_announce_priority
 			F["[i]_add_to_manifest"] >> converter.add_to_manifest

--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -876,7 +876,6 @@ var/datum/job_controller/job_controls
 						src.job_creator.items_in_mob[slot_num] = null
 
 				if("Reselect")
-					var/list/L = list()
 					var/search_for = input(usr, "Search for item (or leave blank for complete list)", "Select item to spawn in mob [slot_num]") as null|text
 					if(!search_for)
 						return

--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -243,6 +243,8 @@ var/datum/job_controller/job_controls
 				dat += "<A href='byond://?src=\ref[src];EditBpItem=[i]'>Starting Backpack Item [i]:</A> [length(src.job_creator.items_in_backpack) >= i ? src.job_creator.items_in_backpack[i] : null]<br>"
 			for(var/i in 1 to 7)
 				dat += "<A href='byond://?src=\ref[src];EditBeltItem=[i]'>Starting Belt Item [i]:</A> [length(src.job_creator.items_in_belt) >= i ? src.job_creator.items_in_belt[i] : null]<br>"
+			for(var/i in 1 to (length(src.job_creator.items_in_mob) + 1))
+				dat += "<A href='byond://?src=\ref[src];EditMobItem=[i]'>Starting inside mob Item [i]:</A> [length(src.job_creator.items_in_mob) >= i ? src.job_creator.items_in_mob[i] : null]<br>"
 			dat += "<A href='byond://?src=\ref[src];GetAccess=1'>Set Access Permissions </A>"
 			if (length(src.job_creator.access) > 1)
 				dat += " "
@@ -866,6 +868,27 @@ var/datum/job_controller/job_controls
 			src.job_creator()
 
 
+		if(href_list["EditMobItem"])
+			var/slot_num = text2num(href_list["EditMobItem"])
+			switch(alert("Clear or reselect slotted item?","Job Creator","Clear","Reselect"))
+				if("Clear")
+					if(length(src.job_creator.items_in_mob) >= slot_num)
+						src.job_creator.items_in_mob[slot_num] = null
+
+				if("Reselect")
+					var/list/L = list()
+					var/search_for = input(usr, "Search for item (or leave blank for complete list)", "Select item to spawn in mob [slot_num]") as null|text
+					if(!search_for)
+						return
+					var/chosen = get_one_match(search_for)
+					if(!chosen || !ispath(chosen, /atom/movable))
+						boutput(usr, "You must pick a movable atom.")
+						return
+					while(length(src.job_creator.items_in_mob) < slot_num)
+						src.job_creator.items_in_mob += null
+					src.job_creator.items_in_mob[slot_num] = chosen
+			src.job_creator()
+
 		if(href_list["EditBeltItem"])
 			var/slot_num = text2num(href_list["EditBeltItem"])
 			switch(alert("Clear or reselect slotted item?","Job Creator","Clear","Reselect"))
@@ -1054,6 +1077,7 @@ var/datum/job_controller/job_controls
 	JOB.receives_implants = src.job_creator.receives_implants
 	JOB.items_in_backpack = src.job_creator.items_in_backpack
 	JOB.items_in_belt = src.job_creator.items_in_belt
+	JOB.items_in_mob = src.job_creator.items_in_mob
 	JOB.spawn_id = src.job_creator.spawn_id
 	JOB.starting_mutantrace = src.job_creator.starting_mutantrace
 	message_admins("Admin [key_name(usr)] created special job [JOB.name]")

--- a/code/datums/jobs/job_parent.dm
+++ b/code/datums/jobs/job_parent.dm
@@ -64,6 +64,7 @@ ABSTRACT_TYPE(/datum/job)
 	var/list/slot_rhan = list()
 	var/list/items_in_backpack = list() // stop giving everyone a free airtank gosh
 	var/list/items_in_belt = list() // works the same as above but is for jobs that spawn with a belt that can hold things
+	var/list/items_in_mob = list() /// Items placed directly inside the mob. If a PDA, then can be put in ID slot by player preference or below var
 	var/put_id_in_pda = FALSE //! Job will automatically have their ID in their PDA on spawn. Overrides player preference; use sparingly.
 	var/access_string = null // used to quickly grab access via string, i.e. "Chief Engineer", completely overrides var/list/access if non-null !!!
 	var/list/access = list(access_fuck_all) // Please define in global get_access() proc (access.dm), so it can also be used by bots etc.

--- a/code/datums/jobs/job_parent.dm
+++ b/code/datums/jobs/job_parent.dm
@@ -64,7 +64,7 @@ ABSTRACT_TYPE(/datum/job)
 	var/list/slot_rhan = list()
 	var/list/items_in_backpack = list() // stop giving everyone a free airtank gosh
 	var/list/items_in_belt = list() // works the same as above but is for jobs that spawn with a belt that can hold things
-	var/list/items_in_mob = list() /// Items placed directly inside the mob. If a PDA, then can be put in ID slot by player preference or below var
+	var/list/items_in_mob = list() //! Items placed directly inside the mob. If a PDA, then can be put in ID slot by player preference or below var
 	var/put_id_in_pda = FALSE //! Job will automatically have their ID in their PDA on spawn. Overrides player preference; use sparingly.
 	var/access_string = null // used to quickly grab access via string, i.e. "Chief Engineer", completely overrides var/list/access if non-null !!!
 	var/list/access = list(access_fuck_all) // Please define in global get_access() proc (access.dm), so it can also be used by bots etc.

--- a/code/datums/jobs/jobs_civilian.dm
+++ b/code/datums/jobs/jobs_civilian.dm
@@ -158,6 +158,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_card = /obj/item/card/id/clown
 	slot_ears = list(/obj/item/device/radio/headset/clown)
 	items_in_belt = list(/obj/item/cloth/towel/clown)
+	items_in_mob = list(/obj/item/currency/spacecash/thousand)
 	change_name_on_spawn = TRUE
 	wiki_link = "https://wiki.ss13.co/Clown"
 

--- a/code/datums/jobs/jobs_civilian.dm
+++ b/code/datums/jobs/jobs_civilian.dm
@@ -158,7 +158,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_card = /obj/item/card/id/clown
 	slot_ears = list(/obj/item/device/radio/headset/clown)
 	items_in_belt = list(/obj/item/cloth/towel/clown)
-	items_in_mob = list(/obj/item/currency/spacecash/thousand)
+	items_in_mob = list(/obj/item/currency/spacecash/one)
 	change_name_on_spawn = TRUE
 	wiki_link = "https://wiki.ss13.co/Clown"
 

--- a/code/datums/jobs/special/jobs_clown.dm
+++ b/code/datums/jobs/special/jobs_clown.dm
@@ -20,6 +20,7 @@ ABSTRACT_TYPE(/datum/job/special/clown)
 	slot_belt = list(/obj/item/storage/fanny/funny)
 	slot_poc1 = list(/obj/item/device/pda2/clown)
 	slot_lhan = list(/obj/item/instrument/bikehorn)
+	items_in_mob = /datum/job/civilian/clown::items_in_mob
 	change_name_on_spawn = TRUE
 	wiki_link = "https://wiki.ss13.co/Clown"
 	faction = list(FACTION_CLOWN)

--- a/code/obj/item/space_cash.dm
+++ b/code/obj/item/space_cash.dm
@@ -130,6 +130,10 @@
 			else // 1mil bby
 				src.icon_state = "cashrbow"
 
+	one
+		default_min_amount = 1
+		default_max_amount = 1
+
 	five
 		default_min_amount = 5
 		default_max_amount = 5

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -230,6 +230,10 @@ else if (istype(JOB, /datum/job/security/security_officer))\
 		for (var/X in JOB.items_in_belt)
 			if(ispath(X))
 				H.equip_new_if_possible(X, SLOT_IN_BELT)
+	// Things spawned directly in the mob
+	for(var/type in JOB.items_in_mob)
+		if(ispath(type))
+			new type(H)
 	// Footwear
 	equip_job_item_slot(JOB.slot_foot, H, SLOT_SHOES)
 	// Suit


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Introduces a new "items_in_mob" job variable for directly spawning items in a mob.
Causes clowns to spawn with 1 credit in their mob

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
With the new ID in PDA option the clown's credit no longer spawns in their mob most of the time, this makes sure there's cash in your clown so make sure to gib them if you're short on dough.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spawned as clown, checked my contents, there were the credits.
Used the admin job editor to edit NTSC to have a gorilla spawn in them, was properly applied.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
