### PR TITLE
Refactor spawner implants

### DIFF
--- a/code/modules/medical/implants/implanter.dm
+++ b/code/modules/medical/implants/implanter.dm
@@ -214,7 +214,7 @@
 	HELP_MESSAGE_OVERRIDE({"When someone dies while implanted with this, they will explode into a cloud of angry wasps. Suiciding will cause no cloud of wasps to appear. This implant will also make wasps friendly to the user."})
 
 	New()
-		src.imp = new /obj/item/implant/revenge/wasp(src)
+		src.imp = new /obj/item/implant/revenge/spawner/wasp(src)
 		..()
 
 /obj/item/implanter/clownspider
@@ -224,7 +224,7 @@
 	HELP_MESSAGE_OVERRIDE({"When someone dies while implanted with this, they will explode into a cloud of angry clownspiders. Suiciding will cause no cloud of wasps to appear. This implant will also make clownspiders friendly to the user."})
 
 	New()
-		src.imp = new /obj/item/implant/revenge/wasp/clownspider(src)
+		src.imp = new /obj/item/implant/revenge/spawner/clownspider(src)
 		..()
 
 /obj/item/implanter/marionette

--- a/code/modules/medical/implants/revenge.dm
+++ b/code/modules/medical/implants/revenge.dm
@@ -125,9 +125,9 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		. = ..()
 
 ABSTRACT_TYPE(/obj/item/implant/revenge/spawner)
-/// Abstract type for implants that spawn mobs when you die. Uses mobs not just critters cause monkeys are human. Who knew.
+/// Abstract type for implants that spawn mobs when you die. Power = number of things spawned.
 /obj/item/implant/revenge/spawner
-	var/mob_type = null
+	var/spawned_type = null
 	var/faction = null
 	implanted(mob/M, mob/I)
 		..()
@@ -143,7 +143,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge/spawner)
 		// enjoy your mobs
 		for (var/i in 1 to power)
 			var/throw_type = THROW_NORMAL
-			var/mob/M = new src.mob_type(get_turf(src))
+			var/mob/M = new src.spawned_type(get_turf(src))
 			if (ismob(M))
 				M.lying = TRUE // So mobs dont hit other mobs when being flung
 				SPAWN(1 SECOND)
@@ -160,7 +160,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge/spawner)
 	name = "funny implant"
 	big_message = " squeaks a little."
 	small_message = "emits a loud honk, uh oh!"
-	mob_type = /mob/living/critter/spider/clown
+	spawned_type = /mob/living/critter/spider/clown
 	power = 8
 	faction = FACTION_CLOWN
 
@@ -169,5 +169,5 @@ ABSTRACT_TYPE(/obj/item/implant/revenge/spawner)
 	big_message = " buzzes, what?"
 	small_message = "buzzes loudly, uh oh!"
 	power = 8
-	mob_type = /mob/living/critter/small_animal/wasp/angry
+	spawned_type = /mob/living/critter/small_animal/wasp/angry
 	faction = FACTION_BOTANY

--- a/code/modules/medical/implants/revenge.dm
+++ b/code/modules/medical/implants/revenge.dm
@@ -124,14 +124,11 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			src.owner?.elecgib()
 		. = ..()
 
-/obj/item/implant/revenge/wasp
-	name = "wasp implant"
-	big_message = " buzzes, what?"
-	small_message = "buzzes loudly, uh oh!"
-	power = 8
-	var/wasp_type = /mob/living/critter/small_animal/wasp/angry
-	var/faction = FACTION_BOTANY
-
+ABSTRACT_TYPE(/obj/item/implant/revenge/spawner)
+/// Abstract type for implants that spawn mobs when you die. Uses mobs not just critters cause monkeys are human. Who knew.
+/obj/item/implant/revenge/spawner
+	var/mob_type = null
+	var/faction = null
 	implanted(mob/M, mob/I)
 		..()
 		if (istype(M) && src.faction)
@@ -143,12 +140,12 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			LAZYLISTREMOVE(M.faction, src.faction)
 
 	do_effect(power)
-		// enjoy your wasps
+		// enjoy your mobs
 		for (var/i in 1 to power)
 			var/throw_type = THROW_NORMAL
-			var/mob/M = new src.wasp_type(get_turf(src))
-			if(ismob(M))
-				M.lying = TRUE // So wasps dont hit other wasps when being flung
+			var/mob/M = new src.mob_type(get_turf(src))
+			if (ismob(M))
+				M.lying = TRUE // So mobs dont hit other mobs when being flung
 				SPAWN(1 SECOND)
 					M.lying = FALSE
 			else
@@ -159,9 +156,18 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			src.owner?.gib()
 		. = ..()
 
-/obj/item/implant/revenge/wasp/clownspider
+/obj/item/implant/revenge/spawner/clownspider
 	name = "funny implant"
 	big_message = " squeaks a little."
 	small_message = "emits a loud honk, uh oh!"
-	wasp_type = /mob/living/critter/spider/clown
+	mob_type = /mob/living/critter/spider/clown
+	power = 8
 	faction = FACTION_CLOWN
+
+/obj/item/implant/revenge/spawner/wasp
+	name = "wasp implant"
+	big_message = " buzzes, what?"
+	small_message = "buzzes loudly, uh oh!"
+	power = 8
+	mob_type = /mob/living/critter/small_animal/wasp/angry
+	faction = FACTION_BOTANY


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactors the mob implanter code to make it easy to add new implanters
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the clownspider implanter inherits from the wasp implanter and adding new implanters shouldn't do that
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested both clownspider and wasp implanters to make sure they function the same after the refactor. 
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

