### PR TITLE
Relax the node version pin to 24

### DIFF
--- a/.github/workflows/beepsky.yml
+++ b/.github/workflows/beepsky.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.14.1
+          node-version: 24
           cache: "yarn"
           cache-dependency-path: |
             ./tgui/yarn.lock


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Relaxes the node version pin to `24`
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* This was originally pinned to `24.14.1` in #26456 to resolve build failures introduced by a bug in `24.15`. As per https://github.com/yarnpkg/berry/issues/7065 this issue was resolved upstream two weeks ago.
