### PR TITLE
Changes the nuclear disaster text to be more accurate

### DIFF
--- a/code/obj/nuclearreactor/misc.dm
+++ b/code/obj/nuclearreactor/misc.dm
@@ -1,8 +1,8 @@
 /obj/decal/poster/wallsign/accident_sign
-	name = "nuclear meltdown tracking sign"
+	name = "nuclear overload tracking sign"
 	icon = 'icons/obj/decals/countdown_sign.dmi'
 	icon_state = "base"
-	desc = "It has been X shifts since the last nuclear meltdown"
+	desc = "It has been X shifts since the last nuclear overload"
 	var/shift_count = 0
 
 	New()
@@ -11,7 +11,7 @@
 		world.save_intra_round_value("nuclear_accident_count_[map_settings.name]", src.shift_count+1)
 		src.UpdateOverlays(image(src.icon, "[round(shift_count/10)]_"), "number10s")
 		src.UpdateOverlays(image(src.icon, "_[round(shift_count%10)]"), "number1s")
-		src.desc = "It has been [shift_count] shift\s since the last nuclear meltdown."
+		src.desc = "It has been [shift_count] shift\s since the last nuclear overload."
 		switch(src.shift_count)
 			if(0)
 				src.desc += " Oh no."

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -235,23 +235,23 @@
 			if(!src.GetParticles("overheat_smoke"))
 				src.UpdateParticles(new/particles/nuke_overheat_smoke(get_turf(src)),"overheat_smoke")
 				src.visible_message(SPAN_ALERT("<b>The [src] begins to smoke!</b>"))
-				logTheThing(LOG_STATION, src, "[src] is at [temperature]K and may meltdown")
+				logTheThing(LOG_STATION, src, "[src] is at [temperature]K and may overload")
 				if(!ON_COOLDOWN(src, "pda_temp_alert", 30 SECONDS)) //prevent spam when it's on the edge
-					src.alertPDA("ALERT: [src] has reached a dangerous temperature. Intervene immediately to prevent meltdown.")
+					src.alertPDA("ALERT: [src] has reached a dangerous temperature. Intervene immediately to prevent overload.")
 					message_ghosts("<b>[src]</b> is getting dangerously hot! [log_loc(src.loc, ghostjump=TRUE)].")
 			if(temperature >= REACTOR_ON_FIRE_TEMP && !src.GetParticles("overheat_fire"))
 				src.UpdateParticles(new/particles/nuke_overheat_fire(get_turf(src)),"overheat_fire")
 				src.visible_message(SPAN_ALERT("<b>The [src] begins to burn!</b>"))
-				logTheThing(LOG_STATION, src, "[src] is at [temperature]K and is likely to meltdown")
+				logTheThing(LOG_STATION, src, "[src] is at [temperature]K and is likely to overload")
 				if(!ON_COOLDOWN(src, "pda_temp_alert_critical", 30 SECONDS)) //prevent spam when it's on the edge
-					src.alertPDA("ALERT: [src] has reached CRITICAL temperature. MELTDOWN IMMINENT.", crisis = TRUE)
-					message_ghosts("<b>[src]</b> is extremely close to melting down! [log_loc(src.loc, ghostjump=TRUE)].")
+					src.alertPDA("ALERT: [src] has reached CRITICAL temperature. OVERLOAD IMMINENT.", crisis = TRUE)
+					message_ghosts("<b>[src]</b> is extremely close to overloading! [log_loc(src.loc, ghostjump=TRUE)].")
 			else if(temperature < REACTOR_ON_FIRE_TEMP && src.GetParticles("overheat_fire"))
 				src.visible_message(SPAN_ALERT("<b>The [src] stops burning.</b>"))
 				logTheThing(LOG_STATION, src, "[src] is cooling from 2500K")
 				src.ClearSpecificParticles("overheat_fire")
 				if(!ON_COOLDOWN(src, "pda_temp_alert_critical", 30 SECONDS)) //prevent spam when it's on the edge
-					src.alertPDA("ALERT: [src] has cooled below critical temperature. Meltdown averted. Have a nice day.", crisis = TRUE)
+					src.alertPDA("ALERT: [src] has cooled below critical temperature. Overload averted. Have a nice day.", crisis = TRUE)
 		else
 			if(src.GetParticles("overheat_smoke"))
 				src.visible_message(SPAN_ALERT("<b>The [src] stops smoking.</b>"))
@@ -381,14 +381,14 @@
 		for(var/i = min(ceil(rads / 2), 50), i>0, i--)
 			shoot_projectile_XY(src, new /datum/projectile/neutron(max(5, min(rads*2,100))), rand(-10,10), rand(-10,10)) //for once, rand(range) returning int is useful
 
-	proc/catastrophicOverload()
+	proc/catastrophicOverload() //IT'S NOT CALLED A MELTDOWN!
 		world.save_intra_round_value("nuclear_accident_count_[map_settings.name]", 0)
 		var/sound/alarm = sound('sound/machines/meltdown_siren.ogg')
 		alarm.repeat = TRUE
 		alarm.volume = 40
 		alarm.channel = 5
 		world << alarm //ew
-		command_alert("A nuclear reactor aboard the station has catastrophically overloaded. Radioactive debris, nuclear fallout, and coolant fires are likely. Immediate evacuation of the surrounding area is strongly advised.", "NUCLEAR MELTDOWN")
+		command_alert("A nuclear reactor aboard the station has catastrophically overloaded. Radioactive debris, nuclear fallout, and coolant fires are likely. Immediate evacuation of the surrounding area is strongly advised.", "NUCLEAR EXPLOSION")
 
 
 		//explode, throw radioactive components everywhere, dump rad gas, throw radioactive debris everywhere


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The notifications about the reactor explosion now accurately describe what is happening. Instead of referring to it as a "meltdown" it is now referred to as an "overload." The sign that counts explosions is also changed.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When the reactor explodes, it is referred to by alerts as a "meltdown." This is not accurate. A meltdown is when a rod or something else in the core melts, which will have already happened when the reactor explodes.

This absolutely is a small nitpick type of change, but it annoys me to no end when I say that we're going through a meltdown and someone else says that "it's not a melt down, some things just melted." That's a meltdown!
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Spawning an overloading reactor and everything went fine.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

I don't think a changelog is necessary.