### PR TITLE
Trainee roles limited by rounds played per department

### DIFF
--- a/_std/defines/jobs.dm
+++ b/_std/defines/jobs.dm
@@ -71,9 +71,9 @@
 #define ROUNDS_MIN_SECASS 5
 
 // Job round maximum (for newbees)
-#define ROUNDS_MAX_RESASS 75
-#define ROUNDS_MAX_MEDASS 75
-#define ROUNDS_MAX_TECHASS 75
+#define ROUNDS_MAX_RESASS 30
+#define ROUNDS_MAX_MEDASS 30
+#define ROUNDS_MAX_TECHASS 30
 
 // World announcement orders
 // Order in which the "John is the Captain!" world messages show up when multiple heads join at the same time (mainly roundstart)

--- a/code/datums/jobs/job_parent.dm
+++ b/code/datums/jobs/job_parent.dm
@@ -74,7 +74,7 @@ ABSTRACT_TYPE(/datum/job)
 	var/bio_effects = null
 	var/objective = null
 	var/rounds_needed_to_play = 0 //0 by default, set to the amount of rounds they should have in order to play this
-	var/rounds_allowed_to_play = 0 //0 by default (which means infinite), set to the amount of rounds they are allowed to have in order to play this, primarily for assistant jobs
+	var/rounds_allowed_to_play_dept = 0 //! Maximum rounds allowed to play this job based on total rounds in the department, used for trainee jobs. 0 (default) is infinite.
 	var/map_can_autooverride = TRUE //! Base the initial limit of job slots on the number of map-defined job start locations.
 	/// Does this job use the name and appearance from the character profile? (for tracking respawned names)
 	var/uses_character_profile = TRUE
@@ -217,8 +217,6 @@ ABSTRACT_TYPE(/datum/job)
 	proc/has_rounds_needed(datum/player/player, var/min = 0, var/max = 0)
 		if (src.rounds_needed_to_play)
 			min = src.rounds_needed_to_play
-		if (src.rounds_allowed_to_play)
-			max = src.rounds_allowed_to_play
 		if (!min && !max)
 			return TRUE
 
@@ -230,3 +228,7 @@ ABSTRACT_TYPE(/datum/job)
 		if (round_num >= min && (round_num <= max || !max))
 			return TRUE
 		return FALSE
+
+	/// Get the number of times the player has played in this department. Used for trainee job caps.
+	proc/dept_rounds_played(datum/player/player)
+		return null

--- a/code/datums/jobs/jobs_engineering.dm
+++ b/code/datums/jobs/jobs_engineering.dm
@@ -7,6 +7,9 @@ ABSTRACT_TYPE(/datum/job/engineering)
 	job_category = JOB_ENGINEERING
 	email_group = MGD_ENGINEER
 
+	dept_rounds_played(datum/player/player)
+		return player?.get_rounds_participated_engineering()
+
 /datum/job/engineering/engineer
 	name = "Engineer"
 	limit = 8
@@ -51,7 +54,7 @@ ABSTRACT_TYPE(/datum/job/engineering)
 	wages = PAY::UNTRAINED
 	trait_list = list("training_engineer")
 	access_string = "Engineer"
-	rounds_allowed_to_play = ROUNDS_MAX_TECHASS
+	rounds_allowed_to_play_dept = ROUNDS_MAX_TECHASS
 	slot_back = list(/obj/item/storage/backpack/engineering)
 	slot_ears = list(/obj/item/device/radio/headset/engineer)
 	slot_jump = list(/obj/item/clothing/under/color/yellow)

--- a/code/datums/jobs/jobs_medical.dm
+++ b/code/datums/jobs/jobs_medical.dm
@@ -5,6 +5,9 @@ ABSTRACT_TYPE(/datum/job/medical)
 	job_category = JOB_MEDICAL
 	email_group = MGD_MEDICAL
 
+	dept_rounds_played(datum/player/player)
+		return player?.get_rounds_participated_medical()
+
 /datum/job/medical/medical_doctor
 	name = "Medical Doctor"
 	limit = 5
@@ -81,7 +84,7 @@ ABSTRACT_TYPE(/datum/job/medical)
 	wages = PAY::UNTRAINED
 	trait_list = list("training_medical")
 	access_string = "Medical Doctor"
-	rounds_allowed_to_play = ROUNDS_MAX_MEDASS
+	rounds_allowed_to_play_dept = ROUNDS_MAX_MEDASS
 	slot_back = list(/obj/item/storage/backpack/medic)
 	slot_belt = list(/obj/item/storage/belt/medical/prepared)
 	slot_foot = list(/obj/item/clothing/shoes/red)

--- a/code/datums/jobs/jobs_science.dm
+++ b/code/datums/jobs/jobs_science.dm
@@ -7,6 +7,10 @@ ABSTRACT_TYPE(/datum/job/research)
 	job_category = JOB_RESEARCH
 	email_group = MGD_RESEARCH
 
+	dept_rounds_played(datum/player/player)
+		return player?.get_rounds_participated_research()
+
+
 /datum/job/research/scientist
 	name = "Scientist"
 	limit = 5
@@ -31,7 +35,7 @@ ABSTRACT_TYPE(/datum/job/research)
 	wages = PAY::UNTRAINED
 	trait_list = list("training_scientist")
 	access_string = "Scientist"
-	rounds_allowed_to_play = ROUNDS_MAX_RESASS
+	rounds_allowed_to_play_dept = ROUNDS_MAX_RESASS
 	slot_back = list(/obj/item/storage/backpack/research)
 	slot_ears = list(/obj/item/device/radio/headset/research)
 	slot_jump = list(/obj/item/clothing/under/color/purple)
@@ -40,3 +44,5 @@ ABSTRACT_TYPE(/datum/job/research)
 	slot_eyes = list(/obj/item/clothing/glasses/spectro)
 	slot_poc1 = list(/obj/item/pen = 50, /obj/item/pen/fancy = 25, /obj/item/pen/red = 5, /obj/item/pen/pencil = 20)
 	wiki_link = "https://wiki.ss13.co/Research_Assistant"
+
+

--- a/code/datums/jobs/jobs_security.dm
+++ b/code/datums/jobs/jobs_security.dm
@@ -8,6 +8,9 @@ ABSTRACT_TYPE(/datum/job/security)
 	job_category = JOB_SECURITY
 	email_group = MGD_SECURITY
 
+	dept_rounds_played(datum/player/player)
+		return player?.get_rounds_participated_security()
+
 /datum/job/security/security_officer
 	name = "Security Officer"
 	limit = 5

--- a/code/datums/preferences/preferences.dm
+++ b/code/datums/preferences/preferences.dm
@@ -1465,14 +1465,10 @@ var/list/removed_jobs = list(
 					reason_tooltip = "This job requires being on the Head of Security whitelist. Mentors may play this job on Fridays. Anyone may play this job on Saturdays."
 				else if (!job_datum.has_rounds_needed(user.client?.player))
 					var/played_rounds = user.client.player.get_rounds_participated()
-					var/needed_rounds = job_datum.rounds_needed_to_play
-					var/allowed_rounds = job_datum.rounds_allowed_to_play
-
-					if (played_rounds < needed_rounds)
-						reason_tooltip =  "You have only played <b>[played_rounds]</b> round[s_es(played_rounds)], but need to play a minimum of <b>[needed_rounds]</b> rounds to play as this job."
-					else
-						reason_tooltip =  "You have already played <b>[played_rounds]</b> rounds, but this job has a cap of <b>[allowed_rounds]</b> allowed rounds. You should be experienced enough to try the full role!"
-
+					reason_tooltip = "You have only played <b>[played_rounds]</b> round[s_es(played_rounds)], but need to play a minimum of <b>[job_datum.rounds_needed_to_play]</b> rounds to play as this job."
+				else if (job_datum.rounds_allowed_to_play_dept && job_datum.dept_rounds_played(user.client.player) >= job_datum.rounds_allowed_to_play_dept)
+					var/played_rounds_dept = job_datum.dept_rounds_played(user.client.player)
+					reason_tooltip = "You have already played <b>[played_rounds_dept]</b> round[s_es(played_rounds_dept)], but this job has a cap of <b>[job_datum.rounds_allowed_to_play_dept]</b> allowed rounds. You should be experienced enough to try the full role!"
 				if (reason_tooltip)
 					if (category != "unwanted")
 						if (category == "favourite")
@@ -1595,24 +1591,23 @@ var/list/removed_jobs = list(
 #else
 		var/datum/job/temp_job = find_job_in_controller_by_string(job,1)
 #endif
-		if (user.client && !temp_job.has_rounds_needed(user.client.player))
-			var/played_rounds = user.client.player.get_rounds_participated()
-			var/needed_rounds = temp_job.rounds_needed_to_play
-			var/allowed_rounds = temp_job.rounds_allowed_to_play
-			var/reason_msg = ""
-			if (allowed_rounds && !needed_rounds)
-				reason_msg =  "You've already played </b>[played_rounds]</b> rounds, but this job has a cap of <b>[allowed_rounds] allowed rounds. You should be experienced enough!</b>"
-			else if (needed_rounds)
-				reason_msg =  "You've only played </b>[played_rounds]</b> rounds and need to play <b>[needed_rounds].</b>"
-			boutput(user, SPAN_ALERT("<b>You cannot play [temp_job.name].</b> [reason_msg]"))
-			if (occ != 4)
-				switch (occ)
-					if (1) src.job_favorite = null
-					if (2) src.jobs_med_priority -= job
-					if (3) src.jobs_low_priority -= job
-				src.jobs_unwanted += job
-			return
-
+		if (user.client)
+			var/reason_msg = null
+			if (!temp_job.has_rounds_needed(user.client.player))
+				var/played_rounds = user.client.player.get_rounds_participated()
+				reason_msg = "You have only played <b>[played_rounds]</b> round[s_es(played_rounds)], but need to play a minimum of <b>[temp_job.rounds_needed_to_play]</b> rounds to play as this job."
+			if (temp_job.rounds_allowed_to_play_dept && temp_job.dept_rounds_played(user.client.player) >= temp_job.rounds_allowed_to_play_dept)
+				var/played_rounds_dept = temp_job.dept_rounds_played(user.client.player)
+				reason_msg =  "You've already played <b>[played_rounds_dept]</b> rounds in this department, but this job has a cap of <b>[temp_job.rounds_allowed_to_play_dept]</b> allowed rounds. You should be experienced enough to try the full role!"
+			if (reason_msg)
+				boutput(user, SPAN_ALERT("<b>You cannot play [temp_job.name].</b> [reason_msg]"))
+				if (occ != 4)
+					switch (occ)
+						if (1) src.job_favorite = null
+						if (2) src.jobs_med_priority -= job
+						if (3) src.jobs_low_priority -= job
+					src.jobs_unwanted += job
+				return
 		var/picker = "Low Priority"
 		var/datum/job/J = find_job_in_controller_by_string(job)
 		switch (level)

--- a/code/modules/goonhub/api/models/players/PlayerStatsResource.dm
+++ b/code/modules/goonhub/api/models/players/PlayerStatsResource.dm
@@ -8,6 +8,10 @@
 	var/byond_minor		= null // integer
 	var/played			= null // integer
 	var/played_rp		= null // integer
+	var/played_security	= null // integer
+	var/played_medical	= null // integer
+	var/played_research	= null // integer
+	var/played_engineering	= null // integer
 	var/connected		= null // integer
 	var/connected_rp	= null // integer
 	var/time_played		= null // integer
@@ -22,6 +26,10 @@
 	src.byond_minor = response["byond_minor"]
 	src.played = response["played"]
 	src.played_rp = response["played_rp"]
+	src.played_security = response["played_security"]
+	src.played_medical = response["played_medical"]
+	src.played_research = response["played_research"]
+	src.played_engineering = response["played_engineering"]
 	src.connected = response["connected"]
 	src.connected_rp = response["connected_rp"]
 	src.time_played = response["time_played"]

--- a/code/player.dm
+++ b/code/player.dm
@@ -25,6 +25,14 @@ var/global/list/players = list()
 	VAR_PRIVATE/rounds_participated = null
 	/// how many rounds (rp only) theyve declared ready and joined, null with to differentiate between not set and no participation
 	VAR_PRIVATE/rounds_participated_rp = null
+	/// how many rounds declared ready and joined as security, null with to differentiate between not set and no participation
+	VAR_PRIVATE/rounds_participated_security = null
+	/// how many rounds declared ready and joined as medical, null with to differentiate between not set and no participation
+	VAR_PRIVATE/rounds_participated_medical = null
+	/// how many rounds declared ready and joined as research, null with to differentiate between not set and no participation
+	VAR_PRIVATE/rounds_participated_research = null
+	/// how many rounds declared ready and joined as engineering, null with to differentiate between not set and no participation
+	VAR_PRIVATE/rounds_participated_engineering = null
 	/// how many rounds (total) theyve joined to at least the lobby in, null to differentiate between not set and not seen
 	VAR_PRIVATE/rounds_seen = null
 	/// how many rounds (rp only) theyve joined to at least the lobby in, null to differentiate between not set and not seen
@@ -162,6 +170,10 @@ var/global/list/players = list()
 
 		src.rounds_participated_rp = text2num(playerStats.played_rp)
 		src.rounds_participated = text2num(playerStats.played) + src.rounds_participated_rp //the API counts these separately, but we want a combined number
+		src.rounds_participated_security = text2num(playerStats.played_security)
+		src.rounds_participated_medical = text2num(playerStats.played_medical)
+		src.rounds_participated_research = text2num(playerStats.played_research)
+		src.rounds_participated_engineering = text2num(playerStats.played_engineering)
 		src.rounds_seen_rp = text2num(playerStats.connected_rp)
 		src.rounds_seen = text2num(playerStats.connected) + src.rounds_seen_rp //the API counts these separately, but we want a combined number
 		src.last_seen = playerStats.latest_connection?.created_at
@@ -217,6 +229,30 @@ var/global/list/players = list()
 			if (!src.cache_round_stats_blocking()) //if trying to set them fails
 				return null
 		return src.rounds_participated_rp
+
+	proc/get_rounds_participated_security()
+		if (!src.cached_round_stats) //if the stats havent been cached yet
+			if (!src.cache_round_stats_blocking()) //if trying to set them fails
+				return null
+		return src.rounds_participated_security
+
+	proc/get_rounds_participated_medical()
+		if (!src.cached_round_stats) //if the stats havent been cached yet
+			if (!src.cache_round_stats_blocking()) //if trying to set them fails
+				return null
+		return src.rounds_participated_medical
+
+	proc/get_rounds_participated_research()
+		if (!src.cached_round_stats) //if the stats havent been cached yet
+			if (!src.cache_round_stats_blocking()) //if trying to set them fails
+				return null
+		return src.rounds_participated_research
+
+	proc/get_rounds_participated_engineering()
+		if (!src.cached_round_stats) //if the stats havent been cached yet
+			if (!src.cache_round_stats_blocking()) //if trying to set them fails
+				return null
+		return src.rounds_participated_engineering
 
 	/// returns the number of rounds that the player has at least joined the lobby in
 	proc/get_rounds_seen()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Dependent on player API updates - DO NOT MERGE!

Changes trainee limits from 75 general rounds to 30 rounds in that department.

Adds a new `dept_rounds_played` proc which is defined for departments with trainee roles (research, medical, engineering). A proc is also defined for security, but unused as security assistant has diffrerent restrictions. Reworks latejoin and job preference menus to use the new values/procs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Allow players to ease into other roles if they've mained being a botanist for 500 rounds or have otherwise avoided a department for a long time.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

TBD

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)glowbold
(*)Trainee roles are now locked by rounds spent in that department instead of general rounds played.
```
