### PR TITLE
Omnitool screwdriver now has the jab special attack.

### DIFF
--- a/code/obj/item/tool/omnitool.dm
+++ b/code/obj/item/tool/omnitool.dm
@@ -348,6 +348,7 @@ ABSTRACT_TYPE(/datum/omnimode)
 		mode_id = OMNITOOL::MODE_SCREWDRIVER
 		context_icon = "screw"
 		item_type = /obj/item/screwdriver
+		item_special_type = /datum/item_special/jab
 	wirecutters
 		mode_name = "wirecutters"
 		mode_id = OMNITOOL::MODE_WIRECUTTER


### PR DESCRIPTION
## About the PR
- Omnitool screwdriver now uses the jab special attack, same as the base screwdriver.

## Why's this needed?
- Omnitool tools are expected to have the same special attack as their base items.
- Fixes #27451

## Testing
- Omnitool had same special attack as screwdriver while in screwdriver mode.
