### PR TITLE
Brainless/decapitated corpses can no longer be cloned scanned

### DIFF
--- a/code/modules/medical/cloning/console.dm
+++ b/code/modules/medical/cloning/console.dm
@@ -267,7 +267,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/computer/cloning, proc/scan_someone, proc/tr
 	if ((subject.mob_flags & IS_BONEY) && !allow_dead_scanning)
 		show_message("Error: No tissue mass present. Total ossification of subject detected.", "danger")
 		return
-
+	if (!subject.organHolder.brain)
+		show_message("Error: Failed to locate brain matter.", "danger")
+		return
 	var/datum/mind/subjMind = subject.mind
 	if ((!subjMind) || (!subjMind.key))
 		if(subject.ghost?.mind)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents clone scanning a headless/brainless body. Reattach the head/put their brain back in first, and it will work.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People already thought this was a thing, because it makes sense. Why would you be able to get a clone scan of someone with no brain? Also makes removing, stealing, and disposing of someones head/brain as an antag somewhat actually useful too. Leave bodies behind for detective to find that can't just be instantly cloned removing all intrigue. 

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested on local, correct error message came up when trying to scan a headless and brainless corpse. Reattaching the head/brain before scanning worked.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bamlord
(*)You can no longer clone scan a headless/brainless corpse.
```
