### PR TITLE
Wiping floppy disks with a multitool removes applied labels

### DIFF
--- a/code/modules/networks/computer3/disks.dm
+++ b/code/modules/networks/computer3/disks.dm
@@ -90,6 +90,9 @@
 			src.root = new /datum/computer/folder
 			src.root.holder = src
 			src.root.name = "root"
+
+			src.name_suffixes = list()
+			src.UpdateName()
 		else
 			user.visible_message(SPAN_ALERT("<b>[user] is zapped as the multitool sparks off [src]'s write-protect tab! The [src.name] seems unphased.</b>"))
 			elecflash(user,0, power=2, exclude_center = 0)

--- a/code/modules/networks/computer3/disks.dm
+++ b/code/modules/networks/computer3/disks.dm
@@ -90,7 +90,6 @@
 			src.root = new /datum/computer/folder
 			src.root.holder = src
 			src.root.name = "root"
-
 			src.name_suffixes = list()
 			src.UpdateName()
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Exactly what it says on the tin. 

This **only** applies to labels applied using suffixes (usually via a pen or the clone console), **not** to disks with entirely different names. I thought about making that happen too but I figured it was out of scope and it'd also represent a change with larger impact.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is primarily intended as QoL for clone disks; wiping them (like if you scan someone who's DNR, for instance) will retain their name, even though the disk is now cleared of their clone record and can't be used to clone them (and conversely, *can* be used to scan a new person). Removing the suffix can be done manually with a pen right now, but this skips that step and hopefully makes keeping diligent about clearing disks less of a chore!

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Loaded up a local server and wiped some disks. Labeled disks lose their labels. Disks with full name overrides (like coordinate disks for azones) are still wiped but retain their existing names.

https://github.com/user-attachments/assets/f9a9531b-41ba-4270-8010-3794e331f47e


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Ceres et al.
(+)Wiping a floppy disk's contents with a multitool now also removes any labels from that disk.
```
