### PR TITLE
Blocking with c sabre/hadar counterattacks chairdivers.

### DIFF
--- a/_std/defines/item.dm
+++ b/_std/defines/item.dm
@@ -46,6 +46,8 @@
 #define CLICK_DELAY_IN_CONTENTS		(1<<21)
 /// If an item cannot be crushed by the crusher
 #define UNCRUSHABLE					(1<<22)
+/// If the item will counterattack chairflips when blocking
+#define COUNTER_CHAIRFLIP			(1<<23)
 
 //Item function flags
 

--- a/code/datums/abilities/generic.dm
+++ b/code/datums/abilities/generic.dm
@@ -126,6 +126,20 @@
 			if (check_target_immunity(M, source = src))
 				src.visible_message(SPAN_ALERT("<b>[src] bounces off [M] harmlessly!</b>"))
 				return
+
+			if((istype(M.equipped(), /obj/item/sword) || istype(M.equipped(), /obj/item/heavy_power_sword)) && M.hasStatus("blocking"))
+				src.visible_message(SPAN_ALERT("<b>[M] skillfully counters [src]'s dive! Holy shit!</b>"))
+				var/obj/item/S = M.equipped()
+				if(S.chokehold) //deletes the block, nothing happens otherwise
+					qdel(S.chokehold)
+				src.Attackby(S, M)
+				if (src.hasStatus("knockdown") && src.getStatusDuration("knockdown") < 3 SECONDS * effect_mult)
+					src.setStatus("knockdown", 3 SECONDS * effect_mult)
+				else
+					src.changeStatus("knockdown", 3 SECONDS * effect_mult)
+				src.force_laydown_standup()
+				return
+
 			playsound(src.loc, 'sound/impact_sounds/Flesh_Break_1.ogg', 75, 1)
 
 			logTheThing(LOG_COMBAT, src, "[src] chairflips into [constructTarget(M,"combat")], [log_loc(M)].")

--- a/code/datums/abilities/generic.dm
+++ b/code/datums/abilities/generic.dm
@@ -126,13 +126,12 @@
 			if (check_target_immunity(M, source = src))
 				src.visible_message(SPAN_ALERT("<b>[src] bounces off [M] harmlessly!</b>"))
 				return
-
-			if((istype(M.equipped(), /obj/item/sword) || istype(M.equipped(), /obj/item/heavy_power_sword)) && M.hasStatus("blocking"))
+			var/obj/item/I = M.equipped()
+			if(I?.flags & COUNTER_CHAIRFLIP && M.hasStatus("blocking"))
 				src.visible_message(SPAN_ALERT("<b>[M] skillfully counters [src]'s dive! Holy shit!</b>"))
-				var/obj/item/S = M.equipped()
-				if(S.chokehold) //deletes the block, nothing happens otherwise
-					qdel(S.chokehold)
-				src.Attackby(S, M)
+				if(I.chokehold) //deletes the block, nothing happens otherwise
+					qdel(I.chokehold)
+				src.Attackby(I, M)
 				if (src.hasStatus("knockdown") && src.getStatusDuration("knockdown") < 3 SECONDS * effect_mult)
 					src.setStatus("knockdown", 3 SECONDS * effect_mult)
 				else

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -230,6 +230,7 @@ TYPEINFO(/obj/item/sword)
 		src.w_class = W_CLASS_BULKY
 		src.leaves_slash_wound = TRUE
 		src.setItemSpecial(/datum/item_special/swipe/csaber)
+		src.flags |= COUNTER_CHAIRFLIP // enables counter attacking chairflips with block
 		user.unlock_medal("The Force is strong with this one")
 	else
 		src.UpdateIcon()
@@ -246,6 +247,7 @@ TYPEINFO(/obj/item/sword)
 		src.w_class = off_w_class
 		src.leaves_slash_wound = FALSE
 		src.setItemSpecial(null)
+		src.flags &= ~COUNTER_CHAIRFLIP // disables counter attacking chairflips with block
 	user.update_inhands()
 	src.add_fingerprint(user)
 	..()
@@ -1893,6 +1895,7 @@ obj/item/whetstone
 		src.AddComponent(/datum/component/bloodflick)
 		src.setItemSpecial(/datum/item_special/swipe)
 		src.update_special_color()
+		src.flags |= COUNTER_CHAIRFLIP
 		AddComponent(/datum/component/itemblock/reflect/saberblock, null, PROC_REF(get_reflect_color))
 		BLOCK_SETUP(BLOCK_SWORD)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new robust method for energy sword wielders to counter the devious chairdive. Blocking with the sword in your active hand will now counterattack the chairdiver. 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It is ridiculous that someone with a Hadar heavy power sword or csabre needs to put their sword away/run from someone carrying a folded chair. Many an evil monologue has been ruined by some guy diving off a chair.  This PR leaves in the possibility that a chair dive could work, but adds a skill based way to counter it (remembering how to use the block button). It's now more of a last ditch thing, or something you need to time correctly, rather than a guaranteed way to steal someones sword. Aura farm without fear of the chairdive, as long as you are blocking. Also as a cool sideffect this adds midair csabre clashes kinda like that one guy who had the high ground or something. 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Example of chairdiving someone blocking with a csabre



https://github.com/user-attachments/assets/a85aec27-71d0-40b1-a6fc-306905909dac


Example of cool midair csabre duel



https://github.com/user-attachments/assets/86d093f4-6388-4b7a-86e7-a43d6fe129bf


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bamlord
(*)Blocking with a Cyalume Saber or Hadar Heavy Power Sword will now counterattack chairdivers.
```
