### PR TITLE
Decanonize death commando armor being NT

### DIFF
--- a/code/obj/item/clothing/armor.dm
+++ b/code/obj/item/clothing/armor.dm
@@ -261,7 +261,7 @@ TYPEINFO(/obj/item/clothing/suit/armor/vest)
 
 /obj/item/clothing/suit/armor/death_commando
 	name = "death commando armor"
-	desc = "Armor used by NanoTrasen's top secret purge unit. You're not sure how you know this."
+	desc = "An eerie looking set of modern space combat armor."
 	icon_state = "death"
 	item_state = "death"
 	c_flags = SPACEWEAR


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove mentions of NT from the death commando armor
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not matching modern lore/style, change requested by @cogwerks 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Opened devtest, spawned the armor, desc was changed.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

(no changlog needed)
