### PR TITLE
Improve prefab mapedge stack traces

### DIFF
--- a/code/modules/worldgen/prefab/mapPrefab.dm
+++ b/code/modules/worldgen/prefab/mapPrefab.dm
@@ -45,13 +45,25 @@ ABSTRACT_TYPE(/datum/mapPrefab)
 	proc/adjust_position(turf/target)
 		RETURN_TYPE(/turf)
 		// Fail if prefab doesn't fit
-		if(!isnull(prefabSizeX) && (target.x + prefabSizeX) > (world.maxx - src.required_distance_from_mapedge))
-			stack_trace("mapPrefab: Prefab '[name]' with path '[prefabPath]' X size exceeds map size")
-			return null
+		if(!isnull(prefabSizeX))
+			var/leftX = target.x
+			var/rightX = leftX + prefabSizeX - 1
+			if(rightX > world.maxx)
+				stack_trace("mapPrefab: Prefab '[name]' with path '[prefabPath]' X size exceeds map size")
+				return null
+			if(leftX <= src.required_distance_from_mapedge || rightX > (world.maxx - src.required_distance_from_mapedge))
+				stack_trace("mapPrefab: Prefab '[name]' with path '[prefabPath]' spawned too close to the map edge on the X axis")
+				return null
 
-		if(!isnull(prefabSizeY) && (target.y + prefabSizeY) > (world.maxy - src.required_distance_from_mapedge))
-			stack_trace("mapPrefab: Prefab '[name]' with path '[prefabPath]' Y size exceeds map size")
-			return null
+		if(!isnull(prefabSizeY))
+			var/bottomY = target.y
+			var/topY = leftY + prefabSizeY - 1
+			if(topY > world.maxy)
+				stack_trace("mapPrefab: Prefab '[name]' with path '[prefabPath]' Y size exceeds map size")
+				return null
+			if(bottomY <= src.required_distance_from_mapedge || topY > (world.maxy - src.required_distance_from_mapedge))
+				stack_trace("mapPrefab: Prefab '[name]' with path '[prefabPath]' spawned too close to the map edge on the Y axis")
+				return null
 
 		return target
 

--- a/code/modules/worldgen/prefab/mapPrefab.dm
+++ b/code/modules/worldgen/prefab/mapPrefab.dm
@@ -57,7 +57,7 @@ ABSTRACT_TYPE(/datum/mapPrefab)
 
 		if(!isnull(prefabSizeY))
 			var/bottomY = target.y
-			var/topY = leftY + prefabSizeY - 1
+			var/topY = bottomY + prefabSizeY - 1
 			if(topY > world.maxy)
 				stack_trace("mapPrefab: Prefab '[name]' with path '[prefabPath]' Y size exceeds map size")
 				return null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reworks the map prefab "exceeds map size" and "too close to map edge" checks to give different error messages, and also be more accurate in not adding an extra tile to the prefab's expected size

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Evil mapprefab check doesn't even work properly with the math being wrong and the message being wrong

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
This PR's checks