### PR TITLE
Implements Zesty Ranch blood type as an addictive food chemical

### DIFF
--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -270,6 +270,8 @@
 	#define COMSIG_MOB_ITEM_CONSUMED_PRE "mob_itm_atk_consumed_pre"
 	/// When an item is eaten (feeder,item)
 	#define COMSIG_MOB_ITEM_CONSUMED "mob_itm_atk_consumed"
+	/// When an item's been eaten, but there's still some left (feeder,item)
+	#define COMSIG_MOB_ITEM_CONSUMED_PARTIAL "mob_itm_atk_consumed_partial"
 	/// Sent when a mob throws something (target, params)
 	#define COMSIG_MOB_THROW_ITEM "throw_item"
 	/// Sent when a mob throws something that lands nearby

--- a/code/datums/preferences/preferences.dm
+++ b/code/datums/preferences/preferences.dm
@@ -1724,6 +1724,10 @@ var/list/removed_jobs = list(
 			var/datum/part_customization/customization = get_part_customization(part_id)
 			customization.try_apply(character, src.custom_parts)
 
+		// apply special blood
+		if (src.blType == "Zesty Ranch" && character.blood_id != "bloodc")
+			character.blood_id = "zestyranch"
+
 	proc/sanitize_null_values()
 		if (!src.gender || !(src.gender == MALE || src.gender == FEMALE))
 			src.gender = MALE

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3437,9 +3437,9 @@ datum
 			fluid_b = 165
 			fluid_g = 144
 
-#define RANCH_LIKER (1<<0) // disable bad effects
-#define RANCH_IMMUNE (1<<1) // disable all effects
-#define RANCH_ADDICT (1<<2) // enable addiction effects
+#define ZRANCH_LIKER (1<<0) // disable bad effects
+#define ZRANCH_IMMUNE (1<<1) // disable all effects
+#define ZRANCH_ADDICT (1<<2) // enable addiction effects
 		// highly addictive blood type, but also highly polarizing.
 		// previously had this as a fooddrink subtype but still want vampires to be able to use it and i dont feel like dealing with that
 		blood/zestyranch
@@ -3460,35 +3460,35 @@ datum
 			reagent_state = LIQUID
 
 			/// this controls how the chemical behaves inside the mob
-			var/pref_state = RANCH_LIKER
+			var/pref_state = ZRANCH_LIKER
 			/// how much ranch must be in a person to avoid making addiction withdrawal actively worse
 			var/minimum_ranch = 30
 
 			on_add()
 				if(isliving(holder?.my_atom))
 					var/mob/living/M = holder.my_atom
-					src.check_ranch_immunity(M)
+					src.check_ZRANCH_immunity(M)
 
 			on_mob_life(mob/M, mult)
 
-				if (!(src.pref_state & RANCH_IMMUNE))
+				if (!(src.pref_state & ZRANCH_IMMUNE))
 					var/datum/ailment/addiction/addicted = M.addicted_to_reagent(src)
 					if (addicted)
-						if (!(src.pref_state & RANCH_ADDICT))
-							src.pref_state |= RANCH_ADDICT
+						if (!(src.pref_state & ZRANCH_ADDICT))
+							src.pref_state |= ZRANCH_ADDICT
 					else
-						if ((src.pref_state & RANCH_ADDICT))
-							src.pref_state &= ~RANCH_ADDICT
+						if ((src.pref_state & ZRANCH_ADDICT))
+							src.pref_state &= ~ZRANCH_ADDICT
 
-				if (!(src.pref_state & RANCH_IMMUNE))
-					if (src.pref_state & RANCH_ADDICT)
+				if (!(src.pref_state & ZRANCH_IMMUNE))
+					if (src.pref_state & ZRANCH_ADDICT)
 
 						// instead of being based on like / dislike, its now based on how close we are to running out
 						var/amount = holder.get_reagent_amount(src.id)
 
 						if (amount < src.minimum_ranch)
 							M.make_jittery(10 * mult)
-							if(!ON_COOLDOWN(M, "zestyranch_addict_message", 3 SECONDS))
+							if(!ON_COOLDOWN(M, "zestyZRANCH_addict_message", 3 SECONDS))
 								if (probmult(50))
 									var/msg = pick("You feel like you need more...","You can't imagine a world without [src.name]!","You NEED more [src.name]!","Needs more [src.name]. More!", "You're craving [src.name] dressing!", "Anything else just isn't [pick(src.taste)] enough!")
 									boutput(M, SPAN_ALERT(msg), group="addict_[src]")
@@ -3505,7 +3505,7 @@ datum
 									M.take_toxin_damage(0.3 * mult)
 
 					// good OR bad effects
-					if (src.pref_state & RANCH_LIKER)
+					if (src.pref_state & ZRANCH_LIKER)
 						M.reagents.add_reagent("cholesterol", 0.5 * src.calculate_depletion_rate(M, mult))
 						if (probmult(30))
 							M.reagents.add_reagent("msg", 1 * src.calculate_depletion_rate(M, mult))
@@ -3518,18 +3518,18 @@ datum
 							M.nauseate(rand(1,2))
 				..(M, mult)
 
-			proc/check_ranch_immunity(var/mob/living/M)
-				if (!(src.pref_state & RANCH_IMMUNE))
+			proc/check_ZRANCH_immunity(var/mob/living/M)
+				if (!(src.pref_state & ZRANCH_IMMUNE))
 					// disable addiction, remove effects
 					if (M.blood_id == src.id)
-						src.pref_state |= RANCH_IMMUNE
+						src.pref_state |= ZRANCH_IMMUNE
 				else
 					// revoked
 					if (M.blood_id != src.id)
-						src.pref_state &= ~RANCH_IMMUNE
+						src.pref_state &= ~ZRANCH_IMMUNE
 
 				// keep up to date
-				if (src.pref_state & RANCH_LIKER || src.pref_state & RANCH_IMMUNE)
+				if (src.pref_state & ZRANCH_LIKER || src.pref_state & ZRANCH_IMMUNE)
 					src.taste = list("zesty", "ranchy")
 				else
 					src.taste = list("awful", "disgusting")
@@ -3537,26 +3537,26 @@ datum
 			reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume_passed)
 
 				if(method == INGEST && volume_passed >= 1)
-					src.check_ranch_immunity(M)
-					if (!(src.pref_state & RANCH_IMMUNE))
+					src.check_ZRANCH_immunity(M)
+					if (!(src.pref_state & ZRANCH_IMMUNE))
 						// its either delicious or toxic and disgusting to us, unless we're immune to its effects
-						if (src.pref_state & RANCH_ADDICT)
+						if (src.pref_state & ZRANCH_ADDICT)
 							// too late, to the ranch dungeon with you
-							if (!(src.pref_state & RANCH_LIKER))
+							if (!(src.pref_state & ZRANCH_LIKER))
 								boutput(M, SPAN_NOTICE("You're starting to really appreciate the flavor."))
-								src.pref_state |= RANCH_LIKER
+								src.pref_state |= ZRANCH_LIKER
 								src.taste = list("zesty", "ranchy")
 
 						else
 							// you still have time to change your mind before its too late
-							if (src.pref_state & RANCH_LIKER)
+							if (src.pref_state & ZRANCH_LIKER)
 								if (prob(40))
-									src.pref_state &= ~RANCH_LIKER
+									src.pref_state &= ~ZRANCH_LIKER
 									M.nauseate(rand(2,4))
 									src.taste = list("awful", "disgusting")
 							else
 								if (prob(60))
-									src.pref_state |= RANCH_LIKER
+									src.pref_state |= ZRANCH_LIKER
 									src.taste = list("zesty", "ranchy")
 								else
 									M.nauseate(rand(2,4))
@@ -3565,14 +3565,14 @@ datum
 
 			handle_addiction(var/mob/M, var/rate, var/addProb)
 				// dont addict if the mob doesn't like it, or is immune.
-				if ((src.pref_state & RANCH_IMMUNE) || !(src.pref_state & RANCH_LIKER))
+				if ((src.pref_state & ZRANCH_IMMUNE) || !(src.pref_state & ZRANCH_LIKER))
 					addProb = 0
 					rate = 0
 				..(M, rate, addProb)
 
-#undef RANCH_LIKER
-#undef RANCH_IMMUNE
-#undef RANCH_ADDICT
+#undef ZRANCH_LIKER
+#undef ZRANCH_IMMUNE
+#undef ZRANCH_ADDICT
 
 		vomit
 			name = "vomit"

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3437,6 +3437,142 @@ datum
 			fluid_b = 165
 			fluid_g = 144
 
+#define RANCH_LIKER (1<<0) // disable bad effects
+#define RANCH_IMMUNE (1<<1) // disable all effects
+#define RANCH_ADDICT (1<<2) // enable addiction effects
+		// highly addictive blood type, but also highly polarizing.
+		// previously had this as a fooddrink subtype but still want vampires to be able to use it and i dont feel like dealing with that
+		blood/zestyranch
+			name = "zesty ranch"
+			id = "zestyranch"
+			fluid_r = 230
+			fluid_g = 210
+			fluid_b = 184
+			transparency = 255
+			hygiene_value = -2
+			hunger_value = 0.1
+			viscosity = 0.4
+			depletion_rate = 0.4
+			addiction_prob = 20
+			addiction_min = 10
+			taste = list("zesty", "ranchy")
+			description = "An uncommon type of \"Zesty Ranch\" dressing. There is currently an ongoing debate between experts over whether this is infact a real, valid condiment."
+			reagent_state = LIQUID
+
+			/// this controls how the chemical behaves inside the mob
+			var/pref_state = RANCH_LIKER
+			/// how much ranch must be in a person to avoid making addiction withdrawal actively worse
+			var/minimum_ranch = 30
+
+			on_add()
+				if(isliving(holder?.my_atom))
+					var/mob/living/M = holder.my_atom
+					src.check_ranch_immunity(M)
+
+			on_mob_life(mob/M, mult)
+
+				if (!(src.pref_state & RANCH_IMMUNE))
+					var/datum/ailment/addiction/addicted = M.addicted_to_reagent(src)
+					if (addicted)
+						if (!(src.pref_state & RANCH_ADDICT))
+							src.pref_state |= RANCH_ADDICT
+					else
+						if ((src.pref_state & RANCH_ADDICT))
+							src.pref_state &= ~RANCH_ADDICT
+
+				if (!(src.pref_state & RANCH_IMMUNE))
+					if (src.pref_state & RANCH_ADDICT)
+
+						// instead of being based on like / dislike, its now based on how close we are to running out
+						var/amount = holder.get_reagent_amount(src.id)
+
+						if (amount < src.minimum_ranch)
+							M.make_jittery(10 * mult)
+							if(!ON_COOLDOWN(M, "zestyranch_addict_message", 3 SECONDS))
+								if (probmult(50))
+									var/msg = pick("You feel like you need more...","You can't imagine a world without [src.name]!","You NEED more [src.name]!","Needs more [src.name]. More!", "You're craving [src.name] dressing!", "Anything else just isn't [pick(src.taste)] enough!")
+									boutput(M, SPAN_ALERT(msg), group="addict_[src]")
+
+								if (amount < src.minimum_ranch/2)
+									// simulated withdrawal
+									if (probmult(40))
+										var/action = weighted_pick(list("scream"=1,"blur"=2,"drool"=3,"shudder"=3,"groan"=3,"shiver"=3,"burp"=3))
+										if (action == "blur")
+											boutput(M, SPAN_ALERT("Your vision blurs, you REALLY need some [src.name]."), group="addict_[src]")
+											M.change_eye_blurry(rand(7, 10))
+										else
+											M.emote(action)
+									M.take_toxin_damage(0.3 * mult)
+
+					// good OR bad effects
+					if (src.pref_state & RANCH_LIKER)
+						M.reagents.add_reagent("cholesterol", 0.5 * src.calculate_depletion_rate(M, mult))
+						if (probmult(30))
+							M.reagents.add_reagent("msg", 1 * src.calculate_depletion_rate(M, mult))
+						M.HealDamage("All", 0.2 * mult, 0.2 * mult, 0.1 * mult)
+					else
+						M.reagents.add_reagent("cholesterol", 1 * src.calculate_depletion_rate(M, mult))
+						M.take_toxin_damage(0.5 * mult)
+						// instead of msg you get vomit.
+						if (probmult(30))
+							M.nauseate(rand(1,2))
+				..(M, mult)
+
+			proc/check_ranch_immunity(var/mob/living/M)
+				if (!(src.pref_state & RANCH_IMMUNE))
+					// disable addiction, remove effects
+					if (M.blood_id == src.id)
+						src.pref_state |= RANCH_IMMUNE
+				else
+					// revoked
+					if (M.blood_id != src.id)
+						src.pref_state &= ~RANCH_IMMUNE
+
+				// keep up to date
+				if (src.pref_state & RANCH_LIKER || src.pref_state & RANCH_IMMUNE)
+					src.taste = list("zesty", "ranchy")
+				else
+					src.taste = list("awful", "disgusting")
+
+			reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume_passed)
+
+				if(method == INGEST && volume_passed >= 1)
+					src.check_ranch_immunity(M)
+					if (!(src.pref_state & RANCH_IMMUNE))
+						// its either delicious or toxic and disgusting to us, unless we're immune to its effects
+						if (src.pref_state & RANCH_ADDICT)
+							// too late, to the ranch dungeon with you
+							if (!(src.pref_state & RANCH_LIKER))
+								boutput(M, SPAN_NOTICE("You're starting to really appreciate the flavor."))
+								src.pref_state |= RANCH_LIKER
+								src.taste = list("zesty", "ranchy")
+
+						else
+							// you still have time to change your mind before its too late
+							if (src.pref_state & RANCH_LIKER)
+								if (prob(40))
+									src.pref_state &= ~RANCH_LIKER
+									M.nauseate(rand(2,4))
+									src.taste = list("awful", "disgusting")
+							else
+								if (prob(60))
+									src.pref_state |= RANCH_LIKER
+									src.taste = list("zesty", "ranchy")
+								else
+									M.nauseate(rand(2,4))
+
+				..(M, method, volume_passed)
+
+			handle_addiction(var/mob/M, var/rate, var/addProb)
+				// dont addict if the mob doesn't like it, or is immune.
+				if ((src.pref_state & RANCH_IMMUNE) || !(src.pref_state & RANCH_LIKER))
+					addProb = 0
+					rate = 0
+				..(M, rate, addProb)
+
+#undef RANCH_LIKER
+#undef RANCH_IMMUNE
+#undef RANCH_ADDICT
 
 		vomit
 			name = "vomit"

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3464,10 +3464,27 @@ datum
 			/// how much ranch must be in a person to avoid making addiction withdrawal actively worse
 			var/minimum_ranch = 30
 
+			proc/on_eat(var/mob/feeder, var/mob/user, var/obj/item/eaten)
+				if (src.pref_state & ZRANCH_ADDICT)
+					var/mob/living/eater = holder.my_atom
+					// attempting to eat something without the chem wont work
+					if (!eaten.reagents?.has_reagent(src.id))
+						eater.vomit()
+						eater.nauseate(5)
+						eater.changeStatus("knockdown", 2 SECONDS)
+						var/msg = pick("You feel it's missing something...","It tastes [pick(list("awful", "disgusting"))] without [src.name]!","You NEED more [src.name]!","Needs more [src.name]. More!", "You're craving more [src.name] dressing on [eaten]!", "[eaten] just isn't [pick(src.taste)] enough!")
+						boutput(eater, SPAN_ALERT(msg), group="addict_[src]")
+
+
 			on_add()
-				if(isliving(holder?.my_atom))
+				if(isliving(holder.my_atom))
 					var/mob/living/M = holder.my_atom
 					src.check_ZRANCH_immunity(M)
+					RegisterSignals(holder.my_atom, list(COMSIG_MOB_ITEM_CONSUMED,COMSIG_MOB_ITEM_CONSUMED_PARTIAL), PROC_REF(on_eat))
+
+			on_remove()
+				if(isliving(holder.my_atom))
+					UnregisterSignals(holder.my_atom, list(COMSIG_MOB_ITEM_CONSUMED,COMSIG_MOB_ITEM_CONSUMED_PARTIAL))
 
 			on_mob_life(mob/M, mult)
 

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3505,31 +3505,42 @@ datum
 
 						if (amount < src.minimum_ranch)
 							M.make_jittery(10 * mult)
-							if(!ON_COOLDOWN(M, "zestyZRANCH_addict_message", 3 SECONDS))
+							// start side effects
+							M.take_toxin_damage(0.5 * mult)
+							if (amount < src.minimum_ranch/2)
+								M.take_toxin_damage(rand(1,2) * mult)
+
+							if(!ON_COOLDOWN(M, "zestyranch_addict_message", 3 SECONDS))
 								if (probmult(50))
 									var/msg = pick("You feel like you need more...","You can't imagine a world without [src.name]!","You NEED more [src.name]!","Needs more [src.name]. More!", "You're craving [src.name] dressing!", "Anything else just isn't [pick(src.taste)] enough!")
 									boutput(M, SPAN_ALERT(msg), group="addict_[src]")
 
+
 								if (amount < src.minimum_ranch/2)
 									// simulated withdrawal
 									if (probmult(40))
-										var/action = weighted_pick(list("scream"=1,"blur"=2,"drool"=3,"shudder"=3,"groan"=3,"shiver"=3,"burp"=3))
+										var/action = weighted_pick(list("scream"=1,"heartbeat"=1,"blur"=2,"drool"=3,"shudder"=3,"groan"=3,"shiver"=3,"burp"=3))
 										if (action == "blur")
-											boutput(M, SPAN_ALERT("Your vision blurs, you REALLY need some [src.name]."), group="addict_[src]")
+											boutput(M, SPAN_ALERT("Your vision blurs, you REALLY need some [src.name]."), group="addict_[src]2")
 											M.change_eye_blurry(rand(7, 10))
+										else if (action == "heartbeat")
+											boutput(M, SPAN_ALERT("<b>You can feel your heartbeat in your throat!</b>"), group="addict_[src]2")
+											M.playsound_local(M.loc, 'sound/effects/heartbeat.ogg', 50, 1)
 										else
 											M.emote(action)
-									M.take_toxin_damage(0.3 * mult)
 
 					// good OR bad effects
 					if (src.pref_state & ZRANCH_LIKER)
 						M.reagents.add_reagent("cholesterol", 0.5 * src.calculate_depletion_rate(M, mult))
 						if (probmult(30))
 							M.reagents.add_reagent("msg", 1 * src.calculate_depletion_rate(M, mult))
-						M.HealDamage("All", 0.2 * mult, 0.2 * mult, 0.1 * mult)
+
+						if (probmult(50))
+							M.HealDamage("All", 1 * mult, 1 * mult, 1 * mult)
 					else
-						M.reagents.add_reagent("cholesterol", 1 * src.calculate_depletion_rate(M, mult))
-						M.take_toxin_damage(0.5 * mult)
+						M.reagents.add_reagent("cholesterol", 1.5 * src.calculate_depletion_rate(M, mult))
+						M.take_toxin_damage(1 * mult)
+
 						// instead of msg you get vomit.
 						if (probmult(30))
 							M.nauseate(rand(1,2))

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -428,6 +428,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 		if (src.festivity && !ethereal_eater && !inafterlife(consumer))
 			modify_christmas_cheer(src.festivity)
 		if (!src.bites_left)
+			SEND_SIGNAL(consumer, COMSIG_MOB_ITEM_CONSUMED, feeder, src) //one to the mob
+			SEND_SIGNAL(src, COMSIG_ITEM_CONSUMED, consumer, src) //one to the item
 			if (istype(src, /obj/item/reagent_containers/food/snacks/plant/) && prob(20))
 				var/obj/item/reagent_containers/food/snacks/plant/P = src
 				var/doseed = 1
@@ -444,6 +446,9 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 			feeder.u_equip(src)
 			on_finish(consumer, feeder)
 			qdel(src)
+		else
+			SEND_SIGNAL(consumer, COMSIG_MOB_ITEM_CONSUMED_PARTIAL, feeder, src) //one to the mob
+			SEND_SIGNAL(src, COMSIG_ITEM_CONSUMED_PARTIAL, consumer, src) //one to the item
 
 	afterattack(obj/target, mob/user, flag)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Continuing from #25519 after some more thinking and some ideas about how to make its effects unique.

This PR adds Zesty Ranch as a rare food chemical

Zesty ranch now has its own gimmick, being an addictive RNG based chemical compared to just being mostly copy pasted EMSG effects. 

- Good effects: 50% chance for 1 brute/burn/tox heal, decays into cholesterol and a chance of half volume of msg, changes taste description
- Bad effects: 1 tox damage, decays into cholesterol, increases nausea, changes taste description

- 60% chance to change from bad effects to good, and 40% to turn from good effects to bad effects
- Addiction only progresses when Good effects are active

Addiction locks in good effects **with the catch that running out causes new side effects until the chems fully deplete**
and being **unable to eat any foods that do not contain zesty ranch without vomiting.**

- Addicted (<30u) effects: same as good, but with messages about needing more ranch when running low, 1 tox damage
- Addicted (<15u) effects: same as <30u, but with added emotes, occasional blurry vision, and 1-2 tox damage
- Addicted (0 u) effects: no effects

People with zesty ranch as their blood chem are immune to the (good and bad) effects of the chemical entirely, and it does absolutely nothing to / for them.
This is to prevent anyone from just using it on themselves for the positive effects.
<img width="477" height="288" alt="image" src="https://github.com/user-attachments/assets/77c987fc-9316-40c1-80a9-1ff6ca0da645" />
<img width="247" height="29" alt="image" src="https://github.com/user-attachments/assets/a8d5a34e-32f3-4e82-963d-84589162d9ce" />

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
<img width="313" height="139" alt="image" src="https://github.com/user-attachments/assets/d2f21371-bace-4955-b29a-c5c26b8614cf" />

Gives zesty ranch its own niche use for chefs and anyone else who might want to use it. Enables more kitchen / food / whatever gimmicks

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="123" height="258" alt="image" src="https://github.com/user-attachments/assets/8cfdbd21-b47c-474b-98b3-1ee8218e7df5" />

<img width="541" height="47" alt="image" src="https://github.com/user-attachments/assets/f99a1cf0-4b15-49a3-a8c9-f382afd753bd" />


Tested by creating a save file with zesty ranch blood, spawning in, creating a pitcher of the chemical, drinking it and verifying the immunity works
<img width="500" height="408" alt="image" src="https://github.com/user-attachments/assets/021ef9f9-94f6-4d29-a99f-c9b0d678fbae" />

Then creating a staff assistant, mindswapping into the staff assistant to verify the good / bad effects as well as the addiction effects work.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Skeletonman0
(+)the Zesty Ranch blood type is now a highly addictive culinary chemical
```
