### PR TITLE
Added pressure meters to probestation teg

### DIFF
--- a/assets/maps/random_rooms/probstation/9x9/engine-teg.dmm
+++ b/assets/maps/random_rooms/probstation/9x9/engine-teg.dmm
@@ -164,6 +164,10 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
 	},
+/obj/machinery/meter{
+	pixel_x = 9;
+	pixel_y = -8
+	},
 /turf/simulated/floor/engine/glow/blue,
 /area/station/engine/core/thermoelectric)
 "rJ" = (
@@ -214,6 +218,10 @@
 "vU" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
+	},
+/obj/machinery/meter{
+	pixel_x = -10;
+	pixel_y = -8
 	},
 /turf/simulated/floor/engine/glow,
 /area/station/engine/core/thermoelectric)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the pressure meters to the input of the probstation teg
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

automating the blowers is nice, plus you can't actually find them on probestation afaik

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="665" height="434" alt="image" src="https://github.com/user-attachments/assets/9eb44975-225f-42e7-adbb-4e4ee67787ac" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

no need for log