### PR TITLE
Standarized head offices in donut3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -23516,6 +23516,10 @@
 	pixel_x = -5;
 	pixel_y = 13
 	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 5
+	},
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 5
 	},
@@ -36640,6 +36644,10 @@
 	pixel_x = 9;
 	pixel_y = 4
 	},
+/obj/item/stamp/md{
+	pixel_x = -4;
+	pixel_y = -7
+	},
 /turf/simulated/floor/carpet/blue/fancy/narrow/T_east,
 /area/station/medical/head)
 "lxV" = (
@@ -40520,7 +40528,7 @@
 	pixel_x = 8;
 	pixel_y = 2
 	},
-/obj/item/reagent_containers/food/snacks/spaghetti/spicy{
+/obj/item/reagent_containers/food/snacks/spaghetti/spicy/security{
 	pixel_x = -6;
 	pixel_y = 2
 	},
@@ -49355,6 +49363,10 @@
 /obj/item/reagent_containers/food/drinks/mug/HoS{
 	pixel_x = -8;
 	pixel_y = 15
+	},
+/obj/item/stamp/hos{
+	pixel_x = 5;
+	pixel_y = 10
 	},
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 1
@@ -58971,6 +58983,7 @@
 /area/station/engine/engineering)
 "srQ" = (
 /obj/table/wood/auto,
+/obj/machinery/recharger,
 /turf/simulated/floor/carpet/purple/fancy/junction/nw_e,
 /area/station/crew_quarters/hor)
 "srY" = (
@@ -60934,6 +60947,10 @@
 /area/station/hallway/primary/west)
 "sWR" = (
 /obj/table/wood/auto,
+/obj/item/stamp/hop{
+	pixel_x = -6;
+	pixel_y = 9
+	},
 /obj/item/reagent_containers/food/drinks/rum_spaced,
 /obj/item/pen/fancy{
 	pixel_x = 7;
@@ -68377,6 +68394,10 @@
 "vks" = (
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/recharger/wall/sticky{
+	dir = 8;
+	pixel_x = -23
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -77686,6 +77707,10 @@
 /obj/item/card/id/gold/captains_spare{
 	pixel_x = -13
 	},
+/obj/item/stamp/cap{
+	pixel_x = 7;
+	pixel_y = 8
+	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fblue3"
@@ -78977,9 +79002,9 @@
 /obj/item/device/audio_log{
 	pixel_x = -5
 	},
-/obj/item/stamp{
-	pixel_x = -6;
-	pixel_y = 10
+/obj/item/stamp/rd{
+	pixel_x = 12;
+	pixel_y = 7
 	},
 /turf/simulated/floor/carpet/purple/fancy/innercorner{
 	dir = 4


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

*Did the following within donut 3:*

Added the following missing head-of-staff stamps to:
- captain
- Hos
- hop
- rd (replaced the regular stamp on their desk)
- md

Replaced the spaghetti in hos's office with the secure version

Added a recharger in cap's office (between plant & apc)
Added a recharger at hos's bedroom (on the desk by the bed)
Added a recharger at rd's office (at their L shaped desk at the southest point of the office)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
standardization is good! #27504
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
cap:
<img width="460" height="456" alt="captain" src="https://github.com/user-attachments/assets/ede83545-b221-4a7a-aa21-212a68c6adef" />

hop:
<img width="449" height="386" alt="hop" src="https://github.com/user-attachments/assets/d6e854c1-ef58-4188-99de-349bbb153b0f" />

hos:
<img width="234" height="332" alt="hos1" src="https://github.com/user-attachments/assets/66bee91f-4269-441d-81c9-b7f063ee3cb1" />
<img width="377" height="480" alt="hos2" src="https://github.com/user-attachments/assets/e4868ba5-e961-4911-82b3-7339ac67103a" />

md:
<img width="496" height="348" alt="md" src="https://github.com/user-attachments/assets/0ab542ec-44a9-4ba1-b892-d34fb6f828be" />

rd (the cake being off seems to be a bug with plate code, not the map):
<img width="359" height="261" alt="rd" src="https://github.com/user-attachments/assets/d4d00d7b-9ec0-47e5-ab51-7cbfd952364b" />


