### PR TITLE
Standarized head offices in cogmap2

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -26729,6 +26729,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/mob/living/critter/small_animal/cat/jones,
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "fblue6"
@@ -30306,7 +30307,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/mob/living/critter/small_animal/cat/jones,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue2"
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -21990,7 +21990,7 @@
 /area/station/security/hos)
 "buv" = (
 /obj/table/reinforced/auto,
-/obj/item/reagent_containers/food/snacks/spaghetti/spicy,
+/obj/item/reagent_containers/food/snacks/spaghetti/spicy/security,
 /obj/item/kitchen/utensil/fork{
 	pixel_x = 9;
 	pixel_y = 3
@@ -24551,15 +24551,6 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/plating/scorched,
 /area/station/routing/depot)
-"bCY" = (
-/obj/item/device/radio/intercom/bridge,
-/obj/storage/secure/closet/command/hop,
-/obj/decal/poster/wallsign/framed_award/firstbill{
-	pixel_x = 32;
-	pixel_y = -3
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/hop)
 "bDa" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating/scorched,
@@ -26738,7 +26729,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/mob/living/critter/small_animal/cat/jones,
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "fblue6"
@@ -29787,15 +29777,15 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
-"bTk" = (
-/obj/machinery/computer/arcade,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
 	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
+"bTk" = (
+/obj/machinery/computer/arcade,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -29807,7 +29797,7 @@
 "bTl" = (
 /obj/rack,
 /obj/item/clothing/suit/space/captain,
-/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/gas/emergency,
 /obj/item/clothing/head/helmet/space/captain,
 /obj/item/tank/jetpack,
 /obj/machinery/door_control/bolter/new_walls/north{
@@ -29815,7 +29805,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/carpet{
-	dir = 5;
+	dir = 1;
 	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/captain)
@@ -30316,9 +30306,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/mob/living/critter/small_animal/cat/jones,
 /turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "fblue3"
+	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/captain)
 "bUM" = (
@@ -30326,14 +30316,6 @@
 	dir = 4;
 	icon_state = "fblue2"
 	},
-/area/station/crew_quarters/captain)
-"bUN" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "bUP" = (
 /obj/disposalpipe/segment{
@@ -30775,9 +30757,6 @@
 /turf/simulated/floor,
 /area/station/teleporter)
 "bWn" = (
-/obj/table/wood/auto,
-/obj/random_item_spawner/desk_stuff,
-/obj/item/rubberduck,
 /obj/machinery/door_control{
 	id = "lockdown";
 	name = "Bridge Lockdown";
@@ -30785,9 +30764,11 @@
 	pixel_y = 6;
 	dir = 8
 	},
-/obj/item/stamp/cap,
 /obj/blind_switch/directional/west{
 	pixel_y = -6
+	},
+/obj/machinery/computer/announcement/station/captain{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
@@ -30815,8 +30796,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "fblue3"
+	dir = 8;
+	icon_state = "fblue1"
 	},
 /area/station/crew_quarters/captain)
 "bWr" = (
@@ -30832,9 +30813,6 @@
 /turf/simulated/floor/stairs{
 	dir = 8
 	},
-/area/station/crew_quarters/captain)
-"bWu" = (
-/turf/simulated/floor/shuttlebay,
 /area/station/crew_quarters/captain)
 "bWx" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -31130,10 +31108,11 @@
 /area/station/hallway/primary/east)
 "bXF" = (
 /obj/table/wood/auto,
-/obj/machinery/light/lamp/green,
-/obj/item/pinpointer/disk{
-	pixel_x = 10;
-	pixel_y = 9
+/obj/random_item_spawner/desk_stuff,
+/obj/item/stamp/cap,
+/obj/item/rubberduck,
+/obj/item/device/radio/intercom/bridge{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
@@ -31189,11 +31168,6 @@
 	dir = 6;
 	icon_state = "fblue2"
 	},
-/area/station/crew_quarters/captain)
-"bXK" = (
-/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
-/obj/shrub/captainshrub,
-/turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "bXL" = (
 /obj/securearea{
@@ -31569,39 +31543,10 @@
 /obj/window_blinds/cog2/middle,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
-"bZc" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "lockdown";
-	name = "Bridge Lockdown Doors";
-	opacity = 0
-	},
-/obj/window_blinds/cog2/middle,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/captain)
 "bZd" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-8"
+/turf/simulated/floor/carpet{
+	icon_state = "fblue2"
 	},
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "lockdown";
-	name = "Bridge Lockdown Doors";
-	opacity = 0
-	},
-/obj/window_blinds/cog2/right,
-/turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "bZe" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe{
@@ -50983,7 +50928,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/green/fancy/innercorner/nw,
+/turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/station/crew_quarters/hop)
 "eou" = (
 /obj/lattice{
@@ -51027,6 +50972,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"epl" = (
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
 "erl" = (
 /obj/machinery/conveyor/WE{
 	name = "cargo belt - east";
@@ -51422,6 +51376,12 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/kitchen)
+"eNf" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/green/fancy/innercorner/east,
+/area/station/crew_quarters/hop)
 "eNG" = (
 /mob/living/critter/small_animal/frog{
 	name = "Bump"
@@ -51762,6 +51722,9 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/maintenance/disposal)
+"fbG" = (
+/turf/simulated/floor/carpet/green/fancy/innercorner/sw,
+/area/station/crew_quarters/hop)
 "fcs" = (
 /obj/machinery/camera/directional/west{
 	pixel_y = 10
@@ -53394,8 +53357,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/manufacturer/personnel,
-/turf/simulated/floor/carpet/green/fancy/edge/north,
+/turf/simulated/floor/carpet/green/fancy/edge,
 /area/station/crew_quarters/hop)
 "gCo" = (
 /obj/table/reinforced/auto,
@@ -53761,6 +53723,12 @@
 /obj/random_item_spawner/snacks/maybe_few,
 /turf/simulated/floor/grime,
 /area/station/storage/auxillary)
+"gOT" = (
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "fblue3"
+	},
+/area/station/crew_quarters/captain)
 "gOW" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -54038,6 +54006,12 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
+"hcQ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/green/fancy/innercorner/west,
+/area/station/crew_quarters/hop)
 "hdq" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/mapping_helper/wingrille_spawn/auto/reinforced,
@@ -54763,6 +54737,16 @@
 	icon_state = "fgreen2"
 	},
 /area/station/garden/owlery)
+"hHR" = (
+/obj/table/wood/auto,
+/obj/machinery/light/lamp/green,
+/obj/item/pinpointer/disk{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/machinery/light,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
 "hHS" = (
 /obj/disposalpipe/switch_junction/biofilter{
 	dir = 4;
@@ -54980,8 +54964,7 @@
 /turf/simulated/floor,
 /area/station/bridge/customs)
 "hNA" = (
-/obj/machinery/firealarm/directional/east,
-/turf/simulated/floor/black,
+/turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/hop)
 "hNS" = (
 /obj/machinery/atmospherics/pipe/manifold{
@@ -56010,6 +55993,12 @@
 /obj/machinery/ghostdrone_factory/part3,
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
+"izb" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/green/fancy/edge/west,
+/area/station/crew_quarters/hop)
 "izd" = (
 /obj/mesh/catwalk{
 	dir = 5
@@ -56109,8 +56098,6 @@
 	},
 /area/mining/magnet)
 "iEI" = (
-/obj/table/wood/auto,
-/obj/random_item_spawner/desk_stuff,
 /obj/blind_switch/directional/west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hop)
@@ -56938,25 +56925,10 @@
 	},
 /area/station/engine/inner)
 "jlE" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "lockdown";
-	name = "Bridge Lockdown Doors";
-	opacity = 0
-	},
-/obj/window_blinds/cog2/middle,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/station/crew_quarters/hop)
 "jmg" = (
 /obj/decal/poster/wallsign/stencil/right/o{
@@ -57090,7 +57062,10 @@
 	},
 /area/station/ranch)
 "jtq" = (
-/obj/machinery/light_switch/directional/north,
+/obj/item/storage/secure/ssafe{
+	pixel_x = 0;
+	pixel_y = 26
+	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fblue2"
@@ -58083,6 +58058,12 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/science/lab)
+"kdu" = (
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "fblue3"
+	},
+/area/station/crew_quarters/captain)
 "kdz" = (
 /obj/table/reinforced/auto,
 /obj/mapping_helper/firedoor_spawn,
@@ -59134,6 +59115,12 @@
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
+"kVR" = (
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fblue3"
+	},
+/area/station/crew_quarters/captain)
 "kWZ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -59295,12 +59282,12 @@
 /area/station/routing/engine)
 "kZS" = (
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/carpet/green/fancy/innercorner/sw,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/green/fancy/innercorner/omni,
 /area/station/crew_quarters/hop)
 "lal" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -60389,6 +60376,12 @@
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
+"lVu" = (
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fblue2"
+	},
+/area/station/crew_quarters/captain)
 "lVF" = (
 /obj/machinery/power/pt_laser{
 	dir = 8
@@ -60418,14 +60411,13 @@
 /area/station/maintenance/south)
 "lXz" = (
 /obj/table/wood/auto,
-/obj/machinery/light/lamp/green,
-/obj/item/item_box/gold_star{
-	item_amount = 20
+/obj/random_item_spawner/desk_stuff,
+/obj/item/reagent_containers/food/drinks/rum_spaced{
+	pixel_x = -6;
+	pixel_y = 14
 	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/item/device/radio/intercom/bridge{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hop)
@@ -60438,19 +60430,8 @@
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/auxdish)
 "lYd" = (
-/obj/mapping_helper/wingrille_spawn/auto/reinforced,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "lockdown";
-	name = "Bridge Lockdown Doors";
-	opacity = 0
-	},
-/obj/window_blinds/cog2/right,
-/turf/simulated/floor/plating,
+/obj/machinery/manufacturer/personnel,
+/turf/simulated/floor/carpet/green/fancy/edge/north,
 /area/station/crew_quarters/hop)
 "lYA" = (
 /obj/mapping_helper/firedoor_spawn,
@@ -61667,6 +61648,10 @@
 /mob/living/critter/small_animal/mouse,
 /turf/simulated/floor/plating/scorched,
 /area/station/storage/warehouse)
+"mSM" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/shuttlebay,
+/area/station/crew_quarters/captain)
 "mSN" = (
 /obj/mapping_helper/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass/security/alt,
@@ -63111,7 +63096,7 @@
 	pixel_x = -1;
 	pixel_y = -21
 	},
-/turf/simulated/floor/carpet/green/fancy/edge/se,
+/turf/simulated/floor/carpet/green/fancy/edge/south,
 /area/station/crew_quarters/hop)
 "ofP" = (
 /obj/machinery/door/airlock/pyro/maintenance{
@@ -63513,6 +63498,25 @@
 	dir = 10
 	},
 /area/station/hallway/secondary/entry)
+"ozu" = (
+/obj/table/wood/auto,
+/obj/machinery/light/lamp/green,
+/obj/item/item_box/gold_star{
+	item_amount = 20
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/hop)
+"ozJ" = (
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "fblue3"
+	},
+/area/station/crew_quarters/captain)
 "oAn" = (
 /obj/mesh/catwalk{
 	dir = 6
@@ -65547,6 +65551,11 @@
 	dir = 6
 	},
 /area/station/hydroponics/bay)
+"qkE" = (
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/light,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/hop)
 "qkG" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -65681,6 +65690,21 @@
 	dir = 1
 	},
 /area/station/medical/medbay/surgery/storage)
+"qoX" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/window_blinds/cog2/middle,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/hop)
 "qpr" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/firealarm/directional/west,
@@ -68096,6 +68120,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/east)
+"skG" = (
+/turf/simulated/floor/black,
+/area/station/crew_quarters/hop)
 "skI" = (
 /obj/cable/orange{
 	icon_state = "4-8"
@@ -68289,6 +68316,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"ssW" = (
+/obj/machinery/light_switch/directional/east,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
 "stF" = (
 /obj/mesh/grille/steel,
 /obj/disposalpipe/segment/mail/bent/west,
@@ -68373,6 +68404,25 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
+"sxD" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/window_blinds/cog2/middle,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/captain)
 "sxK" = (
 /obj/disposalpipe/segment,
 /obj/mesh/catwalk,
@@ -68684,7 +68734,6 @@
 /area/station/crew_quarters/arcade/dungeon)
 "sHf" = (
 /obj/storage/secure/closet/command/captain,
-/obj/item/device/radio/intercom/bridge,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fblue2"
@@ -69097,14 +69146,6 @@
 "tcw" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/staff)
-"tcE" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/hop)
 "tdm" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/secdetector{
@@ -69547,6 +69588,12 @@
 /obj/blind_switch/directional/east,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/ce)
+"trM" = (
+/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
+/obj/shrub/captainshrub,
+/obj/machinery/light,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
 "tsV" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cell_charger,
@@ -70160,6 +70207,15 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/security/checkpoint/podbay)
+"tTz" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fblue2"
+	},
+/area/station/crew_quarters/captain)
 "tTE" = (
 /obj/machinery/light{
 	dir = 1;
@@ -70705,6 +70761,9 @@
 	icon_state = "fpurple2"
 	},
 /area/station/crew_quarters/cafeteria)
+"uvf" = (
+/turf/simulated/floor/carpet/green/fancy/innercorner/nw,
+/area/station/crew_quarters/hop)
 "uvo" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -71005,6 +71064,27 @@
 	},
 /turf/simulated/floor/black,
 /area/research_outpost)
+"uJw" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/window_blinds/cog2/middle,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/hop)
 "uJL" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -71285,6 +71365,7 @@
 /obj/item/reagent_containers/food/drinks/bottle/ntbrew,
 /obj/machinery/light_switch/directional/west,
 /mob/living/critter/small_animal/dog/george/orwell,
+/obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hop)
 "uUh" = (
@@ -71399,6 +71480,24 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/mining/magnet)
+"uZz" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/window_blinds/cog2/middle,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/captain)
 "uZB" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/southwest)
@@ -71494,8 +71593,10 @@
 /turf/simulated/floor/carpet/green/fancy/innercorner/ne,
 /area/station/crew_quarters/hop)
 "vgV" = (
-/obj/machinery/firealarm/directional/east,
-/turf/simulated/floor/carpet/arcade,
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "fblue2"
+	},
 /area/station/crew_quarters/captain)
 "vht" = (
 /obj/disposalpipe/segment/mail/horizontal,
@@ -72109,6 +72210,21 @@
 /obj/decal/stripe_delivery,
 /turf/simulated/floor,
 /area/station/hangar/main)
+"vIt" = (
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/window_blinds/cog2/right,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/captain)
 "vJb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -74176,6 +74292,24 @@
 /obj/mapping_helper/access/armory,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"xEp" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/window_blinds/cog2/middle,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/hop)
 "xEv" = (
 /obj/machinery/atmospherics/binary/valve/notify_admins{
 	dir = 1;
@@ -74544,6 +74678,19 @@
 	dir = 9
 	},
 /area/station/engine/engineering)
+"xSo" = (
+/obj/storage/secure/closet/command/hop,
+/obj/decal/poster/wallsign/framed_award/firstbill{
+	pixel_x = 32;
+	pixel_y = -3
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/hop)
 "xSG" = (
 /obj/lattice{
 	dir = 1;
@@ -140718,7 +140865,7 @@ aaa
 aaa
 aao
 aaa
-aaa
+xJC
 xJC
 xJC
 xJC
@@ -140740,7 +140887,7 @@ iKC
 bTg
 bTg
 bTg
-aaa
+bTg
 aaa
 aao
 aaa
@@ -141020,8 +141167,8 @@ aaa
 aaa
 abs
 aaa
-aaa
 xJC
+ozu
 lXz
 iEI
 jbH
@@ -141041,8 +141188,8 @@ bTh
 bUI
 bWn
 bXF
+hHR
 bTg
-aaa
 aaa
 abs
 aaa
@@ -141322,10 +141469,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
 nGh
 rIh
 nqs
+izb
 tMp
 iyu
 bAc
@@ -141342,9 +141489,9 @@ bAc
 jtq
 bUJ
 bWo
+lVu
 bXG
 bZa
-aaa
 aaa
 aaa
 aaa
@@ -141624,10 +141771,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
 szy
 jzg
 kTu
+eNf
 vgK
 ogd
 bAc
@@ -141643,10 +141790,10 @@ bPX
 bAc
 sHf
 bUK
+kdu
 bWp
 bXH
 bZb
-aaa
 aaa
 aaa
 aaa
@@ -141926,7 +142073,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+uJw
 jlE
 gBG
 kZS
@@ -141946,9 +142093,9 @@ bAd
 bTk
 bUL
 bWq
+tTz
 bXI
-bZc
-aaa
+sxD
 aaa
 aaa
 aaa
@@ -142228,11 +142375,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
+xEp
 lYd
-xGc
-ifu
-oWT
+fbG
+hcQ
+uvf
 ofK
 bAc
 bBM
@@ -142246,11 +142393,11 @@ bOx
 bBM
 bAc
 bTl
-bUM
-bUM
-bXJ
+ozJ
+kVR
+gOT
 bZd
-aaa
+uZz
 aaa
 aaa
 aaa
@@ -142530,11 +142677,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-xJC
-bCY
-jbH
-tcE
+qoX
+xGc
+oWT
+ifu
+oWT
 hNA
 hJe
 bBN
@@ -142548,11 +142695,11 @@ bOy
 bBN
 pCX
 vgV
-bUN
-bWr
-bXK
-bTg
-aaa
+bUM
+bUM
+bUM
+bXJ
+vIt
 aaa
 aaa
 aaa
@@ -142832,12 +142979,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 xJC
-xJC
-hmz
-xJC
-xJC
+xSo
+skG
+jbH
+skG
+qkE
 bAc
 pjg
 bDK
@@ -142849,12 +142996,12 @@ bIT
 bOy
 bPY
 bAc
+epl
+ssW
+bWr
+bWr
+trM
 bTg
-bTg
-bWs
-bXL
-bTg
-aaa
 aaa
 aaa
 aaa
@@ -143134,12 +143281,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aam
-buR
-aaI
-aaa
+xJC
+xJC
+xJC
+hmz
+xJC
+xJC
 bAc
 bBP
 bDK
@@ -143151,12 +143298,12 @@ bMf
 bOz
 bPZ
 iSO
-aaa
 bTg
-bWt
 bTg
-aaa
-aaa
+bWs
+bXL
+bTg
+bTg
 aaa
 aaa
 aaa
@@ -143438,9 +143585,9 @@ aaa
 aaa
 aaa
 aaa
-hsl
+aam
 buR
-hsl
+aaI
 aaa
 bAf
 bBQ
@@ -143455,7 +143602,7 @@ bQa
 cBj
 aaa
 bTg
-bWu
+bWt
 bTg
 aaa
 aaa
@@ -143741,7 +143888,7 @@ aaa
 aaa
 aaa
 hsl
-cOx
+buR
 hsl
 aaa
 bAg
@@ -143757,7 +143904,7 @@ bQb
 bAg
 aaa
 bTg
-jOW
+mSM
 bTg
 aaa
 aaa
@@ -144043,7 +144190,7 @@ aaa
 aaa
 aaa
 hsl
-hsl
+cOx
 hsl
 aaa
 bAh
@@ -144059,7 +144206,7 @@ bQc
 bQd
 aaa
 bTg
-tQm
+jOW
 bTg
 aaa
 aaa
@@ -144344,9 +144491,9 @@ aaa
 aaa
 aaa
 aaa
-arQ
-aaa
-arQ
+hsl
+hsl
+hsl
 aaa
 aam
 bAg
@@ -144360,9 +144507,9 @@ bOD
 cBj
 aaI
 aaa
-arQ
-aaa
-arQ
+bTg
+tQm
+bTg
 aaa
 aaa
 aaa
@@ -144646,9 +144793,9 @@ aaa
 aaa
 aaa
 aaa
+arQ
 aaa
-aaa
-aaa
+arQ
 aaa
 aam
 bAh
@@ -144662,9 +144809,9 @@ bDO
 bQd
 aaI
 aaa
+arQ
 aaa
-aaa
-aaa
+arQ
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Standardize the head offices per the checks in #27504 , specifically
increased the size of cap's office to fit a captain announcement console.
swapped the breath mask with a gas mask in cap's office.
grew the hop office for symmetry.
added the spaced rum to hop's office.
made the spaghetti in the hos's office sufficiently spicy
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#27504
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="881" height="497" alt="cap" src="https://github.com/user-attachments/assets/f568047d-d23f-431f-bbe1-d4d99ef54317" />
<img  width="863" height="431" alt="hop" src="https://github.com/user-attachments/assets/d0766edd-ad21-459d-93c1-0775487507c4" />
<img width="518" height="426" alt="hos" src="https://github.com/user-attachments/assets/8e9be79e-bef0-4135-ae81-d5feee2f402e" />

also tested the comm console can link, blinds work, and that you cant see nor access the safe from outside cap's room.
It also improves the "flow" of the hop/cap offices, fixing the weird intercom-behind-locker thing they had

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->
