### PR TITLE
Standarized cogmap1's head offices

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -5268,6 +5268,15 @@
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
+"ayK" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fred1"
+	},
+/area/station/crew_quarters/captain)
 "ayM" = (
 /obj/stool/bar,
 /turf/simulated/floor/carpet{
@@ -36508,7 +36517,7 @@
 /area/station/maintenance/central)
 "ftg" = (
 /obj/table/reinforced/auto,
-/obj/item/reagent_containers/food/snacks/spaghetti/spicy{
+/obj/item/reagent_containers/food/snacks/spaghetti/spicy/security{
 	pixel_x = -2;
 	pixel_y = 4
 	},
@@ -37200,8 +37209,6 @@
 	dir = 8;
 	tag = ""
 	},
-/obj/shrub/captainshrub,
-/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred2"
@@ -38862,6 +38869,14 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
+"gVg" = (
+/obj/shrub/captainshrub,
+/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fred2"
+	},
+/area/station/crew_quarters/captain)
 "gVk" = (
 /obj/mesh/catwalk{
 	dir = 4
@@ -45561,6 +45576,15 @@
 /obj/landmark/pest,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
+"lBf" = (
+/obj/machinery/computer/announcement/station/captain{
+	dir = 8
+	},
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "fred6"
+	},
+/area/station/crew_quarters/captain)
 "lBr" = (
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/auto/glassblock/indigo,
@@ -48709,8 +48733,8 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "fred6"
+	dir = 4;
+	icon_state = "fred2"
 	},
 /area/station/crew_quarters/captain)
 "nEP" = (
@@ -59509,6 +59533,25 @@
 "uMC" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hop)
+"uNB" = (
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/captain)
 "uNH" = (
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
@@ -89312,7 +89355,7 @@ moc
 mXQ
 adC
 adC
-adC
+aal
 adC
 adC
 adC
@@ -89612,9 +89655,9 @@ bbP
 uNH
 nHW
 bbP
+bbP
 waj
 bbP
-aal
 adC
 adC
 adC
@@ -89914,13 +89957,13 @@ bbP
 cTJ
 pwx
 fRS
+gVg
 frQ
 bbP
 bbP
 bbP
 iRs
 wJq
-adC
 adC
 adC
 adC
@@ -90216,13 +90259,13 @@ bbP
 gbf
 bdR
 beL
+beL
 bfI
 ikX
 aqA
 bhp
 biv
 ifi
-adC
 adC
 adC
 adC
@@ -90518,13 +90561,13 @@ jOM
 bcT
 foB
 oiu
+ayK
 dwR
 fAA
 lFi
 bhq
 eJk
 mQu
-adC
 adC
 adC
 adC
@@ -90820,13 +90863,13 @@ bbP
 tuC
 bdT
 beN
+beL
 bKt
 qCO
 aqA
 bhr
 bix
 dfe
-adC
 adC
 adC
 adC
@@ -91123,12 +91166,12 @@ bcV
 vuo
 beO
 nED
+lBf
 bbP
 bbP
 bbP
 gqO
 mPo
-adC
 adC
 adC
 adC
@@ -91424,9 +91467,9 @@ bbP
 uVp
 gKO
 luE
+uNB
 eFX
 bbP
-aah
 adC
 adC
 adC


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaced the spaghetti in the hos's office with the secure version.
Expended cap's office to fit a personal announcement console.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#27504
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

cap
<img width="707" height="732" alt="captain" src="https://github.com/user-attachments/assets/5f46537f-a521-4891-9810-9d12fe0f1df1" />
<img width="678" height="756" alt="captain2" src="https://github.com/user-attachments/assets/6c9664a9-d3f5-4490-aa8d-688e85c7fd41" />

hos
<img width="488" height="513" alt="hos1" src="https://github.com/user-attachments/assets/8ff6389f-4e3f-4a20-a27d-ec71e3ba4171" />
<img width="523" height="127" alt="hos2" src="https://github.com/user-attachments/assets/e7bf6299-7a30-4b2d-bf54-5f532124190c" />

