### PR TITLE
Move the donut 2 science nuke to donut 3 asylum

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -4377,9 +4377,6 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/cable{
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/black/grime,
 /area/station/medical/asylum/maintenance)
 "bpe" = (
@@ -11886,14 +11883,6 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/hallway/secondary/construction2)
-"dEG" = (
-/obj/machinery/networked/mainframe/zeta{
-	tag = "ZETA_MAINFRAME"
-	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/black/grime,
-/area/station/medical/asylum/maintenance)
 "dEN" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/disposalpipe/segment,
@@ -148898,7 +148887,7 @@ jPH
 knx
 uyx
 bpb
-dEG
+tAZ
 wwE
 wwE
 wwE

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2772,6 +2772,9 @@
 /area/station/hallway/primary/west)
 "aOO" = (
 /obj/decal/cleanable/dirt,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/sanitary/blue,
 /area/station/medical/asylum/bathroom)
 "aOP" = (
@@ -4373,6 +4376,9 @@
 	},
 /obj/cable{
 	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/black/grime,
 /area/station/medical/asylum/maintenance)
@@ -11880,6 +11886,14 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/hallway/secondary/construction2)
+"dEG" = (
+/obj/machinery/networked/mainframe/zeta{
+	tag = "ZETA_MAINFRAME"
+	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/black/grime,
+/area/station/medical/asylum/maintenance)
 "dEN" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/disposalpipe/segment,
@@ -19468,6 +19482,9 @@
 	dir = 8;
 	name = "the other best seat in the house"
 	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/black/grime,
 /area/station/medical/asylum/bathroom)
 "gag" = (
@@ -24084,6 +24101,9 @@
 /turf/simulated/floor/carpet,
 /area/station/security/detectives_office)
 "hvv" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/wall/false_wall{
 	color = "#87befd";
 	icon = 'icons/turf/walls/jen.dmi';
@@ -25954,6 +25974,14 @@
 /obj/machinery/light/traffic_light/trader_left/delay3,
 /turf/space,
 /area/space)
+"idy" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/obj/machinery/power/data_terminal,
+/turf/space,
+/area/station/turret_protected/AIbaseoutside)
 "idR" = (
 /turf/simulated/floor/caution/corner{
 	dir = 1
@@ -31923,6 +31951,15 @@
 	dir = 4
 	},
 /area/station/hydroponics/bay)
+"jVo" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/sanitary/blue,
+/area/station/medical/asylum/bathroom)
 "jVp" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -64143,6 +64180,9 @@
 	},
 /obj/machinery/networked/nuclear_charge,
 /obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/black/grime,
 /area/station/medical/asylum/bathroom)
 "tVB" = (
@@ -73344,6 +73384,9 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload_foyer)
 "wGD" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black/grime,
 /area/station/medical/asylum/bathroom)
 "wGE" = (
@@ -120568,7 +120611,7 @@ nuJ
 llA
 nSh
 nSh
-vVA
+idy
 xms
 nsJ
 qPC
@@ -120870,7 +120913,7 @@ rdj
 rwP
 nSh
 nSh
-vVA
+idy
 xms
 nsJ
 fnD
@@ -148855,7 +148898,7 @@ jPH
 knx
 uyx
 bpb
-aXw
+dEG
 wwE
 wwE
 wwE
@@ -149756,7 +149799,7 @@ lSP
 bku
 hID
 nWS
-nWS
+jVo
 cVZ
 gjj
 blC

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -64141,6 +64141,8 @@
 /obj/machinery/camera/directional/north{
 	pixel_x = -10
 	},
+/obj/machinery/networked/nuclear_charge,
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/black/grime,
 /area/station/medical/asylum/bathroom)
 "tVB" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
We have a spare nuclear charge soo might as well put it on the donut 3 asylum.
DNM until donut 2 archive is merged for continuity reasons.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- How often (per day) do you want to nuke the clown?
- Blobs spawning here can be lame and if someone occasionally manages to nuke them that might be cool too
- Look otherwise it's just lying around in centcom taking up warehouse space
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested blowing up the nuke, resulted in superficial damage to the north side of the station, a couple of breaches.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(*)Moved the spare nuclear charge from donut 2 science to donut 3 asylum.
```
