### PR TITLE
Standarized oshan head offices

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -14883,11 +14883,6 @@
 /obj/stool/bed,
 /obj/machinery/light/incandescent/warm,
 /obj/item/clothing/suit/bedsheet/royal,
-/obj/machinery/recharger/wall/sticky{
-	dir = 1;
-	pixel_x = 1;
-	pixel_y = 25
-	},
 /turf/simulated/floor/carpet/purple/standard/narrow/T_north,
 /area/station/crew_quarters/captain)
 "bwj" = (
@@ -22821,6 +22816,11 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "cje" = (
+/obj/machinery/recharger/wall/sticky{
+	dir = 1;
+	pixel_x = 1;
+	pixel_y = 25
+	},
 /turf/simulated/floor/carpet/purple/standard/narrow/T_north,
 /area/station/crew_quarters/captain)
 "cjf" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -3927,6 +3927,7 @@
 	},
 /area/station/medical/head)
 "asB" = (
+/obj/critter/bat/doctor,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue2"
 	},
@@ -4033,6 +4034,10 @@
 	},
 /obj/item/pen/crayon/random{
 	pixel_x = 2
+	},
+/obj/item/stamp/rd{
+	pixel_x = 11;
+	pixel_y = 7
 	},
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -14878,6 +14883,11 @@
 /obj/stool/bed,
 /obj/machinery/light/incandescent/warm,
 /obj/item/clothing/suit/bedsheet/royal,
+/obj/machinery/recharger/wall/sticky{
+	dir = 1;
+	pixel_x = 1;
+	pixel_y = 25
+	},
 /turf/simulated/floor/carpet/purple/standard/narrow/T_north,
 /area/station/crew_quarters/captain)
 "bwj" = (
@@ -14952,6 +14962,10 @@
 /area/station/mining/staff_room)
 "bwL" = (
 /obj/machinery/light/incandescent/warm,
+/obj/item/storage/secure/ssafe{
+	pixel_x = 0;
+	pixel_y = 26
+	},
 /turf/simulated/floor/carpet/purple/standard/narrow/nw,
 /area/station/crew_quarters/captain)
 "bwM" = (
@@ -19845,7 +19859,7 @@
 /obj/machinery/recharger{
 	pixel_y = 9
 	},
-/obj/item/reagent_containers/food/snacks/spaghetti/spicy,
+/obj/item/reagent_containers/food/snacks/spaghetti/spicy/security,
 /obj/item/kitchen/utensil/fork{
 	dir = 8;
 	pixel_y = -7
@@ -32600,6 +32614,10 @@
 	pixel_x = -2;
 	pixel_y = 12
 	},
+/obj/item/stamp/ce{
+	pixel_x = 6;
+	pixel_y = 6
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/ce)
 "jEU" = (
@@ -40649,6 +40667,10 @@
 /obj/item/item_box/postit,
 /obj/item/pen,
 /obj/item/kitchen/food_box/sugar_box,
+/obj/item/stamp/ce{
+	pixel_x = -7;
+	pixel_y = 13
+	},
 /turf/simulated/floor/yellow/checker{
 	dir = 8
 	},
@@ -49546,7 +49568,6 @@
 /area/station/chapel/sanctuary)
 "wSI" = (
 /obj/machinery/power/apc/autoname_west,
-/obj/critter/bat/doctor,
 /obj/cable{
 	icon_state = "0-4"
 	},

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -40667,10 +40667,6 @@
 /obj/item/item_box/postit,
 /obj/item/pen,
 /obj/item/kitchen/food_box/sugar_box,
-/obj/item/stamp/ce{
-	pixel_x = -7;
-	pixel_y = 13
-	},
 /turf/simulated/floor/yellow/checker{
 	dir = 8
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Standardize the head of staff offices on oshan by:
- adding the missing stamps at ce & rd offices
- moved dr. acula to the md's office
- changed the hos's pasta's type to the secure version (for better validation)
- added a recharger & safe (near the bathroom) at the cap's office 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
standardization is good, #27504 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="564" height="452" alt="cap" src="https://github.com/user-attachments/assets/2a8b9193-5b9e-4056-9840-6ad60e089cd3" />
<img width="389" height="343" alt="ce" src="https://github.com/user-attachments/assets/02884256-fb73-4a12-814d-f5f59276f022" />
<img width="353" height="361" alt="hos" src="https://github.com/user-attachments/assets/003ea921-a5fe-4d0d-96d1-7b5955adcc85" />
<img width="445" height="368" alt="md" src="https://github.com/user-attachments/assets/80c21d2f-605e-438f-881e-ccc7bdd42e5a" />
<img width="461" height="371" alt="rd" src="https://github.com/user-attachments/assets/db9252ba-f946-4fe5-b57a-9061060a4d51" />
