### PR TITLE
QMs can buy a fossil from Gragg

### DIFF
--- a/code/modules/economy/traders/gragg.dm
+++ b/code/modules/economy/traders/gragg.dm
@@ -30,7 +30,9 @@
 			/datum/commodity/trader/gragg/artifact
 		),
 		TRADER_RARITY_UNCOMMON = list(),
-		TRADER_RARITY_RARE = list()
+		TRADER_RARITY_RARE = list(
+			/datum/commodity/trader/gragg/fossil
+		)
 	)
 
 	dialogue_greet = list("HELLO. WANT BUY TASTY ROCKS. TRADE?",
@@ -118,6 +120,17 @@
 	alt_type_chance = 5
 	possible_names = list("SELLING WEIRD THING I DUG UP. DONT KNOW WHAT IS.",
 	"ODD LITTLE THING. DUG IT UP. NO IDEA. CAN BUY IF WANT.")
+
+/datum/commodity/trader/gragg/fossil
+	comname = "Rock With Picture"
+	comtype = /obj/item/fossil/stone
+	amount = 1
+	price_boundary = list(PAY::IMPORTANT*2, PAY::IMPORTANT*3)
+	possible_alt_types = list(/obj/item/fossil/cobryl, /obj/item/fossil/molitz)
+	alt_type_chance = 5
+	possible_names = list("SELLING ROCK WITH WEIRD PICTURE. DON'T KNOW WHO DREW IT.",
+	"SELLING ROCK WITH IMPRINT ON IT. ARTIST UNKNOWN.",
+	"TOLD ONE ROCK DRAWING CAN BUY MANY ROCKS WITH NO DRAWING. BUY IF AGREE.")
 
 // Gragg wants these things
 


### PR DESCRIPTION
## About the PR
- Gragg will now sell "Rock With Picture", usually a stone fossil. Only one will be available at a time and it is given the rare commodity rarity. It should cost above market price unless fossils are considered a hot item.

## Why's this needed?
- The idea is that this gives genetics and cargo a reason to interact with each other while still keeping fossils rare.

## Testing
<img width="217" height="190" alt="Screenshot 2026-08-17 075551" src="https://github.com/user-attachments/assets/6b59f97d-40f7-495c-824b-cbe7537c5530" />

## Changelog
```changelog
(u)LorrMaster
(*)Quartermasters now have a chance to be able to buy a fossil from Gragg.
```
