### PR TITLE
Reinforced glass sheets crafting fix

### DIFF
--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -422,7 +422,7 @@ MATERIAL
 						a_type = map_settings ? map_settings.rwindows_thin : /obj/window/reinforced
 					else
 						a_type = map_settings ? map_settings.windows_thin : /obj/window
-					currentRecipe = /datum/sheet_crafting_recipe/unreinforced/glass/smallwindow
+					currentRecipe = /datum/sheet_crafting_recipe/glass/smallwindow
 					a_callback = /proc/window_reinforce_callback
 
 				if("bigwindow")
@@ -434,7 +434,7 @@ MATERIAL
 						a_type = map_settings ? map_settings.rwindows : /obj/window/reinforced
 					else
 						a_type = map_settings ? map_settings.windows : /obj/window
-					currentRecipe = /datum/sheet_crafting_recipe/unreinforced/glass/bigwindow
+					currentRecipe = /datum/sheet_crafting_recipe/glass/bigwindow
 					a_callback = /proc/window_reinforce_full_callback
 
 				if("remetal")
@@ -1162,9 +1162,9 @@ MATERIAL
 
 
 ABSTRACT_TYPE(/datum/sheet_crafting_recipe)
+ABSTRACT_TYPE(/datum/sheet_crafting_recipe/glass)
 ABSTRACT_TYPE(/datum/sheet_crafting_recipe/unreinforced)
 ABSTRACT_TYPE(/datum/sheet_crafting_recipe/unreinforced/metal)
-ABSTRACT_TYPE(/datum/sheet_crafting_recipe/unreinforced/glass)
 ABSTRACT_TYPE(/datum/sheet_crafting_recipe/unreinforced/wood)
 ABSTRACT_TYPE(/datum/sheet_crafting_recipe/reinforced)
 /datum/sheet_crafting_recipe
@@ -1346,7 +1346,7 @@ ABSTRACT_TYPE(/datum/sheet_crafting_recipe/reinforced)
 		icon = 'icons/obj/items/scrapweapons.dmi'
 		icon_state = "shaft"
 
-/datum/sheet_crafting_recipe/unreinforced/glass
+/datum/sheet_crafting_recipe/glass
 	required_mat_flags = MATERIAL_CRYSTAL
 
 	smallwindow


### PR DESCRIPTION
## About the PR
- Large windows, small windows, and display cases can now be crafted using reinforced glass again.

## Why's this needed?
- Fixes #27501 

## Testing
<img width="523" height="316" alt="Screenshot 2026-08-17 092947" src="https://github.com/user-attachments/assets/73fba350-fd4c-4aca-8f3b-7f6edcb32e19" />
