### PR TITLE
Changes amphibian dehydration to be a disease

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -2036,15 +2036,7 @@ TYPEINFO(/datum/mutantrace/frog) /// abstract parent for traits shared across am
 		if (isdead(src.mob))
 			return
 		if(src.mob.sims.getValue("Thirst") < 25.0) // dehydration effect
-			if (prob(10))
-				src.mob.visible_message(SPAN_EMOTE(pick("[mob] wrinkles up conspicuously.", "[mob] quietly wheezes.", "[mob]'s third eyelids stick to [his_or_her(src.mob)] eyes for a moment.")))
-		if(src.mob.sims.getValue("Thirst") < 1.0)
-			if (prob(50))
-				src.mob.take_oxygen_deprivation(15)
-			if (prob(10))
-				src.mob.visible_message(SPAN_ALERT(pick("[mob] struggles to breathe!", "[mob] gasps for air!")))
-			if (prob(20))
-				src.mob.emote(pick("choke","gasp"))
+			src.mob.contract_disease(/datum/ailment/disease/dehydration, null, null, 1)
 
 	proc/dermal_absorbtion(var/absorbtion_rate) // it's actually spelled "absorption" but every other absorption proc is misspelled too
 		if(!src.mob)

--- a/code/modules/medical/diseases/dehydration.dm
+++ b/code/modules/medical/diseases/dehydration.dm
@@ -1,0 +1,47 @@
+/datum/ailment/disease/dehydration // applied to frogs on 25 thirst or below
+	name = "Dehydration"
+	scantype = "Medical Emergency"
+	max_stages = 2
+	stage_prob = 0 // stage progression is contingent on thirst values, not RNG
+	spread = "The patient is lethally dehydrated"
+	cure_flags = CURE_CUSTOM
+	cure_desc = "Water ingestion"
+	affected_species = list("Human")
+//
+/datum/ailment/disease/dehydration/stage_act(var/mob/living/carbon/human/affected_mob, var/datum/ailment_data/D, mult)
+	if (..())
+		return
+
+	if (!isfrog(affected_mob))
+		affected_mob.cure_disease(D) // frogs only, bucko (otherwise it could cause issues with the thirst sim on classic)
+		return
+
+	if (affected_mob.sims.getValue("Thirst") > 25.0)
+		affected_mob.cure_disease(D)
+		return
+
+	switch(D.stage)
+		if(1)
+			if(probmult(3))
+				affected_mob.visible_message(SPAN_EMOTE("[affected_mob] wrinkles up conspicuously."))
+			if(probmult(3))
+				affected_mob.visible_message(SPAN_EMOTE("[affected_mob] quietly wheezes."))
+			if(probmult(5))
+				affected_mob.visible_message(SPAN_EMOTE("[affected_mob]'s third eyelids stick to [his_or_her(affected_mob)] eyes for a moment.")) // if dehydration is ever used on nonfrogs, adding if (isfrog(affected_mob)) for this one is a good idea i think
+			if(probmult(1))
+				boutput(affected_mob, SPAN_ALERT("Your throat feels dry."))
+			if (affected_mob.sims.getValue("Thirst") < 1.0)
+				D.stage = 2
+		if(2)
+			if (probmult(50)) // probably not the value we want for this
+				affected_mob.take_oxygen_deprivation(15)
+			if(probmult(10))
+				affected_mob.emote("choke")
+			if(probmult(10))
+				affected_mob.emote("gasp")
+			if(probmult(5))
+				affected_mob.visible_message(SPAN_ALERT("[affected_mob] struggles to breathe!"))
+			if(probmult(5))
+				affected_mob.visible_message(SPAN_ALERT("[affected_mob] gasps for air!"))
+			if (affected_mob.sims.getValue("Thirst") > 1.0)
+				D.stage = 1

--- a/code/modules/medical/diseases/dehydration.dm
+++ b/code/modules/medical/diseases/dehydration.dm
@@ -3,7 +3,7 @@
 	scantype = "Medical Emergency"
 	max_stages = 2
 	stage_prob = 0 // stage progression is contingent on thirst values, not RNG
-	spread = "The patient is lethally dehydrated"
+	spread = null // dehydration is not contagious, contrary to popular belief
 	cure_flags = CURE_CUSTOM
 	cure_desc = "Water ingestion"
 	affected_species = list("Human")
@@ -12,8 +12,8 @@
 	if (..())
 		return
 
-	if (!isfrog(affected_mob))
-		affected_mob.cure_disease(D) // frogs only, bucko (otherwise it could cause issues with the thirst sim on classic)
+	if (!affected_mob.sims?.getValue("Thirst"))
+		affected_mob.cure_disease(D) // if you don't have thirst you can't get dehydrated
 		return
 
 	if (affected_mob.sims.getValue("Thirst") > 25.0)
@@ -22,26 +22,18 @@
 
 	switch(D.stage)
 		if(1)
-			if(probmult(3))
-				affected_mob.visible_message(SPAN_EMOTE("[affected_mob] wrinkles up conspicuously."))
-			if(probmult(3))
-				affected_mob.visible_message(SPAN_EMOTE("[affected_mob] quietly wheezes."))
-			if(probmult(5))
-				affected_mob.visible_message(SPAN_EMOTE("[affected_mob]'s third eyelids stick to [his_or_her(affected_mob)] eyes for a moment.")) // if dehydration is ever used on nonfrogs, adding if (isfrog(affected_mob)) for this one is a good idea i think
+			if(probmult(10))
+				affected_mob.visible_message(SPAN_EMOTE(pick("[affected_mob] wrinkles up conspicuously.", "[affected_mob] quietly wheezes.", "[affected_mob]'s third eyelids stick to [his_or_her(affected_mob)] eyes for a moment.")))
 			if(probmult(1))
 				boutput(affected_mob, SPAN_ALERT("Your throat feels dry."))
 			if (affected_mob.sims.getValue("Thirst") < 1.0)
 				D.stage = 2
 		if(2)
-			if (probmult(50)) // probably not the value we want for this
+			if (probmult(50))
 				affected_mob.take_oxygen_deprivation(15)
+			if(probmult(20))
+				affected_mob.emote(pick("choke","gasp"))
 			if(probmult(10))
-				affected_mob.emote("choke")
-			if(probmult(10))
-				affected_mob.emote("gasp")
-			if(probmult(5))
-				affected_mob.visible_message(SPAN_ALERT("[affected_mob] struggles to breathe!"))
-			if(probmult(5))
-				affected_mob.visible_message(SPAN_ALERT("[affected_mob] gasps for air!"))
+				affected_mob.visible_message(SPAN_ALERT(pick("[affected_mob] struggles to breathe!", "[affected_mob] gasps for air!")))
 			if (affected_mob.sims.getValue("Thirst") > 1.0)
 				D.stage = 1

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1721,6 +1721,7 @@
 #include "code\modules\medical\diseases\cluwneing_around.dm"
 #include "code\modules\medical\diseases\cold.dm"
 #include "code\modules\medical\diseases\corrupt_robotic_transformation.dm"
+#include "code\modules\medical\diseases\dehydration.dm"
 #include "code\modules\medical\diseases\dna_spread.dm"
 #include "code\modules\medical\diseases\exploding_head_syndrome.dm"
 #include "code\modules\medical\diseases\fake_gbs.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes the dehydration effects seen in the frog mutantrace to be a disease rather than stored on the mutantrace itself, fixing issues with symptoms occurring after death and allowing dehydration to be displayed on medical scanners. It is still contingent on the same thirst values as before, and still kills frogs at approximately the same speed (give or take RNG).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This makes dehydration suck way less for frogs and medical players, as they can tell on the medical scanner what's happening instead of having to rely on outside knowledge.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="647" height="481" alt="Screenshot 2026-08-17 171618" src="https://github.com/user-attachments/assets/397a63c2-72d6-4c17-aa36-5f381f1c2e2d" />
<img width="641" height="421" alt="Screenshot 2026-08-17 171712" src="https://github.com/user-attachments/assets/6e0c49b8-a443-4cf4-a270-9cb6c1c71e7e" />
<img width="573" height="473" alt="Screenshot 2026-08-17 171900" src="https://github.com/user-attachments/assets/f419a316-1f03-4f13-b899-48fcf141dc06" />
<img width="642" height="363" alt="Screenshot 2026-08-17 171928" src="https://github.com/user-attachments/assets/3e323be6-05f0-4c92-9242-b5556caf4984" />
<img width="659" height="887" alt="Screenshot 2026-08-17 172243" src="https://github.com/user-attachments/assets/4385aa6f-0fce-4280-825d-b9df4b5dca26" />


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->