### PR TITLE
Nerf Salvager power sinks

### DIFF
--- a/code/WorkInProgress/salvager/salvager_magpie.dm
+++ b/code/WorkInProgress/salvager/salvager_magpie.dm
@@ -1038,8 +1038,8 @@ ABSTRACT_TYPE(/datum/commodity/magpie/sell)
 		comname = "Power Sink and Storage"
 		comtype = /obj/item/device/powersink/salvager
 		desc = "A device that can be used to drain power and sell it back to the M4GP13."
-		price = 1000
-		amount = 4
+		price = 5000
+		amount = 3
 
 	crank
 		comname = "Crank (5x pills)"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases the cost of a salvager power sink from 1k > 5k
Reduces the available salvager power sinks from 4 > 3

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
For a device capable of crippling the entire station in a matter of minutes 1k is a steal and a meta has formed where salvagers just buy this roundstart and stick it down before the engine can be setup.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Todo tomorrow, but they're just simple number changes.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Salvager power sink cost increased from 1k > 5k. Purchase limit decreased from 4 > 3
```
