### PR TITLE
Fixed misisng stamp in hos's at cog2

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -19159,6 +19159,10 @@
 /obj/blind_switch/directional/west{
 	pixel_y = 5
 	},
+/obj/item/stamp/hos{
+	pixel_x = 6;
+	pixel_y = -6
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/hos)
 "bkI" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added a hos stamp to the office on cogmap2, missed at the previous standarization
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#27504 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="542" height="401" alt="cogmap2_hos_office_stampped" src="https://github.com/user-attachments/assets/7d4eda45-89ce-4df8-91ad-d8bd9e860302" />
