### PR TITLE
Nuclear objective counts outside of nuclear emergency

### DIFF
--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -673,13 +673,22 @@ ABSTRACT_TYPE(/datum/objective/madness)
 /datum/objective/specialist/nuclear
 	explanation_text = "Destroy the station with a nuclear device."
 	medal_name = "Manhattan Project"
+	var/detonation_successful = FALSE //Completion saved here so that roundending nukes still grant success outside the nuclear emergency mode
+
+	New(text, datum/mind/owner, datum/antagonist/antag_role)
+		. = ..()
+		START_TRACKING
+
+	disposing()
+		STOP_TRACKING
+		. = ..()
 
 	check_completion()
 		if (ticker?.mode && istype(ticker.mode, /datum/game_mode/nuclear))
 			var/datum/game_mode/nuclear/N = ticker.mode
 			if (N && istype(N) && (N.finished == -1 || N.finished == -2))
-				return 1
-		return 0
+				return TRUE
+		return src.detonation_successful
 
 /datum/objective/specialist/absorb
 	medal_name = "Many names, many faces"

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -673,7 +673,7 @@ ABSTRACT_TYPE(/datum/objective/madness)
 /datum/objective/specialist/nuclear
 	explanation_text = "Destroy the station with a nuclear device."
 	medal_name = "Manhattan Project"
-	var/detonation_successful = FALSE //Completion saved here so that roundending nukes still grant success outside the nuclear emergency mode
+	var/static/detonation_successful = FALSE //Set to TRUE by any nuke that plays the station destruction cinematic
 
 	New(text, datum/mind/owner, datum/antagonist/antag_role)
 		. = ..()
@@ -684,10 +684,6 @@ ABSTRACT_TYPE(/datum/objective/madness)
 		. = ..()
 
 	check_completion()
-		if (ticker?.mode && istype(ticker.mode, /datum/game_mode/nuclear))
-			var/datum/game_mode/nuclear/N = ticker.mode
-			if (N && istype(N) && (N.finished == -1 || N.finished == -2))
-				return TRUE
 		return src.detonation_successful
 
 /datum/objective/specialist/absorb

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -466,6 +466,9 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 
 		var/datum/hud/cinematic/all_clients/nuclear_bomb/cinematic = new
 		cinematic.play()
+		for_by_tcl(objective, /datum/objective/specialist/nuclear)
+			objective.detonation_successful = TRUE //Confirm objectives before ending the round
+			break
 		if(istype(gamemode))
 			gamemode.nuke_detonated = 1
 			gamemode.check_win()
@@ -483,8 +486,6 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 		creepify_station()
 
 		if(!istype(gamemode)) //The station exploded, the cinematic has played, end the round naturally instead of forcing a reboot
-			for_by_tcl(objective, /datum/objective/specialist/nuclear)
-				objective.detonation_successful = TRUE
 			ticker.mode.force_round_finished = TRUE
 
 	proc/change_status_display()

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -483,6 +483,8 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 		creepify_station()
 
 		if(!istype(gamemode)) //The station exploded, the cinematic has played, end the round naturally instead of forcing a reboot
+			for_by_tcl(objective, /datum/objective/specialist/nuclear)
+				objective.detonation_successful = TRUE
 			ticker.mode.force_round_finished = TRUE
 
 	proc/change_status_display()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the nuclear operative objective "Destroy the station with a nuclear device" to be completable outside of the Nuclear Emergency mode. Note that only Nukeops and Nukeop gunbots get this objective, NOT generic syndicate agents (unless the objective is manually granted)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Any nukeops events making use of extended or any other mode would fail to properly evaluate the completion of this objective and thus granting of the medal.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested micronukes changing the variable that marks the objective completed, it did not, then set off a proper nuke and the objective was marked as completed in the round summary.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)The Nuclear Operative "Destroy the station with a nuclear device" objective can now be completed outside of the Nuclear Emergency gamemode (if you have the objective and a station-destroying nuke in any other mode).
```
