### PR TITLE
Fix consume verb mutantrace check

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2007,7 +2007,7 @@ Tries to put an item in an available backpack, belt storage, pocket, or hand slo
 
 			usr.visible_message(SPAN_ALERT("[usr] finishes [pick("taking bites out of","chomping","chewing","biting","eating","gnawing")] [H]. That was [pick("gross","horrific","disturbing","weird","horrible","funny","strange","odd","creepy","bloody","gory","shameful","awkward","unusual")]!"))
 
-			if (prob(10) && !H.mutantrace)
+			if (prob(10) && !istype(H.mutantrace,/datum/mutantrace/ithillid))
 				usr.reagents.add_reagent("prions", 10)
 				SPAWN(rand(20,50)) boutput(usr, SPAN_ALERT("You don't feel so good."))
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes immunity check for getting prions from the consume verb


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
consume verb currently grants EVERYONE immunity due to a mistake when turning humans into a mutantrace

it really, really should have a downside for most people.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="474" height="372" alt="image" src="https://github.com/user-attachments/assets/2a769c43-7414-4d8d-8762-a38fe6950c8f" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
