### PR TITLE
Slapping people knocks cigarettes out of their mouths

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1456,14 +1456,11 @@
 									dork.drop_item(cig)
 									cig.set_loc(dork.loc)
 									cig.dropped(dork)
-									message = "<b>[src]</b> slaps [cig] out of [M]'s mouth!"
-									maptext_out = "<I>slaps [M] across the face!</I>"
-								else
-									message = "<b>[src]</b> slaps [M] across the face! Ouch!"
-									maptext_out = "<I>slaps [M] across the face!</I>"
-							else
-								message = "<b>[src]</b> slaps [M] across the face! Ouch!"
-								maptext_out = "<I>slaps [M] across the face!</I>"
+									cig.throw_at(get_edge_cheap(dork.loc, turn(get_dir(src, dork), src.hand == LEFT_HAND ? -90 : 90)), 3, 2)
+									SPAWN(0) //SPAWN so this only outputs after the initial emote text
+									dork.visible_message(SPAN_ALERT("[cig] is knocked out of [dork]'s mouth!"))
+							message = "<b>[src]</b> slaps [M] across the face! Ouch!"
+							maptext_out = "<I>slaps [M] across the face!</I>"
 						else
 							message = "<b>[src]</b> slaps [himself_or_herself(src)]!"
 							maptext_out = "<I>slaps [himself_or_herself(src)]!</I>"

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1449,11 +1449,18 @@
 									return
 
 						if (M)
-							if(ishuman(M) && istype(M.wear_mask?, /obj/item/clothing/mask/cigarette))
-								var/obj/item/clothing/mask/cigarette/cig = M.wear_mask
-								M.u_equip(cig)
-								message = "<b>[src]</b> slaps [cig] out of [M]'s mouth!"
-								maptext_out = "<I>slaps [M] across the face!</I>"
+							if(ishuman(M))
+								var/mob/living/carbon/human/dork = M
+								if(istype(dork.wear_mask, /obj/item/clothing/mask/cigarette))
+									var/obj/item/clothing/mask/cigarette/cig = dork.wear_mask
+									dork.drop_item(cig)
+									cig.set_loc(dork.loc)
+									cig.dropped(dork)
+									message = "<b>[src]</b> slaps [cig] out of [M]'s mouth!"
+									maptext_out = "<I>slaps [M] across the face!</I>"
+								else
+									message = "<b>[src]</b> slaps [M] across the face! Ouch!"
+									maptext_out = "<I>slaps [M] across the face!</I>"
 							else
 								message = "<b>[src]</b> slaps [M] across the face! Ouch!"
 								maptext_out = "<I>slaps [M] across the face!</I>"

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1452,13 +1452,10 @@
 							if(ishuman(M))
 								var/mob/living/carbon/human/dork = M
 								if(istype(dork.wear_mask, /obj/item/clothing/mask/cigarette))
-									var/obj/item/clothing/mask/cigarette/cig = dork.wear_mask
-									dork.drop_item(cig)
-									cig.set_loc(dork.loc)
-									cig.dropped(dork)
-									cig.throw_at(get_edge_cheap(dork.loc, turn(get_dir(src, dork), src.hand == LEFT_HAND ? -90 : 90)), 3, 2)
+									var/obj/item/clothing/cig = dork.wear_mask //saving this as a variable because [dork.wear_mask] in the visible_message doesn't return anything, even though it's called BEFORE the item is removed. weird stuff!
 									SPAWN(0) //SPAWN so this only outputs after the initial emote text
 									dork.visible_message(SPAN_ALERT("[cig] is knocked out of [dork]'s mouth!"))
+									cig.throw_worn_item(get_edge_cheap(dork.loc, turn(get_dir(src, dork), src.hand == LEFT_HAND ? -90 : 90)), 3, 2)
 							message = "<b>[src]</b> slaps [M] across the face! Ouch!"
 							maptext_out = "<I>slaps [M] across the face!</I>"
 						else

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1449,8 +1449,14 @@
 									return
 
 						if (M)
-							message = "<b>[src]</b> slaps [M] across the face! Ouch!"
-							maptext_out = "<I>slaps [M] across the face!</I>"
+							if(ishuman(M) && istype(M.wear_mask?, /obj/item/clothing/mask/cigarette))
+								var/obj/item/clothing/mask/cigarette/cig = M.wear_mask
+								M.u_equip(cig)
+								message = "<b>[src]</b> slaps [cig] out of [M]'s mouth!"
+								maptext_out = "<I>slaps [M] across the face!</I>"
+							else
+								message = "<b>[src]</b> slaps [M] across the face! Ouch!"
+								maptext_out = "<I>slaps [M] across the face!</I>"
 						else
 							message = "<b>[src]</b> slaps [himself_or_herself(src)]!"
 							maptext_out = "<I>slaps [himself_or_herself(src)]!</I>"

--- a/code/obj/item/clothing.dm
+++ b/code/obj/item/clothing.dm
@@ -114,6 +114,15 @@ ABSTRACT_TYPE(/obj/item/clothing)
 		user.u_equip(src)
 		qdel(src)
 
+	// throw_at() but it also automatically unequips the item. adding this for cigarette slapping, putting it here because it might be useful for other stuff in the future
+	proc/throw_worn_item(var/target, var/range, var/speed)
+		if(ismob(src.loc))
+			var/mob/owner = src.loc
+			owner.drop_item(src)
+			src.set_loc(owner.loc)
+			src.dropped(owner)
+		src.throw_at(target, range, speed)
+
 /obj/item/clothing/material_trigger_on_mob_attacked(var/mob/attacker, var/mob/attacked, var/atom/weapon, var/situation_modifier)
 	// if someone wearing this gets attacked, only trigger this if the corresponding zone is hit
 	if (src.material && (src.equipped_in_slot))

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -83,16 +83,12 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 			if(ishuman(target))
 				var/mob/living/carbon/human/dork = target
 				if(istype(dork.wear_mask, /obj/item/clothing/mask/cigarette))
-					var/obj/item/clothing/mask/cigarette/cig = dork.wear_mask
-					dork.drop_item(cig)
-					cig.set_loc(dork.loc)
-					cig.dropped(dork)
+					dork.visible_message(SPAN_ALERT("[dork.wear_mask] is knocked out of [dork]'s mouth!"))
 					if(ismob(challenger))
 						var/mob/slapper = challenger
-						cig.throw_at(get_edge_cheap(dork.loc, turn(get_dir(slapper, dork), slapper.hand == LEFT_HAND ? -90 : 90)), 3, 2)
+						dork.wear_mask.throw_worn_item(get_edge_cheap(dork.loc, turn(get_dir(slapper, dork), slapper.hand == LEFT_HAND ? -90 : 90)), 3, 2)
 					else
-						cig.throw_at(get_edge_cheap(dork.loc, turn(get_dir(challenger, dork), 90)), 3, 2) //just assume they're slapping with their right hand(or whatever appendage they have) since most people are right-handed
-					dork.visible_message(SPAN_ALERT("[cig] is knocked out of [dork]'s mouth!"))
+						dork.wear_mask.throw_worn_item(get_edge_cheap(dork.loc, turn(get_dir(challenger, dork), 90)), 3, 2) //just assume they're slapping with their right hand(or whatever appendage they have) since most people are right-handed
 		else
 			target.visible_message(
 				SPAN_ALERT("<b>[challenger]</b> slaps [target] in the face with [src]!")

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -77,9 +77,22 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 		if (ismob(target))
 			target.visible_message(
 				"<span><b>[challenger]</b> slaps [target] in the face with [src]!</span>",
-				SPAN_ALERT("<b>[challenger] slaps you in the face with [src]! [capitalize(he_or_she(challenger))] has offended your honour!")
+				SPAN_ALERT("<b>[challenger] slaps you in the face with [src]! [capitalize(he_or_she(challenger))] has offended your honor!")
 			)
 			logTheThing(LOG_COMBAT, challenger, "glove-slapped [constructTarget(target,"combat")]")
+			if(ishuman(target))
+				var/mob/living/carbon/human/dork = target
+				if(istype(dork.wear_mask, /obj/item/clothing/mask/cigarette))
+					var/obj/item/clothing/mask/cigarette/cig = dork.wear_mask
+					dork.drop_item(cig)
+					cig.set_loc(dork.loc)
+					cig.dropped(dork)
+					if(ismob(challenger))
+						var/mob/slapper = challenger
+						cig.throw_at(get_edge_cheap(dork.loc, turn(get_dir(slapper, dork), slapper.hand == LEFT_HAND ? -90 : 90)), 3, 2)
+					else
+						cig.throw_at(get_edge_cheap(dork.loc, turn(get_dir(challenger, dork), 90)), 3, 2) //just assume they're slapping with their right hand(or whatever appendage they have) since most people are right-handed
+					dork.visible_message(SPAN_ALERT("[cig] is knocked out of [dork]'s mouth!"))
 		else
 			target.visible_message(
 				SPAN_ALERT("<b>[challenger]</b> slaps [target] in the face with [src]!")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[ACTIONS] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Slapping someone (either with the emote or with the glove attack) knocks any cigarettes (or other such smokable items) out of their mouths. Cigarette trajectory is determined by the slapper's angle relative to the smoker, and which hand the slapper is using. Also corrects an instance of "honour" to "honor," since Goonstation uses American English.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It makes logical sense that you could slap a cigarette out of someone's mouth, and I can't really see why not. It would also be really funny to see someone slapping someone else's cigarette into a disposal unit.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
https://www.youtube.com/shorts/AXQZ0a_Tuvs
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)nova2053
(+)You can now slap cigarettes out of peoples' mouths. Cigarette trajectory is determined by your angle relative to the person you slap and which hand you're using.
```
