### PR TITLE
Fix zombie item usage

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -770,7 +770,7 @@ ADMIN_INTERACT_PROCS(/obj/item, proc/admin_set_stack_amount)
 	if (!src.anchored)
 		click_drag_tk(over_object, src_location, over_location, over_control, params)
 
-	if (usr.stat || usr.restrained() || !can_reach(usr, src) || usr.getStatusDuration("unconscious") || usr.sleeping || usr.lying || isAIeye(usr) || isAI(usr) || isrobot(usr) || isghostdrone(usr) || isghostcritter(usr) || (over_object && over_object.event_handler_flags & NO_MOUSEDROP_QOL) || isintangible(usr))
+	if (usr.stat || usr.restrained() || !can_reach(usr, src) || usr.getStatusDuration("unconscious") || usr.sleeping || usr.lying || isAIeye(usr) || isAI(usr) || isrobot(usr) || iszombie(usr) || isghostdrone(usr) || isghostcritter(usr) || (over_object && over_object.event_handler_flags & NO_MOUSEDROP_QOL) || isintangible(usr))
 		return
 
 	var/on_turf = isturf(src.loc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
makes it so zombies cannot move items from their bag and belt to their hand by clickdragging them to their clothes/other hud elements
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
zombies should not be shooting people and using tools
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="165" height="182" alt="image" src="https://github.com/user-attachments/assets/18e10c7e-1f7c-4046-9610-a48ebb2bb0a6" />

(nothing is in my hands because order is restored... zombies are nolonger entering the stone age)
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->