### PR TITLE
Fixes frog (not Abzunian) stable mutagen immunity

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -2245,6 +2245,7 @@ TYPEINFO(/datum/mutantrace/frog/amphibian) // trait mutantrace
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/amphibian/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/amphibian/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_HUMAN_EYES | HAS_NO_SKINTONE | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS | WEARS_UNDERPANTS | LIGHT_EYES)
+	dna_mutagen_banned = FALSE
 	blood_color = "#50b558"
 
 	ghost_icon_state = "ghost-amphibian"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds the "dna_mutagen_banned = FALSE" flag to trait amphibians (notably not Abzunians, shelterfrogs, or the abstract parent) to fix an issue where the changeling DNA sting and stable mutagen do not work properly with frog players.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There is no reason for trait mutantraces to be immune to stable mutagen.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="237" height="154" alt="Screenshot 2026-08-20 144329" src="https://github.com/user-attachments/assets/93269cca-6ebb-4ffb-bcc7-2842f762b08d" />

Works with the trait mutantraces.


<img width="247" height="158" alt="Screenshot 2026-08-20 144600" src="https://github.com/user-attachments/assets/b8faab0f-3c8a-497b-98af-d5a8d752e9e5" />

Nonhuman amphibians continue to not work with stable mutagen, as intended.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->