### PR TITLE
Silver bullets can be reclaimed in the portable reclaimer

### DIFF
--- a/code/WorkInProgress/MarqStuff.dm
+++ b/code/WorkInProgress/MarqStuff.dm
@@ -788,7 +788,7 @@
 		current_projectile.name = loaded.name
 		loaded.set_loc(A)
 		current_projectile.implanted = A
-		current_projectile.material = loaded.head_material
+		current_projectile.coating = loaded.head_material
 		var/default_damage = 7
 		if(loaded.head_material)
 			if(loaded.head_material.hasProperty("hard"))

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -43,9 +43,9 @@
 								implanted.forensic_ID = P.forensic_ID
 							src.implant += implanted
 							implanted.forensic_holder = P.forensic_holder // Give projectile forensics to the implanted bullet
-							if (P.proj_data.material)
+							if (P.proj_data.coating)
 								implanted.material_amt = P.material_amount_total()
-								implanted.setMaterial(P.proj_data.material)
+								implanted.setMaterial(P.proj_data.coating)
 							implanted.implanted(src, null, 60)
 							//extra damage from silver for werewolves
 							if (istype(implanted, /datum/material/metal/silver) && iswerewolf(src))
@@ -77,9 +77,9 @@
 						if (P.forensic_ID)
 							implanted.forensic_ID = P.forensic_ID
 						implanted.forensic_holder = P.forensic_holder
-						if (P.proj_data.material)
+						if (P.proj_data.coating)
 							implanted.material_amt = P.material_amount_total()
-							implanted.setMaterial(P.proj_data.material)
+							implanted.setMaterial(P.proj_data.coating)
 						implanted.implanted(src, null, 100)
 					//extra damage from silver for werewolves
 						if (istype(implanted, /datum/material/metal/silver) && iswerewolf(src))
@@ -133,7 +133,7 @@
 								implanted.forensic_ID = P.forensic_ID
 							implanted.forensic_holder = P.forensic_holder
 							implanted.material_amt = P.material_amount_total()
-							implanted.setMaterial(P.proj_data.material)
+							implanted.setMaterial(P.proj_data.coating)
 							implanted.implanted(src, null, 0)
 	return 1
 

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -44,6 +44,7 @@
 							src.implant += implanted
 							implanted.forensic_holder = P.forensic_holder // Give projectile forensics to the implanted bullet
 							if (P.proj_data.material)
+								implanted.material_amt = P.material_amount_total()
 								implanted.setMaterial(P.proj_data.material)
 							implanted.implanted(src, null, 60)
 							//extra damage from silver for werewolves
@@ -77,6 +78,7 @@
 							implanted.forensic_ID = P.forensic_ID
 						implanted.forensic_holder = P.forensic_holder
 						if (P.proj_data.material)
+							implanted.material_amt = P.material_amount_total()
 							implanted.setMaterial(P.proj_data.material)
 						implanted.implanted(src, null, 100)
 					//extra damage from silver for werewolves
@@ -130,6 +132,7 @@
 							if (P.forensic_ID)
 								implanted.forensic_ID = P.forensic_ID
 							implanted.forensic_holder = P.forensic_holder
+							implanted.material_amt = P.material_amount_total()
 							implanted.setMaterial(P.proj_data.material)
 							implanted.implanted(src, null, 0)
 	return 1

--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -470,20 +470,6 @@ proc/ui_describe_reagents(atom/A, show_overdose = FALSE)
 					boutput(user, SPAN_NOTICE("[I] is already fully coated, more won't do any good."))
 				return
 
-		//Hacky thing to make silver bullets (maybe todo later : all items can be dipped in any solution?)
-		else if (istype(I, /obj/item/ammo/bullets/bullet_22HP) ||istype(I, /obj/item/ammo/bullets/bullet_22) || istype(I, /obj/item/ammo/bullets/a38) || istype(I, /obj/item/ammo/bullets/custom) || (I.type == /obj/item/handcuffs) || istype(I,/datum/projectile/bullet/revolver_38))
-			if ("silver" in src.reagents.reaction(I, react_volume = src.reagents.total_volume))
-				user.visible_message(SPAN_ALERT("<b>[user]</b> dips [I] into [src] coating it in silver. Watch out, evil creatures!"))
-				I.tooltip_rebuild = TRUE
-			else
-				if(istype(I, /obj/item/ammo/bullets))
-					var/obj/item/ammo/A = I
-					I = A.ammo_type
-				if (I.material && I.material.getID() == "silver")
-					boutput(user, SPAN_NOTICE("[I] is already coated, more silver won't do any good."))
-				else
-					boutput(user, SPAN_NOTICE("[src] doesn't have enough silver in it to coat [I]."))
-
 		else if (istype(I, /obj/item/reagent_containers/iv_drip))
 			var/obj/item/reagent_containers/iv_drip/W = I
 			if (W.slashed == 1)

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -513,17 +513,7 @@
 	reaction_obj(var/obj/item/I, var/volume)
 		if (I.material && I.material.getID() == "silver")
 			return 1
-
 		.= 1
-
-		if (volume >= 20)
-			if (istype(I, /obj/item/ammo/bullets/bullet_22HP) || istype(I, /obj/item/ammo/bullets/bullet_22) || istype(I, /obj/item/ammo/bullets/a38) || istype(I, /obj/item/ammo/bullets/custom) || istype(I,/datum/projectile/bullet/revolver_38))
-				var/obj/item/ammo/bullets/bullet_holder = I
-				var/datum/projectile/ammo_type = bullet_holder.ammo_type
-				if (ammo_type && !(ammo_type.material && ammo_type.material.getID() == "silver"))
-					ammo_type.material = getMaterial("silver")
-					holder.remove_reagent(src.id, 20)
-					.= 0
 		if (volume >= 50)
 			if (I.type == /obj/item/handcuffs)
 				I.setMaterial(getMaterial("silver"))

--- a/code/modules/materials/Mat_FabParts.dm
+++ b/code/modules/materials/Mat_FabParts.dm
@@ -197,7 +197,7 @@
 		if(!istype(I, /obj/item/ammo/bullets)) return 0
 		var/obj/item/ammo/bullets/ammo = I
 		if(ammo.amount_left == 0) return 0
-		if(ammo.ammo_type.material) return 0
+		if(ammo.ammo_type.coating) return 0
 		return ..()
 
 /datum/matfab_part/chemical

--- a/code/modules/materials/Mat_FabParts.dm
+++ b/code/modules/materials/Mat_FabParts.dm
@@ -51,6 +51,14 @@
 		if(I.material.getProperty("electrical") < 5) return 0
 		return ..()
 
+/datum/matfab_part/silver
+	name = "Silver"
+	checkMatch(var/obj/item/I)
+		if(!I.material) return 0
+		if(!istype(I, /obj/item/material_piece) && !istype(I, /obj/item/raw_material)) return 0
+		if(I.material.getID() != "silver") return 0
+		return ..()
+
 /datum/matfab_part/charge
 	name = "Explosive Charge"
 	checkMatch(var/obj/item/I)
@@ -183,6 +191,14 @@
 		if(!istype(I, /obj/item/lens) ||  !I.material) return 0
 		return ..()
 
+/datum/matfab_part/ammo_container
+	name = "Ammunition Container"
+	checkMatch(var/obj/item/I)
+		if(!istype(I, /obj/item/ammo/bullets)) return 0
+		var/obj/item/ammo/bullets/ammo = I
+		if(ammo.amount_left == 0) return 0
+		if(ammo.ammo_type.material) return 0
+		return ..()
 
 /datum/matfab_part/chemical
 	name = "Chemical"
@@ -217,6 +233,9 @@
 	var/obj/item/assigned = null
 	/// If TRUE, slot does not have to be filled.
 	var/optional = FALSE
+	/// If FALSE, the assigned item is not destroyed in the building process.
+	/// However, this does not necessarily mean that the assigned item can be used multiple times in the same build cycle.
+	var/consume = TRUE
 
 	/// Does the object match our conditions?
 	proc/checkMatch(var/obj/item/I)

--- a/code/modules/materials/Mat_FabParts.dm
+++ b/code/modules/materials/Mat_FabParts.dm
@@ -233,9 +233,8 @@
 	var/obj/item/assigned = null
 	/// If TRUE, slot does not have to be filled.
 	var/optional = FALSE
-	/// If FALSE, the assigned item is not destroyed in the building process.
-	/// However, this does not necessarily mean that the assigned item can be used multiple times in the same build cycle.
-	var/consume = TRUE
+	/// If FALSE, the assigned item is not destroyed automatically in the building process
+	var/auto_consume = TRUE
 
 	/// Does the object match our conditions?
 	proc/checkMatch(var/obj/item/I)

--- a/code/modules/materials/Mat_FabRecipes.dm
+++ b/code/modules/materials/Mat_FabRecipes.dm
@@ -304,6 +304,25 @@
 			newObj.set_loc(getOutputLocation(owner))
 		return
 
+/datum/matfab_recipe/bullets_coated
+	name = "Bullet Coating"
+	desc = "Coat bullets in silver."
+	category = "Weapon"
+
+	New()
+		..()
+		required_parts.Add(new/datum/matfab_part/ammo_container {part_name = "Ammo"; required_amount = 1; consume = FALSE} ())
+		required_parts.Add(new/datum/matfab_part/silver {part_name = "Silver"; required_amount = 1} ())
+
+	build(amount, var/obj/machinery/nanofab/owner)
+		for(var/i=0, i<amount, i++)
+			var/obj/item/ammo/bullets/ammo = getObjectByPartName("Ammo")
+			var/atom/source = getObjectByPartName("Silver")
+			ammo.ammo_type.material = source.material
+			ammo.ammo_type.material_amt = 1 / ammo.max_amount
+			ammo.set_loc(getOutputLocation(owner))
+		return
+
 /datum/matfab_recipe/arrow
 	name = "Arrow"
 	desc = "A simple arrow used as ammunition for bows."

--- a/code/modules/materials/Mat_FabRecipes.dm
+++ b/code/modules/materials/Mat_FabRecipes.dm
@@ -318,13 +318,13 @@
 	getMaxAmount()
 		var/obj/item/ammo/bullets/ammo = getObjectByPartName("Ammo")
 		var/obj/item/source = getObjectByPartName("Coating")
-		return min(floor(source.material_amount_total() / ammo.ammo_type.material_amt), ammo.amount_left)
+		return min(floor(source.material_amount_total() / ammo.ammo_type.coating_amount), ammo.amount_left)
 
 	canBuild(var/amount = 1, var/atom/owner)
 		var/obj/item/ammo/bullets/ammo = getObjectByPartName("Ammo")
 		var/obj/item/source = getObjectByPartName("Coating")
 		var/enough_ammo = ammo.amount_left >= amount
-		var/enough_mats = source.material_amount_total() >= (ammo.ammo_type.material_amt * amount)
+		var/enough_mats = source.material_amount_total() >= (ammo.ammo_type.coating_amount * amount)
 		return enough_ammo && enough_mats
 
 	build(amount, var/obj/machinery/nanofab/owner)
@@ -334,10 +334,10 @@
 		var/obj/item/ammo/bullets/ammo_excess = ammo.split(ammo.amount_left - amount)
 		if(ammo_excess)
 			ammo_excess.set_loc(getOutputLocation(owner))
-		ammo.ammo_type.material = source.material
+		ammo.ammo_type.coating = source.material
 		ammo.set_loc(getOutputLocation(owner))
 
-		var/mat_cost = ammo.ammo_type.material_amt * amount
+		var/mat_cost = ammo.ammo_type.coating_amount * amount
 		var/source_cost_amount = mat_cost / source.material_amt
 		var/source_count_ceil = ceil(source_cost_amount)
 		var/excess_sheet_count = floor((source_count_ceil - source_cost_amount) / 0.1)

--- a/code/modules/materials/Mat_FabRecipes.dm
+++ b/code/modules/materials/Mat_FabRecipes.dm
@@ -334,11 +334,13 @@
 		var/obj/item/ammo/bullets/ammo_excess = ammo.split(ammo.amount_left - amount)
 		if(ammo_excess)
 			ammo_excess.set_loc(getOutputLocation(owner))
+		var/datum/projectile/new_ammo_type = new ammo.ammo_type.type // Ammo type might be shared somewhere else
+		ammo.ammo_type = new_ammo_type
 		ammo.ammo_type.coating = source.material
 		ammo.set_loc(getOutputLocation(owner))
 
 		var/mat_cost = ammo.ammo_type.coating_amount * amount
-		var/source_cost_amount = mat_cost / source.material_amt
+		var/source_cost_amount = round(mat_cost / source.material_amt, 0.01)
 		var/source_count_ceil = ceil(source_cost_amount)
 		var/excess_sheet_count = floor((source_count_ceil - source_cost_amount) / 0.1)
 		if(excess_sheet_count)

--- a/code/modules/materials/Mat_FabRecipes.dm
+++ b/code/modules/materials/Mat_FabRecipes.dm
@@ -311,9 +311,9 @@
 
 	New()
 		..()
-		required_parts.Add(new/datum/matfab_part/ammo_container {part_name = "Ammo"; required_amount = 1; consume = FALSE} ())
-		// Matsci balance isn't quite ready for radioactive bullets yet
-		required_parts.Add(new/datum/matfab_part/silver {part_name = "Coating"; required_amount = 1} ())
+		required_parts.Add(new/datum/matfab_part/ammo_container {part_name = "Ammo"; required_amount = 1; auto_consume = FALSE} ())
+		// Currently only limited to silver for balance reasons
+		required_parts.Add(new/datum/matfab_part/silver {part_name = "Coating"; required_amount = 1; auto_consume = FALSE} ())
 
 	getMaxAmount()
 		var/obj/item/ammo/bullets/ammo = getObjectByPartName("Ammo")
@@ -341,7 +341,7 @@
 		ammo.set_loc(getOutputLocation(owner))
 
 		var/mat_cost = ammo.ammo_type.coating_amount * amount
-		var/source_cost_amount = round(mat_cost / source.material_amt, 0.01)
+		var/source_cost_amount = round(mat_cost / source.material_amt, 0.01) // if math is so amazing, then why do floats exist?
 		var/source_count_ceil = ceil(source_cost_amount)
 		var/excess_sheet_count = floor((source_count_ceil - source_cost_amount) / 0.1)
 		if(excess_sheet_count)

--- a/code/modules/materials/Mat_FabRecipes.dm
+++ b/code/modules/materials/Mat_FabRecipes.dm
@@ -337,6 +337,7 @@
 		var/datum/projectile/new_ammo_type = new ammo.ammo_type.type // Ammo type might be shared somewhere else
 		ammo.ammo_type = new_ammo_type
 		ammo.ammo_type.coating = source.material
+		ammo.tooltip_rebuild = TRUE
 		ammo.set_loc(getOutputLocation(owner))
 
 		var/mat_cost = ammo.ammo_type.coating_amount * amount

--- a/code/modules/materials/Mat_FabRecipes.dm
+++ b/code/modules/materials/Mat_FabRecipes.dm
@@ -307,20 +307,47 @@
 /datum/matfab_recipe/bullets_coated
 	name = "Bullet Coating"
 	desc = "Coat bullets in silver."
-	category = "Weapon"
+	category = "Weapons"
 
 	New()
 		..()
 		required_parts.Add(new/datum/matfab_part/ammo_container {part_name = "Ammo"; required_amount = 1; consume = FALSE} ())
-		required_parts.Add(new/datum/matfab_part/silver {part_name = "Silver"; required_amount = 1} ())
+		// Matsci balance isn't quite ready for radioactive bullets yet
+		required_parts.Add(new/datum/matfab_part/silver {part_name = "Coating"; required_amount = 1} ())
+
+	getMaxAmount()
+		var/obj/item/ammo/bullets/ammo = getObjectByPartName("Ammo")
+		var/obj/item/source = getObjectByPartName("Coating")
+		return min(floor(source.material_amount_total() / ammo.ammo_type.material_amt), ammo.amount_left)
+
+	canBuild(var/amount = 1, var/atom/owner)
+		var/obj/item/ammo/bullets/ammo = getObjectByPartName("Ammo")
+		var/obj/item/source = getObjectByPartName("Coating")
+		var/enough_ammo = ammo.amount_left >= amount
+		var/enough_mats = source.material_amount_total() >= (ammo.ammo_type.material_amt * amount)
+		return enough_ammo && enough_mats
 
 	build(amount, var/obj/machinery/nanofab/owner)
-		for(var/i=0, i<amount, i++)
-			var/obj/item/ammo/bullets/ammo = getObjectByPartName("Ammo")
-			var/atom/source = getObjectByPartName("Silver")
-			ammo.ammo_type.material = source.material
-			ammo.ammo_type.material_amt = 1 / ammo.max_amount
-			ammo.set_loc(getOutputLocation(owner))
+		var/obj/item/ammo/bullets/ammo = getObjectByPartName("Ammo")
+		var/obj/item/source = getObjectByPartName("Coating")
+
+		var/obj/item/ammo/bullets/ammo_excess = ammo.split(ammo.amount_left - amount)
+		if(ammo_excess)
+			ammo_excess.set_loc(getOutputLocation(owner))
+		ammo.ammo_type.material = source.material
+		ammo.set_loc(getOutputLocation(owner))
+
+		var/mat_cost = ammo.ammo_type.material_amt * amount
+		var/source_cost_amount = mat_cost / source.material_amt
+		var/source_count_ceil = ceil(source_cost_amount)
+		var/excess_sheet_count = floor((source_count_ceil - source_cost_amount) / 0.1)
+		if(excess_sheet_count)
+			// Output excess material as sheets
+			var/obj/item/sheet/excess_sheets = new()
+			excess_sheets.setMaterial(source.material)
+			excess_sheets.set_stack_amount(excess_sheet_count)
+			excess_sheets.set_loc(getOutputLocation(owner))
+		source.change_stack_amount(-source_count_ceil)
 		return
 
 /datum/matfab_recipe/arrow

--- a/code/modules/materials/Mat_Fabrication.dm
+++ b/code/modules/materials/Mat_Fabrication.dm
@@ -4,6 +4,7 @@
 #ifdef MAP_OVERRIDE_NADIR
 	/datum/matfab_recipe/catarod,
 #endif
+	/datum/matfab_recipe/bullets_coated,
 	/datum/matfab_recipe/spear,
 	/datum/matfab_recipe/arrow,
 	/datum/matfab_recipe/bow,
@@ -331,6 +332,7 @@
 						for(var/datum/matfab_part/P in selectedRecipe.required_parts)
 							if(P.assigned)
 								parts += "[P.part_name]: [P.assigned]"
+							if(P.assigned && P.consume)
 								P.assigned.change_stack_amount(-(P.required_amount*howMany))
 								if(QDELETED(P.assigned))
 									P.assigned = null

--- a/code/modules/materials/Mat_Fabrication.dm
+++ b/code/modules/materials/Mat_Fabrication.dm
@@ -332,7 +332,7 @@
 						for(var/datum/matfab_part/P in selectedRecipe.required_parts)
 							if(P.assigned)
 								parts += "[P.part_name]: [P.assigned]"
-							if(P.assigned && P.consume)
+							if(P.assigned && P.auto_consume)
 								P.assigned.change_stack_amount(-(P.required_amount*howMany))
 								if(QDELETED(P.assigned))
 									P.assigned = null

--- a/code/modules/projectiles/_projectile_datum.dm
+++ b/code/modules/projectiles/_projectile_datum.dm
@@ -122,6 +122,9 @@ ABSTRACT_TYPE(/datum/projectile)
 			if("power", "ks_ratio")
 				generate_inverse_stats()
 
+	proc/is_same_ammo(datum/projectile/other)
+		return (src.type == other.type) && (src.material == other.material)
+
 	proc
 		generate_stats()
 			src.power = damage + stun

--- a/code/modules/projectiles/_projectile_datum.dm
+++ b/code/modules/projectiles/_projectile_datum.dm
@@ -53,8 +53,8 @@ ABSTRACT_TYPE(/datum/projectile)
 	var/zone = null              // todo: if fired from a handheld gun, check the targeted zone --- this should be in the goddamn obj
 	var/affected_by_gravity = FALSE	 // If a projectile should go shorter or further based on turf G-forces
 
-	var/datum/material/material = null
-	var/material_amt = 0.1 // How much material is in each bullet
+	var/datum/material/coating = null
+	var/coating_amount = 0.1 // How much material is in each bullet
 
 	var/casing = null
 	var/reagent_payload = null
@@ -123,7 +123,7 @@ ABSTRACT_TYPE(/datum/projectile)
 				generate_inverse_stats()
 
 	proc/is_same_ammo(datum/projectile/other)
-		return (src.type == other.type) && (src.material == other.material)
+		return (src.type == other.type) && (src.coating == other.coating)
 
 	proc
 		generate_stats()

--- a/code/modules/projectiles/_projectile_datum.dm
+++ b/code/modules/projectiles/_projectile_datum.dm
@@ -122,6 +122,7 @@ ABSTRACT_TYPE(/datum/projectile)
 			if("power", "ks_ratio")
 				generate_inverse_stats()
 
+	/// Returns true of the two ammo types are effectively the same.
 	proc/is_same_ammo(datum/projectile/other)
 		return (src.type == other.type) && (src.coating == other.coating)
 

--- a/code/modules/projectiles/_projectile_datum.dm
+++ b/code/modules/projectiles/_projectile_datum.dm
@@ -54,6 +54,7 @@ ABSTRACT_TYPE(/datum/projectile)
 	var/affected_by_gravity = FALSE	 // If a projectile should go shorter or further based on turf G-forces
 
 	var/datum/material/material = null
+	var/material_amt = 1 // How much material is in each bullet
 
 	var/casing = null
 	var/reagent_payload = null

--- a/code/modules/projectiles/_projectile_datum.dm
+++ b/code/modules/projectiles/_projectile_datum.dm
@@ -54,7 +54,7 @@ ABSTRACT_TYPE(/datum/projectile)
 	var/affected_by_gravity = FALSE	 // If a projectile should go shorter or further based on turf G-forces
 
 	var/datum/material/material = null
-	var/material_amt = 1 // How much material is in each bullet
+	var/material_amt = 0.1 // How much material is in each bullet
 
 	var/casing = null
 	var/reagent_payload = null

--- a/code/modules/projectiles/_projectile_object.dm
+++ b/code/modules/projectiles/_projectile_object.dm
@@ -314,9 +314,8 @@
 			src.icon = 'icons/obj/projectiles.dmi'
 			src.icon_state = null
 			src.invisibility = INVIS_NONE
-			if (!proj_data) return //ZeWaka: Fix for null.override_color
-			if (!proj_data.override_color && !proj_data.material)
-				src.color = "#ffffff"
+			src.color = "#ffffff"
+
 	proc/get_len()
 		return sqrt(src.xo**2 + src.yo**2)
 	// Awful var names. TODO rename pretty much everything here, or at least document the functions

--- a/code/modules/projectiles/_projectile_object.dm
+++ b/code/modules/projectiles/_projectile_object.dm
@@ -308,14 +308,14 @@
 			src.icon = proj_data.icon
 			src.icon_state = proj_data.icon_state
 			src.invisibility = proj_data.invisibility
-			if (!proj_data.override_color)
+			if (!proj_data.override_color && !proj_data.material)
 				src.color = proj_data.color_icon
 		else
 			src.icon = 'icons/obj/projectiles.dmi'
 			src.icon_state = null
 			src.invisibility = INVIS_NONE
 			if (!proj_data) return //ZeWaka: Fix for null.override_color
-			if (!proj_data.override_color)
+			if (!proj_data.override_color && !proj_data.material)
 				src.color = "#ffffff"
 	proc/get_len()
 		return sqrt(src.xo**2 + src.yo**2)

--- a/code/modules/projectiles/_projectile_object.dm
+++ b/code/modules/projectiles/_projectile_object.dm
@@ -238,7 +238,7 @@
 			proj_data.on_hit(A, angle_to_dir(src.angle), src)
 
 		//Trigger material on attack.
-		proj_data?.material?.triggerOnAttack(src, src.shooter, A)
+		proj_data?.coating?.triggerOnAttack(src, src.shooter, A)
 
 		if (istype(A,/turf))
 			// if we hit a turf apparently the bullet is magical and hits every single object in the tile, nice shooting tex
@@ -308,7 +308,7 @@
 			src.icon = proj_data.icon
 			src.icon_state = proj_data.icon_state
 			src.invisibility = proj_data.invisibility
-			if (!proj_data.override_color && !proj_data.material)
+			if (!proj_data.override_color && !proj_data.coating)
 				src.color = proj_data.color_icon
 		else
 			src.icon = 'icons/obj/projectiles.dmi'

--- a/code/modules/projectiles/_projectile_utils.dm
+++ b/code/modules/projectiles/_projectile_utils.dm
@@ -1,3 +1,6 @@
+#define GUN_KINETIC_MATERIAL_RATIO_CASING 0.2
+#define GUN_KINETIC_MATERIAL_RATIO_BULLET 0.8
+
 //Global procs for firing, reflecting projectiles
 
 // THIS IS INTENDED FOR POINTBLANKING.
@@ -112,8 +115,14 @@
 	P.power = DATA.power
 
 	P.proj_data = DATA
+	if(DATA.material)
+		// alter_projectile may trigger material procs. Add material first
+		P.material_amt = DATA.material_amt * GUN_KINETIC_MATERIAL_RATIO_BULLET // 20% of the material goes to the casing instead
+		P.setMaterial(DATA.material)
 	alter_proj?.Invoke(P)
 
+	if(QDELETED(P))
+		return // projectile got deleted by alter_projectile
 	if(P.proj_data == DATA)
 		P.initial_power = P.power //allows us to set projectile power in callback without needing a new projectile datum
 	else
@@ -122,7 +131,6 @@
 
 	P.set_icon()
 	P.name = DATA.name
-	P.setMaterial(DATA.material)
 
 
 	if (DATA.implanted)

--- a/code/modules/projectiles/_projectile_utils.dm
+++ b/code/modules/projectiles/_projectile_utils.dm
@@ -1,5 +1,5 @@
 #define GUN_KINETIC_MATERIAL_RATIO_CASING 0.2
-#define GUN_KINETIC_MATERIAL_RATIO_BULLET 0.8
+#define GUN_KINETIC_MATERIAL_RATIO_BULLET 0.8 // 20% less bullet per bullet
 
 //Global procs for firing, reflecting projectiles
 
@@ -117,7 +117,9 @@
 	P.proj_data = DATA
 	if(DATA.coating)
 		// alter_projectile may trigger material procs. Add material first
-		P.material_amt = DATA.coating_amount * GUN_KINETIC_MATERIAL_RATIO_BULLET // 20% of the material goes to the casing instead
+		P.material_amt = DATA.coating_amount
+		if(DATA.casing)
+			P.material_amt *= GUN_KINETIC_MATERIAL_RATIO_BULLET // Some of the material goes to the casing instead
 		P.setMaterial(DATA.coating)
 	alter_proj?.Invoke(P)
 

--- a/code/modules/projectiles/_projectile_utils.dm
+++ b/code/modules/projectiles/_projectile_utils.dm
@@ -115,10 +115,10 @@
 	P.power = DATA.power
 
 	P.proj_data = DATA
-	if(DATA.material)
+	if(DATA.coating)
 		// alter_projectile may trigger material procs. Add material first
-		P.material_amt = DATA.material_amt * GUN_KINETIC_MATERIAL_RATIO_BULLET // 20% of the material goes to the casing instead
-		P.setMaterial(DATA.material)
+		P.material_amt = DATA.coating_amount * GUN_KINETIC_MATERIAL_RATIO_BULLET // 20% of the material goes to the casing instead
+		P.setMaterial(DATA.coating)
 	alter_proj?.Invoke(P)
 
 	if(QDELETED(P))

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -17,12 +17,15 @@ ABSTRACT_TYPE(/datum/projectile/bullet)
 
 	// caliber list: update as needed
 	// 0.22 pistol / zipgun
+	// 0.223 - assault rifle
 	// 0.308 - rifles
+	// 0.355 - pistol (9mm)
 	// 0.357 - revolver
 	// 0.38 - detective
 	// 0.40 - blowgun darts
 	// 0.41 - derringer
 	// 0.72 - shotgun shell, 12ga
+	// 1.05  - 4 gauge
 	// 1.57 - grenade shell, 40mm
 	// 1.58 - RPG-7 (Tube is 40mm too, though warheads are usually larger in diameter.)
 	ie_type = "K"

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1858,15 +1858,15 @@ datum/projectile/bullet/autocannon
 					src.CHEM = W
 					src.damage = CHEM.launcher_damage
 					src.has_grenade = 1
-					src.material = CHEM.material
-					src.material_amt = CHEM.material_amt
+					src.coating = CHEM.material
+					src.coating_amount = CHEM.material_amt
 					return 1
 				else if (istype(W, /obj/item/old_grenade))
 					src.OLD = W
 					src.damage = OLD.launcher_damage
 					src.has_grenade = 1
-					src.material = OLD.material
-					src.material_amt = OLD.material_amt
+					src.coating = OLD.material
+					src.coating_amount = OLD.material_amt
 					return 1
 				else
 					return 0
@@ -1882,16 +1882,16 @@ datum/projectile/bullet/autocannon
 					src.CHEM.set_loc(T)
 				src.CHEM = null
 				src.has_grenade = 0
-				src.material = null
-				src.material_amt = initial(src.material_amt)
+				src.coating = null
+				src.coating_amount = initial(src.coating_amount)
 				return 1
 			else if (src.OLD != null)
 				if (T)
 					src.OLD.set_loc(T)
 				src.OLD = null
 				src.has_grenade = 0
-				src.material = null
-				src.material_amt = initial(src.material_amt)
+				src.coating = null
+				src.coating_amount = initial(src.coating_amount)
 				return 1
 			else //how did this happen?
 				return 0

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -649,6 +649,7 @@ toxic - poisons
 	shot_sound = 'sound/effects/syringeproj.ogg'
 	no_hit_message = 1
 	casing = null
+	coating_amount = 0.2
 	reagent_payload = "curare"
 	implanted = /obj/item/implant/projectile/body_visible/blowdart
 	has_impact_particles = FALSE
@@ -1272,6 +1273,7 @@ toxic - poisons
 	hit_type = DAMAGE_BLUNT
 	impact_image_state = "bullethole"
 	casing = /obj/item/casing/shotgun/orange
+	coating_amount = 0.2
 
 	on_hit(atom/hit)
 		new /obj/effects/explosion/fiery(get_turf(hit))
@@ -1395,6 +1397,7 @@ toxic - poisons
 
 	impact_image_state = "bullethole-large"
 	casing = /obj/item/casing/cannon
+	coating_amount = 0.5
 	pierces = 4
 	shot_sound_extrarange = 1
 
@@ -1672,6 +1675,7 @@ datum/projectile/bullet/autocannon
 	shot_sound = 'sound/weapons/launcher.ogg'
 	impact_image_state = "bullethole-large"
 	casing = /obj/item/casing/grenade
+	coating_amount = 0.2
 
 	explosive
 		name = "40mm HEDP round"
@@ -1704,6 +1708,7 @@ datum/projectile/bullet/autocannon
 	shot_sound = 'sound/weapons/launcher.ogg'
 	impact_image_state = "bullethole-large"
 	casing = /obj/item/casing/grenade
+	coating_amount = 0.2
 	implanted = null
 
 	var/list/smokeLocs = list()
@@ -1748,6 +1753,7 @@ datum/projectile/bullet/autocannon
 	shot_sound = 'sound/weapons/launcher.ogg'
 	impact_image_state = "bullethole-large"
 	casing = /obj/item/casing/grenade
+	coating_amount = 0.2
 	hit_type = DAMAGE_BLUNT
 	hit_mob_sound = 'sound/misc/splash_1.ogg'
 	hit_object_sound = 'sound/misc/splash_1.ogg'
@@ -1773,6 +1779,7 @@ datum/projectile/bullet/autocannon
 	hit_type = DAMAGE_BLUNT
 	impact_image_state = "bullethole-large"
 	casing = /obj/item/casing/grenade
+	coating_amount = 0.2
 	ie_type = null
 
 	on_hit(atom/hit, dirflag, obj/projectile/proj)
@@ -1809,6 +1816,7 @@ datum/projectile/bullet/autocannon
 	hit_mob_sound = 'sound/impact_sounds/Energy_Hit_3.ogg'
 	impact_image_state = "bullethole-large"
 	casing = /obj/item/casing/grenade
+	coating_amount = 0.2
 	ie_type = null
 
 	on_hit(atom/hit, dirflag, obj/projectile/proj)
@@ -1832,6 +1840,7 @@ datum/projectile/bullet/autocannon
 	shot_sound = 'sound/weapons/launcher.ogg'
 	impact_image_state = "bullethole-large"
 	casing = /obj/item/casing/grenade
+	coating_amount = 0.2
 	implanted = null
 
 	var/has_grenade = 0
@@ -1952,6 +1961,7 @@ datum/projectile/bullet/autocannon
 	shot_sound = 'sound/weapons/launcher.ogg'
 	impact_image_state = "bullethole-large"
 	casing = /obj/item/casing/grenade
+	coating_amount = 0.2
 	implanted = null
 	has_impact_particles = FALSE
 
@@ -1979,6 +1989,7 @@ datum/projectile/bullet/autocannon
 	hit_type = DAMAGE_BLUNT
 	damage = 40
 	dissipation_delay = 30
+	coating_amount = 1
 	cost = 1
 	shot_sound = 'sound/weapons/rocket.ogg'
 	impact_image_state = "bullethole-large"
@@ -2089,6 +2100,7 @@ ABSTRACT_TYPE(/datum/projectile/bullet/homing/rocket)
 	shot_sound = 'sound/weapons/rocket.ogg'
 	impact_image_state = "bullethole-large"
 	shot_number = 1
+	coating_amount = 1
 	cost = 1
 	damage = 15
 	icon_state = "mininuke"
@@ -2194,6 +2206,7 @@ ABSTRACT_TYPE(/datum/projectile/bullet/homing/rocket)
 	hit_type = DAMAGE_BLUNT
 	damage = 5
 	dissipation_delay = 30
+	coating_amount = 1
 	cost = 1
 	shot_sound = 'sound/weapons/rocket.ogg'
 	impact_image_state = "bullethole-large"
@@ -2234,6 +2247,7 @@ ABSTRACT_TYPE(/datum/projectile/bullet/homing/rocket)
 	hit_type = DAMAGE_BLUNT
 	damage = 120
 	dissipation_delay = 30
+	coating_amount = 1
 	cost = 1
 	shot_sound = 'sound/weapons/rocket.ogg'
 	impact_image_state = "bullethole-large"
@@ -2330,6 +2344,7 @@ ABSTRACT_TYPE(/datum/projectile/bullet/homing/rocket)
 	stun = 200
 	dissipation_delay = 300
 	dissipation_rate = 5
+	coating_amount = 1
 	cost = 1
 	shot_sound = 'sound/effects/explosion_new2.ogg'
 	shot_volume = 90
@@ -2406,6 +2421,7 @@ ABSTRACT_TYPE(/datum/projectile/bullet/homing/rocket)
 	sname = "Get In"
 	shot_sound = 'sound/weapons/ribbit.ogg' //heh
 	casing = null
+	coating_amount = 1
 	impact_image_state = null
 
 	New()

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -1858,11 +1858,15 @@ datum/projectile/bullet/autocannon
 					src.CHEM = W
 					src.damage = CHEM.launcher_damage
 					src.has_grenade = 1
+					src.material = CHEM.material
+					src.material_amt = CHEM.material_amt
 					return 1
 				else if (istype(W, /obj/item/old_grenade))
 					src.OLD = W
 					src.damage = OLD.launcher_damage
 					src.has_grenade = 1
+					src.material = OLD.material
+					src.material_amt = OLD.material_amt
 					return 1
 				else
 					return 0
@@ -1878,12 +1882,16 @@ datum/projectile/bullet/autocannon
 					src.CHEM.set_loc(T)
 				src.CHEM = null
 				src.has_grenade = 0
+				src.material = null
+				src.material_amt = initial(src.material_amt)
 				return 1
 			else if (src.OLD != null)
 				if (T)
 					src.OLD.set_loc(T)
 				src.OLD = null
 				src.has_grenade = 0
+				src.material = null
+				src.material_amt = initial(src.material_amt)
 				return 1
 			else //how did this happen?
 				return 0

--- a/code/obj/item/gun/ammo/bullets.dm
+++ b/code/obj/item/gun/ammo/bullets.dm
@@ -59,7 +59,11 @@
 	attackby(obj/b, mob/user)
 		if(istype(b, /obj/item/gun/kinetic) && b:allowReverseReload)
 			b.Attackby(src, user)
-		else if(b.type == src.type)
+			return
+		if(!istype(b, /obj/item/ammo/bullets))
+			return ..()
+		var/obj/item/ammo/bullets/bullets = b
+		if(bullets.ammo_type.is_same_ammo(src.ammo_type))
 			var/obj/item/ammo/bullets/A = b
 			if(A.amount_left<1)
 				user.show_text("There's no ammo left in [A.name].", "red")
@@ -185,25 +189,18 @@
 		if (A.amount_left < 1)
 			return AMMO_RELOAD_SOURCE_EMPTY // Magazine's empty.
 		var/datum/projectile/K_type = K.ammo.ammo_type
-		if(K.ammo.amount_left > 0)
-			if(K_type.material != A.ammo_type.material)
-				return AMMO_RELOAD_TYPE_SWAP // Ammo materials are different
-			if(K_type.material && (K_type.material_amt != A.ammo_type.material_amt))
-				return AMMO_RELOAD_TYPE_SWAP // Different material amounts
 		if (K.ammo.amount_left >= K.max_ammo_capacity)
-			if (K_type.type != A.ammo_type.type)
+			if (!K_type.is_same_ammo(A.ammo_type))
 				return AMMO_RELOAD_TYPE_SWAP // Call swap().
 			return AMMO_RELOAD_ALREADY_FULL // Gun's full.
-		if (K.ammo.amount_left > 0 && K.ammo.ammo_type.type != A.ammo_type.type)
+		if (K.ammo.amount_left > 0 && (!K_type.is_same_ammo(A.ammo_type)))
 			return AMMO_RELOAD_TYPE_SWAP // Call swap().
-
 		else
-
 			// The gun may have been fired; eject casings if so (Convair880).
 			K.ejectcasings()
 
 			// Required for swap() to work properly (Convair880).
-			if (K.ammo.type != A.type || A.force_new_current_projectile)
+			if (!K.ammo.ammo_type.is_same_ammo(A.ammo_type) || A.force_new_current_projectile)
 				var/obj/item/ammo/bullets/ammoGun = new A.type
 				ammoGun.amount_left = K.ammo.amount_left
 				ammoGun.ammo_type = K.ammo.ammo_type

--- a/code/obj/item/gun/ammo/bullets.dm
+++ b/code/obj/item/gun/ammo/bullets.dm
@@ -275,7 +275,7 @@
 		ammoDrop.icon = src.icon
 		ammoDrop.icon_state = src.icon_state
 		ammoDrop.ammo_type = new src.ammo_type.type
-		ammoDrop.ammo_type.material = src.ammo_type.material
+		ammoDrop.ammo_type.coating = src.ammo_type.coating
 		ammoDrop.delete_on_reload = src.delete_on_reload
 		src.UpdateIcon()
 		ammoDrop.UpdateIcon()
@@ -284,8 +284,8 @@
 	get_desc()
 		if(src.amount_left == 0)
 			return . += "There are no bullets left!"
-		else if(ammo_type.material)
-			return . += "There [src.amount_left == 1 ? "is" : "are"] [src.amount_left] [ammo_type.material.getName()]-coated bullet\s left!"
+		else if(ammo_type.coating)
+			return . += "There [src.amount_left == 1 ? "is" : "are"] [src.amount_left] [ammo_type.coating.getName()]-coated bullet\s left!"
 		return . += "There [src.amount_left == 1 ? "is" : "are"] [src.amount_left] bullet\s left!"
 
 	temperature_expose(datum/gas_mixture/air, temperature, volume)
@@ -307,8 +307,8 @@
 
 	on_material_scan()
 		. = ..()
-		if(src.ammo_type.material)
-			return "Each bullet is coated in [src.ammo_type.material_amt] unit\s of [src.ammo_type.material]."
+		if(src.ammo_type.coating)
+			return "Each bullet is coated in [src.ammo_type.coating_amount] unit\s of [src.ammo_type.coating]"
 
 
 //no caliber:
@@ -334,7 +334,7 @@
 	icon_empty = "custom-0"
 
 	onMaterialChanged()
-		ammo_type.material = src.material
+		ammo_type.coating = src.material
 
 		if(src.material)
 			ammo_type.power = round(material.getProperty("density") * 2 + material.getProperty("hard"))

--- a/code/obj/item/gun/ammo/bullets.dm
+++ b/code/obj/item/gun/ammo/bullets.dm
@@ -164,6 +164,15 @@
 			return 1
 
 	proc/loadammo(var/obj/item/ammo/bullets/A, var/obj/item/gun/kinetic/K)
+		/* So bullet reloading is using this convoluted system for some reason.
+			- From what I can tell, loadammo() gets called first in order to figure out the type of reload.
+			- Most returned cases are just for displaying different kinds of messages.
+			- If the ammo is being swapped, swap() gets called to make the change
+			- THEN swap() has a case where it might call loadammo() AGAIN after it has emptied the gun (I think?) or something of the sort.
+			- Maybe it is doing this in case the ammo doesn't fit in a single container?
+			- In short: I recommend nuking the entire reload system. (LorrMaster)
+		*/
+
 		// Also see attackby() in kinetic.dm.
 		if (!A || !K)
 			return 0 // Error message.
@@ -187,17 +196,21 @@
 		if (K.ammo.amount_left < 0)
 			K.ammo.amount_left = 0
 		if (A.amount_left < 1)
-			return AMMO_RELOAD_SOURCE_EMPTY // Magazine's empty.
+			return AMMO_RELOAD_SOURCE_EMPTY // Trying to reload with an empty magazine
 		var/datum/projectile/K_type = K.ammo.ammo_type
 		if (K.ammo.amount_left >= K.max_ammo_capacity)
+			// The gun is already full
 			if (!K_type.is_same_ammo(A.ammo_type))
-				return AMMO_RELOAD_TYPE_SWAP // Call swap().
-			return AMMO_RELOAD_ALREADY_FULL // Gun's full.
+				return AMMO_RELOAD_TYPE_SWAP // Gun is full but the ammo types are different. Call swap().
+			return AMMO_RELOAD_ALREADY_FULL
 		if (K.ammo.amount_left > 0 && (!K_type.is_same_ammo(A.ammo_type)))
-			return AMMO_RELOAD_TYPE_SWAP // Call swap().
+			return AMMO_RELOAD_TYPE_SWAP //  Gun is not empty. Ammo types are different. Call swap().
 		else
-			// The gun may have been fired; eject casings if so (Convair880).
-			K.ejectcasings()
+			// (LorrMaster) If you are at this point in the code, then that means...
+			// A) The gun is empty and a different type of ammo is being inserted
+			// B) The gun may or may not have ammo, but the ammo being inserted is the same as before
+
+			K.ejectcasings() // The gun may have been fired; eject casings if so (Convair880).
 
 			// Required for swap() to work properly (Convair880).
 			if (!K.ammo.ammo_type.is_same_ammo(A.ammo_type) || A.force_new_current_projectile)
@@ -264,6 +277,8 @@
 	proc/after_unload(mob/user)
 		return
 
+	/// Remove ammo from this container and place it into a new container. Ammo is identical in each.
+	/// Returns the new container that the ammo was moved to, or null if there was no need to move anything
 	proc/split(var/split_amount)
 		RETURN_TYPE(/obj/item/ammo/bullets)
 		if(split_amount >= src.amount_left || split_amount <= 0)
@@ -274,7 +289,7 @@
 		ammoDrop.name = src.name
 		ammoDrop.icon = src.icon
 		ammoDrop.icon_state = src.icon_state
-		ammoDrop.ammo_type = new src.ammo_type.type
+		ammoDrop.ammo_type = new src.ammo_type.type // Creating a new ammo type in case you want to edit something.
 		ammoDrop.ammo_type.coating = src.ammo_type.coating
 		ammoDrop.delete_on_reload = src.delete_on_reload
 		src.UpdateIcon()
@@ -284,7 +299,7 @@
 	get_desc()
 		if(src.amount_left == 0)
 			return . += "There are no bullets left!"
-		else if(ammo_type.coating)
+		if(ammo_type.coating)
 			return . += "There [src.amount_left == 1 ? "is" : "are"] [src.amount_left] [ammo_type.coating.getName()]-coated bullet\s left!"
 		return . += "There [src.amount_left == 1 ? "is" : "are"] [src.amount_left] bullet\s left!"
 

--- a/code/obj/item/gun/ammo/bullets.dm
+++ b/code/obj/item/gun/ammo/bullets.dm
@@ -185,8 +185,11 @@
 		if (A.amount_left < 1)
 			return AMMO_RELOAD_SOURCE_EMPTY // Magazine's empty.
 		var/datum/projectile/K_type = K.ammo.ammo_type
-		if(K_type.material != A.ammo_type.material || (K_type.material && (K_type.material_amt != A.ammo_type.material_amt)))
-			return AMMO_RELOAD_TYPE_SWAP // Ammo materials are different
+		if(K.ammo.amount_left > 0)
+			if(K_type.material != A.ammo_type.material)
+				return AMMO_RELOAD_TYPE_SWAP // Ammo materials are different
+			if(K_type.material && (K_type.material_amt != A.ammo_type.material_amt))
+				return AMMO_RELOAD_TYPE_SWAP // Different material amounts
 		if (K.ammo.amount_left >= K.max_ammo_capacity)
 			if (K_type.type != A.ammo_type.type)
 				return AMMO_RELOAD_TYPE_SWAP // Call swap().
@@ -263,6 +266,23 @@
 
 	proc/after_unload(mob/user)
 		return
+
+	proc/split(var/split_amount)
+		RETURN_TYPE(/obj/item/ammo/bullets)
+		if(split_amount >= src.amount_left || split_amount <= 0)
+			return null
+		var/obj/item/ammo/bullets/ammoDrop = new src.type
+		ammoDrop.amount_left = split_amount
+		src.amount_left -= split_amount
+		ammoDrop.name = src.name
+		ammoDrop.icon = src.icon
+		ammoDrop.icon_state = src.icon_state
+		ammoDrop.ammo_type = new src.ammo_type.type
+		ammoDrop.ammo_type.material = src.ammo_type.material
+		ammoDrop.delete_on_reload = src.delete_on_reload
+		src.UpdateIcon()
+		ammoDrop.UpdateIcon()
+		return ammoDrop
 
 	get_desc()
 		if(src.amount_left == 0)
@@ -1049,6 +1069,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	name = "20mm AP shells"
 	amount_left = 4
 	max_amount = 4
+	material_amt = 0.5
 	icon_state = "40mm_lethal"
 	ammo_type = new/datum/projectile/bullet/cannon
 	ammo_cat = AMMO_CANNON_20MM
@@ -1117,6 +1138,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	ammo_type = new/datum/projectile/bullet/four_bore
 	amount_left = 6
 	max_amount = 6
+	material_amt = 0.5
 	ammo_cat = AMMO_FOUR_BORE
 	icon_state = "4b-6"
 	icon_empty = "4b-0"
@@ -1151,6 +1173,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "Some high explosive grenades, for use in 40mm weapons."
 	amount_left = 2
 	max_amount = 2
+	material_amt = 0.5
 	icon_state = "40mm_HE_pod"
 	ammo_type = new/datum/projectile/bullet/autocannon
 	ammo_cat = AMMO_CANNON_40MM
@@ -1175,6 +1198,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "A box of general utility 40mm grenades."
 	amount_left = 8
 	max_amount = 8
+	material_amt = 0.2
 	icon_state = "40mm_lethal"
 	ammo_type = new/datum/projectile/bullet/grenade_round/
 	ammo_cat = AMMO_GRENADE_40MM
@@ -1205,6 +1229,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "Some smoke shells, for the 40mm platform."
 	amount_left = 5
 	max_amount = 5
+	material_amt = 0.2
 	icon_state = "40mm_smoke"
 	ammo_type = new/datum/projectile/bullet/smoke
 	ammo_cat = AMMO_GRENADE_40MM
@@ -1224,6 +1249,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	ammo_type = new/datum/projectile/bullet/marker
 	amount_left = 5
 	max_amount = 5
+	material_amt = 0.2
 	icon_state = "40mm_paint"
 	ammo_cat = AMMO_GRENADE_40MM
 	w_class = W_CLASS_NORMAL
@@ -1238,6 +1264,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	ammo_type = new/datum/projectile/bullet/pbr
 	amount_left = 2
 	max_amount = 2
+	material_amt = 0.2
 	icon_state = "40mm_nonlethal"
 	ammo_cat = AMMO_GRENADE_40MM
 	w_class = W_CLASS_NORMAL
@@ -1252,6 +1279,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	ammo_type = new/datum/projectile/bullet/stunbaton
 	amount_left = 2
 	max_amount = 2
+	material_amt = 0.5
 	icon_state = "40mm_nonlethal"
 	ammo_cat = AMMO_GRENADE_40MM
 	w_class = W_CLASS_NORMAL
@@ -1266,6 +1294,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	ammo_type = new/datum/projectile/bullet/breach_flashbang
 	amount_left = 5
 	max_amount = 5
+	material_amt = 0.2
 	icon_state = "40mm_nonlethal"
 	ammo_cat = AMMO_GRENADE_40MM
 	w_class = W_CLASS_NORMAL
@@ -1284,6 +1313,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "A 40mm shell used for converting hand grenades into impact detonation explosive shells"
 	amount_left = 1
 	max_amount = 1
+	material_amt = 0.2
 	icon_state = "paintballr-4"
 	ammo_type = new/datum/projectile/bullet/grenade_shell
 	ammo_cat = AMMO_GRENADE_40MM
@@ -1358,6 +1388,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "A mean high-explosive rocket, guaranteed to cause destruction in a large radius."
 	amount_left = 1
 	max_amount = 1
+	material_amt = 1
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "rpg_rocket"
 	ammo_type = new /datum/projectile/bullet/rpg
@@ -1372,6 +1403,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "A high-explosive missile, equipped with pod-seeking guidance systems."
 	amount_left = 1
 	max_amount = 1
+	material_amt = 1
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "pod_seeking_missile"
 	ammo_type = new /datum/projectile/bullet/homing/pod_seeking_missile
@@ -1385,6 +1417,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	name = "MRL rocket pack"
 	amount_left = 6
 	max_amount = 6
+	material_amt = 0.2
 	icon_state = "mrl_rocketpack"
 	ammo_type = new /datum/projectile/bullet/homing/rocket/mrl
 	ammo_cat = AMMO_ROCKET_MRL
@@ -1398,6 +1431,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "An experimental rocket containing an energy payload designed to collapse singularities. It's made mostly of electronics and seems pretty fragile."
 	amount_left = 1
 	max_amount = 1
+	material_amt = 1
 	icon = 'icons/obj/items/ammo.dmi'
 	icon_state = "regularrocket"
 	ammo_type = new /datum/projectile/bullet/antisingularity
@@ -1412,6 +1446,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "I am become mini-death, the destroyer of mini-worlds."
 	amount_left = 1
 	max_amount = 1
+	material_amt = 1
 	icon = 'icons/obj/items/ammo.dmi'
 	icon_state = "mininuke"
 	ammo_type = new /datum/projectile/bullet/mininuke
@@ -1492,6 +1527,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	icon_empty = "meow_ammo-0"
 	amount_left = 1
 	max_amount = 1
+	material_amt = 1
 	ammo_type = new/datum/projectile/special/meowitzer
 	ammo_cat = AMMO_HOWITZER
 	w_class = W_CLASS_NORMAL
@@ -1510,6 +1546,7 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	icon_empty = "meow_ammo-0"
 	amount_left = 1
 	max_amount = 1
+	material_amt = 1
 	ammo_type = new/datum/projectile/bullet/howitzer
 	ammo_cat = AMMO_HOWITZER
 	w_class = W_CLASS_NORMAL

--- a/code/obj/item/gun/ammo/bullets.dm
+++ b/code/obj/item/gun/ammo/bullets.dm
@@ -1066,7 +1066,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	name = "20mm AP shells"
 	amount_left = 4
 	max_amount = 4
-	material_amt = 0.5
 	icon_state = "40mm_lethal"
 	ammo_type = new/datum/projectile/bullet/cannon
 	ammo_cat = AMMO_CANNON_20MM
@@ -1135,7 +1134,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	ammo_type = new/datum/projectile/bullet/four_bore
 	amount_left = 6
 	max_amount = 6
-	material_amt = 0.5
 	ammo_cat = AMMO_FOUR_BORE
 	icon_state = "4b-6"
 	icon_empty = "4b-0"
@@ -1170,7 +1168,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "Some high explosive grenades, for use in 40mm weapons."
 	amount_left = 2
 	max_amount = 2
-	material_amt = 0.5
 	icon_state = "40mm_HE_pod"
 	ammo_type = new/datum/projectile/bullet/autocannon
 	ammo_cat = AMMO_CANNON_40MM
@@ -1195,7 +1192,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "A box of general utility 40mm grenades."
 	amount_left = 8
 	max_amount = 8
-	material_amt = 0.2
 	icon_state = "40mm_lethal"
 	ammo_type = new/datum/projectile/bullet/grenade_round/
 	ammo_cat = AMMO_GRENADE_40MM
@@ -1226,7 +1222,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "Some smoke shells, for the 40mm platform."
 	amount_left = 5
 	max_amount = 5
-	material_amt = 0.2
 	icon_state = "40mm_smoke"
 	ammo_type = new/datum/projectile/bullet/smoke
 	ammo_cat = AMMO_GRENADE_40MM
@@ -1246,7 +1241,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	ammo_type = new/datum/projectile/bullet/marker
 	amount_left = 5
 	max_amount = 5
-	material_amt = 0.2
 	icon_state = "40mm_paint"
 	ammo_cat = AMMO_GRENADE_40MM
 	w_class = W_CLASS_NORMAL
@@ -1261,7 +1255,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	ammo_type = new/datum/projectile/bullet/pbr
 	amount_left = 2
 	max_amount = 2
-	material_amt = 0.2
 	icon_state = "40mm_nonlethal"
 	ammo_cat = AMMO_GRENADE_40MM
 	w_class = W_CLASS_NORMAL
@@ -1276,7 +1269,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	ammo_type = new/datum/projectile/bullet/stunbaton
 	amount_left = 2
 	max_amount = 2
-	material_amt = 0.5
 	icon_state = "40mm_nonlethal"
 	ammo_cat = AMMO_GRENADE_40MM
 	w_class = W_CLASS_NORMAL
@@ -1291,7 +1283,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	ammo_type = new/datum/projectile/bullet/breach_flashbang
 	amount_left = 5
 	max_amount = 5
-	material_amt = 0.2
 	icon_state = "40mm_nonlethal"
 	ammo_cat = AMMO_GRENADE_40MM
 	w_class = W_CLASS_NORMAL
@@ -1310,7 +1301,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "A 40mm shell used for converting hand grenades into impact detonation explosive shells"
 	amount_left = 1
 	max_amount = 1
-	material_amt = 0.2
 	icon_state = "paintballr-4"
 	ammo_type = new/datum/projectile/bullet/grenade_shell
 	ammo_cat = AMMO_GRENADE_40MM
@@ -1385,7 +1375,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "A mean high-explosive rocket, guaranteed to cause destruction in a large radius."
 	amount_left = 1
 	max_amount = 1
-	material_amt = 1
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "rpg_rocket"
 	ammo_type = new /datum/projectile/bullet/rpg
@@ -1400,7 +1389,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "A high-explosive missile, equipped with pod-seeking guidance systems."
 	amount_left = 1
 	max_amount = 1
-	material_amt = 1
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "pod_seeking_missile"
 	ammo_type = new /datum/projectile/bullet/homing/pod_seeking_missile
@@ -1414,7 +1402,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	name = "MRL rocket pack"
 	amount_left = 6
 	max_amount = 6
-	material_amt = 0.2
 	icon_state = "mrl_rocketpack"
 	ammo_type = new /datum/projectile/bullet/homing/rocket/mrl
 	ammo_cat = AMMO_ROCKET_MRL
@@ -1428,7 +1415,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "An experimental rocket containing an energy payload designed to collapse singularities. It's made mostly of electronics and seems pretty fragile."
 	amount_left = 1
 	max_amount = 1
-	material_amt = 1
 	icon = 'icons/obj/items/ammo.dmi'
 	icon_state = "regularrocket"
 	ammo_type = new /datum/projectile/bullet/antisingularity
@@ -1443,7 +1429,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	desc = "I am become mini-death, the destroyer of mini-worlds."
 	amount_left = 1
 	max_amount = 1
-	material_amt = 1
 	icon = 'icons/obj/items/ammo.dmi'
 	icon_state = "mininuke"
 	ammo_type = new /datum/projectile/bullet/mininuke
@@ -1524,7 +1509,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	icon_empty = "meow_ammo-0"
 	amount_left = 1
 	max_amount = 1
-	material_amt = 1
 	ammo_type = new/datum/projectile/special/meowitzer
 	ammo_cat = AMMO_HOWITZER
 	w_class = W_CLASS_NORMAL
@@ -1543,7 +1527,6 @@ ABSTRACT_TYPE(/obj/item/ammo/bullets/pipeshot)
 	icon_empty = "meow_ammo-0"
 	amount_left = 1
 	max_amount = 1
-	material_amt = 1
 	ammo_type = new/datum/projectile/bullet/howitzer
 	ammo_cat = AMMO_HOWITZER
 	w_class = W_CLASS_NORMAL

--- a/code/obj/item/gun/ammo/bullets.dm
+++ b/code/obj/item/gun/ammo/bullets.dm
@@ -164,11 +164,11 @@
 			return 1
 
 	proc/loadammo(var/obj/item/ammo/bullets/A, var/obj/item/gun/kinetic/K)
-		/* So bullet reloading is using this convoluted system for some reason.
+		/* So bullet reloading is pretty convoluted
 			- From what I can tell, loadammo() gets called first in order to figure out the type of reload.
 			- Most returned cases are just for displaying different kinds of messages.
 			- If the ammo is being swapped, swap() gets called to make the change
-			- THEN swap() has a case where it might call loadammo() AGAIN after it has emptied the gun (I think?) or something of the sort.
+			- THEN swap() may call loadammo() AGAIN to complete the reload.
 			- Maybe it is doing this in case the ammo doesn't fit in a single container?
 			- In short: I recommend nuking the entire reload system. (LorrMaster)
 		*/

--- a/code/obj/item/gun/ammo/bullets.dm
+++ b/code/obj/item/gun/ammo/bullets.dm
@@ -184,8 +184,11 @@
 			K.ammo.amount_left = 0
 		if (A.amount_left < 1)
 			return AMMO_RELOAD_SOURCE_EMPTY // Magazine's empty.
+		var/datum/projectile/K_type = K.ammo.ammo_type
+		if(K_type.material != A.ammo_type.material || (K_type.material && (K_type.material_amt != A.ammo_type.material_amt)))
+			return AMMO_RELOAD_TYPE_SWAP // Ammo materials are different
 		if (K.ammo.amount_left >= K.max_ammo_capacity)
-			if (K.ammo.ammo_type.type != A.ammo_type.type)
+			if (K_type.type != A.ammo_type.type)
 				return AMMO_RELOAD_TYPE_SWAP // Call swap().
 			return AMMO_RELOAD_ALREADY_FULL // Gun's full.
 		if (K.ammo.amount_left > 0 && K.ammo.ammo_type.type != A.ammo_type.type)
@@ -262,7 +265,11 @@
 		return
 
 	get_desc()
-		return . += "There [src.amount_left == 1 ? "is" : "are"] [src.amount_left][ammo_type.material && istype(ammo_type.material, /datum/material/metal/silver) ? " silver " : " "]bullet\s left!"
+		if(src.amount_left == 0)
+			return . += "There are no bullets left!"
+		else if(ammo_type.material)
+			return . += "There [src.amount_left == 1 ? "is" : "are"] [src.amount_left] [ammo_type.material.getName()]-coated bullet\s left!"
+		return . += "There [src.amount_left == 1 ? "is" : "are"] [src.amount_left] bullet\s left!"
 
 	temperature_expose(datum/gas_mixture/air, temperature, volume)
 		. = ..()
@@ -280,6 +287,11 @@
 					shoot_projectile_DIR(src, src.ammo_type, pick(alldirs))
 					if(src.delete_on_reload && src.amount_left <= 0) //I don't like repeating code, but this is needed to catch if it empties on the second firing
 						qdel(src)
+
+	on_material_scan()
+		. = ..()
+		if(src.ammo_type.material)
+			return "Each bullet is coated in [src.ammo_type.material_amt] unit\s of [src.ammo_type.material]."
 
 
 //no caliber:

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -466,6 +466,8 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	return 0
 
 /obj/item/gun/proc/log_shoot(mob/user, turf/T, obj/projectile/P)
+	if(!P)
+		return
 	logTheThing(LOG_COMBAT, user, "fires \a [src] from [log_loc(user)], vector: ([T.x - user.x], [T.y - user.y]), dir: <I>[dir2text(get_dir_accurate(user, T))]</I>, projectile: <I>[P.name]</I>[P.proj_data && P.proj_data.type ? ", [P.proj_data.type]" : null]")
 
 /obj/item/gun/examine()

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1056,6 +1056,10 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 				else
 					set_current_projectile(new/datum/projectile/bullet/bullet_9mm/smg)
 					projectiles = list(current_projectile, new/datum/projectile/bullet/bullet_9mm/smg/auto)
+			for(var/datum/projectile/bullet/proj in projectiles)
+				// Eh, good enough for now
+				proj.coating = ammo.ammo_type.coating
+				proj.coating_amount = ammo.ammo_type.coating_amount
 
 /obj/item/gun/kinetic/greasegun
 	name = "\improper Grease Gun"
@@ -1126,6 +1130,8 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 				set_current_projectile(new/datum/projectile/bullet/nine_mm_surplus/auto)
 			else if(istype(ammo, /obj/item/ammo/bullets/bullet_9mm/smg))
 				set_current_projectile(new/datum/projectile/bullet/bullet_9mm/smg/auto)
+			src.current_projectile.coating = ammo.ammo_type.coating // Eh, good enough for now
+			src.current_projectile.coating_amount = ammo.ammo_type.coating_amount
 
 	proc/set_auto_delay(delay)
 		. = delay * 10
@@ -3182,6 +3188,10 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 				else // we were in single shot mode
 					set_current_projectile(new/datum/projectile/bullet/assault_rifle)
 					projectiles = list(current_projectile, new/datum/projectile/bullet/assault_rifle/burst)
+			for(var/datum/projectile/bullet/proj in projectiles)
+				// Eh, good enough for now
+				proj.coating = ammo.ammo_type.coating
+				proj.coating_amount = ammo.ammo_type.coating_amount
 
 	attack_self(mob/user as mob)
 		..()	//burst shot has a slight spread.
@@ -3252,6 +3262,10 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 				else // we were in single shot mode
 					set_current_projectile(new/datum/projectile/bullet/assault_rifle)
 					projectiles = list(current_projectile, new/datum/projectile/bullet/assault_rifle/burst)
+			for(var/datum/projectile/bullet/proj in projectiles)
+				// Eh, good enough for now
+				proj.coating = ammo.ammo_type.coating
+				proj.coating_amount = ammo.ammo_type.coating_amount
 
 	attack_self(mob/user)
 		..()	//burst shot has a slight spread.

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -233,7 +233,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 	alter_projectile(obj/projectile/P)
 		. = ..()
-		P.material?.triggerTemp(P, 500 KELVIN)
+		P.material?.triggerTemp(P, 500 KELVIN) // Gun barrels can get pretty hot
 
 	proc/eject_magazine(mob/user)
 		if (src.ammo.amount_left <= 0)
@@ -934,6 +934,13 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 			AddComponent(/datum/component/holdertargeting/fullauto, 1.2)
 		..()
 
+	attackby(obj/item/ammo/bullets/b, mob/user)
+		var/obj/item/ammo/bullets/previous_ammo = ammo
+		. = ..()
+		if(!previous_ammo.ammo_type.is_same_ammo(b.ammo_type))
+			for(var/datum/projectile/bullet/proj in src.projectiles)
+				proj.coating = ammo.ammo_type.coating
+
 	attack_self(mob/user as mob)
 		..()	//burst shot has a slight spread.
 		if (istype(current_projectile, /datum/projectile/bullet/nine_mm_NATO/auto))
@@ -1038,11 +1045,11 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 
 	//warcrimes brought to you by bullets telling guns how to shoot!
 	attackby(obj/item/ammo/bullets/b, mob/user)
-		. = ..()
-
-		// This gun has multiple modes, so apparently that means we have to go through this mess (LorrMaster)
 		var/obj/item/ammo/bullets/previous_ammo = ammo
 		var/mode_was_auto = current_projectile.fullauto_valid
+		. = ..()
+
+		// This gun has multiple modes, so apparently that means we have to go through this mess
 		if(!previous_ammo.ammo_type.is_same_ammo(ammo.ammo_type)) // we switched ammo types
 			if(istype(ammo, /obj/item/ammo/bullets/nine_mm_surplus))
 				if(mode_was_auto)
@@ -1373,6 +1380,13 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 		set_current_projectile(new/datum/projectile/bullet/veritate)
 		projectiles = list(current_projectile,new/datum/projectile/bullet/veritate/burst)
 		..()
+
+	attackby(obj/item/ammo/bullets/b, mob/user)
+		var/obj/item/ammo/bullets/previous_ammo = ammo
+		. = ..()
+		if(!previous_ammo.ammo_type.is_same_ammo(b.ammo_type))
+			for(var/datum/projectile/bullet/proj in src.projectiles)
+				proj.coating = ammo.ammo_type.coating
 
 	disposing()
 		STOP_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
@@ -3171,11 +3185,11 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 		..()
 
 	attackby(obj/item/ammo/bullets/b, mob/user)  // has to account for whether regular or armor-piercing ammo is loaded AND which firing mode it's using
-		. = ..()
-
-		// This gun has multiple modes, so apparently that means we have to go through this mess (LorrMaster)
 		var/obj/item/ammo/bullets/previous_ammo = ammo
 		var/mode_was_burst = (istype(current_projectile, /datum/projectile/bullet/assault_rifle/burst/))  // was previous mode burst fire?
+		. = ..()
+
+		// This gun has multiple modes, so apparently that means we have to go through this mess
 		if(!previous_ammo.ammo_type.is_same_ammo(ammo.ammo_type)) // we switched ammo types
 			if(istype(ammo, /obj/item/ammo/bullets/assault_rifle/armor_piercing)) // we switched from normal to armor_piercing
 				if(mode_was_burst) // we were in burst shot mode
@@ -3240,11 +3254,11 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 		..()
 
 	attackby(obj/item/ammo/bullets/b, mob/user)  // has to account for whether regular or armor-piercing ammo is loaded AND which firing mode it's using
-		. = ..()
-
-		// This gun has multiple modes, so apparently that means we have to go through this mess (LorrMaster)
 		var/obj/item/ammo/bullets/previous_ammo = ammo
 		var/mode_was_burst = (istype(current_projectile, /datum/projectile/bullet/assault_rifle/burst))  // was previous mode burst fire?
+		. = ..()
+
+		// This gun has multiple modes, so apparently that means we have to go through this mess
 		if(!previous_ammo.ammo_type.is_same_ammo(ammo.ammo_type)) // we switched ammo types
 			if(istype(ammo, /obj/item/ammo/bullets/assault_rifle/armor_piercing)) // we switched from normal to armor_piercing
 				if(mode_was_burst) // we were in burst shot mode
@@ -3327,6 +3341,13 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 		projectiles = list(current_projectile, new/datum/projectile/bullet/lmg/auto)
 		AddComponent(/datum/component/holdertargeting/fullauto, 1.5 DECI SECONDS)
 		..()
+
+	attackby(obj/item/ammo/bullets/b, mob/user)
+		var/obj/item/ammo/bullets/previous_ammo = ammo
+		. = ..()
+		if(!previous_ammo.ammo_type.is_same_ammo(b.ammo_type))
+			for(var/datum/projectile/bullet/proj in src.projectiles)
+				proj.coating = ammo.ammo_type.coating
 
 	disposing()
 		STOP_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1038,9 +1038,11 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 
 	//warcrimes brought to you by bullets telling guns how to shoot!
 	attackby(obj/item/ammo/bullets/b, mob/user)
+		. = ..()
+
+		// This gun has multiple modes, so apparently that means we have to go through this mess (LorrMaster)
 		var/obj/item/ammo/bullets/previous_ammo = ammo
 		var/mode_was_auto = current_projectile.fullauto_valid
-		..()
 		if(!previous_ammo.ammo_type.is_same_ammo(ammo.ammo_type)) // we switched ammo types
 			if(istype(ammo, /obj/item/ammo/bullets/nine_mm_surplus))
 				if(mode_was_auto)
@@ -1056,10 +1058,10 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 				else
 					set_current_projectile(new/datum/projectile/bullet/bullet_9mm/smg)
 					projectiles = list(current_projectile, new/datum/projectile/bullet/bullet_9mm/smg/auto)
+
+			// We created brand new ammo types for some reason, so if the ammo being inserted has a material then we have to reapply it (LorrMaster)
 			for(var/datum/projectile/bullet/proj in projectiles)
-				// Eh, good enough for now
 				proj.coating = ammo.ammo_type.coating
-				proj.coating_amount = ammo.ammo_type.coating_amount
 
 /obj/item/gun/kinetic/greasegun
 	name = "\improper Grease Gun"
@@ -1130,8 +1132,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 				set_current_projectile(new/datum/projectile/bullet/nine_mm_surplus/auto)
 			else if(istype(ammo, /obj/item/ammo/bullets/bullet_9mm/smg))
 				set_current_projectile(new/datum/projectile/bullet/bullet_9mm/smg/auto)
-			src.current_projectile.coating = ammo.ammo_type.coating // Eh, good enough for now
-			src.current_projectile.coating_amount = ammo.ammo_type.coating_amount
+			src.current_projectile.coating = ammo.ammo_type.coating // Apply the ammo's material to the newly created ammo type
 
 	proc/set_auto_delay(delay)
 		. = delay * 10
@@ -3170,9 +3171,11 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 		..()
 
 	attackby(obj/item/ammo/bullets/b, mob/user)  // has to account for whether regular or armor-piercing ammo is loaded AND which firing mode it's using
+		. = ..()
+
+		// This gun has multiple modes, so apparently that means we have to go through this mess (LorrMaster)
 		var/obj/item/ammo/bullets/previous_ammo = ammo
 		var/mode_was_burst = (istype(current_projectile, /datum/projectile/bullet/assault_rifle/burst/))  // was previous mode burst fire?
-		..()
 		if(!previous_ammo.ammo_type.is_same_ammo(ammo.ammo_type)) // we switched ammo types
 			if(istype(ammo, /obj/item/ammo/bullets/assault_rifle/armor_piercing)) // we switched from normal to armor_piercing
 				if(mode_was_burst) // we were in burst shot mode
@@ -3188,10 +3191,10 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 				else // we were in single shot mode
 					set_current_projectile(new/datum/projectile/bullet/assault_rifle)
 					projectiles = list(current_projectile, new/datum/projectile/bullet/assault_rifle/burst)
+
+			// We created brand new ammo types for some reason, so if the ammo being inserted has a material then we have to reapply it (LorrMaster)
 			for(var/datum/projectile/bullet/proj in projectiles)
-				// Eh, good enough for now
 				proj.coating = ammo.ammo_type.coating
-				proj.coating_amount = ammo.ammo_type.coating_amount
 
 	attack_self(mob/user as mob)
 		..()	//burst shot has a slight spread.
@@ -3237,9 +3240,11 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 		..()
 
 	attackby(obj/item/ammo/bullets/b, mob/user)  // has to account for whether regular or armor-piercing ammo is loaded AND which firing mode it's using
+		. = ..()
+
+		// This gun has multiple modes, so apparently that means we have to go through this mess (LorrMaster)
 		var/obj/item/ammo/bullets/previous_ammo = ammo
 		var/mode_was_burst = (istype(current_projectile, /datum/projectile/bullet/assault_rifle/burst))  // was previous mode burst fire?
-		..()
 		if(!previous_ammo.ammo_type.is_same_ammo(ammo.ammo_type)) // we switched ammo types
 			if(istype(ammo, /obj/item/ammo/bullets/assault_rifle/armor_piercing)) // we switched from normal to armor_piercing
 				if(mode_was_burst) // we were in burst shot mode
@@ -3262,10 +3267,10 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 				else // we were in single shot mode
 					set_current_projectile(new/datum/projectile/bullet/assault_rifle)
 					projectiles = list(current_projectile, new/datum/projectile/bullet/assault_rifle/burst)
+
+			// We created brand new ammo types for some reason, so if the ammo being inserted has a material then we have to reapply it (LorrMaster)
 			for(var/datum/projectile/bullet/proj in projectiles)
-				// Eh, good enough for now
 				proj.coating = ammo.ammo_type.coating
-				proj.coating_amount = ammo.ammo_type.coating_amount
 
 	attack_self(mob/user)
 		..()	//burst shot has a slight spread.

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -72,7 +72,10 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 		. = ..()
 		if (src.ammo && (src.ammo.amount_left > 0))
 			var/datum/projectile/ammo_type = src.ammo.ammo_type
-			. += "There are [src.ammo.amount_left][(ammo_type.material && istype(ammo_type.material, /datum/material/metal/silver)) ? " silver " : " "]bullets of [src.ammo.sname] left!"
+			if(ammo_type.material)
+				. += "There are [src.ammo.amount_left] [ammo_type.material.getName()]-coated [src.ammo.sname] bullets left!"
+			else
+				. += "There are [src.ammo.amount_left] bullets of [src.ammo.sname] left!"
 		else
 			. += "There are 0 bullets left!"
 		if (current_projectile)
@@ -188,7 +191,10 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 						var/number_of_casings = max(1, src.current_projectile.shot_number)
 						//DEBUG_MESSAGE("Ejected [number_of_casings] casings from [src].")
 						for (var/i in 1 to number_of_casings)
-							new src.current_projectile.casing(T, src)
+							var/atom/casing = new src.current_projectile.casing(T, src)
+							if(src.ammo.ammo_type.material)
+								casing.material_amt = src.ammo.ammo_type.material_amt * GUN_KINETIC_MATERIAL_RATIO_CASING
+								casing.setMaterial(src.ammo.ammo_type.material)
 			else
 				if (src.casings_to_eject < 0)
 					src.casings_to_eject = 0
@@ -204,7 +210,10 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 						var/number_of_casings = max(1, src.current_projectile.shot_number)
 						//DEBUG_MESSAGE("Ejected [number_of_casings] casings from [src].")
 						for (var/i in 1 to number_of_casings)
-							new src.current_projectile.casing(T, src)
+							var/atom/casing = new src.current_projectile.casing(T, src)
+							if(src.ammo.ammo_type.material)
+								casing.material_amt = src.ammo.ammo_type.material_amt * GUN_KINETIC_MATERIAL_RATIO_CASING
+								casing.setMaterial(src.ammo.ammo_type.material)
 			else
 				if (src.casings_to_eject < 0)
 					src.casings_to_eject = 0
@@ -219,6 +228,10 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 			user.inertia_dir = get_dir_accurate(target, user)
 			user.inertia_value = 1
 			step(user, user.inertia_dir) // Propel user in opposite direction
+
+	alter_projectile(obj/projectile/P)
+		. = ..()
+		P.material?.triggerTemp(P, 500 KELVIN)
 
 	proc/eject_magazine(mob/user)
 		if (src.ammo.amount_left <= 0)
@@ -269,7 +282,10 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 			if(T)
 				//DEBUG_MESSAGE("Ejected [src.casings_to_eject] [src.current_projectile.casing] from [src].")
 				while (src.casings_to_eject > 0)
-					new src.current_projectile.casing(T, src)
+					var/atom/casing = new src.current_projectile.casing(T, src)
+					if(src.ammo.ammo_type.material)
+						casing.material_amt = src.ammo.ammo_type.material_amt * GUN_KINETIC_MATERIAL_RATIO_CASING
+						casing.setMaterial(src.ammo.ammo_type.material)
 					src.casings_to_eject--
 		return
 
@@ -284,6 +300,11 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 			logTheThing(LOG_DEBUG, usr, "<b>Convair880</b>: [usr]'s gun ([src]) ran into the magazine cap, aborting.")
 			return 0
 		return 1
+
+	on_material_scan()
+		. = ..()
+		if(src.ammo?.ammo_type.material)
+			return "Each bullet is coated in [src.ammo.ammo_type.material_amt] unit\s of [src.ammo.ammo_type.material]."
 
 ABSTRACT_TYPE(/obj/item/gun/kinetic/single_action)
 /obj/item/gun/kinetic/single_action
@@ -3021,7 +3042,7 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 	ammobag_magazines = list(/obj/item/ammo/bullets/bullet_9mm/smg)
 	ammobag_restock_cost = 2
 	recoil_strength = 8
-	
+
 	HELP_MESSAGE_OVERRIDE("Can be held with two hands to reduce recoil and improve accuracy.")
 
 	New()

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1038,10 +1038,10 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 
 	//warcrimes brought to you by bullets telling guns how to shoot!
 	attackby(obj/item/ammo/bullets/b, mob/user)
-		var/obj/previous_ammo = ammo
+		var/obj/item/ammo/bullets/previous_ammo = ammo
 		var/mode_was_auto = current_projectile.fullauto_valid
 		..()
-		if(previous_ammo.type != ammo.type)  // we switched ammo types
+		if(!previous_ammo.ammo_type.is_same_ammo(ammo.ammo_type)) // we switched ammo types
 			if(istype(ammo, /obj/item/ammo/bullets/nine_mm_surplus))
 				if(mode_was_auto)
 					set_current_projectile(new/datum/projectile/bullet/nine_mm_surplus/auto)
@@ -1119,9 +1119,9 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 
 	//copy pastes brought to you by bullets telling guns how to shoot!
 	attackby(obj/item/ammo/bullets/b, mob/user)
-		var/obj/previous_ammo = ammo
+		var/obj/item/ammo/bullets/previous_ammo = ammo
 		..()
-		if(previous_ammo.type != ammo.type)  // we switched ammo types
+		if(!previous_ammo.ammo_type.is_same_ammo(ammo.ammo_type))  // we switched ammo types
 			if(istype(ammo, /obj/item/ammo/bullets/nine_mm_surplus))
 				set_current_projectile(new/datum/projectile/bullet/nine_mm_surplus/auto)
 			else if(istype(ammo, /obj/item/ammo/bullets/bullet_9mm/smg))
@@ -3164,10 +3164,10 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 		..()
 
 	attackby(obj/item/ammo/bullets/b, mob/user)  // has to account for whether regular or armor-piercing ammo is loaded AND which firing mode it's using
-		var/obj/previous_ammo = ammo
+		var/obj/item/ammo/bullets/previous_ammo = ammo
 		var/mode_was_burst = (istype(current_projectile, /datum/projectile/bullet/assault_rifle/burst/))  // was previous mode burst fire?
 		..()
-		if(previous_ammo.type != ammo.type)  // we switched ammo types
+		if(!previous_ammo.ammo_type.is_same_ammo(ammo.ammo_type)) // we switched ammo types
 			if(istype(ammo, /obj/item/ammo/bullets/assault_rifle/armor_piercing)) // we switched from normal to armor_piercing
 				if(mode_was_burst) // we were in burst shot mode
 					set_current_projectile(new/datum/projectile/bullet/assault_rifle/burst/armor_piercing)
@@ -3227,10 +3227,10 @@ ABSTRACT_TYPE(/obj/item/survival_rifle_barrel)
 		..()
 
 	attackby(obj/item/ammo/bullets/b, mob/user)  // has to account for whether regular or armor-piercing ammo is loaded AND which firing mode it's using
-		var/obj/previous_ammo = ammo
+		var/obj/item/ammo/bullets/previous_ammo = ammo
 		var/mode_was_burst = (istype(current_projectile, /datum/projectile/bullet/assault_rifle/burst))  // was previous mode burst fire?
 		..()
-		if(previous_ammo.type != ammo.type)  // we switched ammo types
+		if(!previous_ammo.ammo_type.is_same_ammo(ammo.ammo_type)) // we switched ammo types
 			if(istype(ammo, /obj/item/ammo/bullets/assault_rifle/armor_piercing)) // we switched from normal to armor_piercing
 				if(mode_was_burst) // we were in burst shot mode
 					set_current_projectile(new/datum/projectile/bullet/assault_rifle/burst/armor_piercing)

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -122,7 +122,8 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 		if(istype(b, /obj/item/ammo/bullets))
 			if(ON_COOLDOWN(src, "reload_spam", src.reload_cooldown))
 				return
-			switch (src.ammo.loadammo(b,src))
+			var/reload_type = src.ammo.loadammo(b,src)
+			switch (reload_type)
 				if(0)
 					user.show_text("You can't reload this gun.", "red")
 					return
@@ -146,7 +147,8 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 					src.logme_temp(user, src, b)
 					return
 				if(AMMO_RELOAD_TYPE_SWAP)
-					switch (src.ammo.swap(b,src))
+					var/swap_type = src.ammo.swap(b,src)
+					switch (swap_type)
 						if(AMMO_SWAP_INCOMPATIBLE)
 							user.show_text("This ammo won't fit!", "red")
 							return

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -72,8 +72,8 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 		. = ..()
 		if (src.ammo && (src.ammo.amount_left > 0))
 			var/datum/projectile/ammo_type = src.ammo.ammo_type
-			if(ammo_type.material)
-				. += "There are [src.ammo.amount_left] [ammo_type.material.getName()]-coated [src.ammo.sname] bullets left!"
+			if(ammo_type.coating)
+				. += "There are [src.ammo.amount_left] [ammo_type.coating.getName()]-coated [src.ammo.sname] bullets left!"
 			else
 				. += "There are [src.ammo.amount_left] bullets of [src.ammo.sname] left!"
 		else
@@ -194,9 +194,9 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 						//DEBUG_MESSAGE("Ejected [number_of_casings] casings from [src].")
 						for (var/i in 1 to number_of_casings)
 							var/atom/casing = new src.current_projectile.casing(T, src)
-							if(src.ammo.ammo_type.material)
-								casing.material_amt = src.ammo.ammo_type.material_amt * GUN_KINETIC_MATERIAL_RATIO_CASING
-								casing.setMaterial(src.ammo.ammo_type.material)
+							if(src.ammo.ammo_type.coating)
+								casing.material_amt = src.ammo.ammo_type.coating_amount * GUN_KINETIC_MATERIAL_RATIO_CASING
+								casing.setMaterial(src.ammo.ammo_type.coating)
 			else
 				if (src.casings_to_eject < 0)
 					src.casings_to_eject = 0
@@ -213,9 +213,9 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 						//DEBUG_MESSAGE("Ejected [number_of_casings] casings from [src].")
 						for (var/i in 1 to number_of_casings)
 							var/atom/casing = new src.current_projectile.casing(T, src)
-							if(src.ammo.ammo_type.material)
-								casing.material_amt = src.ammo.ammo_type.material_amt * GUN_KINETIC_MATERIAL_RATIO_CASING
-								casing.setMaterial(src.ammo.ammo_type.material)
+							if(src.ammo.ammo_type.coating)
+								casing.material_amt = src.ammo.ammo_type.coating_amount * GUN_KINETIC_MATERIAL_RATIO_CASING
+								casing.setMaterial(src.ammo.ammo_type.coating)
 			else
 				if (src.casings_to_eject < 0)
 					src.casings_to_eject = 0
@@ -285,9 +285,9 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 				//DEBUG_MESSAGE("Ejected [src.casings_to_eject] [src.current_projectile.casing] from [src].")
 				while (src.casings_to_eject > 0)
 					var/atom/casing = new src.current_projectile.casing(T, src)
-					if(src.ammo.ammo_type.material)
-						casing.material_amt = src.ammo.ammo_type.material_amt * GUN_KINETIC_MATERIAL_RATIO_CASING
-						casing.setMaterial(src.ammo.ammo_type.material)
+					if(src.ammo.ammo_type.coating)
+						casing.material_amt = src.ammo.ammo_type.coating_amount * GUN_KINETIC_MATERIAL_RATIO_CASING
+						casing.setMaterial(src.ammo.ammo_type.coating)
 					src.casings_to_eject--
 		return
 
@@ -305,8 +305,8 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 	on_material_scan()
 		. = ..()
-		if(src.ammo?.ammo_type.material)
-			return "Each bullet is coated in [src.ammo.ammo_type.material_amt] unit\s of [src.ammo.ammo_type.material]."
+		if(src.ammo?.ammo_type.coating)
+			return "Each bullet is coated in [src.ammo.ammo_type.coating_amount] unit\s of [src.ammo.ammo_type.coating]"
 
 ABSTRACT_TYPE(/obj/item/gun/kinetic/single_action)
 /obj/item/gun/kinetic/single_action

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -944,11 +944,6 @@
 				reclaim_materials(C.material, C.material_amt * C.amount)
 				reclaim_materials(C.conductor, C.material_amt * C.amount)
 				qdel(C)
-			else if(istype(M, /obj/item/ammo/bullets))
-				var/obj/item/ammo/bullets/ammo = M
-				reclaim_materials(ammo.material, ammo.material_amt * ammo.amount)
-				reclaim_materials(ammo.ammo_type.coating, ammo.ammo_type.coating_amount * ammo.amount_left)
-				qdel(ammo)
 			else
 				reclaim_materials(M.material, M.material_amt * M.amount)
 				qdel(M)
@@ -1202,19 +1197,8 @@
 	proc/is_valid(var/obj/item/I)
 		// Returns TRUE if the item can be reclaimed
 		if (!istype(I))
-			return FALSE
-		if(istype(I, /obj/item/material_piece))
-			return FALSE
-		if(istype(I, /obj/item/nuclear_waste))
-			return FALSE
-		if(I.material)
-			return TRUE
-		if(istype(I, /obj/item/ammo/bullets))
-			var/obj/item/ammo/bullets/ammo = I
-			return ammo.ammo_type.coating && (ammo.amount_left > 0)
-		if(istype(I, /obj/item/wizard_crystal))
-			return TRUE
-		return FALSE
+			return
+		return (I.material && !istype(I,/obj/item/material_piece) && !istype(I,/obj/item/nuclear_waste)) || istype(I,/obj/item/wizard_crystal)
 
 	proc/brain_check(var/obj/item/I, var/mob/user, var/ask)
 		if (!istype(I))

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -935,15 +935,21 @@
 			if (istype(M, /obj/item/wizard_crystal))
 				var/obj/item/wizard_crystal/wc = M
 				wc.setMaterial(getMaterial(wc.assoc_material),0,0,1,0)
-			if (!istype(M.material))
-				M.set_loc(src.loc)
-				src.reject = 1
-				continue
-			else if (istype(M, /obj/item/cable_coil))
+
+			if (istype(M, /obj/item/cable_coil))
 				var/obj/item/cable_coil/C = M
 				reclaim_materials(C.material, C.material_amt * C.amount)
 				reclaim_materials(C.conductor, C.material_amt * C.amount)
 				qdel(C)
+			else if(istype(M, /obj/item/ammo/bullets))
+				var/obj/item/ammo/bullets/ammo = M
+				reclaim_materials(ammo.material, ammo.material_amt * ammo.amount)
+				reclaim_materials(ammo.ammo_type.coating, ammo.ammo_type.coating_amount * ammo.amount_left)
+				qdel(ammo)
+			else if (!istype(M.material))
+				M.set_loc(src.loc)
+				src.reject = 1
+				continue
 			else
 				reclaim_materials(M.material, M.material_amt * M.amount)
 				qdel(M)
@@ -1195,10 +1201,21 @@
 		return output_location
 
 	proc/is_valid(var/obj/item/I)
-		if (!istype(I))
-			return
-		return (I.material && !istype(I,/obj/item/material_piece) && !istype(I,/obj/item/nuclear_waste)) || istype(I,/obj/item/wizard_crystal)
-
+		// Returns TRUE if the item can be reclaimed
+		if (!isitem(I))
+			return FALSE
+		if(istype(I, /obj/item/material_piece))
+			return FALSE
+		if(istype(I, /obj/item/nuclear_waste))
+			return FALSE
+		if(I.material)
+			return TRUE
+		if(istype(I, /obj/item/ammo/bullets))
+			var/obj/item/ammo/bullets/ammo = I
+			return ammo.ammo_type.coating && (ammo.amount_left > 0)
+		if(istype(I, /obj/item/wizard_crystal))
+			return TRUE
+		return FALSE
 	proc/brain_check(var/obj/item/I, var/mob/user, var/ask)
 		if (!istype(I))
 			return

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -1195,7 +1195,6 @@
 		return output_location
 
 	proc/is_valid(var/obj/item/I)
-		// Returns TRUE if the item can be reclaimed
 		if (!istype(I))
 			return
 		return (I.material && !istype(I,/obj/item/material_piece) && !istype(I,/obj/item/nuclear_waste)) || istype(I,/obj/item/wizard_crystal)

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -944,6 +944,11 @@
 				reclaim_materials(C.material, C.material_amt * C.amount)
 				reclaim_materials(C.conductor, C.material_amt * C.amount)
 				qdel(C)
+			else if(istype(M, /obj/item/ammo/bullets))
+				var/obj/item/ammo/bullets/ammo = M
+				reclaim_materials(ammo.material, ammo.material_amt * ammo.amount)
+				reclaim_materials(ammo.ammo_type.coating, ammo.ammo_type.coating_amount * ammo.amount_left)
+				qdel(ammo)
 			else
 				reclaim_materials(M.material, M.material_amt * M.amount)
 				qdel(M)
@@ -1195,9 +1200,21 @@
 		return output_location
 
 	proc/is_valid(var/obj/item/I)
+		// Returns TRUE if the item can be reclaimed
 		if (!istype(I))
-			return
-		return (I.material && !istype(I,/obj/item/material_piece) && !istype(I,/obj/item/nuclear_waste)) || istype(I,/obj/item/wizard_crystal)
+			return FALSE
+		if(istype(I, /obj/item/material_piece))
+			return FALSE
+		if(istype(I, /obj/item/nuclear_waste))
+			return FALSE
+		if(I.material)
+			return TRUE
+		if(istype(I, /obj/item/ammo/bullets))
+			var/obj/item/ammo/bullets/ammo = I
+			return ammo.ammo_type.coating && (ammo.amount_left > 0)
+		if(istype(I, /obj/item/wizard_crystal))
+			return TRUE
+		return FALSE
 
 	proc/brain_check(var/obj/item/I, var/mob/user, var/ask)
 		if (!istype(I))


### PR DESCRIPTION
## About the PR
- Ammo containers with silver-coated bullets can now be placed in the reclaimer to reclaim the bullet material.
- Requires #27574 

## Why's this needed?
- Expected behavior for the reclaimer.

## Testing
<img width="235" height="244" alt="Screenshot 2026-08-22 024901" src="https://github.com/user-attachments/assets/09dd9352-e578-41cf-958a-ee71e3decb09" />

## Changelog
```changelog
(u)LorrMaster
(+)Silver-coated bullets in ammo containers can now be reclaimed.
```
