### PR TITLE
Added pitchers to civie borgs

### DIFF
--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -105,6 +105,7 @@
 		/obj/item/device/camera_viewer/public,
 		/obj/item/pen/omni,
 		/obj/item/paper_bin/robot,
+		/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 	)
 
 // engineer. mechanic.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds pitchers to civilian borgs
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bartending IS a civilian job, why shouldn't they do it?
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Opened the game as borged, picked civilian module, used the beaker. slammed it against the table, successfully used & didn't break.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ANNmagedon
(+)The civilian module for cyborgs now includes a pitcher.
```
