### PR TITLE
Maintain materials and forensics of various robots during construction

### DIFF
--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -1120,6 +1120,7 @@ Frequency:
 	else if (istype(W, /obj/item/device/radio))
 		if (src.build_step >= 2)
 			if (!src.has_radio)
+				W.forensic_holder.copy_to(src.forensic_holder)
 				src.build_step++
 				boutput(user, "You add \the [W] to [src]!")
 				playsound(src, 'sound/impact_sounds/Generic_Stab_1.ogg', 40, TRUE)
@@ -1137,6 +1138,7 @@ Frequency:
 	else if (istype(W, /obj/item/ai_interface))
 		if (src.build_step >= 2)
 			if (!src.has_interface)
+				W.forensic_holder.copy_to(src.forensic_holder)
 				src.build_step++
 				boutput(user, "You add the [W] to [src]!")
 				playsound(src, 'sound/impact_sounds/Generic_Stab_1.ogg', 40, TRUE)
@@ -1156,6 +1158,8 @@ Frequency:
 			boutput(user, "You activate the shell!  Beep bop!")
 			var/mob/living/silicon/hivebot/eyebot/S = new /mob/living/silicon/hivebot/eyebot(get_turf(src))
 			S.cell = src.cell
+			S.setMaterial(src.material)
+			S.forensic_holder = src.forensic_holder
 			src.cell.set_loc(S)
 			src.cell = null
 			qdel(src)

--- a/code/modules/items/instruments/instruments.dm
+++ b/code/modules/items/instruments/instruments.dm
@@ -554,6 +554,9 @@
 			logTheThing(LOG_STATION, user, "builds an amusing duck at [log_loc(src)]")
 			var/obj/machinery/bot/duckbot/D = new /obj/machinery/bot/duckbot
 			D.eggs = rand(2,5) // LAY EGG IS TRUE!!!
+			D.setMaterial(src.material)
+			D.forensic_holder = src.forensic_holder
+			W.forensic_holder.copy_to(D.forensic_holder)
 			boutput(user, SPAN_NOTICE("You add [W] to [src]."))
 			D.set_loc(get_turf(user))
 			qdel(W)
@@ -606,6 +609,9 @@ TYPEINFO(/obj/item/instrument/bikehorn/dramatic)
 			return
 		else
 			var/obj/machinery/bot/chefbot/D = new /obj/machinery/bot/chefbot
+			D.setMaterial(src.material)
+			D.forensic_holder = src.forensic_holder
+			W.forensic_holder.copy_to(D.forensic_holder)
 			boutput(user, SPAN_NOTICE("You add [W] to [src]."))
 			D.set_loc(get_turf(user))
 			qdel(W)

--- a/code/modules/robotics/bot/buttbot.dm
+++ b/code/modules/robotics/bot/buttbot.dm
@@ -19,6 +19,7 @@ TYPEINFO(/obj/machinery/bot/buttbot)
 	bot_move_delay = BUTTBOT_MOVE_SPEED
 	density = 0
 	anchored = UNANCHORED
+	default_material = "butt"
 	on = 1
 	health = 5
 	no_camera = 1
@@ -74,6 +75,7 @@ TYPEINFO(/obj/machinery/bot/buttbot)
 /obj/machinery/bot/buttbot/cyber
 	name = "robuttbot"
 	icon_state = "cyberbuttbot"
+	default_material = "pharosium"
 	default_butt = /obj/item/clothing/head/butt/cyberbutt
 
 /obj/machinery/bot/buttbot/text2speech

--- a/code/modules/robotics/bot/cambot.dm
+++ b/code/modules/robotics/bot/cambot.dm
@@ -323,6 +323,9 @@
 	attackby(obj/item/W, mob/user)
 		if (istype(W, /obj/item/device/prox_sensor))
 			var/obj/machinery/bot/cambot/B = new /obj/machinery/bot/cambot(get_turf(src))
+			B.setMaterial(src.material)
+			B.forensic_holder = src.forensic_holder
+			W.forensic_holder.copy_to(src.forensic_holder)
 			B.name = src.created_name
 			user.u_equip(W)
 			user.u_equip(src)

--- a/code/modules/robotics/bot/firebot.dm
+++ b/code/modules/robotics/bot/firebot.dm
@@ -447,6 +447,8 @@
 
 /obj/item/toolbox_arm/attackby(obj/item/W, mob/user)
 	if ((istype(W, /obj/item/extinguisher)) && (!src.extinguisher))
+		src.setMaterial(W.material)
+		W.forensic_holder.copy_to(src.forensic_holder)
 		src.extinguisher = 1
 		boutput(user, "You add the fire extinguisher to [src]!")
 		src.name = "Toolbox/robot arm/fire extinguisher assembly"
@@ -456,6 +458,9 @@
 	else if ((istype(W, /obj/item/device/prox_sensor)) && (src.extinguisher))
 		boutput(user, "You complete the Firebot! Beep boop.")
 		var/obj/machinery/bot/firebot/S = new /obj/machinery/bot/firebot
+		S.setMaterial(src.material)
+		S.forensic_holder = src.forensic_holder
+		W.forensic_holder.copy_to(S.forensic_holder)
 		S.set_loc(get_turf(src))
 		S.name = src.created_name
 		qdel(W)

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -812,6 +812,9 @@ TYPEINFO(/obj/machinery/bot/medbot/terrifying)
 		return
 	else
 		var/obj/item/firstaid_arm_assembly/A = new /obj/item/firstaid_arm_assembly
+		A.setMaterial(src.material)
+		A.forensic_holder = src.forensic_holder
+		S.forensic_holder.copy_to(A.forensic_holder)
 		if (src.icon_state != "firstaid") // fart
 			A.skin = src.icon_state // farto
 /* all of this is kinda needlessly complicated imo
@@ -834,6 +837,7 @@ TYPEINFO(/obj/machinery/bot/medbot/terrifying)
 
 /obj/item/firstaid_arm_assembly/attackby(obj/item/W, mob/user)
 	if ((istype(W, /obj/item/device/analyzer/healthanalyzer)) && (!src.build_step))
+		W.forensic_holder.copy_to(src.forensic_holder)
 		src.build_step++
 		boutput(user, "You add the health sensor to [src]!")
 		src.name = "First aid/robot arm/health analyzer assembly"
@@ -844,6 +848,9 @@ TYPEINFO(/obj/machinery/bot/medbot/terrifying)
 		src.build_step++
 		boutput(user, "You complete the Medibot! Beep boop.")
 		var/obj/machinery/bot/medbot/S = new /obj/machinery/bot/medbot
+		S.setMaterial(src.material)
+		S.forensic_holder = src.forensic_holder
+		W.forensic_holder.copy_to(S.forensic_holder)
 		S.skin = src.skin
 		S.set_loc(get_turf(src))
 		S.name = src.created_name

--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -78,6 +78,9 @@ TYPEINFO(/obj/item/camera/large)
 
 		else if (istype(W, /obj/item/parts/robot_parts/arm))
 			var/obj/item/camera_arm_assembly/B = new /obj/item/camera_arm_assembly
+			B.setMaterial(src.material)
+			B.forensic_holder = src.forensic_holder
+			W.forensic_holder.copy_to(B.forensic_holder)
 			B.set_loc(user)
 			user.u_equip(W)
 			user.u_equip(src)

--- a/code/obj/item/organs/butt.dm
+++ b/code/obj/item/organs/butt.dm
@@ -200,6 +200,9 @@ TYPEINFO(/obj/item/clothing/head/butt)
 				B.name = "mutagenic buttbot"
 			else if (src.donor || src.donor_name)
 				B.name = "[src.donor_name ? "[src.donor_name]" : "[src.donor.real_name]"] buttbot"
+			B.setMaterial(src.material)
+			B.forensic_holder = src.forensic_holder
+			W.forensic_holder.copy_to(B.forensic_holder)
 			user.show_text("You add [W] to [src]. Fantastic.", "blue")
 			B.set_loc(get_turf(src))
 			src.set_loc(B)
@@ -314,6 +317,9 @@ TYPEINFO(/obj/item/clothing/head/butt/cyberbutt)
 			var/obj/machinery/bot/buttbot/cyber/B = new /obj/machinery/bot/buttbot/cyber(src, W)
 			if (src.donor || src.donor_name)
 				B.name = "[src.donor_name ? "[src.donor_name]" : "[src.donor.real_name]"] robuttbot"
+			B.setMaterial(src.material)
+			B.forensic_holder = src.forensic_holder
+			W.forensic_holder.copy_to(B.forensic_holder)
 			user.show_text("You add [W] to [src]. Fantastic.", "blue")
 			B.set_loc(get_turf(src))
 			src.set_loc(B)


### PR DESCRIPTION
## About the PR
- Material and forensics in now maintained during the construction of AI shells, duckbots, chefbots, buttbots, cambots, firebots, and medbots.

## Why's this needed?
- Expected behavior.

## Testing
<img width="341" height="350" alt="Screenshot 2026-08-23 094741" src="https://github.com/user-attachments/assets/0691ce79-283b-43aa-a290-d831a92e0419" />
<img width="277" height="210" alt="Screenshot 2026-08-23 110257" src="https://github.com/user-attachments/assets/38cdcafb-0038-444e-ab27-bebc1e2e5444" />

## Changelog
```changelog
(u)LorrMaster
(+)Material and forensic data is now maintained for the construction process of various robots
```
