### PR TITLE
Small gang fixes

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1218,6 +1218,7 @@
 	var/datum/gang/gang
 	/// when our next spray sound can beplayed
 	var/next_spray = 0 DECI SECONDS
+	var/tagging_over = FALSE
 
 	New(var/turf/target_turf as turf, var/obj/item/spray_paint_gang/can, var/tag_over)
 		src.target_turf = target_turf
@@ -1225,6 +1226,7 @@
 		src.spraycan = can
 		if (tag_over)
 			src.duration = GANG_SPRAYPAINT_TAG_REPLACE_TIME
+			tagging_over = TRUE
 		..()
 
 	onStart()
@@ -1234,17 +1236,17 @@
 			if (ismob(owner))
 				M = owner
 				src.gang = M?.get_gang()
-			if (gang && src.duration == GANG_SPRAYPAINT_TAG_REPLACE_TIME)
+			if (gang && src.tagging_over)
 				icon = 'icons/obj/decals/gang_tags.dmi'
 				icon_state = "gangtag[src.gang.gang_tag]"
 				var/speedup = src.gang.gear_worn(M)
 				switch (speedup)
 					if (1)
-						duration *= 0.8
+						duration *= 0.9
 					if (2)
-						duration *= 0.6
+						duration *= 0.8
 					if (3)
-						duration *= 0.4
+						duration *= 0.7
 			..()
 		catch(var/exception/e)
 			..()

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1234,17 +1234,17 @@
 			if (ismob(owner))
 				M = owner
 				src.gang = M?.get_gang()
-			if (gang)
+			if (gang && src.duration == GANG_SPRAYPAINT_TAG_REPLACE_TIME)
 				icon = 'icons/obj/decals/gang_tags.dmi'
 				icon_state = "gangtag[src.gang.gang_tag]"
 				var/speedup = src.gang.gear_worn(M)
 				switch (speedup)
 					if (1)
-						duration = 13 SECONDS
+						duration *= 0.8
 					if (2)
-						duration = 9 SECONDS
+						duration *= 0.6
 					if (3)
-						duration = 6 SECONDS
+						duration *= 0.4
 			..()
 		catch(var/exception/e)
 			..()
@@ -1962,10 +1962,11 @@
 
 		//gun score
 		else if (istype(item, /obj/item/gun))
-			if(istype(item, /obj/item/gun/kinetic/foamdartgun))
-				boutput(user, SPAN_ALERT("<b>You cant stash toy guns in the locker</b>"))
-
-				return
+			if (istype(item, /obj/item/gun/kinetic))
+				var/obj/item/gun/kinetic/G = item
+				if (G.ammo_cats && AMMO_FOAMDART in G.ammo_cats)
+					boutput(user, SPAN_ALERT("<b>You cant stash toy guns in the locker</b>"))
+					return
 
 			if(istype(item, /obj/item/gun/kinetic/slamgun) || istype(item, /obj/item/gun/kinetic/zipgun))
 				boutput(user, SPAN_ALERT("<b>This shoddy firearm isn't worth selling.</b>"))

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1966,7 +1966,7 @@
 		else if (istype(item, /obj/item/gun))
 			if (istype(item, /obj/item/gun/kinetic))
 				var/obj/item/gun/kinetic/G = item
-				if (G.ammo_cats && AMMO_FOAMDART in G.ammo_cats)
+				if (G.ammo_cats && (AMMO_FOAMDART in G.ammo_cats))
 					boutput(user, SPAN_ALERT("<b>You cant stash toy guns in the locker</b>"))
 					return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Bug: Gangs use the 'tag over' timer instead of the 'new tag' time if they're wearing any of their outfit.
Fix: Spraying new tags as gang now correctly takes 3 seconds no matter what. Times rebalanced a bit.

Bug: You could hand in toy guns for gang points.
Fix: All foam dart guns can no longer be handed in.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fix good

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Tested and breakpointed both features

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)TDHooligan
(+)Fix: Gangs should now only take 3 seconds to spray a tag in an unoccupied space, instead of 15/12/9 seconds.
(+)Fix: Gangs can no longer hand in foam dart guns.
(+)Tagging over rival tags now takes slightly longer.
```
