### PR TITLE
reintoduce the donut2's rd/md plushies in donut3 & probestation

### DIFF
--- a/assets/maps/random_rooms/probstation/9x9/md+rd_office.dmm
+++ b/assets/maps/random_rooms/probstation/9x9/md+rd_office.dmm
@@ -53,6 +53,7 @@
 "fP" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/pink,
+/obj/item/toy/plush/small/possum/md,
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/crew_quarters/hor)
 "gq" = (
@@ -417,6 +418,7 @@
 "Pt" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/blue,
+/obj/item/toy/plush/small/bee/rd,
 /turf/simulated/floor/carpet/blue/fancy/edge/west,
 /area/station/medical/head)
 "PG" = (

--- a/code/modules/items/gimmick/plushies.dm
+++ b/code/modules/items/gimmick/plushies.dm
@@ -232,6 +232,10 @@ TYPEINFO(/obj/submachine/claw_machine)
 	name = "super cute bee plush toy"
 	icon_state = "bee_cute"
 
+/obj/item/toy/plush/small/bee/rd
+	name = "RD's Heisenbee plush"
+	desc = "A very special plush."
+
 /obj/item/toy/plush/small/buddy
 	name = "buddy plush toy"
 	icon_state = "buddy"
@@ -263,6 +267,10 @@ TYPEINFO(/obj/submachine/claw_machine)
 /obj/item/toy/plush/small/possum
 	name = "possum plush toy"
 	icon_state = "possum"
+
+/obj/item/toy/plush/small/possum/md
+	name = "MD's Morty plush"
+	desc = "Part of a matching set."
 
 /obj/item/toy/plush/small/brullbar
 	name = "brullbar plush toy"

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -15243,6 +15243,7 @@
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
 	},
+/obj/item/toy/plush/small/possum/md,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "eJM" = (
@@ -69860,6 +69861,7 @@
 	dir = 8
 	},
 /obj/item/clothing/suit/bedsheet/black,
+/obj/item/toy/plush/small/bee/rd,
 /turf/simulated/floor/carpet/blue/fancy/narrow/T_west,
 /area/station/medical/head)
 "vFi" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Readd the donut 2 md & rd plushies into donut 3 (cause donut) and probestation (they share a prefab, it was ment to be) as proper items
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
donut 3
<img width="432" height="292" alt="d3-md" src="https://github.com/user-attachments/assets/c379f06c-db13-4187-be86-91e3a8ef167f" />
<img width="307" height="152" alt="d3-rd" src="https://github.com/user-attachments/assets/ef103cfb-5f9b-40dd-9e2b-951420762be3" />
probe
<img width="450" height="440" alt="probe-md" src="https://github.com/user-attachments/assets/9ff34707-5219-4a78-8557-6a4cdd48004c" />
<img width="400" height="276" alt="probe-rd" src="https://github.com/user-attachments/assets/9c36c325-55ca-4b30-88c2-b35750867bbe" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ANNmagedon
(+)A familiar pair of plushies previously lost with the end of donut 2 has appeared on donut 3.
```
