### PR TITLE
adds syndicate cyborg check

### DIFF
--- a/_std/macros/antagchecks.dm
+++ b/_std/macros/antagchecks.dm
@@ -7,7 +7,8 @@
 #define issleeperagent(x) (istype(x, /mob/living/carbon/human) && x:mind && x:mind:get_antagonist(ROLE_SLEEPER_AGENT))
 #define issyndicateagent(x) (istype(x, /mob/living/carbon/human) && x:mind && (x:mind:get_antagonist(ROLE_SYNDICATE_AGENT) || x:mind:get_antagonist(ROLE_SYNDICATE_COMMANDER) || x:mind:get_antagonist(ROLE_SYNDICATE_MONKEY)))
 #define isnukeopgunbot(x) (istype(x, /mob/living/critter/robotic/gunbot/syndicate) && x:mind && x:mind:get_antagonist(ROLE_NUKEOP_GUNBOT))
-#define istrainedsyndie(x) (istraitor(x) || isnukeop(x) || issleeperagent(x) || issyndicateagent(x) || isnukeopgunbot(x) || isomnitraitor(x))
+#define issyndicatecyborg(x) (istype(x, /mob/living/silicon/robot) && x:mind && x:mind:get_antagonist(ROLE_SYNDICATE_ROBOT))
+#define istrainedsyndie(x) (istraitor(x) || isnukeop(x) || issleeperagent(x) || issyndicateagent(x) || isnukeopgunbot(x) || isomnitraitor(x) || issyndicatecyborg(x))
 
 #define isomnitraitor(x) (istype(x, /mob/living/carbon/human) && x:mind && x:mind:get_antagonist(ROLE_OMNITRAITOR))
 #define issawflybuddy(x) (istrainedsyndie(x) || isspythief(x))

--- a/_std/macros/antagchecks.dm
+++ b/_std/macros/antagchecks.dm
@@ -7,7 +7,7 @@
 #define issleeperagent(x) (istype(x, /mob/living/carbon/human) && x:mind && x:mind:get_antagonist(ROLE_SLEEPER_AGENT))
 #define issyndicateagent(x) (istype(x, /mob/living/carbon/human) && x:mind && (x:mind:get_antagonist(ROLE_SYNDICATE_AGENT) || x:mind:get_antagonist(ROLE_SYNDICATE_COMMANDER) || x:mind:get_antagonist(ROLE_SYNDICATE_MONKEY)))
 #define isnukeopgunbot(x) (istype(x, /mob/living/critter/robotic/gunbot/syndicate) && x:mind && x:mind:get_antagonist(ROLE_NUKEOP_GUNBOT))
-#define issyndicatecyborg(x) (istype(x, /mob/living/silicon/robot) && x:mind && x:mind:get_antagonist(ROLE_SYNDICATE_ROBOT))
+#define issyndicatecyborg(x) (istype(x, /mob/living/silicon/robot) && x:syndicate)
 #define istrainedsyndie(x) (istraitor(x) || isnukeop(x) || issleeperagent(x) || issyndicateagent(x) || isnukeopgunbot(x) || isomnitraitor(x) || issyndicatecyborg(x))
 
 #define isomnitraitor(x) (istype(x, /mob/living/carbon/human) && x:mind && x:mind:get_antagonist(ROLE_OMNITRAITOR))

--- a/code/obj/machinery/door/door_control.dm
+++ b/code/obj/machinery/door/door_control.dm
@@ -665,6 +665,9 @@ TYPEINFO(/obj/machinery/door_control)
 	if (ON_COOLDOWN(src, "scan", 2 SECONDS))
 		return
 	playsound(src.loc, 'sound/effects/handscan.ogg', 50, 1)
+	if(issilicon(user) || isrobocritter(user)) //syndie borgs/gunbots have door access when post is online, but cannot use the scanner
+		src.say("No biometric profile detected.")
+		return
 	if (istrainedsyndie(user))
 		var/datum/listening_post/listening_post = get_singleton(/datum/listening_post)
 		var/first_unlock_text


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds antag check for syndicate cyborgs and implements it into istrainedsyndie so they don't get targeted by sawflies and such 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Syndie borgs should probably count as trained syndies. 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
works on local
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)bamlord
(+)Syndicate cyborgs are now counted as trained syndicates for the purposes of targeting and item descriptions etc. 
```
