### PR TITLE
adds throwing damage to swordfish + literal swordfish

### DIFF
--- a/code/modules/fishing/fish.dm
+++ b/code/modules/fishing/fish.dm
@@ -709,6 +709,7 @@ TYPEINFO(/obj/item/reagent_containers/food/fish/swordfish)
 	category = FISH_CATEGORY_OCEAN
 	rarity = ITEM_RARITY_RARE
 	force = 6
+	throwforce = 10
 	hit_type = DAMAGE_STAB
 
 	New()
@@ -730,6 +731,7 @@ TYPEINFO(/obj/item/reagent_containers/food/fish/literal_swordfish)
 	attack_verbs = "stabs"
 	rarity = ITEM_RARITY_LEGENDARY
 	force = 13
+	throwforce = 15
 	hit_type = DAMAGE_CUT
 	contraband = 3
 	hitsound = 'sound/impact_sounds/Blade_Small_Bloody.ogg'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
10 damage for swordfish, 15 damage for literal swordfish
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
felt very strange for a stabbing weapon to not have actual throwing damage
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
tried throwing both at a monkey. it worked. monkey ended up killing me with the swordfish however.
