### PR TITLE
Lottery medal + atm fix

### DIFF
--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -206,13 +206,6 @@
 			user.client.add_to_bank(SB.amount)
 			boutput(user, SPAN_ALERT("You deposit [SB.amount] spacebux into your account!"))
 			qdel(SB)
-		else if(istype(I, /obj/item/currency/spacecash/))
-			if (src.accessed_record)
-				boutput(user, SPAN_NOTICE("You insert the cash into the ATM."))
-				src.accessed_record["current_money"] += I.amount
-				I.amount = 0
-				qdel(I)
-			else boutput(user, SPAN_ALERT("You need to log in before depositing cash!"))
 		else if(istype(I, /obj/item/currency/buttcoin/))
 			if (src.accessed_record)
 				boutput(user, SPAN_NOTICE("You force the cash into the ATM."))
@@ -220,23 +213,6 @@
 				I.amount = 0
 				qdel(I)
 			else boutput(user, SPAN_ALERT("You need to log in before depositing cash!"))
-		else if(istype(I, /obj/item/lotteryTicket))
-			if (src.accessed_record)
-				boutput(user, SPAN_NOTICE("You insert the lottery ticket into the ATM."))
-				if(I:winner)
-					boutput(user, SPAN_NOTICE("Congratulations, this ticket is a winner netting you [I:winner] credits"))
-					src.accessed_record["current_money"] += I:winner
-
-					if(wagesystem.lotteryJackpot > I:winner)
-						wagesystem.lotteryJackpot -= I:winner
-					else
-						wagesystem.lotteryJackpot = 0
-
-
-				else
-					boutput(user, SPAN_ALERT("This ticket isn't a winner. Better luck next time!"))
-				qdel(I)
-			else boutput(user, SPAN_ALERT("You need to log in before inserting a ticket!"))
 		else
 			..()
 		return
@@ -495,6 +471,7 @@
 						wagesystem.lotteryJackpot -= I:winner
 					else
 						wagesystem.lotteryJackpot = 0
+					user.unlock_medal("Guess who won the lottery!", TRUE)
 					src.Attackhand(user)
 				else
 					boutput(user, SPAN_ALERT("This ticket isn't a winner. Better luck next time!"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the lottery medal not being awarded by adding the unlock to the ATM  submachine which is what most stations actually use (dumb me for not checking). Also deleted redundant code from  /obj/machinery/computer/ATM which I noticed when trying to figure out why the medal wasn't working. 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugfix 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Can't test the medal unlock but the ATMs were working when inserting winning tickets on local
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->