### PR TITLE
Smoke ban fliptonium

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2464,6 +2464,7 @@ datum
 			fluid_r = 209
 			fluid_g = 31
 			fluid_b = 117
+			fluid_flags = FLUID_SMOKE_BANNED
 			transparency = 175
 			addiction_prob = 0.2
 			addiction_min = 10


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Smoke bans both fliptonium and glowing fliptonium.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Okay okay I know this is soul removal but hear me out:
Smoke bombing glowing fliptonium is instant sensory overload and makes everything worse for everyone. It's almost impossible to actually play the game after a single random scientist floods the shuttle/medbay with this stuff. I contemplate cryoing every time it happens and I cannot be the only one.
You can still manually set every object on the shuttle flipping but the rest of the crew has a chance to shove you over and call you a nerd as god intended.
## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Fliptonium can no longer be used with smoke powder.
```
