### PR TITLE
Fermid rework 2.5

### DIFF
--- a/code/mob/living/critter/mining_critter.dm
+++ b/code/mob/living/critter/mining_critter.dm
@@ -11,6 +11,7 @@
 	var/list/bite_adjectives = list("vicious","vengeful","violent")
 	sound_attack = 'sound/impact_sounds/Flesh_Tear_1.ogg'
 	can_beat_up_robots = TRUE //angry space ants
+	miss_prob = 95
 	var/tears_off_limbs = FALSE //Basically checks if the attack should tear off limbs (Only available to Hulk Fermids at this time)
 	harm(mob/target, var/mob/user)
 		if (!user || !target)

--- a/code/mob/living/critter/mining_critter.dm
+++ b/code/mob/living/critter/mining_critter.dm
@@ -19,11 +19,11 @@
 		if (!target.melee_attack_test(user))
 			return
 		src.custom_msg = SPAN_COMBAT("<b>[user] bites [target] with [his_or_her(user)] [pick(src.bite_adjectives)] mandibles!</b>")
-		..()
 		if (ishuman(target) && tears_off_limbs && prob(20))
 			var/mob/living/carbon/human/limb_loser = target
 			if(limb_loser.limbs)
 				limb_loser.sever_limb(pick(list("l_arm", "r_arm", "l_leg", "r_leg")))
+		..()
 /datum/limb/mouth/fermid/fermid_hulk
 	tears_off_limbs = TRUE
 	dam_low = 5

--- a/code/mob/living/critter/mining_critter.dm
+++ b/code/mob/living/critter/mining_critter.dm
@@ -135,11 +135,6 @@
 			bite.handleCast(target)
 			return TRUE
 
-	critter_basic_attack(mob/target)
-		if(prob(30))
-			src.swap_hand()
-		return ..()
-
 	death()
 		src.reagents.add_reagent("atropine", 50, null)
 		src.reagents.add_reagent("haloperidol", 50, null)

--- a/code/mob/living/critter/mining_critter.dm
+++ b/code/mob/living/critter/mining_critter.dm
@@ -253,6 +253,8 @@
 
 		src.pixel_x -= 16
 		src.add_stam_mod_max("queen", 50)
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_STUN_RESIST, "queen", 25)
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_STUN_RESIST_MAX, "queen", 25)
 
 /mob/living/critter/fermid/hulk
 	name = "fermid hulk"
@@ -280,6 +282,8 @@
 		APPLY_MOVEMENT_MODIFIER(src, /datum/movement_modifier/big_fermid, src)
 		src.pixel_x -= 16
 		src.add_stam_mod_max("hulk", 50)
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_STUN_RESIST, "hulk", 25)
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_STUN_RESIST_MAX, "hulk", 25)
 	purple
 		recolor = "#b90fab"
 		speed = /datum/movement_modifier/big_fermid_fast

--- a/code/mob/living/critter/mining_critter.dm
+++ b/code/mob/living/critter/mining_critter.dm
@@ -281,7 +281,6 @@
 		..()
 		var/datum/handHolder/HH = hands[1]
 		HH.limb = new /datum/limb/mouth/fermid/fermid_hulk
-		APPLY_MOVEMENT_MODIFIER(src, /datum/movement_modifier/big_fermid, src)
 		src.pixel_x -= 16
 		src.add_stam_mod_max("hulk", 50)
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_STUN_RESIST, "hulk", 25)

--- a/code/mob/living/critter/mining_critter.dm
+++ b/code/mob/living/critter/mining_critter.dm
@@ -20,7 +20,7 @@
 			return
 		src.custom_msg = SPAN_COMBAT("<b>[user] bites [target] with [his_or_her(user)] [pick(src.bite_adjectives)] mandibles!</b>")
 		..()
-		if (ishuman(target) && tears_off_limbs && prob(15))
+		if (ishuman(target) && tears_off_limbs && prob(20))
 			var/mob/living/carbon/human/limb_loser = target
 			if(limb_loser.limbs)
 				limb_loser.sever_limb(pick(list("l_arm", "r_arm", "l_leg", "r_leg")))

--- a/code/mob/living/critter/mining_critter.dm
+++ b/code/mob/living/critter/mining_critter.dm
@@ -257,6 +257,7 @@
 		..()
 
 		src.pixel_x -= 16
+		src.add_stam_mod_max("queen", 50)
 
 /mob/living/critter/fermid/hulk
 	name = "fermid hulk"
@@ -283,6 +284,7 @@
 		HH.limb = new /datum/limb/mouth/fermid/fermid_hulk
 		APPLY_MOVEMENT_MODIFIER(src, /datum/movement_modifier/big_fermid, src)
 		src.pixel_x -= 16
+		src.add_stam_mod_max("hulk", 50)
 	purple
 		recolor = "#b90fab"
 		speed = /datum/movement_modifier/big_fermid_fast

--- a/code/mob/living/critter/mining_critter.dm
+++ b/code/mob/living/critter/mining_critter.dm
@@ -246,9 +246,9 @@
 	icon = 'icons/misc/bigcritter.dmi'
 	icon_state = "fermid-queen"
 	icon_state_dead = "fermid-queen-dead"
-	health_brute = 50
+	health_brute = 100
 	health_brute_vuln = 0.6
-	health_burn = 25
+	health_burn = 50
 	health_burn_vuln = 0.1
 	pull_w_class = W_CLASS_BULKY
 	speed = /datum/movement_modifier/big_fermid
@@ -264,9 +264,9 @@
 	icon = 'icons/misc/bigcritter.dmi'
 	icon_state = "fermid-hulk"
 	icon_state_dead = "fermid-hulk-dead"
-	health_brute = 40
+	health_brute = 90
 	health_brute_vuln = 0.5
-	health_burn = 25
+	health_burn = 50
 	health_burn_vuln = 0.1
 	pull_w_class = W_CLASS_BULKY
 	add_abilities = list(/datum/targetable/critter/bite/fermid_bite, /datum/targetable/critter/slam/fermid)

--- a/code/mob/living/critter/mining_critter.dm
+++ b/code/mob/living/critter/mining_critter.dm
@@ -19,15 +19,15 @@
 		if (!target.melee_attack_test(user))
 			return
 		src.custom_msg = SPAN_COMBAT("<b>[user] bites [target] with [his_or_her(user)] [pick(src.bite_adjectives)] mandibles!</b>")
+		..()
 		if (ishuman(target) && tears_off_limbs && prob(20))
 			var/mob/living/carbon/human/limb_loser = target
 			if(limb_loser.limbs)
 				limb_loser.sever_limb(pick(list("l_arm", "r_arm", "l_leg", "r_leg")))
-		..()
 /datum/limb/mouth/fermid/fermid_hulk
 	tears_off_limbs = TRUE
-	dam_low = 5
-	dam_high = 12
+	dam_low = 10
+	dam_high = 22
 
 ///////////////////////////////////////////////
 // FERMID
@@ -243,9 +243,9 @@
 	icon = 'icons/misc/bigcritter.dmi'
 	icon_state = "fermid-queen"
 	icon_state_dead = "fermid-queen-dead"
-	health_brute = 100
+	health_brute = 200
 	health_brute_vuln = 0.6
-	health_burn = 50
+	health_burn = 100
 	health_burn_vuln = 0.1
 	pull_w_class = W_CLASS_BULKY
 	speed = /datum/movement_modifier/big_fermid
@@ -255,8 +255,8 @@
 
 		src.pixel_x -= 16
 		src.add_stam_mod_max("queen", 50)
-		APPLY_ATOM_PROPERTY(src, PROP_MOB_STUN_RESIST, "queen", 25)
-		APPLY_ATOM_PROPERTY(src, PROP_MOB_STUN_RESIST_MAX, "queen", 25)
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_STUN_RESIST, "queen", 50)
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_STUN_RESIST_MAX, "queen", 50)
 
 /mob/living/critter/fermid/hulk
 	name = "fermid hulk"
@@ -264,9 +264,9 @@
 	icon = 'icons/misc/bigcritter.dmi'
 	icon_state = "fermid-hulk"
 	icon_state_dead = "fermid-hulk-dead"
-	health_brute = 90
+	health_brute = 150
 	health_brute_vuln = 0.5
-	health_burn = 50
+	health_burn = 75
 	health_burn_vuln = 0.1
 	pull_w_class = W_CLASS_BULKY
 	add_abilities = list(/datum/targetable/critter/bite/fermid_bite, /datum/targetable/critter/slam/fermid)
@@ -283,8 +283,8 @@
 		HH.limb = new /datum/limb/mouth/fermid/fermid_hulk
 		src.pixel_x -= 16
 		src.add_stam_mod_max("hulk", 50)
-		APPLY_ATOM_PROPERTY(src, PROP_MOB_STUN_RESIST, "hulk", 25)
-		APPLY_ATOM_PROPERTY(src, PROP_MOB_STUN_RESIST_MAX, "hulk", 25)
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_STUN_RESIST, "hulk", 50)
+		APPLY_ATOM_PROPERTY(src, PROP_MOB_STUN_RESIST_MAX, "hulk", 50)
 	purple
 		recolor = "#b90fab"
 		speed = /datum/movement_modifier/big_fermid_fast

--- a/code/mob/living/critter/mining_critter.dm
+++ b/code/mob/living/critter/mining_critter.dm
@@ -26,6 +26,8 @@
 				limb_loser.sever_limb(pick(list("l_arm", "r_arm", "l_leg", "r_leg")))
 /datum/limb/mouth/fermid/fermid_hulk
 	tears_off_limbs = TRUE
+	dam_low = 5
+	dam_high = 12
 
 ///////////////////////////////////////////////
 // FERMID


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes slight tweaks to the Fermids. Namely, reducing the chance for their bite ability to miss during combat, as well as restricting their limbs used to JUST biting. No more pesky punches from the ants. The Hulk's bite now has a 20% chance to delimb the target. 

It also implements a higher health and stamina total for the Fermid Queen and Hulk, as well as increased stamina resistance. 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
During live testing for the second Fermid rework, it was determined that the queen and the hulk were easily overwhelmed, and lacked the punchiness of a true boss critter for the Fermids. By tweaking these values and behaviors, I hope to make the Fermids a little more challenging to fight in the long run, before I start to implement the queen's abilities and tweak their behavior further. 
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I've tested these on local thoroughly, but changes may need to be made once they're tested against a group of people. 
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)swinglow20
(+)Made Fermid Hulks and Queens tankier, and made their bite more likely to land. 
```
