### PR TITLE
Grenade runtime fixes / Sawflies no longer attempt to get twice as much therapy

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -218,6 +218,8 @@ TYPEINFO(/area)
 			//If any mobs are entering, within a thing or otherwise
 			if (length(enteringMobs) > 0)
 				for (var/mob/enteringM in enteringMobs) //each dumb mob
+					if(get_area(enteringM) == src)
+						continue // The mob may be exiting a cart or be inside an item
 					SEND_SIGNAL(src, COMSIG_AREA_ENTERED_BY_MOB, enteringM)
 					if( !(isliving(enteringM) || iswraith(enteringM)) ) continue
 					//Wake up a bunch of lazy darn critters

--- a/code/datums/effects/system/bad_smoke_spread.dm
+++ b/code/datums/effects/system/bad_smoke_spread.dm
@@ -11,7 +11,7 @@ proc/ClearBadsmokeRefs(var/atom/A)
 
 /datum/effects/system/bad_smoke_spread
 	var/number = 3
-	var/cardinals = 0
+	var/spread_cardinal = FALSE
 	var/turf/location
 	var/atom/holder
 	var/total_smoke = 0 // To stop it being spammed and lagging!
@@ -22,22 +22,22 @@ proc/ClearBadsmokeRefs(var/atom/A)
 		..()
 		START_TRACKING
 
-/datum/effects/system/bad_smoke_spread/proc/set_up(n = 5, c = 0, loca, direct, color)
-	if(n > 20)
-		n = 20
-	number = n
-	cardinals = c
+/datum/effects/system/bad_smoke_spread/proc/set_up(number = 5, spread_cardinal = FALSE, location, dir, color)
+	if(number > 20)
+		number = 20
+	src.number = number
+	src.spread_cardinal = spread_cardinal
 	src.color = color
-	if(istype(loca, /turf/))
-		location = loca
+	if(isturf(location))
+		src.location = location
 	else
-		location = get_turf(loca)
-	if(direct)
-		direction = direct
+		location = get_turf(location)
+	if(dir)
+		direction = dir
 
 
-/datum/effects/system/bad_smoke_spread/proc/attach(atom/atom)
-	holder = atom
+/datum/effects/system/bad_smoke_spread/proc/attach(atom/A)
+	holder = A
 	holder.temp_flags |= HAS_BAD_SMOKE
 
 /datum/effects/system/bad_smoke_spread/disposing()
@@ -61,7 +61,7 @@ proc/ClearBadsmokeRefs(var/atom/A)
 			src.total_smoke++
 			var/direction = src.direction
 			if(!direction)
-				if(src.cardinals)
+				if(src.spread_cardinal)
 					direction = pick(cardinal)
 				else
 					direction = pick(alldirs)

--- a/code/datums/effects/system/harmless_smoke_spread.dm
+++ b/code/datums/effects/system/harmless_smoke_spread.dm
@@ -6,30 +6,30 @@
 
 /datum/effects/system/harmless_smoke_spread
 	var/number = 3
-	var/cardinals = 0
+	var/spread_cardinal = 0
 	var/turf/location
 	var/atom/holder
 	var/total_smoke = 0 // To stop it being spammed and lagging!
 	var/direction
 	var/color
 
-/datum/effects/system/harmless_smoke_spread/proc/set_up(n = 5, c = 0, loca, direct, color)
-	if(n > 10)
-		n = 10
-	number = n
-	cardinals = c
-	if(istype(loca, /turf/))
-		location = loca
+/datum/effects/system/harmless_smoke_spread/proc/set_up(number = 5, spread_cardinal = FALSE, location, dir, color)
+	if(number > 10)
+		number = 10
+	src.number = number
+	src.spread_cardinal = spread_cardinal
+	if(isturf(location))
+		src.location = location
 	else
-		location = get_turf(loca)
-	if(direct)
-		direction = direct
+		src.location = get_turf(location)
+	if(dir)
+		src.direction = dir
 	if(color)
 		src.color = color
 
 
-/datum/effects/system/harmless_smoke_spread/proc/attach(atom/atom)
-	holder = atom
+/datum/effects/system/harmless_smoke_spread/proc/attach(atom/A)
+	holder = A
 
 /datum/effects/system/harmless_smoke_spread/proc/start()
 	var/i = 0
@@ -46,7 +46,7 @@
 			src.total_smoke++
 			var/direction = src.direction
 			if(!direction)
-				if(src.cardinals)
+				if(src.spread_cardinal)
 					direction = pick(cardinal)
 				else
 					direction = pick(alldirs)

--- a/code/datums/effects/system/mustard_gas_spread.dm
+++ b/code/datums/effects/system/mustard_gas_spread.dm
@@ -5,26 +5,26 @@
 /////////////////////////////////////////////
 /datum/effects/system/mustard_gas_spread
 	var/number = 3
-	var/cardinals = 0
+	var/spread_cardinal = FALSE
 	var/turf/location
 	var/atom/holder
 	var/total_smoke = 0 // To stop it being spammed and lagging!
 	var/direction
 
-/datum/effects/system/mustard_gas_spread/proc/set_up(n = 5, c = 0, loca, direct)
-	if(n > 20)
-		n = 20
-	number = n
-	cardinals = c
-	if(istype(loca, /turf/))
-		location = loca
+/datum/effects/system/mustard_gas_spread/proc/set_up(number = 5, spread_cardinal = FALSE, location, dir)
+	if(number > 20)
+		number = 20
+	src.number = number
+	src.spread_cardinal = spread_cardinal
+	if(isturf(location))
+		src.location = location
 	else
-		location = get_turf(loca)
-	if(direct)
-		direction = direct
+		src.location = get_turf(location)
+	if(dir)
+		direction = dir
 
-/datum/effects/system/mustard_gas_spread/proc/attach(atom/atom)
-	holder = atom
+/datum/effects/system/mustard_gas_spread/proc/attach(atom/A)
+	holder = A
 
 /datum/effects/system/mustard_gas_spread/proc/start()
 	var/i = 0
@@ -38,7 +38,7 @@
 			src.total_smoke++
 			var/direction = src.direction
 			if(!direction)
-				if(src.cardinals)
+				if(src.spread_cardinal)
 					direction = pick(cardinal)
 				else
 					direction = pick(alldirs)

--- a/code/datums/effects/system/spark_spread.dm
+++ b/code/datums/effects/system/spark_spread.dm
@@ -1,23 +1,23 @@
 /datum/effects/system/spark_spread
 	var/number = 3
-	var/cardinals = 0
+	var/spread_cardinal = FALSE
 	var/turf/location
 	var/atom/holder
 	var/total_sparks = 0 // To stop it being spammed and lagging!
 	var/list/livesparks = new
 
-/datum/effects/system/spark_spread/proc/set_up(n = 3, c = 0, loca)
-	if(n > 10)
-		n = 10
-	number = n
-	cardinals = c
-	if(istype(loca, /turf/))
-		location = loca
+/datum/effects/system/spark_spread/proc/set_up(number = 3, spread_cardinal = FALSE, location)
+	if(number > 10)
+		number = 10
+	src.number = number
+	src.spread_cardinal = spread_cardinal
+	if(isturf(location))
+		src.location = location
 	else
-		location = get_turf(loca)
+		src.location = get_turf(location)
 
-/datum/effects/system/spark_spread/proc/attach(atom/atom)
-	holder = atom
+/datum/effects/system/spark_spread/proc/attach(atom/A)
+	holder = A
 
 /datum/effects/system/spark_spread/proc/detach()
 	holder = null
@@ -79,7 +79,7 @@
 
 			// Set direction and distance to travel
 			var/direction
-			if(src.cardinals)
+			if(src.spread_cardinal)
 				direction = pick(cardinal)
 			else
 				direction = pick(alldirs)

--- a/code/datums/effects/system/steam_spread.dm
+++ b/code/datums/effects/system/steam_spread.dm
@@ -17,23 +17,23 @@ steam.start() -- spawns the effect
 
 /datum/effects/system/steam_spread
 	var/number = 3
-	var/cardinals = 0
+	var/spread_cardinal = FALSE
 	var/turf/location
 	var/atom/holder
 	var/color = null
 	var/plane = null
 
-/datum/effects/system/steam_spread/proc/set_up(n = 3, c = 0, turf/loc, color=null, plane=null)
-	if(n > 10)
-		n = 10
-	src.number = n
-	src.cardinals = c
+/datum/effects/system/steam_spread/proc/set_up(number = 3, spread_cardinal = FALSE, turf/loc, color=null, plane=null)
+	if(number > 10)
+		number = 10
+	src.number = number
+	src.spread_cardinal = spread_cardinal
 	src.location = loc
 	src.color = color
 	src.plane = plane
 
-/datum/effects/system/steam_spread/proc/attach(atom/atom)
-	holder = atom
+/datum/effects/system/steam_spread/proc/attach(atom/A)
+	holder = A
 
 /datum/effects/system/steam_spread/proc/start(var/clear_holder = 0)
 	if (clear_holder)
@@ -50,7 +50,7 @@ steam.start() -- spawns the effect
 				steam.plane = src.plane
 			steam.set_loc(src.location)
 			var/direction
-			if(src.cardinals)
+			if(src.spread_cardinal)
 				direction = pick(cardinal)
 			else
 				direction = pick(alldirs)

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -1214,7 +1214,7 @@
 	return null
 
 /mob/living/check_attack_resistance(var/obj/item/I, var/mob/attacker)
-	var/alc_amt = src.reagents.get_reagent_amount("ethanol")
+	var/alc_amt = src.reagents?.get_reagent_amount("ethanol")
 	//no permanent boost for the alc immune
 	if (!isalcoholresistant(src))
 		alc_amt += GET_ATOM_PROPERTY(src, PROP_MOB_ALCOHOL_RESIST)

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -504,25 +504,25 @@ TYPEINFO(/obj/item/old_grenade/smoke)
 
 			SPAWN(0)
 				if (src)
-					if (M && istype(M, /obj/item/old_grenade/smoke/mustard))
+					if (M?.mustard_gas && istype(M, /obj/item/old_grenade/smoke/mustard))
 						M.mustard_gas.start()
 					else
 						src.smoke.start()
 
 					sleep(1 SECOND)
-					if (M && istype(M, /obj/item/old_grenade/smoke/mustard))
+					if (M?.mustard_gas && istype(M, /obj/item/old_grenade/smoke/mustard))
 						M.mustard_gas.start()
 					else
 						src.smoke.start()
 
 					sleep(1 SECOND)
-					if (M && istype(M, /obj/item/old_grenade/smoke/mustard))
+					if (M?.mustard_gas && istype(M, /obj/item/old_grenade/smoke/mustard))
 						M.mustard_gas.start()
 					else
 						src.smoke.start()
 
 					sleep(1 SECOND)
-					if (M && istype(M, /obj/item/old_grenade/smoke/mustard))
+					if (M?.mustard_gas && istype(M, /obj/item/old_grenade/smoke/mustard))
 						M.mustard_gas.start()
 					else
 						src.smoke.start()

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -490,63 +490,46 @@ TYPEINFO(/obj/item/old_grenade/smoke)
 
 	New()
 		..()
-		src.smoke = new /datum/effects/system/bad_smoke_spread/
-		src.smoke.attach(src)
-		src.smoke.set_up(10, 0, src.loc)
+		src.init_smoke()
 
 	detonate()
 		var/turf/T = ..()
-		if (T)
-			var/obj/item/old_grenade/smoke/mustard/M = null
-			if (istype(src, /obj/item/old_grenade/smoke/mustard))
-				M = src
-			playsound(T, 'sound/effects/smoke.ogg', 50, TRUE, -3)
-
-			SPAWN(0)
-				if (src)
-					if (M?.mustard_gas && istype(M, /obj/item/old_grenade/smoke/mustard))
-						M.mustard_gas.start()
-					else
-						src.smoke.start()
-
-					sleep(1 SECOND)
-					if (M?.mustard_gas && istype(M, /obj/item/old_grenade/smoke/mustard))
-						M.mustard_gas.start()
-					else
-						src.smoke.start()
-
-					sleep(1 SECOND)
-					if (M?.mustard_gas && istype(M, /obj/item/old_grenade/smoke/mustard))
-						M.mustard_gas.start()
-					else
-						src.smoke.start()
-
-					sleep(1 SECOND)
-					if (M?.mustard_gas && istype(M, /obj/item/old_grenade/smoke/mustard))
-						M.mustard_gas.start()
-					else
-						src.smoke.start()
-
-					if (M && istype(M, /obj/item/old_grenade/smoke/mustard))
-						qdel(M)
-					else
-						qdel(src)
-		else
+		if (!T)
 			qdel(src)
-		return
+			return
+		playsound(T, 'sound/effects/smoke.ogg', 50, TRUE, -3)
+
+		SPAWN(0)
+			src.update_smoke()
+			for(var/i in 1 to 3)
+				sleep(1 SECOND)
+				if(QDELETED(src))
+					return
+				src.update_smoke()
+
+	proc/init_smoke()
+		src.smoke = new /datum/effects/system/bad_smoke_spread/
+		src.smoke.attach(src)
+		src.smoke.set_up(10, FALSE, src.loc)
+
+	proc/update_smoke()
+		src.smoke?.start()
 
 /obj/item/old_grenade/smoke/mustard
 	name = "mustard gas grenade"
-	var/datum/effects/system/mustard_gas_spread/mustard_gas
 	icon_state = "mustard"
 	icon_state_armed = "mustard1"
+	/// The different smoke datums appear to not ACTUALLY be subtypes of a datum called "/datum/effects/system"
+	/// They're completely different datums. This should be fixed at some point.
+	var/datum/effects/system/mustard_gas_spread/mustard_gas
 
-	New()
-		..()
-		if (usr?.loc) //Wire: Fix for Cannot read null.loc
-			src.mustard_gas = new /datum/effects/system/mustard_gas_spread/
-			src.mustard_gas.attach(src)
-			src.mustard_gas.set_up(5, 0, usr.loc)
+	init_smoke()
+		src.mustard_gas = new /datum/effects/system/mustard_gas_spread/
+		src.mustard_gas.attach(src)
+		src.mustard_gas.set_up(5, FALSE, src.loc)
+
+	update_smoke()
+		src.mustard_gas?.start()
 
 /obj/item/old_grenade/stinger
 	name = "stinger grenade"


### PR DESCRIPTION
## About the PR
- Fix for mobs inside other objects counting as entering an area twice (once when the object enters the area and a second time when the mob leaves the object it is in). This produced a runtime if it occurred in a therapy area.
- Runtime error fix when csabres attacks attempted to check if sawflies (and presumably other robots) were drunk.
- Runtime error fix when mustard gas suddenly stopped existing.

## Why's this needed?
- Runtimes that were produced while I was testing grenade white holes.

## Testing
<img width="377" height="330" alt="Screenshot 2026-08-28 040730" src="https://github.com/user-attachments/assets/6688e489-1457-4bf7-a644-f27c07d44854" />
