### PR TITLE
Fix issues with the tar command, archives, and computer datum metadata

### DIFF
--- a/_std/namespaces/dwaine/syscalls.dm
+++ b/_std/namespaces/dwaine/syscalls.dm
@@ -194,6 +194,13 @@ ADD_TO_NAMESPACE(DWAINE, SYSCALL)(var/const/RECVFILE = 24)
 ADD_TO_NAMESPACE(DWAINE, SYSCALL)(var/const/BREAK = 25)
 
 /**
+ *	Get the deepest existing folder in the specified filepath.
+ *	Accepted data fields:
+ *	- `"path"`: The filepath to get a directory for.
+ */
+ADD_TO_NAMESPACE(DWAINE, SYSCALL)(var/const/PGET = 26)
+
+/**
  *	Reply to a request for information.
  *	Has unique data fields for each implementation, depending on the data requested.
  */

--- a/code/modules/networks/computer3/mainframe2/filetypes/__computer_parent.dm
+++ b/code/modules/networks/computer3/mainframe2/filetypes/__computer_parent.dm
@@ -43,3 +43,6 @@ ABSTRACT_TYPE(/datum/computer)
 /datum/computer/proc/copy_file(depth = 0)
 	RETURN_TYPE(/datum/computer)
 	return
+
+/datum/computer/proc/get_archive_size()
+	return size

--- a/code/modules/networks/computer3/mainframe2/filetypes/_folder_parent.dm
+++ b/code/modules/networks/computer3/mainframe2/filetypes/_folder_parent.dm
@@ -55,6 +55,7 @@
 	C.holding_folder = src
 
 	if (src.gen)
+		C.metadata ||= list()
 		if (isnull(C.metadata["owner"]))
 			C.metadata["owner"] = src.metadata["owner"]
 		if (isnull(C.metadata["group"]))

--- a/code/modules/networks/computer3/mainframe2/filetypes/_folder_parent.dm
+++ b/code/modules/networks/computer3/mainframe2/filetypes/_folder_parent.dm
@@ -33,6 +33,12 @@
 	copy.name = src.name
 	copy.holder = src.holder
 
+	copy.metadata ||= list()
+	if (src.metadata)
+		copy.metadata["owner"] = src.metadata["owner"]
+		copy.metadata["permission"] = src.metadata["permission"]
+		copy.metadata["group"] = src.metadata["group"]
+
 	depth += 1
 	for (var/datum/computer/C as anything in src.contents)
 		copy.add_file(C.copy_file(depth))

--- a/code/modules/networks/computer3/mainframe2/filetypes/archive.dm
+++ b/code/modules/networks/computer3/mainframe2/filetypes/archive.dm
@@ -7,6 +7,7 @@
 	var/uncompressed_size = 0
 	// Generally assumed that all contained files will be expendable copies.
 	var/tmp/list/contained_files = null
+	var/tmp/max_depth = 0
 	var/max_contained_size = 48
 
 /datum/computer/file/archive/New()
@@ -33,7 +34,7 @@
 	if (!C || ((src.uncompressed_size + C.size) > src.max_contained_size))
 		return FALSE
 
-	if (istype(C, /datum/computer/file/archive))
+	if (C == src) // An archive cannot contain itself
 		return FALSE
 
 	src.contained_files += C

--- a/code/modules/networks/computer3/mainframe2/filetypes/archive.dm
+++ b/code/modules/networks/computer3/mainframe2/filetypes/archive.dm
@@ -21,11 +21,7 @@
 	. = ..()
 
 /datum/computer/file/archive/copy_file()
-	var/datum/computer/file/archive/copy = new src.type()
-
-	for (var/variable_name as anything in src.vars)
-		if (issaved(src.vars[variable_name]))
-			copy.vars[variable_name] = src.vars[variable_name]
+	var/datum/computer/file/archive/copy = ..() // handle our metadata
 
 	copy.contained_files ||= list()
 	for (var/datum/computer/C as anything in src.contained_files)

--- a/code/modules/networks/computer3/mainframe2/filetypes/archive.dm
+++ b/code/modules/networks/computer3/mainframe2/filetypes/archive.dm
@@ -7,7 +7,6 @@
 	var/uncompressed_size = 0
 	// Generally assumed that all contained files will be expendable copies.
 	var/tmp/list/contained_files = null
-	var/tmp/max_depth = 0
 	var/max_contained_size = 48
 
 /datum/computer/file/archive/New()
@@ -31,7 +30,7 @@
 	return copy
 
 /datum/computer/file/archive/proc/add_file(datum/computer/C)
-	if (!C || ((src.uncompressed_size + C.size) > src.max_contained_size))
+	if (!C || ((src.uncompressed_size + C.get_archive_size()) > src.max_contained_size))
 		return FALSE
 
 	if (C == src) // An archive cannot contain itself
@@ -40,3 +39,6 @@
 	src.contained_files += C
 	src.uncompressed_size += C.size
 	return TRUE
+
+/datum/computer/file/archive/get_archive_size()
+	return uncompressed_size

--- a/code/modules/networks/computer3/mainframe2/programs/_program_parent.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/_program_parent.dm
@@ -8,8 +8,8 @@
 	name = "mainframe program"
 	extension = "MPG"
 
-	/// The mainframe computer that this program is bring run by.
-	var/obj/machinery/networked/mainframe/master = null
+	/// The mainframe computer that this program is being run by.
+	var/tmp/obj/machinery/networked/mainframe/master = null // should not be copied because it's recreated on New anyway
 	/// Whether this program can be executed by the kernel.
 	var/executable = TRUE
 	/// Whether this program requires a holder data disc.

--- a/code/modules/networks/computer3/mainframe2/programs/os/kernel/kernel.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/os/kernel/kernel.dm
@@ -8,7 +8,7 @@
 	size = 16
 
 	/// A list of cached DWAINE syscall datums, indexed by their ID.
-	var/list/datum/dwaine_syscall/syscalls = null
+	var/tmp/list/datum/dwaine_syscall/syscalls = null
 
 	/// A list of users currently connected to the OS, indexed by their user ID.
 	var/tmp/list/datum/mainframe2_user_data/users = null

--- a/code/modules/networks/computer3/mainframe2/programs/os/kernel/syscalls/pget.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/os/kernel/syscalls/pget.dm
@@ -1,0 +1,16 @@
+/datum/dwaine_syscall/pget
+	id = DWAINE::SYSCALL::PGET
+
+/datum/dwaine_syscall/pget/execute(sendid, list/data, datum/computer/file/file)
+	if (!sendid)
+		return DWAINE::ERR::SIG::GENERIC
+
+	var/datum/computer/file/mainframe_program/caller_prog = src.kernel.master.processing[sendid]
+	if (!data["path"] || !caller_prog)
+		return DWAINE::ERR::SIG::NOTARGET
+
+	var/datum/computer/folder/target_directory = src.kernel.parse_directory(data["path"], src.kernel.holder.root, FALSE, caller_prog.useracc)
+	if (!target_directory) // no part of the given filepath exists at all
+		return DWAINE::ERR::SIG::NOFILE
+
+	return target_directory

--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -286,6 +286,11 @@
 		src.message_user("tar: Cannot handle file [current_path][to_copy]")
 		return
 
+	// avoid copying files we don't have permission for
+	// this can happen if you copy /, which you can see, which contains /proc, which you need superuser for
+	if (!src.check_read_permission(to_copy, src.useracc))
+		return
+
 	if (istype(to_copy, /datum/computer/folder))
 		var/datum/computer/folder/folder_to_copy = to_copy
 		var/datum/computer/folder/folder_copy = new()

--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -266,21 +266,17 @@
 		src.message_reply_and_user("[current_path][to_extract.name]")
 
 	if (istype(to_extract, /datum/computer/folder))
-		if (!istype(T))
-			if (src.signal_program(1, list("command" = DWAINE::SYSCALL::TSPAWN, "passusr" = TRUE, "path" = "/bin/mkdir", "args" = "[target_path][to_extract.name]")) == DWAINE::ERR::SIG::NOTARGET)
-				src.message_user("mkdir: command not found.")
+		// we don't check istype(T) because we don't directly FWRITE folders, only leaf nodes like files
+		// if that changes, this will have to be adjusted
+		if (src.signal_program(1, list("command" = DWAINE::SYSCALL::TSPAWN, "passusr" = TRUE, "path" = "/bin/mkdir", "args" = "[target_path][to_extract.name]")) == DWAINE::ERR::SIG::NOTARGET)
+			src.message_user("mkdir: command not found.")
 
-			if (!istype(src.signal_program(1, list("command" = DWAINE::SYSCALL::FGET, "path" = "[target_path][to_extract.name]")), /datum/computer/folder))
-				src.message_user("tar: Failed to create directory [to_extract.name]")
+		if (!istype(src.signal_program(1, list("command" = DWAINE::SYSCALL::FGET, "path" = "[target_path][to_extract.name]")), /datum/computer/folder))
+			src.message_user("tar: Failed to create directory [to_extract.name]")
 
-			var/datum/computer/folder/folder = to_extract
-			for (var/datum/computer/C as anything in folder.contents)
-				src.recursive_extract(C, "[target_path][to_extract.name]/", "[current_path][to_extract.name]/", depth + 1)
-
-		else if (src.opt_skip)
-			src.message_user("tar: [target_path][to_extract.name] already exists, skipping.")
-		else
-			src.message_user("tar: [target_path][to_extract.name] already exists, cannot overwrite folder - skipping.")
+		var/datum/computer/folder/folder = to_extract
+		for (var/datum/computer/C as anything in folder.contents)
+			src.recursive_extract(C, "[target_path][to_extract.name]/", "[current_path][to_extract.name]/", depth + 1)
 
 	else if (istype(to_extract, /datum/computer/file))
 		if (!istype(T) || !src.opt_skip)

--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -258,14 +258,18 @@
 
 	else if (istype(to_extract, /datum/computer/file))
 		if (!istype(T) || !src.opt_skip)
-			var/outcome = src.signal_program(1, list("command" = DWAINE::SYSCALL::FWRITE, "path" = "[target_path]", "mkdir" = TRUE, "replace" = TRUE), to_extract)
-			switch (outcome)
-				if (DWAINE::ERR::SIG::NOWRITE)
-					src.message_user("tar: [target_path][to_extract.name]: permission denied.")
-				if (DWAINE::ERR::SIG::GENERIC)
-					src.message_user("tar: Error extracting [target_path][to_extract.name]")
-				if (DWAINE::ERR::SIG::NOTARGET)
-					src.message_user("tar: Bad path: [target_path] for file [to_extract.name]")
+			// if we don't copy the file, deleting the archive will delete the copied files
+			// and if it's extracted multiple times, deleting any of the copies will delete all of them, plus the one on the archive
+			var/datum/computer/file/output_file = to_extract.copy_file()
+			if(output_file)
+				var/outcome = src.signal_program(1, list("command" = DWAINE::SYSCALL::FWRITE, "path" = "[target_path]", "mkdir" = TRUE, "replace" = TRUE), output_file)
+				switch (outcome)
+					if (DWAINE::ERR::SIG::NOWRITE)
+						src.message_user("tar: [target_path][output_file.name]: permission denied.")
+					if (DWAINE::ERR::SIG::GENERIC)
+						src.message_user("tar: Error extracting [target_path][output_file.name]")
+					if (DWAINE::ERR::SIG::NOTARGET)
+						src.message_user("tar: Bad path: [target_path] for file [output_file.name]")
 
 		else
 			src.message_user("[target_path][to_extract.name] already exists, skipping")

--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -119,7 +119,7 @@
 			target_path = current
 
 		if (!istype(src.signal_program(1, list("command" = DWAINE::SYSCALL::FGET, "path" = target_path)), /datum/computer/folder))
-			src.message_user("tar: cannot read target directory [target_path]")
+			src.message_user("tar: Cannot read target directory [target_path]")
 			mainframe_prog_exit
 			return
 
@@ -136,7 +136,33 @@
 			mainframe_prog_exit
 			return
 
-		src.current_archive = new /datum/computer/file/archive()
+		var/datum/computer/file/archive/archive = new /datum/computer/file/archive()
+		// we have to get the destination (or its existing parent folder) here to ensure holder is set properly
+		// otherwise folders in the archive will fail to copy/extract
+		var/list/separated_filepath = splittext(archive_path, "/")
+		var/path_length = length(separated_filepath)
+		archive.name = separated_filepath[path_length]
+		separated_filepath.Cut(path_length)
+		var/new_path = jointext(separated_filepath, "/") || "/"
+		var/datum/computer/folder/output_parent = src.signal_program(1, list("command" = DWAINE::SYSCALL::PGET, "path" = new_path))
+		switch(output_parent)
+			if (DWAINE::ERR::SIG::NOFILE) // no part of the given directory exists
+				src.message_user("tar: Cannot find directory [separated_filepath[1]]")
+				mainframe_prog_exit
+				return
+			if (DWAINE::ERR::SIG::NOTARGET)
+				src.message_user("tar: Invalid output path [archive_path]")
+				mainframe_prog_exit
+				return
+			if (DWAINE::ERR::SIG::GENERIC)
+				src.message_user("tar: Error while finding output directory [new_path]")
+				mainframe_prog_exit
+				return
+		// if we're still here, we must have a destination, or at least a parent dir for it
+		archive.holder = output_parent.holder
+		// set current_archive so deep_copy can check it
+		src.current_archive = archive
+
 		for (var/path as anything in unaffected)
 			var/datum/computer/C = src.signal_program(1, list("command" = DWAINE::SYSCALL::FGET, "path" = ABSOLUTE_PATH(path, current)))
 			if (!istype(C))
@@ -151,13 +177,6 @@
 				return
 
 			src.current_archive.add_file(copy)
-
-		var/list/separated_filepath = splittext(archive_path, "/")
-		var/path_length = length(separated_filepath)
-		src.current_archive.name = separated_filepath[path_length]
-		separated_filepath.Cut(path_length)
-
-		var/new_path = jointext(separated_filepath, "/") || "/"
 
 		switch (src.signal_program(1, list("command" = DWAINE::SYSCALL::FWRITE, "path" = new_path, "mkdir" = TRUE, "replace" = TRUE), src.current_archive))
 			if (DWAINE::ERR::SIG::NOWRITE)
@@ -303,9 +322,11 @@
 
 	if (istype(to_copy, /datum/computer/folder))
 		var/datum/computer/folder/folder_to_copy = to_copy
+		// we can't just use copy_file for folders because we have to check read perms and filetype
 		var/datum/computer/folder/folder_copy = new()
 
 		folder_copy.name = folder_to_copy.name
+		folder_copy.holder = src.current_archive.holder
 		for (var/datum/computer/C as anything in folder_to_copy.contents)
 			var/datum/computer/copy = src.deep_copy(C, "[current_path][to_copy.name]/", depth + 1)
 			if (istype(copy))

--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -19,6 +19,8 @@
 	VAR_PRIVATE/tmp/opt_verbose = null
 	/// Whether `tar` should extract the contents of an existing archive. Mutually exclusive with `opt_create` and `opt_list`.
 	VAR_PRIVATE/tmp/opt_extract = null
+	/// The current archive being created, used to prevent storing an archive inside itself.
+	VAR_PRIVATE/tmp/datum/computer/file/archive/current_archive = null
 
 /datum/computer/file/mainframe_program/utility/tar/initialize(initparams)
 	if (..())
@@ -134,7 +136,7 @@
 			mainframe_prog_exit
 			return
 
-		var/datum/computer/file/archive/archive = new()
+		src.current_archive = new /datum/computer/file/archive()
 		for (var/path as anything in unaffected)
 			var/datum/computer/C = src.signal_program(1, list("command" = DWAINE::SYSCALL::FGET, "path" = ABSOLUTE_PATH(path, current)))
 			if (!istype(C))
@@ -148,16 +150,16 @@
 				mainframe_prog_exit
 				return
 
-			archive.add_file(copy)
+			src.current_archive.add_file(copy)
 
 		var/list/separated_filepath = splittext(archive_path, "/")
 		var/path_length = length(separated_filepath)
-		archive.name = separated_filepath[path_length]
+		src.current_archive.name = separated_filepath[path_length]
 		separated_filepath.Cut(path_length)
 
 		var/new_path = jointext(separated_filepath, "/") || "/"
 
-		switch (src.signal_program(1, list("command" = DWAINE::SYSCALL::FWRITE, "path" = new_path, "mkdir" = TRUE, "replace" = TRUE), archive))
+		switch (src.signal_program(1, list("command" = DWAINE::SYSCALL::FWRITE, "path" = new_path, "mkdir" = TRUE, "replace" = TRUE), src.current_archive))
 			if (DWAINE::ERR::SIG::NOWRITE)
 				src.message_user("tar: Cannot write destination [src.opt_file]")
 			if (DWAINE::ERR::SIG::NOTARGET)
@@ -193,6 +195,11 @@
 /datum/computer/file/mainframe_program/utility/tar/message_user(msg, render, file)
 	if (src.opt_quiet)
 		return
+
+	. = ..()
+
+/datum/computer/file/mainframe_program/utility/tar/disposing()
+	src.current_archive = null // just in case
 
 	. = ..()
 
@@ -282,9 +289,12 @@
 		src.message_user("tar: Stack overflow.")
 		return
 
-	// there may need to be a check here to avoid copying an archive into itself
-	// but when this proc is currently called, at time of writing,
-	// the archive is not actually on the filesystem and so cannot be archived
+	// at time of writing, the archive is not actually on the filesystem during its creation
+	// and so cannot be stored in itself. but better safe than sorry,
+	// since maybe tar will be able to add files to an archive someday
+	if (to_copy == src.current_archive)
+		src.message_user("tar: Cannot handle file [current_path][to_copy]")
+		return
 
 	// avoid copying files we don't have permission for
 	// this can happen if you copy /, which you can see, which contains /proc, which you need superuser for

--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -282,9 +282,9 @@
 		src.message_user("tar: Stack overflow.")
 		return
 
-	if (istype(to_copy, /datum/computer/file/archive))
-		src.message_user("tar: Cannot handle file [current_path][to_copy]")
-		return
+	// there may need to be a check here to avoid copying an archive into itself
+	// but when this proc is currently called, at time of writing,
+	// the archive is not actually on the filesystem and so cannot be archived
 
 	// avoid copying files we don't have permission for
 	// this can happen if you copy /, which you can see, which contains /proc, which you need superuser for

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -417,14 +417,10 @@ proc/castRay(var/atom/A, var/Angle, var/Distance) //Adapted from some forum stuf
 	. = findtext(text, prefix, start, end) //was findtextEx
 
 /proc/dd_hassuffix(text, suffix)
-	var/start = length(text) - length(suffix)
-	if(start)
-		. = findtext(text, suffix, start, null)
+	. = findtext(text, suffix, -length(suffix), null)
 
 /proc/dd_hasSuffix(text, suffix)
-	var/start = length(text) - length(suffix)
-	if(start)
-		. = findtext(text, suffix, start, null) //was findtextEx
+	. = findtext(text, suffix, -length(suffix), null) //was findtextEx
 
 /proc/dd_centertext(message, length)
 	. = length(message)

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1879,6 +1879,7 @@
 #include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\fwrite.dm"
 #include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\mount.dm"
 #include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\msg_term.dm"
+#include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\pget.dm"
 #include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\tfork.dm"
 #include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\tkill.dm"
 #include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\tlist.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

<!-- THE MYTHICAL DWAINE CONTRIBUTOR ARRIVES -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- fixes various causes of metadata-less files (specifically archives and folders).
- fixes an issue where a null metadata list on a computer datum caused `add_file()` to runtime, which posed problems for specifically extracting files from archives via `tar`.
- also fixes files extracted via `tar` not actually being copies, so multiple extractions would create multiple references to the same file, which is bad.
- archives can now contain archives, with the caveat that they cannot contain themselves, and compressed archives add their full uncompressed size to their containing archive's total, not just the 8kb total. this might be a little out of scope, but it fixes an issue with archives on databanks just getting wiped entirely.
- `tar`'s `deep_copy()` now checks permissions for every file copied, not just the root
- the kernel's syscalls list is no longer copied when the kernel file is, avoiding a shared reference that caused hangs when deleting the copy
- archives now have their `holder` set correctly, and so do folders they contain
- `tar` will now extract folders even if they exist, because (currently) folders are never written, only the files inside them (directories are made via `FWRITE`)
- the `-k` (skip) flag only applies to files rather than folders
- `dd_hassuffix()` now actually works properly, e.g. `dd_hassuffix("/", "/")` will be true, avoiding issues with trying to extract into root

~~(i need to re-test this just in case which is why it's opened as a draft)~~ tested!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- copied archives would skip copying metadata because that's only done in `/datum/computer/file/copy_file()` and it didn't call parent. so it had no metadata and `/datum/computer/folder/add_file()` would have a bad index runtime because it tried to index into a null list.
- folders did not copy their metadata when copied like files do, causing a similar issue.
- archives would not copy their files on extract, meaning:
  - if the archive was deleted all the extracted files would be deleted too;
  - if you deleted the extracted file it would vanish from the archive; and
  - if you extracted it multiple times and deleted one, all of them would vanish.
- archives could not contain archives, so the content mirroring used for tape databanks would delete/fail to mirror archives on the tape reel. specifically it'd fail on the `sync` step.
- archives could copy files that the user creating the archive can't see, by containing a parent folder with less restrictive permissions
- deleting a copy of the DWAINE kernel caused the kernel to hang
- copying an archive containing a directory caused the directory to lose its contents
- currently if you try to extract a folder that already exists all the contents are skipped, which is really annoying.
- trying to extract an archive into `/` will, currently, append an extra `/`, so you end up with things like `//bin/` that don't exist.

basically tar is actually usable now

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="380" height="350" alt="image" src="https://github.com/user-attachments/assets/116afc35-5392-4bb0-83ac-add0c8483310" />

it didn't error on copy to the output folder, and it did before (because metadata was null)

<img width="380" height="350" alt="image" src="https://github.com/user-attachments/assets/33eccbf0-f52d-4e13-92a2-f9bc32c1cc2c" />

archives no longer vanish off of databanks after reloading/reconnecting them

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Penelope Haze
(+)Extracting files on DWAINE with the tar command should no longer lead to files failing to extract or randomly disappearing.
(+)DWAINE archive files created with the tar command can now contain archive files. Archives-in-archives cost storage space equal to their uncompressed size.
(+)DWAINE archives will now extract folders that already exist, and the -k (skip) flag now only applies to files.
```
