### PR TITLE
Standarized clairon headofffices

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -18159,6 +18159,10 @@
 /obj/item/clipboard,
 /obj/item/paper_bin,
 /obj/item/pen/fancy,
+/obj/item/stamp/md{
+	pixel_x = 8;
+	pixel_y = 5
+	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/omni,
 /area/station/medical/head)
 "icY" = (
@@ -18830,6 +18834,7 @@
 	pixel_x = -1;
 	pixel_y = 2
 	},
+/obj/item/clothing/glasses/healthgoggles/upgraded,
 /turf/simulated/floor/carpet/blue/fancy/innercorner/omni,
 /area/station/medical/head)
 "ixl" = (
@@ -23368,6 +23373,10 @@
 "lIB" = (
 /obj/stool/bee_bed/heisenbee,
 /obj/critter/domestic_bee/heisenbee,
+/obj/item/reagent_containers/food/snacks/beefood{
+	pixel_x = 9;
+	pixel_y = 7
+	},
 /turf/simulated/floor/carpet/purple/fancy/edge/sw,
 /area/station/science/research_director)
 "lJj" = (
@@ -25162,6 +25171,12 @@
 /obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff,
+/obj/machinery/recharger/wall{
+	dir = 4;
+	pixel_x = 28;
+	pixel_y = 0
 	},
 /turf/simulated/floor/grass/random,
 /area/station/crew_quarters/captain)
@@ -27098,6 +27113,9 @@
 /obj/decal/tile_edge/line/green{
 	dir = 10;
 	icon_state = "line1"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_x = 26
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
@@ -35010,7 +35028,7 @@
 /area/ghostdrone_factory)
 "tBS" = (
 /obj/table/wood/auto,
-/obj/item/reagent_containers/food/snacks/spaghetti/spicy,
+/obj/item/reagent_containers/food/snacks/spaghetti/spicy/security,
 /obj/item/kitchen/utensil/fork{
 	pixel_x = 9;
 	pixel_y = 3
@@ -38823,7 +38841,6 @@
 /obj/machinery/light_switch/directional/north{
 	pixel_x = 10
 	},
-/obj/item/pen/crayon/golden,
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/crew_quarters/hop)
 "wbm" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Standarized the clairon head offices by:

Captain:
- added safe (next to the locker)
- added a wall recharger (not sticky cause it kept picking the wrong wall) (next to the bush)
- a bottle of "the good stuff" under the bush

hos:
- swapped the spicy spaghetti with the secure variant (better test-ability) 

hop:
- reduced gold crayon count to 1 (got rid of the one under the lamp, was almost invisible)

rd:
- added bee food to the office, by the bee bed

md:
- added a pair of upgraded health goggles (right desk)
- added their stamp (left desk)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#27504
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<img width="660" height="457" alt="capn" src="https://github.com/user-attachments/assets/fdfe4656-eee9-4eb4-a0bc-33d109f3718e" />

<img width="439" height="344" alt="hop" src="https://github.com/user-attachments/assets/d440d5d8-4c1b-408c-a1e1-0e857f84a13b" />

<img width="370" height="486" alt="hos" src="https://github.com/user-attachments/assets/05ae8b03-3e00-47cb-a603-ecce6ea7e49c" />

<img width="376" height="470" alt="mdir" src="https://github.com/user-attachments/assets/51c0270e-301d-458c-adef-11132d5c6f1b" />

<img width="468" height="454" alt="rd" src="https://github.com/user-attachments/assets/6e39c299-6d49-4dd2-bf3b-8d43d1efb7c6" />



