### PR TITLE
Standarized neon head offices

### DIFF
--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -2524,7 +2524,7 @@
 /obj/stool/chair{
 	dir = 4
 	},
-/mob/living/critter/small_animal/bat/doctor,
+/obj/critter/bat/doctor,
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/medical/head)
 "bVQ" = (
@@ -4702,6 +4702,10 @@
 	pixel_y = 8
 	},
 /obj/machinery/light/incandescent/cool,
+/obj/item/stamp/hop{
+	pixel_x = 8;
+	pixel_y = 8
+	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/hop)
 "duV" = (
@@ -4848,6 +4852,7 @@
 	id = "capquarters";
 	dir = 2
 	},
+/obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "dyT" = (
@@ -16223,7 +16228,7 @@
 /area/iss)
 "lbB" = (
 /obj/table/reinforced/auto,
-/obj/item/reagent_containers/food/snacks/spaghetti/spicy{
+/obj/item/reagent_containers/food/snacks/spaghetti/spicy/security{
 	pixel_y = 6
 	},
 /obj/item/kitchen/utensil/fork{
@@ -27407,7 +27412,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/light/incandescent/warm,
+/obj/machinery/recharger/wall/sticky,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "thz" = (
@@ -28507,6 +28512,10 @@
 /obj/item/rocko,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/item/stamp/ce{
+	pixel_x = 5;
+	pixel_y = 12
 	},
 /turf/simulated/floor/carpet/green,
 /area/station/crew_quarters/ce)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Standarize the heads office in neon by:

- adding the missing hop & ce stamps
- adding a recharger to cap's office (moved the light to be above the announcement computer instead of coms console for it)
- replaced the spicy spaghetti at hos with the secure variant for testability
- replaced mob acula with critter acula cause only they have the code for the crew goal (tragic)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#27504

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="660" height="457" alt="capn" src="https://github.com/user-attachments/assets/3491c1d4-6e66-4973-84ac-7e1b9ae34787" />
<img width="439" height="344" alt="hop" src="https://github.com/user-attachments/assets/5340fa18-010a-4e35-a17f-0e8ee8fecfe0" />
<img width="370" height="486" alt="hos" src="https://github.com/user-attachments/assets/86e95bc1-8308-46d1-b285-b53f5e8f4a0f" />
<img width="376" height="470" alt="mdir" src="https://github.com/user-attachments/assets/7261d2a2-1b11-4c9c-be91-040f01282eea" />
<img width="468" height="454" alt="rd" src="https://github.com/user-attachments/assets/e2feda4c-3d87-4192-9433-9c9ba25c5c0a" />
