### PR TITLE
Batiline material mixing fixes

### DIFF
--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -540,10 +540,6 @@ ABSTRACT_TYPE(/datum/material)
 			src.vars[triggername] = getFusedTriggers(mat1.vars[triggername], mat2.vars[triggername], src)
 			handleTriggerGenerations(src.vars[triggername])
 
-		//Make sure the newly merged properties are informed about the fact that they just changed. Has to happen after triggers.
-		for(var/datum/material_property/nProp in src.properties)
-			nProp.onValueChanged(src, src.properties[nProp])
-
 		//Texture merging. SUPER DUPER UGLY AAAAH
 		if(mat2.texture && !mat1.texture)
 			src.texture = mat2.texture
@@ -567,6 +563,21 @@ ABSTRACT_TYPE(/datum/material)
 		src.parent_materials.Add(mat2)
 
 		triggerOnMix(src, mat1, mat2, bias)
+		// A quirk of how mix effects work. They are triggered by the resulting material, not the source materials.
+		// If this is the last generation of a mix effect, then it will not be passed on to trigger on future generations.
+		// Remove it now, since it is effectively gone.
+		for(var/datum/materialProc/current in src.triggersOnMix)
+			if(current.max_generations != -1 && src.triggersOnMix[current] == current.max_generations)
+				src.triggersOnMix.Remove(current)
+
+		for(var/datum/material_property/nProp in src.properties)
+			// Only round after the properties have all been adjusted
+			var/prop_val = round(src.properties[nProp])
+			src.properties[nProp] = clamp(prop_val, nProp.min_value, nProp.max_value)
+
+		//Make sure the newly merged properties are informed about the fact that they just changed. Has to happen after triggers.
+		for(var/datum/material_property/nProp in src.properties)
+			nProp.onValueChanged(src, src.properties[nProp])
 
 		//RUN VALUE CHANGED ON ALL PROPERTIES TO TRIGGER PROPERS EVENTS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -2512,8 +2523,8 @@ ABSTRACT_TYPE(/datum/material/rubber)
 		var/rads = new_mat.getProperty("radioactive")
 		var/n_rads = new_mat.getProperty("n_radioactive")
 
-		new_mat.adjustProperty("reflective", rads / 2)
-		new_mat.adjustProperty("density", n_rads / 2)
+		new_mat.adjustProperty("reflective", rads)
+		new_mat.adjustProperty("density", n_rads)
 
 		new_mat.removeProperty("radioactive")
 		new_mat.removeProperty("n_radioactive")

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -2523,8 +2523,8 @@ ABSTRACT_TYPE(/datum/material/rubber)
 		var/rads = new_mat.getProperty("radioactive")
 		var/n_rads = new_mat.getProperty("n_radioactive")
 
-		new_mat.adjustProperty("reflective", rads)
-		new_mat.adjustProperty("density", n_rads)
+		new_mat.adjustProperty("reflective", rads / 2)
+		new_mat.adjustProperty("density", n_rads / 2)
 
 		new_mat.removeProperty("radioactive")
 		new_mat.removeProperty("n_radioactive")

--- a/code/modules/materials/Mat_Properties.dm
+++ b/code/modules/materials/Mat_Properties.dm
@@ -20,7 +20,7 @@ ABSTRACT_TYPE(/datum/material_property)
 
 	proc/getValueMerged(var/value_left, var/value_right, var/left_bias, var/right_bias)
 		var/result = (value_left * left_bias) + (value_right * right_bias)
-		return round(result)
+		return result // Results get rounded after TRIGGERS_ON_MIX has been called
 
 	proc/onValueChanged(var/datum/material/M, var/new_value)
 		return
@@ -296,7 +296,7 @@ ABSTRACT_TYPE(/datum/material_property)
 		if(value_right == INFINITY)
 			return value_left
 		var/result = (value_left * left_bias) + (value_right * right_bias)
-		return round(result)
+		return result
 
 /// Literally just indicating that it can be refined into good nuclear fuel in the centrifuge
 /datum/material_property/spent_fuel


### PR DESCRIPTION
## About the PR
- Interpolating materials will now only round properties *after* `trigger_on_mix` effects have taken place.
- Last generation `trigger_on_mix` effects are removed from the interpolated material after the trigger has been called.

## Why's this needed?
- Fixes #27657 
- Mixing effects are passed on to and triggered by the resulting material, not the original materials. This created an issue where a last-generation material would say that it would have an effect when mixing when that effect would actually never be passed on to be triggered.

## Testing
<img width="282" height="222" alt="Screenshot 2026-08-31 081653" src="https://github.com/user-attachments/assets/08edd96e-725f-4278-a117-f99fb6901aa6" />
