### PR TITLE
Vampire glare now partially pierces eye protection

### DIFF
--- a/code/modules/antagonists/vampire/abilities/glare.dm
+++ b/code/modules/antagonists/vampire/abilities/glare.dm
@@ -1,6 +1,6 @@
 /datum/targetable/vampire/glare
 	name = "Glare"
-	desc = "Stuns one target for a short time. Blocked by eye protection."
+	desc = "Stuns one target for a short time. Eye protection reduces the effect."
 	icon_state = "glare"
 	targeted = 1
 	target_nodamage_check = 1

--- a/code/modules/antagonists/vampire/abilities/glare.dm
+++ b/code/modules/antagonists/vampire/abilities/glare.dm
@@ -60,7 +60,10 @@
 			JOB_XP(target, "Chaplain", 2)
 			target.visible_message(SPAN_ALERT("<B>[target] glares right back at [M]!</B>"))
 		else
-			target.apply_flash(30, 15, stamina_damage = 350)
+			if (!target.eyes_protected_from_light())
+				target.apply_flash(30, 15, stamina_damage = 350)
+			else
+				target.do_disorient(50, disorient = 10 SECONDS)
 
 		if (isliving(target))
 			target:was_harmed(M, special = "vamp")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If someone has "full" eye protection, vampire glare will now do 50 stamina damage and disorient them for 10 seconds.
This is a bit snowflakey but I tried to go via the `apply_flash` - `do_disorient` chain and it would make such a mess of both procs to require a full rewrite.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Vampire has always struggled early on, especially compared to changelings. This should allow them to at least glare and run from a single security officer (or extremely gamer botanist), rather than getting the horrible *dink* of shame when it just pings straight off their glasses.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="333" height="234" alt="image" src="https://github.com/user-attachments/assets/59d585fd-871e-42bd-ab28-c74ccc60ca03" />

Security officer (mildly annoyed), tdu (horizontal as normal)
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Vampire glare now partially pierces eye protection, doing 50 stamina damage and 10 seconds of disorient to anyone with full eye protection.
```
