### PR TITLE
Fix copying and deleting certain DWAINE files causing mainframe instability

### DIFF
--- a/code/modules/networks/computer3/mainframe2/programs/_program_parent.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/_program_parent.dm
@@ -8,8 +8,8 @@
 	name = "mainframe program"
 	extension = "MPG"
 
-	/// The mainframe computer that this program is bring run by.
-	var/obj/machinery/networked/mainframe/master = null
+	/// The mainframe computer that this program is being run by.
+	var/tmp/obj/machinery/networked/mainframe/master = null // should not be copied because it's recreated on New anyway
 	/// Whether this program can be executed by the kernel.
 	var/executable = TRUE
 	/// Whether this program requires a holder data disc.

--- a/code/modules/networks/computer3/mainframe2/programs/os/kernel/kernel.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/os/kernel/kernel.dm
@@ -8,7 +8,7 @@
 	size = 16
 
 	/// A list of cached DWAINE syscall datums, indexed by their ID.
-	var/list/datum/dwaine_syscall/syscalls = null
+	var/tmp/list/datum/dwaine_syscall/syscalls = null
 
 	/// A list of users currently connected to the OS, indexed by their user ID.
 	var/tmp/list/datum/mainframe2_user_data/users = null


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Separated from #27639.
The syscalls list is no longer copied by reference in `copy_file()`, because it's marked as `tmp`.
Master is not copied for programs either, by also being marked as `tmp`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Copying `/proc/kernel` and deleting the copy hung the mainframe by deleting the active `rm` syscall.
`master` would be copied when copying files, which is bad and also unnecessary because it's re-set on `New()` anyway.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Copying `/proc/kernel` and deleting the copy no longer causes a runtime/crash.