### PR TITLE
Fix hassuffix not detecting suffixes properly

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -35,6 +35,7 @@
 #include "rand.dm"
 #include "deletions.dm"
 #include "explosions.dm"
+#include "string_prefix_suffix.dm"
 #include "monkey_thunderdome.dm"
 #include "reagent_id_typos.dm"
 #include "record_database.dm"

--- a/code/modules/unit_tests/string_prefix_suffix.dm
+++ b/code/modules/unit_tests/string_prefix_suffix.dm
@@ -1,0 +1,45 @@
+#define TEST_PREFIX(SAMPLE, PREFIX) TEST_ASSERT(dd_hasprefix(SAMPLE, PREFIX), "'"+ PREFIX + "' was not detected as a prefix for the string '" + SAMPLE + "'")
+#define TEST_SUFFIX(SAMPLE, SUFFIX) TEST_ASSERT(dd_hassuffix(SAMPLE, SUFFIX), "'"+ SUFFIX + "' was not detected as a suffix for the string '" + SAMPLE + "'")
+#define TEST_PREFIX_EX(SAMPLE, PREFIX) TEST_ASSERT(dd_hasPrefix(SAMPLE, PREFIX), "'"+ PREFIX + "' was not detected as a case-sensitive prefix for the string '" + SAMPLE + "'")
+#define TEST_SUFFIX_EX(SAMPLE, SUFFIX) TEST_ASSERT(dd_hasSuffix(SAMPLE, SUFFIX), "'"+ SUFFIX + "' was not detected as a case-sensitive suffix for the string '" + SAMPLE + "'")
+#define TEST_NO_PREFIX(SAMPLE, PREFIX) TEST_ASSERT(!dd_hasprefix(SAMPLE, PREFIX), "'"+ PREFIX + "' was incorrectly detected as a prefix for the string '" + SAMPLE + "'")
+#define TEST_NO_SUFFIX(SAMPLE, SUFFIX) TEST_ASSERT(!dd_hassuffix(SAMPLE, SUFFIX), "'"+ SUFFIX + "' was incorrectly detected as a suffix for the string '" + SAMPLE + "'")
+#define TEST_NO_PREFIX_EX(SAMPLE, PREFIX) TEST_ASSERT(!dd_hasPrefix(SAMPLE, PREFIX), "'"+ PREFIX + "' was incorrectly detected as a case-sensitive prefix for the string '" + SAMPLE + "'")
+#define TEST_NO_SUFFIX_EX(SAMPLE, SUFFIX) TEST_ASSERT(!dd_hasSuffix(SAMPLE, SUFFIX), "'"+ SUFFIX + "' was incorrectly detected as a case-sensitive suffix for the string '" + SAMPLE + "'")
+
+/datum/unit_test/string_prefix_suffix/Run()
+	// i would add zero-character/degenerate cases here, but i can't decide how those should behave
+	// one-character prefix/suffix
+	TEST_PREFIX("/", "/")
+	TEST_SUFFIX("/", "/")
+	TEST_PREFIX_EX("/", "/")
+	TEST_SUFFIX_EX("/", "/")
+	TEST_PREFIX("/a", "/")
+	TEST_NO_SUFFIX("/a", "/")
+	TEST_SUFFIX("a/", "/")
+	TEST_NO_PREFIX("a/", "/")
+	// two-character
+	TEST_NO_PREFIX("/", "//")
+	TEST_NO_SUFFIX("/", "//")
+	TEST_PREFIX("//", "//")
+	TEST_SUFFIX("//", "//")
+	TEST_PREFIX("//a", "//")
+	TEST_SUFFIX("a//", "//")
+	TEST_NO_PREFIX("a//", "//")
+	TEST_NO_SUFFIX("//a", "//")
+	// case-sensitive
+	TEST_NO_PREFIX_EX("ABC", "a")
+	TEST_NO_SUFFIX_EX("ABC", "c")
+	TEST_PREFIX_EX("ABC", "A")
+	TEST_PREFIX_EX("ABC", "AB")
+	TEST_SUFFIX_EX("ABC", "C")
+	TEST_SUFFIX_EX("ABC", "BC")
+
+#undef TEST_PREFIX
+#undef TEST_SUFFIX
+#undef TEST_PREFIX_EX
+#undef TEST_SUFFIX_EX
+#undef TEST_NO_PREFIX
+#undef TEST_NO_SUFFIX
+#undef TEST_NO_PREFIX_EX
+#undef TEST_NO_SUFFIX_EX

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -414,13 +414,13 @@ proc/castRay(var/atom/A, var/Angle, var/Distance) //Adapted from some forum stuf
 /proc/dd_hasPrefix(text, prefix)
 	var/start = 1
 	var/end = length(prefix) + 1
-	. = findtext(text, prefix, start, end) //was findtextEx
+	. = findtextEx(text, prefix, start, end)
 
 /proc/dd_hassuffix(text, suffix)
 	. = findtext(text, suffix, -length(suffix), null)
 
 /proc/dd_hasSuffix(text, suffix)
-	. = findtext(text, suffix, -length(suffix), null) //was findtextEx
+	. = findtextEx(text, suffix, -length(suffix), null)
 
 /proc/dd_centertext(message, length)
 	. = length(message)

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -417,14 +417,10 @@ proc/castRay(var/atom/A, var/Angle, var/Distance) //Adapted from some forum stuf
 	. = findtext(text, prefix, start, end) //was findtextEx
 
 /proc/dd_hassuffix(text, suffix)
-	var/start = length(text) - length(suffix)
-	if(start)
-		. = findtext(text, suffix, start, null)
+	. = findtext(text, suffix, -length(suffix), null)
 
 /proc/dd_hasSuffix(text, suffix)
-	var/start = length(text) - length(suffix)
-	if(start)
-		. = findtext(text, suffix, start, null) //was findtextEx
+	. = findtext(text, suffix, -length(suffix), null) //was findtextEx
 
 /proc/dd_centertext(message, length)
 	. = length(message)


### PR DESCRIPTION
## About the PR
Changes `dd_hassuffix()` to be more accurate and adds a simple unit test to hopefully avoid regression. Split out of #27639.
Also makes the case-sensitive variants case-sensitive again.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cases like `dd_hassuffix("/", "/")` didn't work, I'm unsure about which others didn't work.
This may have also caused other things using it to not work in certain cases.
EDIT: Apparently the case-sensitive variants were not case-sensitive for some reason.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
It worked in the original PR to fix a bug with `tar`, and also I added a unit test to cover additional cases.