### PR TITLE
Fix issues with DWAINE computer datums not having expected metadata

### DIFF
--- a/code/modules/networks/computer3/mainframe2/filetypes/_folder_parent.dm
+++ b/code/modules/networks/computer3/mainframe2/filetypes/_folder_parent.dm
@@ -55,6 +55,7 @@
 	C.holding_folder = src
 
 	if (src.gen)
+		C.metadata ||= list()
 		if (isnull(C.metadata["owner"]))
 			C.metadata["owner"] = src.metadata["owner"]
 		if (isnull(C.metadata["group"]))

--- a/code/modules/networks/computer3/mainframe2/filetypes/_folder_parent.dm
+++ b/code/modules/networks/computer3/mainframe2/filetypes/_folder_parent.dm
@@ -33,6 +33,12 @@
 	copy.name = src.name
 	copy.holder = src.holder
 
+	copy.metadata ||= list()
+	if (src.metadata)
+		copy.metadata["owner"] = src.metadata["owner"]
+		copy.metadata["permission"] = src.metadata["permission"]
+		copy.metadata["group"] = src.metadata["group"]
+
 	depth += 1
 	for (var/datum/computer/C as anything in src.contents)
 		copy.add_file(C.copy_file(depth))

--- a/code/modules/networks/computer3/mainframe2/filetypes/archive.dm
+++ b/code/modules/networks/computer3/mainframe2/filetypes/archive.dm
@@ -21,11 +21,7 @@
 	. = ..()
 
 /datum/computer/file/archive/copy_file()
-	var/datum/computer/file/archive/copy = new src.type()
-
-	for (var/variable_name as anything in src.vars)
-		if (issaved(src.vars[variable_name]))
-			copy.vars[variable_name] = src.vars[variable_name]
+	var/datum/computer/file/archive/copy = ..() // handle our metadata
 
 	copy.contained_files ||= list()
 	for (var/datum/computer/C as anything in src.contained_files)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes some common causes of DWAINE computer datums not having metadata, and initializes metadata in `add_file()` to avoid runtimes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some operations (like copying) on some files (like archive contents) would fail due to missing metadata causing a null reference runtime error.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Split out of #27639. I made sure there that the file operations that were having runtime errors didn't cause issues. There's still some remaining issues with archives/`tar` that need to be addressed in another PR.