### PR TITLE
Fix tar copying files it doesn't have permission for

### DIFF
--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -282,6 +282,11 @@
 		src.message_user("tar: Cannot handle file [current_path][to_copy]")
 		return
 
+	// avoid copying files we don't have permission for
+	// this can happen if you copy /, which you can see, which contains /proc, which you need superuser for
+	if (!src.check_read_permission(to_copy, src.useracc))
+		return
+
 	if (istype(to_copy, /datum/computer/folder))
 		var/datum/computer/folder/folder_to_copy = to_copy
 		var/datum/computer/folder/folder_copy = new()


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a read permission check to `deep_copy()` for each file being archived. Separated out of #27639.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The `tar` program on DWAINE would copy subfolders and files in subfolders the user did not have permission to read, e.g. `tar -c -f theEntireInternet /` would include `/proc` even if you weren't a superuser. This, in conjunction with other bugs, allowed non-superusers to temporarily crash the mainframe until it rebooted.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Archiving `/` no longer includes `/proc/` as a non-superuser.