### PR TITLE
Fix deleting archives deleting extracted files

### DIFF
--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -260,16 +260,14 @@
 		if (!istype(T) || !src.opt_skip)
 			// if we don't copy the file, deleting the archive will delete the copied files
 			// and if it's extracted multiple times, deleting any of the copies will delete all of them, plus the one on the archive
-			var/datum/computer/file/output_file = to_extract.copy_file()
-			if(output_file)
-				var/outcome = src.signal_program(1, list("command" = DWAINE::SYSCALL::FWRITE, "path" = "[target_path]", "mkdir" = TRUE, "replace" = TRUE), output_file)
-				switch (outcome)
-					if (DWAINE::ERR::SIG::NOWRITE)
-						src.message_user("tar: [target_path][output_file.name]: permission denied.")
-					if (DWAINE::ERR::SIG::GENERIC)
-						src.message_user("tar: Error extracting [target_path][output_file.name]")
-					if (DWAINE::ERR::SIG::NOTARGET)
-						src.message_user("tar: Bad path: [target_path] for file [output_file.name]")
+			var/outcome = src.signal_program(1, list("command" = DWAINE::SYSCALL::FWRITE, "path" = "[target_path]", "mkdir" = TRUE, "replace" = TRUE), to_extract.copy_file())
+			switch (outcome)
+				if (DWAINE::ERR::SIG::NOWRITE)
+					src.message_user("tar: [target_path][to_extract.name]: permission denied.")
+				if (DWAINE::ERR::SIG::GENERIC)
+					src.message_user("tar: Error extracting [target_path][to_extract.name]")
+				if (DWAINE::ERR::SIG::NOTARGET)
+					src.message_user("tar: Bad path: [target_path] for file [to_extract.name]")
 
 		else
 			src.message_user("[target_path][to_extract.name] already exists, skipping")

--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -258,14 +258,18 @@
 
 	else if (istype(to_extract, /datum/computer/file))
 		if (!istype(T) || !src.opt_skip)
-			var/outcome = src.signal_program(1, list("command" = DWAINE::SYSCALL::FWRITE, "path" = "[target_path]", "mkdir" = TRUE, "replace" = TRUE), to_extract)
-			switch (outcome)
-				if (DWAINE::ERR::SIG::NOWRITE)
-					src.message_user("tar: [target_path][to_extract.name]: permission denied.")
-				if (DWAINE::ERR::SIG::GENERIC)
-					src.message_user("tar: Error extracting [target_path][to_extract.name]")
-				if (DWAINE::ERR::SIG::NOTARGET)
-					src.message_user("tar: Bad path: [target_path] for file [to_extract.name]")
+			// if we don't copy the file, deleting the archive will delete the copied files
+			// and if it's extracted multiple times, deleting any of the copies will delete all of them, plus the one on the archive
+			var/datum/computer/file/output_file = to_extract.copy_file()
+			if(output_file)
+				var/outcome = src.signal_program(1, list("command" = DWAINE::SYSCALL::FWRITE, "path" = "[target_path]", "mkdir" = TRUE, "replace" = TRUE), output_file)
+				switch (outcome)
+					if (DWAINE::ERR::SIG::NOWRITE)
+						src.message_user("tar: [target_path][output_file.name]: permission denied.")
+					if (DWAINE::ERR::SIG::GENERIC)
+						src.message_user("tar: Error extracting [target_path][output_file.name]")
+					if (DWAINE::ERR::SIG::NOTARGET)
+						src.message_user("tar: Bad path: [target_path] for file [output_file.name]")
 
 		else
 			src.message_user("[target_path][to_extract.name] already exists, skipping")


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Extracting from a DWAINE archive file with `tar` now creates a copy of the archived file instead of just adding the actual file from the archive directly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This prevents an issue where deleting the extracted file, or deleting the archive, would delete the archived copy/all extracted copies of that file, respectively.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Split out of #27639. It worked there, though it's more difficult to test without all the other fixes because `tar` is kind of buggy at the moment.
