### PR TITLE
Extract already-existing folders in tar

### DIFF
--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -7,7 +7,8 @@
 	VAR_PRIVATE/tmp/opt_create = null
 	/// The filepath of the archive to be created, read, or extracted. Mutually exclusive with `opt_temporary`.
 	VAR_PRIVATE/tmp/opt_file = null
-	/// When extracting from an archive, whether `tar` should skip over already existing filepaths or overwrite them with archive contents.
+	/// When extracting from an archive, whether `tar` should skip over already existing files or overwrite them with archive contents.
+	/// Does not apply to folders.
 	VAR_PRIVATE/tmp/opt_skip = null
 	/// Whether `tar` should list the contents of an archive. Mutually exclusive with `opt_create` and `opt_extract`.
 	VAR_PRIVATE/tmp/opt_list = null
@@ -240,8 +241,6 @@
 		src.message_reply_and_user("[current_path][to_extract.name]")
 
 	if (istype(to_extract, /datum/computer/folder))
-		// we don't check istype(T) because we don't directly FWRITE folders, only leaf nodes like files
-		// if that changes, this will have to be adjusted
 		if (src.signal_program(1, list("command" = DWAINE::SYSCALL::TSPAWN, "passusr" = TRUE, "path" = "/bin/mkdir", "args" = "[target_path][to_extract.name]")) == DWAINE::ERR::SIG::NOTARGET)
 			src.message_user("mkdir: command not found.")
 

--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -240,21 +240,17 @@
 		src.message_reply_and_user("[current_path][to_extract.name]")
 
 	if (istype(to_extract, /datum/computer/folder))
-		if (!istype(T))
-			if (src.signal_program(1, list("command" = DWAINE::SYSCALL::TSPAWN, "passusr" = TRUE, "path" = "/bin/mkdir", "args" = "[target_path][to_extract.name]")) == DWAINE::ERR::SIG::NOTARGET)
-				src.message_user("mkdir: command not found.")
+		// we don't check istype(T) because we don't directly FWRITE folders, only leaf nodes like files
+		// if that changes, this will have to be adjusted
+		if (src.signal_program(1, list("command" = DWAINE::SYSCALL::TSPAWN, "passusr" = TRUE, "path" = "/bin/mkdir", "args" = "[target_path][to_extract.name]")) == DWAINE::ERR::SIG::NOTARGET)
+			src.message_user("mkdir: command not found.")
 
-			if (!istype(src.signal_program(1, list("command" = DWAINE::SYSCALL::FGET, "path" = "[target_path][to_extract.name]")), /datum/computer/folder))
-				src.message_user("tar: Failed to create directory [to_extract.name]")
+		if (!istype(src.signal_program(1, list("command" = DWAINE::SYSCALL::FGET, "path" = "[target_path][to_extract.name]")), /datum/computer/folder))
+			src.message_user("tar: Failed to create directory [to_extract.name]")
 
-			var/datum/computer/folder/folder = to_extract
-			for (var/datum/computer/C as anything in folder.contents)
-				src.recursive_extract(C, "[target_path][to_extract.name]/", "[current_path][to_extract.name]/", depth + 1)
-
-		else if (src.opt_skip)
-			src.message_user("tar: [target_path][to_extract.name] already exists, skipping.")
-		else
-			src.message_user("tar: [target_path][to_extract.name] already exists, cannot overwrite folder - skipping.")
+		var/datum/computer/folder/folder = to_extract
+		for (var/datum/computer/C as anything in folder.contents)
+			src.recursive_extract(C, "[target_path][to_extract.name]/", "[current_path][to_extract.name]/", depth + 1)
 
 	else if (istype(to_extract, /datum/computer/file))
 		if (!istype(T) || !src.opt_skip)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Separated out of #27639. Already-existing destination folders in `tar -x` will not be skipped, because we don't write folders, only files. The `-k` flag to `tar` will now only skip existing files, not existing folders.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This made it a lot harder to extract backup archives in a way that didn't really add anything and didn't actually seem super intentional.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I copied `/bin` into an archive, deleted `/bin/grep`, confirmed `grep` no longer existed in `/bin/`, then extracted the backup archive into `/`. That properly restored `/bin/grep`.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Penelope Haze
(+)The DWAINE tar program will now extract files in destination folders that already exist, and the -k flag only skips existing files rather than folders.
```
