### PR TITLE
Allow DWAINE tar archives to contain other archives

### DIFF
--- a/code/modules/networks/computer3/mainframe2/filetypes/__computer_parent.dm
+++ b/code/modules/networks/computer3/mainframe2/filetypes/__computer_parent.dm
@@ -43,3 +43,6 @@ ABSTRACT_TYPE(/datum/computer)
 /datum/computer/proc/copy_file(depth = 0)
 	RETURN_TYPE(/datum/computer)
 	return
+
+/datum/computer/proc/get_archive_size()
+	return src.size

--- a/code/modules/networks/computer3/mainframe2/filetypes/archive.dm
+++ b/code/modules/networks/computer3/mainframe2/filetypes/archive.dm
@@ -7,6 +7,7 @@
 	var/uncompressed_size = 0
 	// Generally assumed that all contained files will be expendable copies.
 	var/tmp/list/contained_files = null
+	var/tmp/max_depth = 0
 	var/max_contained_size = 48
 
 /datum/computer/file/archive/New()
@@ -37,7 +38,7 @@
 	if (!C || ((src.uncompressed_size + C.size) > src.max_contained_size))
 		return FALSE
 
-	if (istype(C, /datum/computer/file/archive))
+	if (C == src) // An archive cannot contain itself
 		return FALSE
 
 	src.contained_files += C

--- a/code/modules/networks/computer3/mainframe2/filetypes/archive.dm
+++ b/code/modules/networks/computer3/mainframe2/filetypes/archive.dm
@@ -7,7 +7,6 @@
 	var/uncompressed_size = 0
 	// Generally assumed that all contained files will be expendable copies.
 	var/tmp/list/contained_files = null
-	var/tmp/max_depth = 0
 	var/max_contained_size = 48
 
 /datum/computer/file/archive/New()
@@ -35,12 +34,15 @@
 	return copy
 
 /datum/computer/file/archive/proc/add_file(datum/computer/C)
-	if (!C || ((src.uncompressed_size + C.size) > src.max_contained_size))
+	if (!C || ((src.uncompressed_size + C.get_archive_size()) > src.max_contained_size))
 		return FALSE
 
 	if (C == src) // An archive cannot contain itself
 		return FALSE
 
 	src.contained_files += C
-	src.uncompressed_size += C.size
+	src.uncompressed_size += C.get_archive_size()
 	return TRUE
+
+/datum/computer/file/archive/get_archive_size()
+	return src.uncompressed_size

--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -278,9 +278,9 @@
 		src.message_user("tar: Stack overflow.")
 		return
 
-	if (istype(to_copy, /datum/computer/file/archive))
-		src.message_user("tar: Cannot handle file [current_path][to_copy]")
-		return
+	// there may need to be a check here to avoid copying an archive into itself
+	// but when this proc is currently called, at time of writing,
+	// the archive is not actually on the filesystem and so cannot be archived
 
 	if (istype(to_copy, /datum/computer/folder))
 		var/datum/computer/folder/folder_to_copy = to_copy

--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -19,6 +19,8 @@
 	VAR_PRIVATE/tmp/opt_verbose = null
 	/// Whether `tar` should extract the contents of an existing archive. Mutually exclusive with `opt_create` and `opt_list`.
 	VAR_PRIVATE/tmp/opt_extract = null
+	/// The current archive being created, used to prevent storing an archive inside itself.
+	VAR_PRIVATE/tmp/datum/computer/file/archive/current_archive = null
 
 /datum/computer/file/mainframe_program/utility/tar/initialize(initparams)
 	if (..())
@@ -134,7 +136,7 @@
 			mainframe_prog_exit
 			return
 
-		var/datum/computer/file/archive/archive = new()
+		src.current_archive = new /datum/computer/file/archive()
 		for (var/path as anything in unaffected)
 			var/datum/computer/C = src.signal_program(1, list("command" = DWAINE::SYSCALL::FGET, "path" = ABSOLUTE_PATH(path, current)))
 			if (!istype(C))
@@ -148,16 +150,16 @@
 				mainframe_prog_exit
 				return
 
-			archive.add_file(copy)
+			src.current_archive.add_file(copy)
 
 		var/list/separated_filepath = splittext(archive_path, "/")
 		var/path_length = length(separated_filepath)
-		archive.name = separated_filepath[path_length]
+		src.current_archive.name = separated_filepath[path_length]
 		separated_filepath.Cut(path_length)
 
 		var/new_path = jointext(separated_filepath, "/") || "/"
 
-		switch (src.signal_program(1, list("command" = DWAINE::SYSCALL::FWRITE, "path" = new_path, "mkdir" = TRUE, "replace" = TRUE), archive))
+		switch (src.signal_program(1, list("command" = DWAINE::SYSCALL::FWRITE, "path" = new_path, "mkdir" = TRUE, "replace" = TRUE), src.current_archive))
 			if (DWAINE::ERR::SIG::NOWRITE)
 				src.message_user("tar: Cannot write destination [src.opt_file]")
 			if (DWAINE::ERR::SIG::NOTARGET)
@@ -193,6 +195,11 @@
 /datum/computer/file/mainframe_program/utility/tar/message_user(msg, render, file)
 	if (src.opt_quiet)
 		return
+
+	. = ..()
+
+/datum/computer/file/mainframe_program/utility/tar/disposing()
+	src.current_archive = null // just in case
 
 	. = ..()
 
@@ -278,9 +285,12 @@
 		src.message_user("tar: Stack overflow.")
 		return
 
-	// there may need to be a check here to avoid copying an archive into itself
-	// but when this proc is currently called, at time of writing,
-	// the archive is not actually on the filesystem and so cannot be archived
+	// at time of writing, the archive is not actually on the filesystem during its creation
+	// and so cannot be stored in itself. but better safe than sorry,
+	// since maybe tar will be able to add files to an archive someday
+	if (to_copy == src.current_archive)
+		src.message_user("tar: Cannot handle file [current_path][to_copy]")
+		return
 
 	if (istype(to_copy, /datum/computer/folder))
 		var/datum/computer/folder/folder_to_copy = to_copy


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Split out of #27639.
Relaxes the restrictions on archives inside of archives, with two caveats:
- An archive must not contain itself. Pretty obvious!
- An archive's storage cost is the total size of its uncompressed contents, rather than its compressed size, meaning you can't get infinite compression (down to 8kb) through repeated archiving.

To achieve this I added a helper for size-in-archive, `get_archive_size()`, to computer datums. It returns `size` by default for all computer datums except archives, which return `uncompressed_size` instead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This fixes some jank with archive files disappearing off of tape drives, because they use archives internally to mirror their file contents to the mainframe.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
I moved an archive to `/mnt/artlab`, then reset the connection on the artlab tape drive. Without these changes, the archive vanished. With these changes, the archive stays there.

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Penelope Haze
(+)DWAINE tar archives can now contain other archives, at the cost of their uncompressed size rather than compressed size.
```
