### PR TITLE
Fix DWAINE tar archives losing subfolder contents on copy

### DIFF
--- a/_std/namespaces/dwaine/syscalls.dm
+++ b/_std/namespaces/dwaine/syscalls.dm
@@ -194,6 +194,13 @@ ADD_TO_NAMESPACE(DWAINE, SYSCALL)(var/const/RECVFILE = 24)
 ADD_TO_NAMESPACE(DWAINE, SYSCALL)(var/const/BREAK = 25)
 
 /**
+ *	Get the deepest existing folder in the specified filepath.
+ *	Accepted data fields:
+ *	- `"path"`: The filepath to get a directory for.
+ */
+ADD_TO_NAMESPACE(DWAINE, SYSCALL)(var/const/PGET = 26)
+
+/**
  *	Reply to a request for information.
  *	Has unique data fields for each implementation, depending on the data requested.
  */

--- a/code/modules/networks/computer3/mainframe2/programs/os/kernel/syscalls/pget.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/os/kernel/syscalls/pget.dm
@@ -1,0 +1,16 @@
+/datum/dwaine_syscall/pget
+	id = DWAINE::SYSCALL::PGET
+
+/datum/dwaine_syscall/pget/execute(sendid, list/data, datum/computer/file/file)
+	if (!sendid)
+		return DWAINE::ERR::SIG::GENERIC
+
+	var/datum/computer/file/mainframe_program/caller_prog = src.kernel.master.processing[sendid]
+	if (!data["path"] || !caller_prog)
+		return DWAINE::ERR::SIG::NOTARGET
+
+	var/datum/computer/folder/target_directory = src.kernel.parse_directory(data["path"], src.kernel.holder.root, FALSE, caller_prog.useracc)
+	if (!target_directory) // no part of the given filepath exists at all
+		return DWAINE::ERR::SIG::NOFILE
+
+	return target_directory

--- a/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
+++ b/code/modules/networks/computer3/mainframe2/programs/utilities/tar.dm
@@ -120,7 +120,7 @@
 			target_path = current
 
 		if (!istype(src.signal_program(1, list("command" = DWAINE::SYSCALL::FGET, "path" = target_path)), /datum/computer/folder))
-			src.message_user("tar: cannot read target directory [target_path]")
+			src.message_user("tar: Cannot read target directory [target_path]")
 			mainframe_prog_exit
 			return
 
@@ -137,7 +137,33 @@
 			mainframe_prog_exit
 			return
 
-		src.current_archive = new /datum/computer/file/archive()
+		var/datum/computer/file/archive/archive = new /datum/computer/file/archive()
+		// we have to get the destination (or its existing parent folder) here to ensure holder is set properly
+		// otherwise folders in the archive will fail to copy/extract
+		var/list/separated_filepath = splittext(archive_path, "/")
+		var/path_length = length(separated_filepath)
+		archive.name = separated_filepath[path_length]
+		separated_filepath.Cut(path_length)
+		var/new_path = jointext(separated_filepath, "/") || "/"
+		var/datum/computer/folder/output_parent = src.signal_program(1, list("command" = DWAINE::SYSCALL::PGET, "path" = new_path))
+		switch(output_parent)
+			if (DWAINE::ERR::SIG::NOFILE) // no part of the given directory exists
+				src.message_user("tar: Cannot find directory [separated_filepath[1]]")
+				mainframe_prog_exit
+				return
+			if (DWAINE::ERR::SIG::NOTARGET)
+				src.message_user("tar: Invalid output path [archive_path]")
+				mainframe_prog_exit
+				return
+			if (DWAINE::ERR::SIG::GENERIC)
+				src.message_user("tar: Error while finding output directory [new_path]")
+				mainframe_prog_exit
+				return
+		// if we're still here, we must have a destination, or at least a parent dir for it
+		archive.holder = output_parent.holder
+		// set current_archive so deep_copy can check it
+		src.current_archive = archive
+
 		for (var/path as anything in unaffected)
 			var/datum/computer/C = src.signal_program(1, list("command" = DWAINE::SYSCALL::FGET, "path" = ABSOLUTE_PATH(path, current)))
 			if (!istype(C))
@@ -152,13 +178,6 @@
 				return
 
 			src.current_archive.add_file(copy)
-
-		var/list/separated_filepath = splittext(archive_path, "/")
-		var/path_length = length(separated_filepath)
-		src.current_archive.name = separated_filepath[path_length]
-		separated_filepath.Cut(path_length)
-
-		var/new_path = jointext(separated_filepath, "/") || "/"
 
 		switch (src.signal_program(1, list("command" = DWAINE::SYSCALL::FWRITE, "path" = new_path, "mkdir" = TRUE, "replace" = TRUE), src.current_archive))
 			if (DWAINE::ERR::SIG::NOWRITE)
@@ -296,9 +315,11 @@
 
 	if (istype(to_copy, /datum/computer/folder))
 		var/datum/computer/folder/folder_to_copy = to_copy
+		// we can't just use copy_file for folders because we have to check read perms and filetype
 		var/datum/computer/folder/folder_copy = new()
 
 		folder_copy.name = folder_to_copy.name
+		folder_copy.holder = src.current_archive.holder
 		for (var/datum/computer/C as anything in folder_to_copy.contents)
 			var/datum/computer/copy = src.deep_copy(C, "[current_path][to_copy.name]/", depth + 1)
 			if (istype(copy))

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1881,6 +1881,7 @@
 #include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\fwrite.dm"
 #include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\mount.dm"
 #include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\msg_term.dm"
+#include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\pget.dm"
 #include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\tfork.dm"
 #include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\tkill.dm"
 #include "code\modules\networks\computer3\mainframe2\programs\os\kernel\syscalls\tlist.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Split out of #27639. ~~Depends on #27671.~~ No more dependencies left, they're all in.
Adds the `PGET` syscall (in theory it's "parent get" or "path get", but in reality it's "dget was already taken" and "dirget places it right between dget and dlist which is annoying"), which is effectively a wrapper for `parse_directory()`. It returns the deepest folder in a path that already exists, e.g. if you have `/foo/bar/`, `PGET /foo/bar/baz/qux` will give `/foo/bar/`.
Adds the first use of the `PGET` syscall in the `tar` program, to ensure the archive and its contents have `holder` set properly. Folders without `holder` will fail to be copied and so, when the archive is copied, just vanish.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes copied archives losing files inside of subfolders.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested in #27639. I ran `tar -c -f binfiles /bin`, then did `cp binfiles binbackup`, then did `tar -l -f binbackup`. Without the change it only contains `bin` (no files in the subdirectory), with the change it still has all the subdirectories. `tar -l -f binfiles` has the files either way.
