### PR TITLE
Menhir indirect entry countermeasure

### DIFF
--- a/_std/defines/component_defines/component_defines_datum.dm
+++ b/_std/defines/component_defines/component_defines_datum.dm
@@ -32,6 +32,8 @@
 	#define COMSIG_AREA_ENTERED_BY_MOB "mob_entered_area"
 	/// whenever a mob exits an area (exited mob)
 	#define COMSIG_AREA_EXITED_BY_MOB "mob_exited_area"
+	/// whenever an atom enters the area indirectly (i.e. through teleportation or phase shift)
+	#define COMSIG_AREA_INDIRECT_ENTRY "atom_indirect_entry"
 
 // ---- TGUI signals ----
 	/// A TGUI window was opened by a user (receives tgui datum)

--- a/code/WorkInProgress/menhir_tech.dm
+++ b/code/WorkInProgress/menhir_tech.dm
@@ -62,7 +62,7 @@ TYPEINFO_NEW(/obj/effects/menhir_fog)
 /datum/fishing_spot/biodome_lake/menhir
 	fishing_atom_type = /turf/unsimulated/floor/setpieces/menhir_cavepool
 
-/area/station/crown // stole this code from the void definition
+/area/station/crown
 	name = "The Crown"
 	icon_state = "purple"
 	filler_turf = "/turf/unsimulated/floor/setpieces/bluefloor"
@@ -75,6 +75,7 @@ TYPEINFO_NEW(/obj/effects/menhir_fog)
 /area/station/crown/New()
 	. = ..()
 	START_TRACKING_CAT(TR_CAT_AREA_PROCESS)
+	RegisterSignal(src, COMSIG_AREA_INDIRECT_ENTRY, PROC_REF(redirect_intruder))
 
 /area/station/crown/disposing()
 	STOP_TRACKING_CAT(TR_CAT_AREA_PROCESS)
@@ -89,6 +90,8 @@ TYPEINFO_NEW(/obj/effects/menhir_fog)
 
 		var/turf/noisy_turf = pick(get_area_turfs(/area/station/crown))
 		playsound(noisy_turf, weirdnoise, 70, 1)
+
+/area/station/crown/proc/redirect_intruder(var/atom/movable/AM, var/teleport_source)
 
 #define ARC_NOT_READY 0
 #define ARC_READY 1

--- a/code/WorkInProgress/menhir_tech.dm
+++ b/code/WorkInProgress/menhir_tech.dm
@@ -91,7 +91,26 @@ TYPEINFO_NEW(/obj/effects/menhir_fog)
 		var/turf/noisy_turf = pick(get_area_turfs(/area/station/crown))
 		playsound(noisy_turf, weirdnoise, 70, 1)
 
-/area/station/crown/proc/redirect_intruder(var/atom/movable/AM, var/teleport_source)
+/area/station/crown/proc/redirect_intruder(_, var/atom/movable/AM, var/teleport_source)
+	var/do_redirect
+	switch(teleport_source)
+		if("magic")
+			do_redirect = TRUE
+			if(ismob(AM))
+				var/mob/M = AM
+				boutput(M, SPAN_ALERT("You're whisked away to somewhere else entirely!"))
+		if("mechcomp")
+			do_redirect = TRUE
+			if(ismob(AM))
+				var/mob/M = AM
+				boutput(M, SPAN_ALERT("Something redirects your teleportation!"))
+		else
+			do_redirect = FALSE
+	if(do_redirect)
+		SPAWN(1)
+			var/turf/go_turf = pick_landmark(LANDMARK_MENHIR_OUTREACH)
+			AM.set_loc(go_turf)
+			showswirl(go_turf)
 
 #define ARC_NOT_READY 0
 #define ARC_READY 1

--- a/code/modules/antagonists/wizard/abilities/phaseshift.dm
+++ b/code/modules/antagonists/wizard/abilities/phaseshift.dm
@@ -103,6 +103,8 @@
 			junk_to_dump.set_loc(mobloc)
 
 		qdel(holder)
+		var/area/dest_area = get_area(H)
+		SEND_SIGNAL(dest_area, COMSIG_AREA_INDIRECT_ENTRY, H, "magic")
 
 /obj/dummy/spell_invis
 	name = "water"

--- a/code/modules/antagonists/wizard/abilities/warp.dm
+++ b/code/modules/antagonists/wizard/abilities/warp.dm
@@ -69,4 +69,5 @@
 			var/mob/living/carbon/human/H = target
 			H.shoes?.magnetic_teleport_check(H, get_turf(H), destination)
 		logTheThing(LOG_COMBAT, holder.owner, "warped [constructTarget(target,"combat")] from [log_loc(target)] to [log_loc(destination)].")
+		SEND_SIGNAL(src, COMSIG_AREA_INDIRECT_ENTRY, target, "warp")
 		target.set_loc(destination)

--- a/code/modules/antagonists/wizard/abilities/warp.dm
+++ b/code/modules/antagonists/wizard/abilities/warp.dm
@@ -65,9 +65,10 @@
 		target.visible_message(SPAN_ALERT("[target] is warped away!"))
 		playsound(target.loc, 'sound/effects/mag_warp.ogg', 25, 1, -1)
 		var/turf/destination = pick(randomturfs)
+		var/area/dest_area = get_area(destination)
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = target
 			H.shoes?.magnetic_teleport_check(H, get_turf(H), destination)
 		logTheThing(LOG_COMBAT, holder.owner, "warped [constructTarget(target,"combat")] from [log_loc(target)] to [log_loc(destination)].")
-		SEND_SIGNAL(src, COMSIG_AREA_INDIRECT_ENTRY, target, "warp")
 		target.set_loc(destination)
+		SEND_SIGNAL(dest_area, COMSIG_AREA_INDIRECT_ENTRY, target, "magic")

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -840,8 +840,11 @@ ABSTRACT_TYPE(/datum/projectile/special)
 				P.die()
 
 	on_end(obj/projectile/P)
+		var/turf/dumpturf = get_turf(P)
+		var/area/dumparea = get_area(dumpturf)
 		for (var/atom/movable/AM in P.contents)
-			AM.set_loc(get_turf(P))
+			AM.set_loc(dumpturf)
+			SEND_SIGNAL(dumparea, COMSIG_AREA_INDIRECT_ENTRY, AM, "mechcomp")
 		qdel(src.eye_glider)
 		src.eye_glider = null
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[FEAT][FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a new area signal fired off by certain means of relocation, COMSIG_AREA_INDIRECT_ENTRY, and sets up a listener in Menhir's Crown area to redirect anything entering through those means. Redirected atoms will be sent to a random "outreach" landmark (curated "random" spots around the station).

The list of indirect entry methods currently consists of:
- Wizard's Warp ability (anything warped into the Crown will warp right back out again)
- Wizard's Phaseshift ability (redirection is applied if you rematerialize inside the Crown, you can pass through safely)
- Mechcomp teleportation (redirection is applied if you rematerialize inside the Crown, you can pass through safely)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Wizards being able to hide out in the Crown (or lock people in there sometimes with Warp) is a bit troublesome, as is mechcomping into the area, and this takes care of both cleanly in one fell swoop.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Successfully intercepted a Phase Shift and redirected to an outreach turf.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(*)Menhir's big big artifact now redirects guests who entered by certain unorthodox means.
```
