### PR TITLE
Fix artifact reagent containers causing random runtime errors

### DIFF
--- a/code/obj/artifacts/artifact_items/pitcher.dm
+++ b/code/obj/artifacts/artifact_items/pitcher.dm
@@ -7,7 +7,7 @@
 	can_recycle = 0
 
 	New(var/loc, var/forceartiorigin)
-		..()
+		..(loc)
 		var/datum/artifact/pitcher/AS = new /datum/artifact/pitcher(src)
 		if (forceartiorigin)
 			AS.validtypes = list("[forceartiorigin]")

--- a/code/obj/artifacts/artifact_items/watering_can.dm
+++ b/code/obj/artifacts/artifact_items/watering_can.dm
@@ -8,7 +8,7 @@
 	can_recycle = FALSE
 
 	New(var/loc, var/forceartiorigin)
-		..()
+		..(loc, null) // do not pass our artifact origin as a reagent type
 		var/datum/artifact/watercan/AS = new /datum/artifact/watercan(src)
 		if (forceartiorigin)
 			AS.validtypes = list("[forceartiorigin]")


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes `forceartiorigin` in `/obj/item/reagent_containers/glass/wateringcan/artifact/New()` being passed as `new_initial_reagents` to `/obj/item/reagent_containers/New()`.

Also does the same for the pitcher artifact.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes random runtimes on Menhir in runtime testing, caused by artifact watering cans.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
spawned an artifact watering can, no runtime! Woo :)

<img width="429" height="646" alt="image" src="https://github.com/user-attachments/assets/9eab2e91-a18f-4eba-a1b7-75171316b1f8" />
