### PR TITLE
Nuclear Bomb Map Marker

### DIFF
--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -54,7 +54,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 		MAKE_SENDER_RADIO_PACKET_COMPONENT(null, null, FREQ_STATUS_DISPLAY)
 
 		get_self_and_decoys() // links them up
-		AddComponent(/datum/component/minimap_marker/minimap, MAP_SYNDICATE | MAP_ADMIN, "nuclear_bomb")
+		AddComponent(/datum/component/minimap_marker/minimap, MAP_SYNDICATE | MAP_OBSERVER, "nuclear_bomb")
 
 		START_TRACKING
 		..()

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -54,6 +54,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 		MAKE_SENDER_RADIO_PACKET_COMPONENT(null, null, FREQ_STATUS_DISPLAY)
 
 		get_self_and_decoys() // links them up
+		AddComponent(/datum/component/minimap_marker/minimap, MAP_SYNDICATE | MAP_ADMIN, "nuclear_bomb")
 
 		START_TRACKING
 		..()

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -54,7 +54,7 @@ ADMIN_INTERACT_PROCS(/obj/machinery/nuclearbomb, proc/arm, proc/set_time_left)
 		MAKE_SENDER_RADIO_PACKET_COMPONENT(null, null, FREQ_STATUS_DISPLAY)
 
 		get_self_and_decoys() // links them up
-		AddComponent(/datum/component/minimap_marker/minimap, MAP_SYNDICATE | MAP_OBSERVER, "nuclear_bomb")
+		AddComponent(/datum/component/minimap_marker/minimap, MAP_SYNDICATE | MAP_ADMIN, "nuclear_bomb")
 
 		START_TRACKING
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Nuclear bombs have markers on Syndicate and Admin minimaps.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows admins and nukies to track bombs more efficiently, though notably nukies will need to bring the minimap controller from the cairngorm if they want to do this from the station.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="1313" height="736" alt="image" src="https://github.com/user-attachments/assets/c764f740-9411-4ffd-b7f5-75122c46214a" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(+)Nuclear bombs now have a minimap marker for syndicate and admin minimaps.
```
