### PR TITLE
Changes steve's mixtape to reflect the similar ability

### DIFF
--- a/code/modules/economy/traders/steve.dm
+++ b/code/modules/economy/traders/steve.dm
@@ -123,5 +123,5 @@
 	comname = "Our Mixtape"
 	comtype = /obj/item/sound_tape/ling_recording
 	amount = 1
-	price_boundary = list(PAY::DONTBUYIT*1,PAY::DONTBUYIT*2)
+	price_boundary = list(PAY::DONTBUYIT*1.5,PAY::DONTBUYIT*3.5)
 	possible_names = list("The recording of us- me, a human who is a singular person, singing. We feel sheepish about selling this.")

--- a/code/obj/item/device/sound_tape.dm
+++ b/code/obj/item/device/sound_tape.dm
@@ -164,7 +164,7 @@ TYPEINFO(/obj/item/sound_tape/lightbreaker)
 	activate(mob/user as mob)
 		..()
 		for (var/mob/living/HH in hearers(user, null)) // Works on EVERYONE, bring earmuffs
-			HH.apply_sonic_stun(0, 0, 0, 10, 70, rand(0, 2))
+			HH.apply_sonic_stun(0, 0, 0, 10, 35, rand(0, 2))
 		return TRUE
 
 /obj/item/spookbook //Wander Office item, not meant to look like a lightbreaker to the average player

--- a/code/obj/item/device/sound_tape.dm
+++ b/code/obj/item/device/sound_tape.dm
@@ -161,6 +161,11 @@ TYPEINFO(/obj/item/sound_tape/lightbreaker)
 	ammo = 1
 	ammo_max = 1
 
+	activate(mob/user as mob)
+		..()
+		for (var/mob/living/HH in hearers(user, null)) // Works on EVERYONE, bring earmuffs
+			HH.apply_sonic_stun(0, 0, 0, 10, 70, rand(0, 2))
+		return TRUE
 
 /obj/item/spookbook //Wander Office item, not meant to look like a lightbreaker to the average player
 	name = "worn book"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes steve's mixtape to have a stun similar to abomination screech.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having unique utility items as a alternative for QMs then just buying guns is always a good idea (and not new, given gragg's erebite). With its negligible ammo and the fact it doesn't exempt the user should make it niche enough to still be avaliable in this method.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Ran on a local, spawned and used the tape. Tested with and without ear protection.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cheekybrdy
(+)Steve's Mixtape now acts similar to its unrecorded variant.
```
