### PR TITLE
Fix Neon Diner Backroom for Spief objective

### DIFF
--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -15181,7 +15181,7 @@
 "ksh" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
-	welded = TRUE
+	welded = 1
 	},
 /turf/simulated/floor/grime,
 /area/diner/backroom)

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -15181,7 +15181,7 @@
 "ksh" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
-	welded = true
+	welded = TRUE
 	},
 /turf/simulated/floor/grime,
 /area/diner/backroom)

--- a/maps/neon.dmm
+++ b/maps/neon.dmm
@@ -15179,8 +15179,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "ksh" = (
-/turf/simulated/wall/false_wall/reinforced,
-/area/diner/kitchen)
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	welded = true
+	},
+/turf/simulated/floor/grime,
+/area/diner/backroom)
 "ksy" = (
 /obj/table/wood/auto,
 /obj/machinery/light/incandescent/warm,
@@ -75534,10 +75538,10 @@ xAt
 xAt
 dEp
 xAt
-oXW
-oXW
+rco
+rco
 ksh
-oXW
+rco
 oXW
 oXW
 qpn


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the false wall that lead to the previously walled off diner backroom area with a welded door to preserve the ✨lore✨ of the note thats inside
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #27711
Spief can potentially have the diner backroom as a dropoff location and having it completely walled off means people may not know it exists or what is considered "the backroom"
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
went to diner, saw welded door labeled "Space Diner Backroom"
unwelded door
opened door
closed door
<img width="391" height="190" alt="image" src="https://github.com/user-attachments/assets/1e1a6744-3a09-4dbc-aa30-176d99059cc3" />
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->