### PR TITLE
Fix telepad ping_reply

### DIFF
--- a/code/modules/networks/computer3/mainframe2/telesci.dm
+++ b/code/modules/networks/computer3/mainframe2/telesci.dm
@@ -149,6 +149,8 @@ TYPEINFO(/obj/machinery/networked/telepad)
 				new_signal.data["address_1"] = signal_sender
 				new_signal.data["sender"] = src.net_id
 				new_signal.data["command"] = "ping_reply"
+				new_signal.data["device"] = src.device_tag
+				new_signal.data["netid"] = src.net_id
 				SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, new_signal)
 			return
 		//the only


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR
Fixes the lack of a netid and device fields in wireless telepad ping replies, so the reply may show up on pinging tools.

## Why's this needed?
Bringing it in line with how packet pings ordinarily behave.

## Testing
Used the PDA ping tool on 147.9 near a telepad, both the NetID and device designation to showed up.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
