### PR TITLE
Robot Clothing Hotfix 2

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2897,7 +2897,6 @@ TYPEINFO(/mob/living/silicon/robot)
 				clothed_image.alpha = U.alpha
 				clothed_image.color = U.color
 				clothed_image.layer = U.wear_layer
-				clothed_image.overlays = null
 				if (U.worn_material_texture_image)
 					U.worn_material_texture_image.layer = clothed_image.layer + 0.1
 					clothed_image.overlays += U.worn_material_texture_image


### PR DESCRIPTION
The refresh code was deleting wigs, that is removed by this hotfix, and wasn't necessary anyway.

<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR 
Just removed a line of code that was intended to refresh to sprites, but was deleting wigs when worn by borgs.<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

## Why's this needed? 
I messed up.
This is the fix~<!-- Describe why you think this should be added to the game. -->

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
https://github.com/goonstation/goonstation/pull/27715#issue-5323283987
Clothing and wigs were fine again.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)GabbySins
(+)Wigs can be worn by borgs again.
```
