### PR TITLE
The default_material should now always be a text ID

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -94,17 +94,8 @@ TYPEINFO(/atom)
 	New(turf/newLoc)
 		. = ..()
 		// Lets stop having 5 implementations of this that all do it differently
-		if (!src.material && default_material)
-			var/datum/material/mat = istext(default_material) ? getMaterial(default_material) : default_material
-			src.setMaterial(mat)
-
-	proc/get_default_material_id()
-		if (istext(src.default_material))
-			return src.default_material
-		var/datum/material/default_mat = src.default_material
-		if (istype(default_mat))
-			return default_mat.getID()
-		return null
+		if (!src.material && src.default_material)
+			src.setMaterial(getMaterial(src.default_material))
 
 	proc/name_prefix(var/text_to_add, var/return_prefixes = 0, var/prepend = 0)
 		if( !name_prefixes ) name_prefixes = list()

--- a/code/obj/item/rcd/rcd.dm
+++ b/code/obj/item/rcd/rcd.dm
@@ -234,7 +234,7 @@ TYPEINFO(/obj/item/rcd)
 		var/turf/simulated/floor/T = A.ReplaceWithFloor()
 		T.inherit_area()
 		T.setMaterial(getMaterial(material_name))
-		T.default_material = getMaterial(material_name)
+		T.plating_material = material_name
 		return
 
 	proc/handle_build_wall(turf/A, mob/user)
@@ -344,8 +344,7 @@ TYPEINFO(/obj/item/rcd)
 		if (istype(A, /turf/simulated/floor) || istype(A, /turf/simulated/space_phoenix_ice_tunnel))
 			var/turf/simulated/floor/T = A
 			if(istype(T) && T.intact)
-				var/datum/material/mat = istext(T.default_material) ? getMaterial(T.default_material) : T.default_material
-				if(length(restricted_materials) && !(mat?.getID() in restricted_materials))
+				if(length(restricted_materials) && !(T.default_material in restricted_materials))
 					boutput(user, "Target object is not made of a material this RCD can deconstruct.")
 					return
 			src.do_rcd_action(user, A, "removing \the [A]", matter_remove_floor, time_remove_floor, PROC_REF(do_delete_floor), src)

--- a/code/obj/machinery/arc_electroplater.dm
+++ b/code/obj/machinery/arc_electroplater.dm
@@ -124,7 +124,7 @@ TYPEINFO(/obj/machinery/arc_electroplater)
 		if(!W.can_arcplate)
 			boutput(user, SPAN_ALERT("That cannot be plated!"))
 			return
-		if(W.material && W.material.getID() != W.get_default_material_id())
+		if(W.material && W.material.getID() != W.default_material)
 			boutput(user, SPAN_ALERT("You can't plate something that already has a non-standard material!"))
 			return
 
@@ -218,7 +218,7 @@ TYPEINFO(/obj/machinery/arc_electroplater)
 		var/cancel_arcplate = FALSE
 		if(!my_bar?.material || !successful)
 			cancel_arcplate = TRUE
-		else if(target_item.material && target_item.material.getID() != target_item.get_default_material_id())
+		else if(target_item.material && target_item.material.getID() != target_item.default_material)
 			cancel_arcplate = TRUE
 		else if(isitem(target_item))
 			var/obj/item/I = target_item

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -19,7 +19,7 @@
 	provides_grip = FALSE
 	/// if this floor can be pried up
 	var/pryable = TRUE
-	var/has_material = TRUE
+	var/datum/material/plating_material = null //! Material of the floor when the floor tile is removed
 
 	/// Set to instantiated material datum ([getMaterial()]) for custom material floors
 	var/reinforced = FALSE
@@ -34,6 +34,7 @@
 
 	New()
 		..()
+		src.plating_material = src.material
 		roundstart_icon_state = icon_state
 		roundstart_dir = dir
 		#ifdef XMAS
@@ -2203,9 +2204,10 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 	setIntact(FALSE)
 	broken = 0
 	burnt = 0
-	if(default_material)
-		var/datum/material/mat = istext(default_material) ? getMaterial(default_material) : default_material
-		src.setMaterial(mat)
+	if(src.plating_material)
+		src.setMaterial(src.plating_material)
+	else if(src.default_material)
+		src.setMaterial(getMaterial(src.default_material))
 	else
 		src.setMaterial(getMaterial("steel"))
 	levelupdate()
@@ -2313,7 +2315,7 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 		if (!intact)
 			if(T.amount >= 1)
 				restore_tile(do_hide)
-				src.default_material = src.material
+				src.plating_material = src.material
 
 				// if we have a special icon state and it doesn't have a material variant
 				// and at the same time the base floor icon state does have a material variant


### PR DESCRIPTION
## About the PR
- Floors no longer use their `default_material` as a way to store their plating material. This should remove any cases where the `default_material` is not a text ID.

## Why's this needed?
- The `default_material` should always be a text ID. All else is heresy.

## Testing
<img width="228" height="321" alt="Screenshot 2026-09-02 122502" src="https://github.com/user-attachments/assets/043c3a46-9c22-47af-a53a-8d1782bf8325" />
