### PR TITLE
Fixed the Emergency Power Equipment Crate also containing the contents of the Basic Power Kit

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1858,7 +1858,7 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 	name = "Emergency Power Equipment"
 	desc = "x2 Circular Power Treadmill Deployers."
 	category = "Engineering"
-	flatpack_frames = list(/obj/machinery/power/power_wheel/hamster = 2)
+	frames = list(/obj/machinery/power/power_wheel/hamster = 2)
 	cost = PAY::TRADESMAN*10
 	containertype = /obj/storage/crate
 	containername = "Crew Power Generation Kit"

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1854,11 +1854,11 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 	containertype = /obj/storage/crate
 	containername = "Basic Power Kit"
 
-/datum/supply_packs/complex/basic_power_kit/crew
+/datum/supply_packs/complex/emergency_power_equipment
 	name = "Emergency Power Equipment"
 	desc = "x2 Circular Power Treadmill Deployers."
 	category = "Engineering"
-	frames = list(/obj/machinery/power/power_wheel/hamster = 2)
+	flatpack_frames = list(/obj/machinery/power/power_wheel/hamster = 2)
 	cost = PAY::TRADESMAN*10
 	containertype = /obj/storage/crate
 	containername = "Crew Power Generation Kit"


### PR DESCRIPTION
…

<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR 
This changes the Emergency Power Equipment Crate (2x Kinetic Generators) to not also contain the Basic Power Kit's contents (2x Power Furnaces, 1x SMES Unit)

## Why's this needed? 
The power furnaces and SMES were most likely a bug, as they were not listed in the contents of the EPE purchase

## Testing Confirmed 
By purchasing Emergency Power Equipment Crate and confirming that crate no longer contains Power Furnaces and a SMES Unit

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
