### PR TITLE
Jagged crystal sprite fix

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -299,7 +299,6 @@
 	name = "molitz crystal"
 	desc = "An unusual crystal of Molitz."
 	icon = 'icons/obj/items/materials/molitz.dmi'
-	icon_state = "ore$$molitz_b"
 	material_name = "Molitz Beta"
 	default_material = "molitz_b"
 	crystal = 1

--- a/code/obj/item/organs/flock.dm
+++ b/code/obj/item/organs/flock.dm
@@ -4,8 +4,8 @@
 	blood_type = "flockdrone_fluid"
 	blood_color = "#1bdebd"
 	desc = "That thing should not be in there, nopenopenope."
-	icon = 'icons/obj/items/materials/materials.dmi'
-	icon_state = "ore$$starstone" //wooo reused sprites
+	icon = 'icons/obj/items/materials/starstone.dmi'
+	icon_state = "ore3_$$starstone" //wooo reused sprites
 	mat_changename = FALSE
 	broken = TRUE
 	unusual = TRUE


### PR DESCRIPTION
## About the PR
- The `icon_state` for jagged crystal was broken by #23400, this PR fixes that.
- Removed an unused initial `icon_state` for molitz beta caused by the same PR.

## Why's this needed?
- Visible sprites good

## Testing
<img width="317" height="259" alt="Screenshot 2026-09-03 003355" src="https://github.com/user-attachments/assets/2f127635-f33d-4252-8833-d5390ddfbf5b" />
