### PR TITLE
removes misplaced light on nadir

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -8342,7 +8342,6 @@
 /obj/cable{
 	dir = null
 	},
-/obj/machinery/light/emergency,
 /obj/machinery/chem_heater{
 	pixel_x = -4;
 	dir = 4


### PR DESCRIPTION
## About the PR 
This PR removes an emergency light that's placed over another emergency light behind the Nadir bar.
<img width="234" height="188" alt="image" src="https://github.com/user-attachments/assets/18e09022-daee-47d7-8091-dd8bbaba7ca8" />


## Why's this needed?
Lights probably shouldn't be stacked like this!

## Testing 
<img width="334" height="201" alt="lighteradicated" src="https://github.com/user-attachments/assets/d7fa30f6-2c34-4264-be08-ea92d932b7c6" />

