### PR TITLE
Renames "splinching" and fixes its dropped limb messages

### DIFF
--- a/code/modules/telescience/teleporter_old.dm
+++ b/code/modules/telescience/teleporter_old.dm
@@ -260,17 +260,17 @@ ADMIN_INTERACT_PROCS(/obj/machinery/teleport/portal_generator, proc/engage, proc
 	return 0
 
 // /mob/living/carbon/human/list_ejectables() looked pretty similar to what I wanted, but this doesn't have organs that you need to live
-//drop a non-vital organ or a limb //shamelessly stolen from Harry Potter as is this whole ability
-proc/splinch(var/mob/M as mob, var/probability)
+//drop a non-vital organ or a limb
+proc/organdisplacement(var/mob/M as mob, var/probability)
 	if (prob(probability))
 		if (istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
-			var/part_splinched
+			var/part_displaced
 
-			part_splinched = pick("l_arm", "r_arm", "l_leg", "l_leg","left_eye", "right_eye", "left_lung", "right_lung", "butt", "left_kidney", "right_kidney", "spleen", "pancreas", "appendix", "stomach", "intestines", "tail")
-			if (part_splinched == "l_arm" || part_splinched == "r_arm" || part_splinched == "l_leg" || part_splinched == "l_leg")
-				return H.sever_limb(part_splinched)
+			part_displaced = pick("l_arm", "r_arm", "l_leg", "l_leg","left_eye", "right_eye", "left_lung", "right_lung", "butt", "left_kidney", "right_kidney", "spleen", "pancreas", "appendix", "stomach", "intestines", "tail")
+			if (part_displaced == "l_arm" || part_displaced == "r_arm" || part_displaced == "l_leg" || part_displaced == "l_leg")
+				return H.sever_limb(part_displaced)
 			else
-				return H.organHolder.drop_organ(part_splinched)
+				return H.organHolder.drop_and_throw_organ(part_displaced, showtext = 1)
 
-		// owner.visible_message(SPAN_ALERT("<b>[M]</b> splinches themselves and their [part_splinched] falls off!"))
+		// owner.visible_message(SPAN_ALERT("<b>[M]</b>'s [part_displaced] falls off!"))

--- a/code/obj/portal.dm
+++ b/code/obj/portal.dm
@@ -88,10 +88,9 @@
 				if (prob(failchance)) //oh dear a problem, put em in deep space
 					src.icon_state = "portal1"
 					do_teleport(M, destination, 15)
-					var/part_splinched = splinch(M, 75)
-					if (part_splinched)
-						do_teleport(part_splinched, destination, 8)
-						M.visible_message(SPAN_ALERT("<b>[M]</b> splinches themselves and their [part_splinched] falls off!"))
+					var/part_displaced = organdisplacement(M, 75)
+					if (part_displaced)
+						do_teleport(part_displaced, destination, 8)
 					M.throw_at(destination, 8, 2)
 
 					return


### PR DESCRIPTION
[BUG][QOL]
## About the PR 
This PR replaces all references to "splinching", as it's a term directly ripped from Harry Potter.
It also replaces the drop_organ with a drop_and_throw_organ with visible text, and removes the "splinches themselves" message since there's now already visible messages for both organ and limb loss through teleportation.

## Why's this needed?
I think the game would be better if we didn't have any references to the works of a TERF.
Also the splinch message was kinda broken, incorrectly grabbing the limb names, and printing a second message that basically said the same thing if the dropped part was a limb.
<img width="397" height="29" alt="image2" src="https://github.com/user-attachments/assets/38ed693f-36c1-494c-bad7-cd5fd21355ca" />

## Testing 
Both organs and limbs correctly display messages when lost through teleporting. Everything else functions exactly how it used to.
Dropped organs:
<img width="469" height="92" alt="organloss" src="https://github.com/user-attachments/assets/2c2b4fc7-3e7c-4a31-b9b8-287beb2d5c6a" />
Dropped limbs:
<img width="430" height="48" alt="limbloss" src="https://github.com/user-attachments/assets/664bbb61-21e6-42f8-abee-ba343e848bb5" />
Teleporter with dropped organs around it, for good measure:
<img width="386" height="181" alt="droppedorgans" src="https://github.com/user-attachments/assets/cf62c18a-1c41-4500-909d-e30ff2e683b7" />


