### PR TITLE
Make IR detectors (de)constructable, fix them not reverting to idle and their beam not re-activating automatically.

### DIFF
--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -2435,12 +2435,15 @@ TYPEINFO(/obj/machinery/networked/printer)
 
 		return output
 
+TYPEINFO(/obj/machinery/networked/secdetector)
+	mats = 12
 
 //IR tripwire/threat analyzer.
 /obj/machinery/networked/secdetector
 	name = "IR Detector"
 	desc = "An infrared tripwire and video camera coupled with a sophisticated threat-analysis system."
 	icon_state = "secdetector0"
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL | DECON_DESTRUCT
 	device_tag = "PNET_IR_DETECT"
 
 	var/detector_id = null
@@ -2577,7 +2580,9 @@ TYPEINFO(/obj/machinery/networked/printer)
 		if (active_time > 0)
 			active_time--
 			if (!active_time)
-				//src.state = src.online
+				qdel(src.scan_beam)
+				src.scan_beam = null
+				src.state = src.online
 				src.UpdateIcon(src.online)
 
 		switch (src.state)


### PR DESCRIPTION

## About the PR 
Gives IR detectors decon flags and mats, making them deconstructable and printable. Also fixes a bug where they would not properly revert to their idle state, nor have their detection beam be working.
## Why's this needed?
Reducing the amount of items that're not constructable is always good (deconstructing a detector still takes a full set of tools, so they still require prep to bypass). Detectors are also meant to automatically revert to the idle state, judging from the existence of an active state countdown. Fixed the scan beam not working after reverting to idle by qdel-ing it, I apologise if this is a scuffed fix.
## Testing
Constructed, deconstructed and printed IR detectors successfully. Triggered detectors to both states 2 and 3, reverted to idle and was able to detect again successfully for each.