### PR TITLE
Fix an erroneous duplicate in the injector filler's whitelist

### DIFF
--- a/code/WorkInProgress/sord.dm
+++ b/code/WorkInProgress/sord.dm
@@ -690,7 +690,7 @@ TYPEINFO(/obj/item/reagent_containers/injector_filler)
 	var/image/fluid_image
 	var/list/whitelist = list()
 	var/safe = 1
-	var/additional_whitelist = list("atropine", "calomel", "filgrastim", "heparin", "morphine", "proconvertin", "ephedrine", "acetylsalicylic_acid")
+	var/additional_whitelist = list("atropine", "calomel", "filgrastim", "heparin", "morphine", "proconvertin", "ephedrine")
 
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
See title. #27679 added ASA to the hypo whitelist, but at the time I was unaware that the injector filler used its own expanded whitelist that's set up at runtime from the hypo's one as a baseline, so it didn't occur to me to check. Turns out there's a duplicate, oops.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugfixes good

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Seems to still work fine!
<img width="429" height="114" alt="dreamseeker_WduzgtCYJZ" src="https://github.com/user-attachments/assets/b31e60af-caab-4b34-9738-c5503e90a44f" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->