### PR TITLE
Latex material appearance

### DIFF
--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -76,6 +76,34 @@ triggerOnImage(var/image/target, var/datum/material/source)
 		owner.set_density(0)
 		return
 
+/datum/materialProc/outline_add
+	max_generations = 0
+	var/outline_color = null
+	var/outline_size = 1
+
+	New(var/outline_color, var/outline_size = 1)
+		. = ..()
+		src.outline_color = outline_color
+		src.outline_size = outline_size
+
+	execute(var/atom/location)
+		if(isturf(location))
+			return
+		var/mat_id = location.material.getID()
+		if(!location.uses_default_material_appearance && location.default_material == "[mat_id]")
+			return
+		if(endswith(location.icon_state, "$$[mat_id]") || ("[mat_id]" in location.get_typeinfo().mat_appearances_to_ignore))
+			return
+		var/outline_filter = outline_filter(src.outline_size, src.outline_color)
+		location.add_filter("[mat_id]_outline", 4, outline_filter)
+		return
+
+/datum/materialProc/outline_remove
+	execute(var/atom/location)
+		var/mat_id = location.material.getID()
+		location.remove_filter("[mat_id]_outline")
+		return
+
 /datum/materialProc/ffart_add
 	desc = "It's very hard to move around."
 	max_generations = 1

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -2411,7 +2411,13 @@ ABSTRACT_TYPE(/datum/material/rubber)
 	mat_id = "latex"
 	name = "latex"
 	desc = "A type of synthetic rubber. Conducts electricity poorly."
-	color = "#DDDDDD" //"#FF0000" idgaf ok I want red cables back. no haine, this stuff isnt red.
+	hsl_color = list(1.00, 0.00, 0.00, 0.00,\
+					0.00, 0.00, 0.10, 0.20,\
+					0.00, 0.00, 0.70, 0.25,\
+					0.00, 0.00, 0.00, 0.75,\
+					0.00, 0.00, 0.45, 0.00)
+	color = "#EAEAEA" //"#FF0000" idgaf ok I want red cables back. no haine, this stuff isnt red.
+	alpha = 239
 
 	New()
 		..()
@@ -2420,6 +2426,9 @@ ABSTRACT_TYPE(/datum/material/rubber)
 		setProperty("electrical", 3)
 		setProperty("thermal", 4)
 		setProperty("melting_point", 453 KELVIN) // About the melting point of rubber
+
+		addTrigger(TRIGGERS_ON_ADD, new /datum/materialProc/outline_add(src.color, 0.05))
+		addTrigger(TRIGGERS_ON_REMOVE, new /datum/materialProc/outline_remove())
 
 /datum/material/rubber/synthrubber
 	mat_id = "synthrubber"


### PR DESCRIPTION
## About the PR
- New material appearance for latex.
- Adds a material proc that will give non-turf atoms an outline filter when applied.
- Changes latex material alpha from 255 to 239

## Why's this needed?
- Makes latex distinguishable.

## Testing
<img width="403" height="255" alt="Screenshot 2026-09-05 035501" src="https://github.com/user-attachments/assets/bd24d48d-b4f0-4746-a7d4-39fbd2f1301b" />
