### PR TITLE
Fixed undroppable pens being eaten by pdas/clipboards

### DIFF
--- a/code/modules/writing/pens_writing_etc.dm
+++ b/code/modules/writing/pens_writing_etc.dm
@@ -1102,6 +1102,9 @@
 		src.add_stuff(O, user)
 
 	proc/add_stuff(obj/item/I, mob/user)
+		if(I.cant_drop)
+			return
+			
 		if (istype(I, /obj/item/paper) || istype(I, /obj/item/photo))
 			if (length(src.contents) >= src.max_items)
 				boutput(user, SPAN_NOTICE("[src] can only hold [src.max_items] items!"))

--- a/code/modules/writing/pens_writing_etc.dm
+++ b/code/modules/writing/pens_writing_etc.dm
@@ -1102,7 +1102,7 @@
 		src.add_stuff(O, user)
 
 	proc/add_stuff(obj/item/I, mob/user)
-		if(I.cant_drop)
+		if(istype(I) && I.cant_drop)
 			return
 			
 		if (istype(I, /obj/item/paper) || istype(I, /obj/item/photo))

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -1024,11 +1024,8 @@
 			return
 
 	proc/insert_pen(obj/item/insertedPen, mob/user)
-		if (!istype(insertedPen))
+		if (!istype(insertedPen) || insertedPen.cant_drop)
 			return
-		if(insertedPen.cant_drop)
-			return
-			
 		if (user)
 			user.u_equip(insertedPen)
 			insertedPen.set_loc(src)

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -1026,6 +1026,9 @@
 	proc/insert_pen(obj/item/insertedPen, mob/user)
 		if (!istype(insertedPen))
 			return
+		if(insertedPen.cant_drop)
+			return
+			
 		if (user)
 			user.u_equip(insertedPen)
 			insertedPen.set_loc(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Make pda's & clipboard's pen insertion functionality ignore pens with `cant_drop`
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Borg pens often glitch out with these 2 items, especially the clipboard + me & Teko ran into bugs regarding this when working on omnitool pen mode
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
- As borg clicked with my pen on a pda with no pen, nothing happened.
- As borg clicked with my pen on a clipboard with no pen, nothing happened.

- As human clicked with my pen on a pda with no pen, got inserted.
- As human clicked with my pen on a clipboard with no pen, got inserted.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)ANNmagedon
(+)PDAs & Clipboard should no longer eat the borg's pens.
```
