### PR TITLE
Removable radioactive contamination (+atom washing)

### DIFF
--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -50,6 +50,10 @@
 	#define COMSIG_ATOM_SET_OPACITY "atom_set_opacity"
 	/// get radioactivity level of atom (0 if signal not registered - ie, has no radioactive component) (return_val as a list)
 	#define COMSIG_ATOM_RADIOACTIVITY "atom_get_radioactivity"
+	/// tries to remove some % of whatever cleanable radioactivity is present
+	/// args: category, percent_to_remove = 0.1, return_list, doNeutron = FALSE
+	/// arg explanation: "contamination type" (required), % (0-1) of cleanable contamination to try to remove, return_list of washed-off reagents (optional), apply to specifically neutron radiation
+	#define COMSIG_ATOM_DECONTAMINATE_RADS "atom_decontaminate_rads"
 	/// when an atom is washed in some way (likely missing multiple washing methods) (intentionally doesn't count handwashing)
 	/// (reagent_list (optional), caller (optional))
 	#define COMSIG_ATOM_WASHED "atom_washed"

--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -50,6 +50,9 @@
 	#define COMSIG_ATOM_SET_OPACITY "atom_set_opacity"
 	/// get radioactivity level of atom (0 if signal not registered - ie, has no radioactive component) (return_val as a list)
 	#define COMSIG_ATOM_RADIOACTIVITY "atom_get_radioactivity"
+	/// when an atom is washed in some way (likely missing multiple washing methods) (intentionally doesn't count handwashing)
+	/// (reagent_list (optional), caller (optional))
+	#define COMSIG_ATOM_WASHED "atom_washed"
 	/// when an atom say()s anything
 	/// I swear if you use this to modify a message when you should be using a speech_module, I will hurt you - Amylizzle
 	#define COMSIG_ATOM_SAY "atom_say"

--- a/code/datums/DCS/components/radioactive.dm
+++ b/code/datums/DCS/components/radioactive.dm
@@ -15,9 +15,14 @@ TYPEINFO(/datum/component/radioactive)
 	/// How much radStrength will decay over time. It will take ~ 6 * radStrength seconds to decay completely.
 	var/decay_target = 0
 	var/decay_target_neutron = 0
-	/// How much of our decaying radStrength can be reduced through washing
-	var/washable = 0
-	var/washable_neutron = 0
+	/* Existing contamination types and removal methods. Use these if applicable and document new ones here
+	"surface" = showering/washing in a sink
+	"internal" = medication
+	*/
+	/// Assoc list of removable decaying radStrength amounts
+	/// "contamination type" = amount_that_can_be_somehow_removed
+	var/list/removable_contamination = list()
+	var/list/removable_contamination_neutron = list()
 	/// Internal, do not touch - keeps a record of whether or not we had to add this to the item processing list
 	var/_added_to_items_processing = FALSE
 	/// How wide a range this radiation source affects. Greater than one should be very rarely used, since all atoms in this range will be exposed per tick
@@ -29,7 +34,7 @@ TYPEINFO(/datum/component/radioactive)
 	/// Internal, reference to light component
 	var/datum/component/loctargeting/simple_light/our_light
 
-	Initialize(radStrength=100, decays=FALSE, neutron=FALSE, effectRange=1)
+	Initialize(radStrength=100, decays=FALSE, neutron=FALSE, effectRange=1, contamination_type, removable_amount)
 		if(!istype(parent,/atom) || parent.type == /turf/space) //exact type check to exclude ocean floors
 			return COMPONENT_INCOMPATIBLE
 		. = ..()
@@ -44,19 +49,20 @@ TYPEINFO(/datum/component/radioactive)
 			src.radStrength_neutron = radStrength
 			if(!decays)
 				src.decay_target_neutron = radStrength
-			else // only half of radStrength_neutron can be washed away. semi-arbitrary
-				src.washable_neutron = radStrength * 0.5
+			if(contamination_type && removable_amount)
+				src.removable_contamination_neutron[contamination_type] += removable_amount
 		else
 			src.radStrength = radStrength
 			if(!decays)
 				src.decay_target = radStrength
-			else // only 75% of radStrength can be washed away. semi-arbitrary
-				src.washable = radStrength * 0.75
+			if(contamination_type && removable_amount)
+				src.removable_contamination[contamination_type] += removable_amount
 		src.effect_range = effectRange
 		if(parent.GetComponent(src.type)) //don't redo the filters and stuff if we're a duplicate
 			return
 
 		RegisterSignal(parent, COMSIG_ATOM_RADIOACTIVITY, PROC_REF(get_radioactivity))
+		RegisterSignal(parent, COMSIG_ATOM_DECONTAMINATE_RADS, PROC_REF(decontaminate))
 		RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(examined))
 		RegisterSignal(parent, COMSIG_ATOM_WASHED, PROC_REF(washed))
 		RegisterSignals(parent, list(COMSIG_ATOM_CROSSED,
@@ -140,9 +146,11 @@ TYPEINFO(/datum/component/radioactive)
 		PA.remove_filter("radiation_color_\ref[src]")
 		PA.ClearSpecificOverlays("radiation_overlay_\ref[src]")
 		PA.color = src._backup_color
-		UnregisterSignal(parent, list(COMSIG_ATOM_RADIOACTIVITY))
-		UnregisterSignal(parent, list(COMSIG_ATOM_EXAMINE))
-		UnregisterSignal(parent, list(COMSIG_ATOM_WASHED))
+		UnregisterSignals(parent, list(
+			COMSIG_ATOM_RADIOACTIVITY,
+			COMSIG_ATOM_DECONTAMINATE_RADS,
+			COMSIG_ATOM_EXAMINE,
+			COMSIG_ATOM_WASHED))
 		UnregisterSignal(parent, list(COMSIG_ATOM_CROSSED,
 			COMSIG_ATOM_ENTERED,
 			COMSIG_ATTACKHAND,
@@ -166,8 +174,10 @@ TYPEINFO(/datum/component/radioactive)
 		src.radStrength_neutron = min(100, src.radStrength_neutron + R.radStrength_neutron)
 		src.decay_target = min(100, src.decay_target + R.decay_target)
 		src.decay_target_neutron = min(100, src.decay_target_neutron + R.decay_target_neutron)
-		src.washable = min(75, src.washable + R.washable)
-		src.washable_neutron = min(50, src.washable_neutron + R.washable_neutron)
+		for(var/contam_type in R.removable_contamination)
+			src.removable_contamination[contam_type] += R.removable_contamination[contam_type]
+		for(var/contam_type in R.removable_contamination_neutron)
+			src.removable_contamination_neutron[contam_type] += R.removable_contamination_neutron[contam_type]
 		src.do_filters()
 
 	/// Called every item process tick, handles applying radiation effect to nearby atoms and also decay.
@@ -188,12 +198,18 @@ TYPEINFO(/datum/component/radioactive)
 		if(src.radStrength > src.decay_target && prob(33))
 			var/decreaseBy = 1 * mult
 			src.radStrength = max(src.decay_target, src.radStrength - decreaseBy)
-			src.washable = (max(0, src.washable - decreaseBy))
+			for(var/contam_type in src.removable_contamination)
+				removable_contamination[contam_type] -= decreaseBy
+				if(removable_contamination[contam_type] <= 0)
+					removable_contamination.Remove(contam_type)
 			update_filters = TRUE
 		if(src.radStrength_neutron > src.decay_target_neutron && prob(33))
 			var/decreaseBy = 1 * mult
 			src.radStrength_neutron = max(src.decay_target_neutron, src.radStrength_neutron - decreaseBy)
-			src.washable_neutron = max(0, src.washable_neutron - decreaseBy)
+			for(var/contam_type in src.removable_contamination_neutron)
+				removable_contamination_neutron[contam_type] -= decreaseBy
+				if(removable_contamination_neutron[contam_type] <= 0)
+					removable_contamination_neutron.Remove(contam_type)
 			update_filters = TRUE
 		if(update_filters)
 			src.do_filters()
@@ -242,19 +258,34 @@ TYPEINFO(/datum/component/radioactive)
 		return_val += src.radStrength
 		return TRUE
 
+	proc/decontaminate(atom/owner, category, percent_to_remove = 0.1, list/return_reagents, doNeutron = FALSE)
+		if(isnull(category))
+			CRASH("Attempted to decontaminate [parent] of radioactivity, but no category was given!")
+		var/removed = 0
+		if(src.removable_contamination[category] && !doNeutron)
+			removed = src.removable_contamination[category] * percent_to_remove
+			src.removable_contamination[category] -= removed
+			if(src.removable_contamination[category] <= 0)
+				src.removable_contamination.Remove(category)
+			src.radStrength = max(src.radStrength - removed, src.decay_target)
+		if(return_reagents && removed)
+		// would be nice to have other radioactive reagents that aren't polonium or uranium
+			return_reagents["radium"] += removed
+		removed = 0
+		if(src.removable_contamination_neutron[category] && doNeutron)
+			removed = src.removable_contamination_neutron[category] * percent_to_remove
+			src.removable_contamination_neutron[category] -= removed
+			if(src.removable_contamination_neutron[category] <= 0)
+				src.removable_contamination_neutron.Remove(category)
+			src.radStrength_neutron = max(src.radStrength_neutron - removed, src.decay_target)
+		if(return_reagents && removed)
+			removed *= 2 // n_rad is nastier, giving us more isotopes!
+			return_reagents["radium"] += removed
+		src.do_filters()
+
 	proc/washed(atom/owner, list/return_reagents, sender)
 		var/atom/atom_parent = src.parent
 		if(ON_COOLDOWN(atom_parent, "rad_washing", 2 SECONDS)) return // so spam-clicking sinks doesn't insta-clean
 		// Somewhat arbitrary numbers. We just want diminishing returns.
-		var/washed_off = src.washable * 0.15
-		src.washable -= washed_off
-		src.radStrength = max(src.radStrength - washed_off, src.decay_target)
-		if(return_reagents)
-			return_reagents["radium"] += washed_off
-		washed_off = src.washable_neutron * 0.10
-		src.washable_neutron -= washed_off
-		src.radStrength_neutron = max(src.radStrength_neutron - washed_off, src.decay_target_neutron)
-		if(return_reagents)
-			washed_off *= 2 // n_rad is nastier, giving us more isotopes!
-			return_reagents["radium"] += washed_off
-		src.do_filters()
+		SEND_SIGNAL(src.parent, COMSIG_ATOM_DECONTAMINATE_RADS, "surface", 0.15, return_reagents, FALSE)
+		SEND_SIGNAL(src.parent, COMSIG_ATOM_DECONTAMINATE_RADS, "surface", 0.10, return_reagents, TRUE)

--- a/code/datums/DCS/components/radioactive.dm
+++ b/code/datums/DCS/components/radioactive.dm
@@ -15,6 +15,9 @@ TYPEINFO(/datum/component/radioactive)
 	/// How much radStrength will decay over time. It will take ~ 6 * radStrength seconds to decay completely.
 	var/decay_target = 0
 	var/decay_target_neutron = 0
+	/// How much of our decaying radStrength can be reduced through washing
+	var/washable = 0
+	var/washable_neutron = 0
 	/// Internal, do not touch - keeps a record of whether or not we had to add this to the item processing list
 	var/_added_to_items_processing = FALSE
 	/// How wide a range this radiation source affects. Greater than one should be very rarely used, since all atoms in this range will be exposed per tick
@@ -41,16 +44,21 @@ TYPEINFO(/datum/component/radioactive)
 			src.radStrength_neutron = radStrength
 			if(!decays)
 				src.decay_target_neutron = radStrength
+			else // only half of radStrength_neutron can be washed away. semi-arbitrary
+				src.washable_neutron = radStrength * 0.5
 		else
 			src.radStrength = radStrength
 			if(!decays)
 				src.decay_target = radStrength
+			else // only 75% of radStrength can be washed away. semi-arbitrary
+				src.washable = radStrength * 0.75
 		src.effect_range = effectRange
 		if(parent.GetComponent(src.type)) //don't redo the filters and stuff if we're a duplicate
 			return
 
 		RegisterSignal(parent, COMSIG_ATOM_RADIOACTIVITY, PROC_REF(get_radioactivity))
 		RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(examined))
+		RegisterSignal(parent, COMSIG_ATOM_WASHED, PROC_REF(washed))
 		RegisterSignals(parent, list(COMSIG_ATOM_CROSSED,
 			COMSIG_ATOM_ENTERED,
 			COMSIG_ATTACKHAND,
@@ -134,6 +142,7 @@ TYPEINFO(/datum/component/radioactive)
 		PA.color = src._backup_color
 		UnregisterSignal(parent, list(COMSIG_ATOM_RADIOACTIVITY))
 		UnregisterSignal(parent, list(COMSIG_ATOM_EXAMINE))
+		UnregisterSignal(parent, list(COMSIG_ATOM_WASHED))
 		UnregisterSignal(parent, list(COMSIG_ATOM_CROSSED,
 			COMSIG_ATOM_ENTERED,
 			COMSIG_ATTACKHAND,
@@ -157,6 +166,8 @@ TYPEINFO(/datum/component/radioactive)
 		src.radStrength_neutron = min(100, src.radStrength_neutron + R.radStrength_neutron)
 		src.decay_target = min(100, src.decay_target + R.decay_target)
 		src.decay_target_neutron = min(100, src.decay_target_neutron + R.decay_target_neutron)
+		src.washable = min(75, src.washable + R.washable)
+		src.washable_neutron = min(50, src.washable_neutron + R.washable_neutron)
 		src.do_filters()
 
 	/// Called every item process tick, handles applying radiation effect to nearby atoms and also decay.
@@ -175,10 +186,14 @@ TYPEINFO(/datum/component/radioactive)
 			src.filterize_color(owner) // If the owner has been given a new color, keep it null so that the radiation outline stays green/blue
 		var/update_filters = FALSE
 		if(src.radStrength > src.decay_target && prob(33))
-			src.radStrength = max(src.decay_target, src.radStrength - (1 * mult))
+			var/decreaseBy = 1 * mult
+			src.radStrength = max(src.decay_target, src.radStrength - decreaseBy)
+			src.washable = (max(0, src.washable - decreaseBy))
 			update_filters = TRUE
 		if(src.radStrength_neutron > src.decay_target_neutron && prob(33))
-			src.radStrength_neutron = max(src.decay_target_neutron, src.radStrength_neutron - (1 * mult))
+			var/decreaseBy = 1 * mult
+			src.radStrength_neutron = max(src.decay_target_neutron, src.radStrength_neutron - decreaseBy)
+			src.washable_neutron = max(0, src.washable_neutron - decreaseBy)
 			update_filters = TRUE
 		if(update_filters)
 			src.do_filters()
@@ -226,3 +241,20 @@ TYPEINFO(/datum/component/radioactive)
 			return_val = list()
 		return_val += src.radStrength
 		return TRUE
+
+	proc/washed(atom/owner, list/return_reagents, sender)
+		var/atom/atom_parent = src.parent
+		if(ON_COOLDOWN(atom_parent, "rad_washing", 2 SECONDS)) return // so spam-clicking sinks doesn't insta-clean
+		// Somewhat arbitrary numbers. We just want diminishing returns.
+		var/washed_off = src.washable * 0.15
+		src.washable -= washed_off
+		src.radStrength = max(src.radStrength - washed_off, src.decay_target)
+		if(return_reagents)
+			return_reagents["radium"] += washed_off
+		washed_off = src.washable_neutron * 0.10
+		src.washable_neutron -= washed_off
+		src.radStrength_neutron = max(src.radStrength_neutron - washed_off, src.decay_target_neutron)
+		if(return_reagents)
+			washed_off *= 2 // n_rad is nastier, giving us more isotopes!
+			return_reagents["radium"] += washed_off
+		src.do_filters()

--- a/code/datums/DCS/components/radioactive.dm
+++ b/code/datums/DCS/components/radioactive.dm
@@ -277,7 +277,7 @@ TYPEINFO(/datum/component/radioactive)
 			src.removable_contamination_neutron[category] -= removed
 			if(src.removable_contamination_neutron[category] <= 0)
 				src.removable_contamination_neutron.Remove(category)
-			src.radStrength_neutron = max(src.radStrength_neutron - removed, src.decay_target)
+			src.radStrength_neutron = max(src.radStrength_neutron - removed, src.decay_target_neutron)
 		if(return_reagents && removed)
 			removed *= 2 // n_rad is nastier, giving us more isotopes!
 			return_reagents["radium"] += removed

--- a/code/modules/atmospherics/FEA_turf_tile.dm
+++ b/code/modules/atmospherics/FEA_turf_tile.dm
@@ -452,7 +452,8 @@ var/global/list/turf/hotly_processed_turfs = list()
 			SEND_SIGNAL(AM, COMSIG_ATOM_RADIOACTIVITY, rad_level)
 			if(max(rad_level) > RADGAS_MAXIMUM_CONTAMINATION)
 				continue
-			AM.AddComponent(/datum/component/radioactive,min(src.air.radgas + max(rad_level), max(rad_level) + RADGAS_MAXIMUM_CONTAMINATION_TICK),TRUE,FALSE)
+			var/radStrength = min(src.air.radgas + max(rad_level), max(rad_level) + RADGAS_MAXIMUM_CONTAMINATION_TICK)
+			AM.AddComponent(/datum/component/radioactive,radStrength,TRUE,FALSE,1,"surface",radStrength * 0.95)
 			src.air.radgas -= min(src.air.radgas, RADGAS_MAXIMUM_CONTAMINATION_TICK)/RADGAS_CONTAMINATION_PER_MOLE
 			if(src.air.radgas < RADGAS_MINIMUM_CONTAMINATION_MOLES)
 				break //no point continuing if we've dropped below threshold

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -723,6 +723,12 @@ datum
 					var/mob/living/carbon/human/H = M
 					if (H.organHolder)
 						H.organHolder.heal_organs(1*mult, 1*mult, 1*mult, target_organs)
+				var/list/return_list = list()
+				SEND_SIGNAL(M, COMSIG_ATOM_DECONTAMINATE_RADS, "internal", 0.05, return_list, FALSE)
+				SEND_SIGNAL(M, COMSIG_ATOM_DECONTAMINATE_RADS, "internal", 0.025, return_list, TRUE)
+				// we've leeched some nasty radioactive isotopes from inside cells, right into the bloodstream!
+				for(var/reagent_id in return_list)
+					M.reagents.add_reagent(reagent_id, return_list[reagent_id])
 				..()
 				return
 
@@ -1334,6 +1340,13 @@ datum
 					var/mob/living/carbon/human/H = M
 					if (H.organHolder)
 						H.organHolder.heal_organs(3*mult, 3*mult, 3*mult, target_organs)
+				var/list/return_list = list()
+				// we work faster than iodide! but that means more nasty isotopes faster. oh well.
+				SEND_SIGNAL(M, COMSIG_ATOM_DECONTAMINATE_RADS, "internal", 0.15, return_list, FALSE)
+				SEND_SIGNAL(M, COMSIG_ATOM_DECONTAMINATE_RADS, "internal", 0.075, return_list, TRUE)
+				// we've leeched some nasty radioactive isotopes from inside cells, right into the bloodstream!
+				for(var/reagent_id in return_list)
+					M.reagents.add_reagent(reagent_id, return_list[reagent_id])
 				..()
 				return
 

--- a/code/modules/fluids/sink.dm
+++ b/code/modules/fluids/sink.dm
@@ -82,6 +82,12 @@ TYPEINFO(/obj/machinery/sink)
 		qdel(fluid)
 
 		user.visible_message(SPAN_NOTICE("[user] washes [W]."))
+		var/list/reagent_list = list()
+		SEND_SIGNAL(W, COMSIG_ATOM_WASHED, reagent_list, src)
+		if(istype(src, /obj/machinery/sink/piped) && reagent_list.len) // i knowwww this kinda stinks but there isn't a better place for it
+			var/obj/machinery/sink/piped/piped_src = src
+			for(var/reagent_id in reagent_list)
+				piped_src.drainage.add_reagent(reagent_id, reagent_list[reagent_id])
 		W.clean_forensic() // There's a global proc for this stuff now (Convair880).
 		if (istype(W, /obj/item/device/key/skull))
 			W.icon_state = "skull"
@@ -91,6 +97,8 @@ TYPEINFO(/obj/machinery/sink)
 				return
 		if (W.reagents && W.is_open_container())
 			src.drain_fluid(W.reagents, W.reagents.total_volume)
+
+/obj/machinery/sink/proc/onItemWash(obj/item/W, mob/user)
 
 /obj/machinery/sink/MouseDrop_T(obj/item/reagent_containers/W, mob/user)
 	if (istype(W) && in_interact_range(W, user) && in_interact_range(src, user) && isalive(user) && !isintangible(user))

--- a/code/modules/fluids/sink.dm
+++ b/code/modules/fluids/sink.dm
@@ -82,7 +82,7 @@ TYPEINFO(/obj/machinery/sink)
 		qdel(fluid)
 
 		user.visible_message(SPAN_NOTICE("[user] washes [W]."))
-		src.onItemWash()
+		src.onItemWash(W, user)
 		W.clean_forensic() // There's a global proc for this stuff now (Convair880).
 		if (istype(W, /obj/item/device/key/skull))
 			W.icon_state = "skull"

--- a/code/modules/fluids/sink.dm
+++ b/code/modules/fluids/sink.dm
@@ -82,12 +82,7 @@ TYPEINFO(/obj/machinery/sink)
 		qdel(fluid)
 
 		user.visible_message(SPAN_NOTICE("[user] washes [W]."))
-		var/list/reagent_list = list()
-		SEND_SIGNAL(W, COMSIG_ATOM_WASHED, reagent_list, src)
-		if(istype(src, /obj/machinery/sink/piped) && reagent_list.len) // i knowwww this kinda stinks but there isn't a better place for it
-			var/obj/machinery/sink/piped/piped_src = src
-			for(var/reagent_id in reagent_list)
-				piped_src.drainage.add_reagent(reagent_id, reagent_list[reagent_id])
+		src.onItemWash()
 		W.clean_forensic() // There's a global proc for this stuff now (Convair880).
 		if (istype(W, /obj/item/device/key/skull))
 			W.icon_state = "skull"
@@ -99,6 +94,7 @@ TYPEINFO(/obj/machinery/sink)
 			src.drain_fluid(W.reagents, W.reagents.total_volume)
 
 /obj/machinery/sink/proc/onItemWash(obj/item/W, mob/user)
+	SEND_SIGNAL(W, COMSIG_ATOM_WASHED, null, src)
 
 /obj/machinery/sink/MouseDrop_T(obj/item/reagent_containers/W, mob/user)
 	if (istype(W) && in_interact_range(W, user) && in_interact_range(src, user) && isalive(user) && !isintangible(user))
@@ -379,6 +375,14 @@ TYPEINFO(/obj/machinery/sink/piped)
 		var/datum/reagents/fluid = src.input.pull_from_network(src.input.network, src.reagents.maximum_volume)
 		fluid?.trans_to(src, fluid.total_volume)
 		src.input.push_to_network(src.input.network, fluid)
+
+/obj/machinery/sink/piped/onItemWash(obj/item/W, mob/user)
+	var/list/reagent_list = list()
+	SEND_SIGNAL(W, COMSIG_ATOM_WASHED, reagent_list, src)
+	if(reagent_list.len)
+		var/obj/machinery/sink/piped/piped_src = src
+		for(var/reagent_id in reagent_list)
+			piped_src.drainage.add_reagent(reagent_id, reagent_list[reagent_id])
 
 /obj/machinery/sink/piped/slim
 	name = "plumbed sink"

--- a/code/obj/machinery/shower.dm
+++ b/code/obj/machinery/shower.dm
@@ -80,6 +80,7 @@
 				turf_list += T
 
 			for (var/turf/T as anything in turf_list)
+				var/list/return_reagents = list()
 				src.reagents.reaction(T, 1, 40)
 				for(var/atom/movable/AM as anything in T)
 					// Added. We don't care about unmodified shower heads, though (Convair880).
@@ -90,6 +91,13 @@
 								logTheThing(LOG_CHEMISTRY, M, "is hit by chemicals [log_reagents(src)] from a shower head at [log_loc(M)].")
 
 					src.reagents.reaction(AM, 1, 40) // why the FUCK was this ingest ?? ?? ? ?? ? ?? ? ?? ? ???
+					SEND_SIGNAL(AM, COMSIG_ATOM_WASHED, return_reagents, src)
+				if(return_reagents.len)
+					var/datum/reagents/washed_off_reagents = new
+					for(var/reagent_id in return_reagents)
+						washed_off_reagents.add_reagent(reagent_id, return_reagents[reagent_id])
+					washed_off_reagents.reaction(T)
+
 			src.reagents.remove_any(40 * length(turf_list))
 
 		src.use_power(50)
@@ -228,6 +236,7 @@ TYPEINFO(/obj/machinery/shower/piped)
 					if(prob(1))
 						random_brute_damage(M, 1)
 					cleaned_a_nerd = TRUE
+			SEND_SIGNAL(A, COMSIG_ATOM_WASHED, null, src)
 
 		if(cleaned_a_nerd)
 			playsound(src.loc, 'sound/effects/radio_sweep5.ogg', 50, 0, 0, 0.7)

--- a/code/obj/nuclearreactor/nuclearreactor.dm
+++ b/code/obj/nuclearreactor/nuclearreactor.dm
@@ -839,7 +839,10 @@
 					T.AddComponent(/datum/component/radioactive, 50, TRUE, FALSE, 1)
 				return FALSE
 			//finally, moderation
-			hit.AddComponent(/datum/component/radioactive, min(O.power, density*multiplier), TRUE, FALSE, 1) //make it all glowy
+			var/radStrength = min(O.power, density*multiplier)
+			var/removable_contamination = 0.75 * radStrength // let's say people can remove 75% of the radStrength, with meds or something
+			hit.AddComponent(/datum/component/radioactive, radStrength * 0.8, TRUE, FALSE, 1, "internal", removable_contamination * 0.8) //make it all glowy
+			hit.AddComponent(/datum/component/radioactive, radStrength * 0.2, TRUE, FALSE, 1, "surface", removable_contamination * 0.2)
 			O.power -= density*multiplier
 			var/datum/gas_mixture/gasmix = hit.return_air()
 			if(O.power < 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements surface and internal radioactive contamination as part of `component/radioactive`, with neutrons and fallout gas applying this new type of 'cleanable' contamination. Showering/washing an item in a sink will remove up to 95% of the radioactivity applied by fallout gas, while it will remove up to 15% of radioactivity applied by neutrons (and will, if possible, convert it into radium.) Potassium iodide and pentetic acid can remove up to 60% of radioactivity applied by neutrons to a mob, converting it into radium in a patient's bloodstream.

The above actions attempt to move radStrength and radStrength_neutron closer to decay_target and decay_target_neutron respectively, at a % of the remaining cleanable contamination per action. e.g if "surface" is at 20, a shower will remove 15% of that - reducing it by 3 from 20 to 17, and reducing whatever radStrength is by 3. (Note that hand washing does NOT remove rads.)

The variables `removable_contamination` and `removable_contamination_neutron` keep track of how much `radStrength` and `radStrength_neutron` are eligible for removal by specific means. Currently, "internal" and "surface" are the only used contamination types. Two new signals have been added.

`COMSIG_ATOM_DECONTAMINATE_RADS` is used to try and remove cleanable rads, and is used by potassium iodide, pentetic acid, and component/radioactive under washed(). Args: `category (string, required), percent_to_remove (0-1) = 0.1, list/return_reagents, doNeutron = FALSE`. `return_reagents` is an optional list of reagents that have been 'cleaned' out from the atom - currently being just radium - that can be used to 'move' the radiation elsewhere, if desired.

The new `COMSIG_ATOM_WASHED` signal similarly carries an empty (and uninitialized) reagent list, and the sender of the signal. The latter arg is unused at this time but it felt relevant. Regardless, showers and sinks now call this on atom/movables and items they wash respectively, with sonic showers calling it on all affected atoms (though sending a null reagent list.) Piped sinks and non-sonic showers will now be able to check the reagent list for any washed-off reagents. Piped sinks add the reagents to their drainage, whereas showers will move the reagents to the floor directly beneath the washed movable.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There's precisely 0 way to deal with being irradiated by neutrons besides maybe just getting radiation resistance. I've actually tried showering to get rid of this radiation but it just doesn't work. But now it does! At least partially. And now anti-rads help too!
Also scope creep go brrrrr so now we have the aforementioned ATOM_WASHED functionality in showers and sinks, if anyone's feeling up for adding an external reagent pool for mobs.

Initially this PR was a bit simpler, not having multiple 'contamination types'. However, it was a bit too unrealistic to be able to just wash off neutron radiation that, ostensibly, should be _inside_ things - and thus not washable.


## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="308" height="80" alt="image" src="https://github.com/user-attachments/assets/3d5cf0da-827c-4aa1-b996-1b729529a3fa" />

a little bit of radium from me washing some lightly irradiated credits in a piped sink
<img width="267" height="255" alt="image" src="https://github.com/user-attachments/assets/44c01807-0bae-4a84-8bb1-d96c901743be" />
the glowing green left behind from washing rads off of me

seems 2 work. Monitored the values in the radioactive component on both myself and a test item, and the `radStrength` and `removable_contamination` vars behaved as expected.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Nexusuxen
(+)You can more quickly remove temporary radiation (the green glow, not radiation poisoning) using sinks/showers and iodide/pentetic acid. Cleaning only works for surface contamination, which medicine doesn't help with.
```
