### PR TITLE
Adds Nadir cable run from nuclear engine to siphon

### DIFF
--- a/maps/nadir.dmm
+++ b/maps/nadir.dmm
@@ -684,6 +684,15 @@
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
+"aoy" = (
+/obj/disposalpipe/segment/vertical,
+/obj/cable/purple{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 4
+	},
+/area/station/hallway/secondary/east)
 "aoA" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -2368,6 +2377,14 @@
 /area/station/engine/monitoring{
 	name = "Nuclear Control Room"
 	})
+"beo" = (
+/obj/cable/purple{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/caution/misc{
+	dir = 1
+	},
+/area/station/engine/core/nuclear)
 "beq" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4;
@@ -2572,9 +2589,6 @@
 	},
 /area/station/crew_quarters/lounge)
 "biF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/engine/caution/corner{
 	dir = 1
 	},
@@ -3227,9 +3241,6 @@
 /obj/machinery/door/airlock/pyro/glass/toxins{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/mapping_helper/access/research,
 /obj/mapping_helper/access/engineering_engine,
@@ -3374,9 +3385,6 @@
 "bxX" = (
 /obj/machinery/door/airlock/pyro/glass/toxins{
 	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
 	},
 /obj/mapping_helper/access/research,
 /obj/mapping_helper/access/engineering_engine,
@@ -4579,10 +4587,10 @@
 	},
 /area/station/security/secwing)
 "bZA" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/disposalpipe/segment/horizontal,
+/obj/cable/purple{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -4895,6 +4903,9 @@
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/camera/directional/west{
 	pixel_y = 10
+	},
+/obj/cable/purple{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellowblack/corner{
 	dir = 1
@@ -5788,6 +5799,16 @@
 /area/station/maintenance/outer/nw{
 	name = "Northwest Breach Hull"
 	})
+"cDv" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/vertical,
+/obj/cable/purple{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/science/hall)
 "cDX" = (
 /obj/machinery/door/airlock/pyro/alt,
 /turf/simulated/floor/carpet/green/standard/narrow/north,
@@ -6668,10 +6689,10 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/courtroom)
 "cWN" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment/horizontal,
+/obj/cable/purple{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
 /area/station/science/hall)
 "cWU" = (
@@ -7506,6 +7527,9 @@
 /obj/machinery/fluid_canister,
 /obj/machinery/camera/directional/south{
 	pixel_x = -10
+	},
+/obj/cable/purple{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
 /area/station/science/construction{
@@ -11191,6 +11215,17 @@
 "eZe" = (
 /turf/simulated/floor/black,
 /area/station/bridge/reception)
+"eZl" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine/caution/corner2{
+	dir = 10
+	},
+/area/station/engine/core/nuclear)
 "eZH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -12145,10 +12180,8 @@
 	},
 /area/abandonedmedicalship/robot_trader)
 "fvu" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc/autoname_west,
+/obj/cable,
 /turf/simulated/floor/grey/side{
 	dir = 8
 	},
@@ -12351,6 +12384,15 @@
 	dir = 8
 	},
 /area/station/medical/medbay/cloner)
+"fAe" = (
+/obj/storage/closet/radiation,
+/obj/cable/purple{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/science/construction{
+	name = "Extraction Nexus"
+	})
 "fAh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -13173,6 +13215,9 @@
 	},
 /area/station/hallway/primary/southwest)
 "fQF" = (
+/obj/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/engine/caution/corner2{
 	dir = 10
 	},
@@ -14342,16 +14387,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "gtB" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_north,
 /obj/machinery/door_control{
 	id = "nadir_exnex";
 	name = "Shielding Control";
 	pixel_x = 23;
 	dir = 4;
 	pixel_y = 1
+	},
+/obj/machinery/firealarm/directional/north{
+	pixel_x = 6;
+	pixel_y = 28
+	},
+/obj/machinery/light_switch/directional/north{
+	pixel_x = -7
 	},
 /turf/simulated/floor/engine,
 /area/station/science/construction{
@@ -15806,6 +15854,12 @@
 	},
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/crew_quarters/fitness)
+"gWl" = (
+/obj/cable/orange{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/caution/misc,
+/area/station/engine/core/nuclear)
 "gXa" = (
 /obj/stool/chair/blue{
 	dir = 8
@@ -16296,6 +16350,9 @@
 "hft" = (
 /obj/landmark/gps_waypoint,
 /obj/disposalpipe/junction/left/east,
+/obj/cable/purple{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
@@ -16310,14 +16367,6 @@
 /obj/decal/stage_edge,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/fitness)
-"hgq" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/purpleblack{
-	dir = 4
-	},
-/area/station/science/hall)
 "hgw" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/item/device/radio/intercom{
@@ -16464,19 +16513,6 @@
 /turf/simulated/floor/plating,
 /area/station/engine/inner{
 	name = "Transception Array Control"
-	})
-"hje" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/caution/misc{
-	dir = 6
-	},
-/area/station/science/construction{
-	name = "Extraction Nexus"
 	})
 "hjq" = (
 /obj/machinery/drainage,
@@ -17126,6 +17162,9 @@
 "hxe" = (
 /obj/machinery/camera/directional/east{
 	pixel_y = 10
+	},
+/obj/cable/purple{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/hall)
@@ -17921,6 +17960,9 @@
 "hQs" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/disposalpipe/segment/horizontal,
+/obj/cable/purple{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/east)
 "hQB" = (
@@ -18272,6 +18314,9 @@
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/cable/purple{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 8
@@ -19776,6 +19821,13 @@
 	},
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/crew_quarters/fitness)
+"iCY" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/cable/purple{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/east)
 "iDw" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/cable{
@@ -20136,6 +20188,9 @@
 "iNR" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/alarm/directional/west,
+/obj/cable/purple{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/east)
 "iNU" = (
@@ -21250,6 +21305,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"jpg" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/machinery/door/poddoor/blast/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "bdoormid0";
+	id = "nadir_nukecore";
+	name = "Reactor Core Shielding";
+	opacity = 0
+	},
+/obj/cable/purple{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core/nuclear)
 "jpo" = (
 /turf/simulated/floor/engine/caution/west,
 /area/station/science/teleporter)
@@ -21737,6 +21807,16 @@
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
+"jzM" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/transport,
+/obj/cable/purple{
+	icon_state = "4-9"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/east)
 "jAn" = (
 /obj/storage/cart/trash,
 /turf/simulated/floor/plating,
@@ -24862,6 +24942,9 @@
 /obj/cable/orange{
 	icon_state = "1-4"
 	},
+/obj/cable/orange{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/engine/caution/corner2,
 /area/station/engine/core/nuclear)
 "kQn" = (
@@ -25180,6 +25263,15 @@
 /area/station/hallway/secondary/construction{
 	name = "The Warrens"
 	})
+"kXb" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/cable/purple{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/purpleblack{
+	dir = 8
+	},
+/area/station/hallway/secondary/east)
 "kXn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -25855,6 +25947,13 @@
 	dir = 8
 	},
 /area/station/medical/staff)
+"llW" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/cable/purple{
+	icon_state = "1-6"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/east)
 "lmc" = (
 /obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /obj/machinery/recharger/wall/sticky{
@@ -26300,9 +26399,6 @@
 /turf/simulated/floor/black,
 /area/station/science/teleporter)
 "lxd" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/engine/caution/south,
 /area/station/science/construction{
@@ -27211,6 +27307,21 @@
 /area/station/engine/inner{
 	name = "Transception Array Control"
 	})
+"lON" = (
+/obj/mapping_helper/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/blast/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "bdoormid0";
+	id = "nadir_nukecore";
+	name = "Reactor Core Shielding";
+	opacity = 0
+	},
+/obj/cable/purple{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core/nuclear)
 "lOT" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -29074,6 +29185,15 @@
 /area/station/security/checkpoint/sec_foyer{
 	name = "Secure Release Foyer"
 	})
+"mGY" = (
+/obj/disposalpipe/segment/mail/vertical,
+/obj/cable/purple{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellowblack{
+	dir = 8
+	},
+/area/station/hallway/secondary/east)
 "mHk" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4;
@@ -29418,9 +29538,6 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai_upload)
 "mPG" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/engine/caution/corner,
 /area/station/science/construction{
 	name = "Extraction Nexus"
@@ -30821,6 +30938,9 @@
 /obj/item/slag_shovel,
 /obj/machinery/light/incandescent/netural{
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -32997,13 +33117,13 @@
 /obj/machinery/door/airlock/pyro/glass/sci{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/mapping_helper/firedoor_spawn,
 /obj/disposalpipe/segment/horizontal,
 /obj/mapping_helper/access/engineering_engine,
 /obj/mapping_helper/access/research_foyer,
+/obj/cable/purple{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/science/hall)
 "oxz" = (
@@ -33222,6 +33342,17 @@
 /obj/machinery/vending/capsule,
 /turf/simulated/floor/redblack,
 /area/station/hallway/primary/northeast)
+"oCu" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/hall)
 "oCE" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -34502,10 +34633,13 @@
 	name = "The Warrens"
 	})
 "pfr" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/cable/purple,
+/obj/cable/purple{
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/caution/misc{
+	dir = 6
+	},
 /area/station/science/construction{
 	name = "Extraction Nexus"
 	})
@@ -35126,6 +35260,9 @@
 /area/abandonedmedicalship/robot_trader)
 "psN" = (
 /obj/disposalpipe/segment/horizontal,
+/obj/cable/purple{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
@@ -35866,6 +36003,12 @@
 	dir = 1
 	},
 /area/station/turret_protected/Zeta)
+"pMw" = (
+/obj/machinery/drainage,
+/turf/simulated/floor/engine,
+/area/station/science/construction{
+	name = "Extraction Nexus"
+	})
 "pMA" = (
 /obj/item/clothing/under/gimmick/dolan,
 /turf/simulated/floor/plating,
@@ -37804,18 +37947,20 @@
 /turf/simulated/floor/twotone/darkblue,
 /area/station/crew_quarters/radio/lab)
 "qKz" = (
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -8
-	},
-/obj/machinery/firealarm/directional/north{
-	pixel_x = 6
-	},
 /obj/machinery/door_control{
 	id = "nadir_exnex";
 	name = "Shielding Control";
 	pixel_x = -23;
 	dir = 8;
 	pixel_y = 1
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable/purple{
+	icon_state = "0-2"
+	},
+/obj/item/device/t_scanner{
+	pixel_y = 4;
+	pixel_x = -7
 	},
 /turf/simulated/floor/engine,
 /area/station/science/construction{
@@ -39629,6 +39774,15 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/crew_quarters/quarters_east)
+"rGc" = (
+/obj/mapping_helper/wingrille_spawn/auto/reinforced,
+/obj/cable/purple{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/construction{
+	name = "Extraction Nexus"
+	})
 "rGh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41712,16 +41866,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
-"sGq" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/black,
-/area/station/science/hall)
 "sGr" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -42212,6 +42356,9 @@
 	},
 /obj/disposalpipe/segment/mineral{
 	dir = 8
+	},
+/obj/cable/purple{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 8
@@ -48368,6 +48515,9 @@
 /area/station/chapel/sanctuary)
 "vGu" = (
 /obj/disposalpipe/segment/mail/vertical,
+/obj/cable/purple{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellowblack/corner{
 	dir = 4
 	},
@@ -50082,6 +50232,14 @@
 	},
 /turf/simulated/floor/blackwhite,
 /area/station/storage/eva)
+"wuL" = (
+/obj/cable/purple{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/purpleblack{
+	dir = 4
+	},
+/area/station/science/hall)
 "wuT" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -50503,9 +50661,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/disposalpipe/junction/middle/east,
 /turf/simulated/floor/black,
 /area/station/science/hall)
@@ -50651,6 +50806,9 @@
 /area/station/hydroponics/bay)
 "wJW" = (
 /obj/disposalpipe/segment/horizontal,
+/obj/cable/purple{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -50937,6 +51095,9 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment/horizontal,
+/obj/cable/purple{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
 "wSi" = (
@@ -53692,6 +53853,20 @@
 /obj/mapping_helper/access/chemistry,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"ygX" = (
+/obj/machinery/door/poddoor/blast/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "bdoormid0";
+	id = "nadir_nukecore";
+	name = "Reactor Core Shielding";
+	opacity = 0
+	},
+/obj/cable/purple{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core/nuclear)
 "ygZ" = (
 /turf/simulated/floor/engine/caution/east,
 /area/station/science/construction{
@@ -96986,7 +97161,7 @@ heh
 heh
 heh
 kYv
-sGq
+xzR
 xzR
 xzR
 eWr
@@ -97288,7 +97463,7 @@ ntK
 smh
 mjx
 smh
-hgq
+fUF
 mpD
 fUF
 cPi
@@ -97892,7 +98067,7 @@ fLt
 koD
 oVA
 drI
-tht
+pMw
 jbf
 agE
 hye
@@ -98194,7 +98369,7 @@ hvP
 lBt
 agE
 gtB
-hje
+drI
 lbc
 agE
 kjV
@@ -98798,7 +98973,7 @@ hQF
 drI
 gzn
 gVT
-pfr
+drI
 dwG
 fNC
 gXP
@@ -99100,7 +99275,7 @@ iVa
 drI
 drI
 drI
-pfr
+drI
 drI
 vsd
 gXP
@@ -100308,7 +100483,7 @@ iVa
 drI
 drI
 drI
-pfr
+drI
 drI
 lmY
 gXP
@@ -100610,7 +100785,7 @@ iVa
 drI
 wWl
 nYa
-pfr
+drI
 dwG
 fNC
 gXP
@@ -101517,7 +101692,7 @@ pIf
 oVA
 drI
 tht
-jbf
+fAe
 agE
 nmI
 hOz
@@ -101819,7 +101994,7 @@ gXP
 agE
 fCJ
 hMO
-fCJ
+rGc
 agE
 hlR
 tRU
@@ -102423,7 +102598,7 @@ wnU
 qAc
 wGE
 buS
-qAc
+cDv
 wnU
 qAc
 haT
@@ -102725,7 +102900,7 @@ eLX
 iIC
 cWN
 hxe
-fUF
+wuL
 uSG
 erF
 qKT
@@ -103023,7 +103198,7 @@ lky
 wRi
 xZH
 tDs
-uvn
+oCu
 iYL
 oxy
 wCN
@@ -104840,12 +105015,12 @@ lxX
 hQs
 vGu
 sQU
-pzd
-xpP
+kXb
+mGY
 cib
-iTi
+iCY
 iNR
-iTi
+llW
 cNU
 iTi
 iTi
@@ -105148,7 +105323,7 @@ fac
 ahx
 fYG
 fYG
-fYG
+jzM
 ahx
 ahx
 xmt
@@ -105450,7 +105625,7 @@ hbd
 unW
 cxr
 unW
-unW
+aoy
 unW
 unW
 cxr
@@ -105752,7 +105927,7 @@ hiz
 uNd
 ibV
 uNd
-uNd
+jpg
 uNd
 ocD
 ocD
@@ -106054,7 +106229,7 @@ eTX
 aZV
 uNd
 aZV
-aZV
+ygX
 aZV
 ocD
 xHz
@@ -106356,7 +106531,7 @@ fPO
 fLQ
 ibV
 fLQ
-fLQ
+lON
 fLQ
 ocD
 eNN
@@ -106658,8 +106833,8 @@ lAF
 gcG
 oDS
 hkU
-hkU
-hkU
+beo
+gWl
 dfm
 lGL
 kYA
@@ -106961,7 +107136,7 @@ gzh
 sKX
 tSU
 jOW
-jOW
+eZl
 eDY
 eSP
 vJR


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
[MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

A new purple cable run has been added from the nuclear engine to the Extraction Nexus APC. Some details:

- APC was moved from the west Nexus entrance to the east one, to reduce the length of the run. Light/fire switches have moved in reverse fashion accordingly.
- Each end of the new purple cable run has to be manually connected; the end in the Extraction Nexus just needs one segment of wire severed and turned, while the end in the nuclear reactor has to have two pieces of wire added.
- Slightly adjusted the regular grid wire to the Refinery to make way for the new purple cable run.
- A T-ray scanner was left near the Extraction Nexus APC for easy observation of the cable run.

<img width="900" height="592" alt="image" src="https://github.com/user-attachments/assets/6050e918-f84a-4835-86c7-28d6a825e3dd" />

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The increased draw of the Siphon in high-end setups virtually guarantees the necessity of a direct engine feed, and preinstalling it most of the way reduces the time people have to spend doing unnecessary busywork.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

Entered map, map is wired as intended.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Kubius
(*)Nadir now features a direct cable run from the nuclear reactor to the siphon. Each end doesn't start wired up, but is quick to reconfigure.
```
