### PR TITLE
Rename siphon resonators to something sane

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -3990,7 +3990,7 @@ ABSTRACT_TYPE(/datum/manufacture/locker) //Regular lockers are built using steel
 	category = MANUFACTURER::CATEGORY::MACHINERY
 
 /datum/manufacture/resonator_type_sm
-	name = "Type-SM Resonator"
+	name = "resonant shear mitigator"
 	item_requirements = list("metal_dense" = 10,
 							 "conductive_high" = 20,
 							 "crystal" = 10,

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -3990,7 +3990,7 @@ ABSTRACT_TYPE(/datum/manufacture/locker) //Regular lockers are built using steel
 	category = MANUFACTURER::CATEGORY::MACHINERY
 
 /datum/manufacture/resonator_type_sm
-	name = "Resonant shear mitigator"
+	name = "Resonant Shear Mitigator"
 	item_requirements = list("metal_dense" = 10,
 							 "conductive_high" = 20,
 							 "crystal" = 10,

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -3990,7 +3990,7 @@ ABSTRACT_TYPE(/datum/manufacture/locker) //Regular lockers are built using steel
 	category = MANUFACTURER::CATEGORY::MACHINERY
 
 /datum/manufacture/resonator_type_sm
-	name = "resonant shear mitigator"
+	name = "Resonant shear mitigator"
 	item_requirements = list("metal_dense" = 10,
 							 "conductive_high" = 20,
 							 "crystal" = 10,

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -3979,7 +3979,7 @@ ABSTRACT_TYPE(/datum/manufacture/locker) //Regular lockers are built using steel
 /************ NADIR RESONATORS ************/
 
 /datum/manufacture/resonator_type_ax
-	name = "Type-AX Resonator"
+	name = "Axial Resonator"
 	item_requirements = list("metal_dense" = 15,
 							 "conductive_high" = 20,
 							 "crystal" = 20,

--- a/code/modules/siphon/siphon_controls.dm
+++ b/code/modules/siphon/siphon_controls.dm
@@ -443,9 +443,9 @@
 	<h3>RESONATORS AND DISTANCE</h3>
 	When utilizing resonators in conjunction with the<br>
 	Harmonic Siphon, it's important to understand the<br>
-	effect of distance on Type-AX and shear mitigators.<br>
+	effect of distance on axial resonators and shear mitigators.<br>
 	<br>
-	<strong>Type-AX resonators</strong> influence lateral and vertical<br>
+	<strong>Axial resonators</strong> influence lateral and vertical<br>
 	resonances based on distance from the 'pinch points'.<br>
 	<br>
 	As an example of this, a resonator placed in column F<br>
@@ -468,7 +468,7 @@
 	First of three resonant parameters,<br>
 	charted on the letter axis.<br>
 	<br>
-	Type-AX resonators will raise or lower<br>
+	Axial resonators will raise or lower<br>
 	this value by eight units per intensity at 'point-blank'<br>
 	(columns D or F), diminishing by powers of two to a <br>
 	minimum of one unit at max range (columns A or I).<br>
@@ -483,7 +483,7 @@
 	Second of three resonant parameters,<br>
 	charted on the number axis.<br>
 	<br>
-	Type-AX resonators will raise or lower<br>
+	Axial resonators will raise or lower<br>
 	this value by eight units per intensity at 'point-blank'<br>
 	(rows 3 or 5), diminishing by powers of two to a <br>
 	minimum of one unit at max range (rows 0 or 8).<br>

--- a/code/modules/siphon/siphon_controls.dm
+++ b/code/modules/siphon/siphon_controls.dm
@@ -443,7 +443,7 @@
 	<h3>RESONATORS AND DISTANCE</h3>
 	When utilizing resonators in conjunction with the<br>
 	Harmonic Siphon, it's important to understand the<br>
-	effect of distance on Type-AX and Type-SM resonators.<br>
+	effect of distance on Type-AX and shear mitigators.<br>
 	<br>
 	<strong>Type-AX resonators</strong> influence lateral and vertical<br>
 	resonances based on distance from the 'pinch points'.<br>
@@ -455,10 +455,10 @@
 	This allows these resonators to be placed far from the<br>
 	Siphon and still significantly influence parameters.<br>
 	<br>
-	<strong>Type-SM resonators</strong>, on the other hand, reduce shear<br>
+	<strong>shear mitigators</strong>, on the other hand, reduce shear<br>
 	simply based on their distance from the Siphon itself;<br>
-	as an example, G2 and D6 would both cause a Type-SM<br>
-	resonator to subtract four shear per intensity.<br>
+	as an example, G2 and D6 would both cause a shear<br>
+	mitigator to subtract four shear per intensity.<br>
 	<br>
 	Type-FQ resonators have a more complex set of<br>
 	behaviors documented below; however, their use<br>
@@ -502,7 +502,7 @@
 	the amount of resonance cancelled.<br>
 	<br>
 	Shear cannot be produced directly, but can be mitigated<br>
-	by use of the Type-SM resonator, mitigating eight to one<br>
+	by use of shear mitigators, mitigating eight to one<br>
 	units of shear per intensity, decreasing with greater<br>
 	distance from the Harmonic Siphon.<br>
 	<br>

--- a/code/modules/siphon/siphon_machinery.dm
+++ b/code/modules/siphon/siphon_machinery.dm
@@ -932,7 +932,7 @@ ABSTRACT_TYPE(/obj/machinery/siphon)
 
 //stabilizing resonator, provides purely reduction to shear based on lowest torque value
 /obj/machinery/siphon/resonator/stabilizer
-	name = "\improper Type-SM siphon resonator"
+	name = "resonant shear mitigator"
 	desc = "Field-emitting device used to mitigate resonant shear in a harmonic siphon."
 	icon_state = "stab-closed"
 	regular_desc = "Field-emitting device used to mitigate resonant shear in a harmonic siphon."

--- a/code/modules/siphon/siphon_machinery.dm
+++ b/code/modules/siphon/siphon_machinery.dm
@@ -665,7 +665,7 @@ ABSTRACT_TYPE(/obj/machinery/siphon)
 #define RESONATOR_CABLE_REPAIR_COST 3
 
 /obj/machinery/siphon/resonator
-	name = "\improper Type-AX siphon resonator"
+	name = "axial resonator"
 	desc = "Field-emitting device used to amplify and direct a harmonic siphon. You know this because it says so on the label."
 	icon = 'icons/obj/machines/neodrill_32x32.dmi'
 	icon_state = "res-closed"

--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -57,7 +57,7 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	setup_guide = list(
 		"Type-AX Resonator, Position C4, 3 Intensity<br>",
 		"Type-AX Resonator, Position G4, 3 Intensity<br>",
-		"Type-SM Resonator, Position E3, 3 Intensity<br>"
+		"Shear mitigator, Position E3, 3 Intensity<br>"
 	)
 
 /datum/siphon_mineral/rock

--- a/code/modules/siphon/siphon_minerals.dm
+++ b/code/modules/siphon/siphon_minerals.dm
@@ -55,8 +55,8 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	shear = 0
 	product = /obj/item/raw_material/miracle
 	setup_guide = list(
-		"Type-AX Resonator, Position C4, 3 Intensity<br>",
-		"Type-AX Resonator, Position G4, 3 Intensity<br>",
+		"Axial Resonator, Position C4, 3 Intensity<br>",
+		"Axial Resonator, Position G4, 3 Intensity<br>",
 		"Shear mitigator, Position E3, 3 Intensity<br>"
 	)
 
@@ -69,7 +69,7 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	sens_window = 2
 	product = /obj/item/raw_material/rock
 	setup_guide = list(
-		"Type-AX Resonator, Position F4, 2 Intensity<br>"
+		"Axial Resonator, Position F4, 2 Intensity<br>"
 	)
 
 /datum/siphon_mineral/char
@@ -81,9 +81,9 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	sens_window = 5
 	product = /obj/item/raw_material/char
 	setup_guide = list(
-		"Type-AX Resonator, Position B7, 2 Intensity<br>",
-		"Type-AX Resonator, Position G2, 1 Intensity<br>",
-		"Type-AX Resonator, Position D4, 2 Intensity<br>"
+		"Axial Resonator, Position B7, 2 Intensity<br>",
+		"Axial Resonator, Position G2, 1 Intensity<br>",
+		"Axial Resonator, Position D4, 2 Intensity<br>"
 	)
 
 /datum/siphon_mineral/mauxite
@@ -94,10 +94,10 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	sens_window = 7
 	product = /obj/item/raw_material/mauxite
 	setup_guide = list(
-		"Type-AX Resonator, Position F4, 4 Intensity<br>",
-		"Type-AX Resonator, Position G4, 2 Intensity<br>",
-		"Type-AX Resonator, Position E3, 3 Intensity<br>",
-		"Type-AX Resonator, Position F6, 1 Intensity<br>"
+		"Axial Resonator, Position F4, 4 Intensity<br>",
+		"Axial Resonator, Position G4, 2 Intensity<br>",
+		"Axial Resonator, Position E3, 3 Intensity<br>",
+		"Axial Resonator, Position F6, 1 Intensity<br>"
 	)
 
 /datum/siphon_mineral/molitz
@@ -108,9 +108,9 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	sens_window = 7
 	product = /obj/item/raw_material/molitz
 	setup_guide = list(
-		"Type-AX Resonator, Position E3, 4 Intensity<br>",
-		"Type-AX Resonator, Position E2, 4 Intensity<br>",
-		"Type-AX Resonator, Position D7, 2 Intensity<br>"
+		"Axial Resonator, Position E3, 4 Intensity<br>",
+		"Axial Resonator, Position E2, 4 Intensity<br>",
+		"Axial Resonator, Position D7, 2 Intensity<br>"
 	)
 
 /datum/siphon_mineral/pharosium
@@ -121,9 +121,9 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	sens_window = 7
 	product = /obj/item/raw_material/pharosium
 	setup_guide = list(
-		"Type-AX Resonator, Position F6, 1 Intensity<br>",
-		"Type-AX Resonator, Position G5, 2 Intensity<br>",
-		"Type-AX Resonator, Position E3, 3 Intensity<br>"
+		"Axial Resonator, Position F6, 1 Intensity<br>",
+		"Axial Resonator, Position G5, 2 Intensity<br>",
+		"Axial Resonator, Position E3, 3 Intensity<br>"
 	)
 
 /datum/siphon_mineral/martian
@@ -134,10 +134,10 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	sens_window = 3
 	product = /obj/item/raw_material/martian
 	setup_guide = list(
-		"Type-AX Resonator, Position E7, 3 Intensity<br>",
-		"Type-AX Resonator, Position E2, 1 Intensity<br>",
-		"Type-AX Resonator, Position G6, 3 Intensity<br>",
-		"Type-AX Resonator, Position F4, 1 Intensity<br>"
+		"Axial Resonator, Position E7, 3 Intensity<br>",
+		"Axial Resonator, Position E2, 1 Intensity<br>",
+		"Axial Resonator, Position G6, 3 Intensity<br>",
+		"Axial Resonator, Position F4, 1 Intensity<br>"
 	)
 
 /datum/siphon_mineral/claretine
@@ -149,10 +149,10 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	sens_window = 4
 	product = /obj/item/raw_material/claretine
 	setup_guide = list(
-		"Type-AX Resonator, Position C2, 1 Intensity<br>",
-		"Type-AX Resonator, Position E2, 1 Intensity<br>",
-		"Type-AX Resonator, Position F4, 4 Intensity<br>",
-		"Type-AX Resonator, Position G6, 1 Intensity<br>"
+		"Axial Resonator, Position C2, 1 Intensity<br>",
+		"Axial Resonator, Position E2, 1 Intensity<br>",
+		"Axial Resonator, Position F4, 4 Intensity<br>",
+		"Axial Resonator, Position G6, 1 Intensity<br>"
 	)
 
 /datum/siphon_mineral/bohrum
@@ -164,10 +164,10 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	sens_window = 4
 	product = /obj/item/raw_material/bohrum
 	setup_guide = list(
-		"Type-AX Resonator, Position C2, 2 Intensity<br>",
-		"Type-AX Resonator, Position D3, 2 Intensity<br>",
-		"Type-AX Resonator, Position G6, 1 Intensity<br>",
-		"Type-AX Resonator, Position H7, 1 Intensity<br>"
+		"Axial Resonator, Position C2, 2 Intensity<br>",
+		"Axial Resonator, Position D3, 2 Intensity<br>",
+		"Axial Resonator, Position G6, 1 Intensity<br>",
+		"Axial Resonator, Position H7, 1 Intensity<br>"
 	)
 
 /datum/siphon_mineral/batiline
@@ -179,10 +179,10 @@ ABSTRACT_TYPE(/datum/harmonic_cycle)
 	sens_window = 4
 	product = /obj/item/raw_material/batiline
 	setup_guide = list(
-		"Type-AX Resonator, Position C6, 1 Intensity<br>",
-		"Type-AX Resonator, Position G6, 2 Intensity<br>",
-		"Type-AX Resonator, Position G4, 2 Intensity<br>",
-		"Type-AX Resonator, Position G2, 1 Intensity<br>"
+		"Axial Resonator, Position C6, 1 Intensity<br>",
+		"Axial Resonator, Position G6, 2 Intensity<br>",
+		"Axial Resonator, Position G4, 2 Intensity<br>",
+		"Axial Resonator, Position G2, 1 Intensity<br>"
 	)
 
 /datum/siphon_mineral/fibrilith

--- a/code/modules/writing/papers.dm
+++ b/code/modules/writing/papers.dm
@@ -859,7 +859,7 @@ Only trained personnel should operate station systems. Follow all procedures car
 /obj/item/paper/resonator_type_ax
 	name = "printed card"
 	icon_state = "index_card"
-	info = {"TYPE-AX - AXIAL RESONATOR<br>
+	info = {"AXIAL RESONATOR<br>
 	Provides lateral and vertical resonance, multiplied based on distance from axial pinch points (8x > 4x > 2x > 1x)<br>
 	Maximum 4 intensity"}
 

--- a/code/modules/writing/papers.dm
+++ b/code/modules/writing/papers.dm
@@ -866,7 +866,7 @@ Only trained personnel should operate station systems. Follow all procedures car
 /obj/item/paper/resonator_type_sm
 	name = "printed card"
 	icon_state = "index_card"
-	info = {"TYPE-SM - SHEAR MITIGATOR<br>
+	info = {"SHEAR MITIGATOR<br>
 	Reduces shear by intensity, based on radial distance from siphon (8x > 4x > 2x > 1x)<br>
 	Maximum 3 intensity"}
 

--- a/code/obj/item/manufacturing_blueprints.dm
+++ b/code/obj/item/manufacturing_blueprints.dm
@@ -108,7 +108,7 @@
 	blueprint = /datum/manufacture/resonator_type_ax
 
 /obj/item/paper/manufacturer_blueprint/resonator_type_sm
-	name = "Type-SM Resonator"
+	name = "Shear Mitigator"
 	blueprint = /datum/manufacture/resonator_type_sm
 
 /obj/item/paper/manufacturer_blueprint/resonator_type_fq

--- a/code/obj/item/manufacturing_blueprints.dm
+++ b/code/obj/item/manufacturing_blueprints.dm
@@ -104,7 +104,7 @@
 /******************** Nadir Resonators *******************/
 
 /obj/item/paper/manufacturer_blueprint/resonator_type_ax
-	name = "Type-AX Resonator"
+	name = "Axial Resonator"
 	blueprint = /datum/manufacture/resonator_type_ax
 
 /obj/item/paper/manufacturer_blueprint/resonator_type_sm


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Renames siphon resonators to their actual names that they had anyway instead of their acronyms.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
What the frick is a Type-AX? The siphon is confusing enough without obfuscating what each part even is.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Drafted while I test things, also ideally until I figure out what the hell FQs do and come up with a name for them too.
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech
(+)Harmonic siphon resonators have been renamed to no longer use acronyms, ie "Type AX" -> "Axial resonator".
```
