### PR TITLE
Set wood default material for various objects

### DIFF
--- a/code/modules/cooking/food_and_drink/popsicles.dm
+++ b/code/modules/cooking/food_and_drink/popsicles.dm
@@ -7,6 +7,8 @@
 	throw_speed = 4
 	throw_range = 5
 	w_class = W_CLASS_TINY
+	default_material = "wood"
+	material_amt = MATERIAL::AMOUNT::ROD
 	stamina_damage = 0
 	stamina_cost = 0
 	var/broken = 0

--- a/code/modules/cooking/kitchen_items.dm
+++ b/code/modules/cooking/kitchen_items.dm
@@ -18,6 +18,7 @@ TRAYS
 	throw_speed = 2
 	throw_range = 7
 	w_class = W_CLASS_NORMAL
+	default_material = "wood"
 	desc = "A wooden tube, used to roll dough flat in order to make various edible objects. It's pretty sturdy."
 	stamina_damage = 40
 	stamina_cost = 15
@@ -338,6 +339,8 @@ TRAYS
 	icon_state = "chop_closed"
 	item_state = "chop"
 	w_class = W_CLASS_TINY
+	default_material = "wood"
+	material_amt = MATERIAL::AMOUNT::ROD * 2
 
 	attack_self(mob/user as mob)
 		if(src.icon_state == "chop_closed")
@@ -364,6 +367,8 @@ TRAYS
 	desc = "cheap disposable chopsticks!"
 	icon_state = "chop_open"
 	item_state = "chop"
+	default_material = "wood"
+	material_amt = MATERIAL::AMOUNT::ROD * 2
 	rotatable = 0
 	tool_flags = 0
 
@@ -1178,6 +1183,8 @@ TYPEINFO(/obj/item/plate/pizza_box)
 	desc = "a bamboo mat for rolling sushi"
 	icon_state = "roller-0"
 	w_class = W_CLASS_SMALL
+	default_material = "bamboo"
+	material_amt = MATERIAL::AMOUNT::SHEET
 
 	var/seaweed //0 or 1, storage variable for checking if there's a seaweed overlay without using resources pulling image files
 	var/rice //same :)
@@ -1331,6 +1338,7 @@ TYPEINFO(/obj/item/plate/pizza_box)
 	desc = "a table! with WHEELS!"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "kitchen_island"
+	default_material = "wood"
 
 /obj/item/tongs
 	name = "tongs"

--- a/code/modules/items/instruments/instruments.dm
+++ b/code/modules/items/instruments/instruments.dm
@@ -292,6 +292,7 @@
 	desc = "Not very grand, is it?"
 	icon_state = "piano"
 	item_state = "piano"
+	default_material = "wood"
 	note_range = list("c2", "c7")
 	instrument_sound_directory = "sound/musical_instruments/piano/notes/"
 	sounds_instrument = null
@@ -313,6 +314,7 @@
 	desc = "Mask, cloak and brooding nature not included."
 	icon_state = "organ"
 	item_state = "organ"
+	default_material = "wood"
 	desc_sound = list("nice", "classic", "classical", "great", "impressive", "terrible", "awkward", "striking", "grand", "majestic", "baroque", "gothic", "rumbling", "chilling")
 	sounds_instrument = list('sound/musical_instruments/organ/bach1.ogg',
 	'sound/musical_instruments/organ/bach2.ogg',
@@ -396,6 +398,7 @@
 	item_state = "guitar1"
 	two_handed = 1
 	force = 10
+	default_material = "wood"
 	note_range = list("d2", "c6")
 	instrument_sound_directory = "sound/musical_instruments/guitar/notes/"
 	note_time = 0.18 SECONDS
@@ -880,6 +883,7 @@ TYPEINFO(/obj/item/instrument/bikehorn/dramatic)
 	name = "fiddle"
 	icon_state = "fiddle"
 	item_state = "fiddle"
+	default_material = "wood"
 	desc_sound = list("slick", "egotistical", "snazzy", "technical", "impressive") // works just as well for fiddles as it does for trumpets I guess  :v
 	sounds_instrument = list()
 	note_range = list("a3", "g6")

--- a/code/modules/ranch/ranch_objs.dm
+++ b/code/modules/ranch/ranch_objs.dm
@@ -24,6 +24,7 @@ TYPEINFO(/obj/submachine/chicken_incubator)
 	icon_state = "incubator"
 	density = 1
 	anchored = ANCHORED
+	default_material = "wood"
 	var/obj/item/reagent_containers/food/snacks/ingredient/egg/my_egg = null
 	var/incubate_count = 0
 	var/image/egg_overlay = null
@@ -163,6 +164,7 @@ TYPEINFO(/obj/submachine/chicken_incubator)
 	name = "incubator parts"
 	icon = 'icons/obj/ranch/ranch_obj.dmi'
 	icon_state = "incubator_parts"
+	default_material = "wood"
 	w_class = W_CLASS_NORMAL
 
 // Ranch Feed Proxy
@@ -618,6 +620,7 @@ TYPEINFO(/obj/chicken_nesting_box)
 	density = 0
 	anchored = UNANCHORED
 	deconstruct_flags = DECON_SCREWDRIVER
+	default_material = "wood"
 
 	attackby(obj/item/W, mob/user)
 		if(istype(W,/obj/item/incubator_parts))

--- a/code/modules/writing/pens_writing_etc.dm
+++ b/code/modules/writing/pens_writing_etc.dm
@@ -975,6 +975,8 @@
 	item_state = "clipboard0"
 	throwforce = 1
 	w_class = W_CLASS_NORMAL
+	default_material = "wood"
+	material_amt = MATERIAL::AMOUNT::SHEET * 2
 	throw_speed = 3
 	throw_range = 10
 	desc = "You can put paper on it. Ah, technology!"

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -705,6 +705,7 @@
 	icon = 'icons/obj/items/cigarettes.dmi'
 	icon_state = "cigarbox"
 	item_state = "cigarbox"
+	default_material = "wood"
 	w_class = W_CLASS_TINY
 	throwforce = 2
 	var/cigcount = 5

--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -561,6 +561,7 @@ TYPEINFO(/obj/item/clothing/shoes/cowboy/boom)
 	name = "chef's clogs"
 	desc = "Sturdy shoes that minimize injury from falling objects or knives."
 	icon_state = "chef"
+	default_material = "wood"
 	kick_bonus = 1
 	step_sound = "step_wood"
 	step_priority = STEP_PRIORITY_LOW

--- a/code/obj/item/dice.dm
+++ b/code/obj/item/dice.dm
@@ -694,6 +694,7 @@ var/list/rollList = list()
 	name = "dice box"
 	desc = "A fancy box for holding up to five dice."
 	icon_state = "dicebox"
+	default_material = "wood"
 	var/firstopen = 1 //helps organize overlays
 	var/setcolor //color of the dice set
 

--- a/code/obj/item/kendo.dm
+++ b/code/obj/item/kendo.dm
@@ -59,6 +59,7 @@
 	inhand_image_icon = 'icons/mob/inhand/hand_weapons.dmi'
 	icon_state = "shinai"
 	item_state = "shinai-light"
+	default_material = "bamboo"
 
 	w_class = W_CLASS_BULKY
 	two_handed = 1

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1134,6 +1134,7 @@ TYPEINFO(/obj/item/bat)
 	inhand_image_icon = 'icons/mob/inhand/hand_weapons.dmi'
 	icon_state = "baseballbat"
 	item_state = "baseballbat"
+	default_material = "wood"
 	hitsound = 'sound/impact_sounds/bat_wood.ogg'
 	hit_type = DAMAGE_BLUNT
 	force = 12

--- a/code/obj/item/mousetrap.dm
+++ b/code/obj/item/mousetrap.dm
@@ -5,6 +5,8 @@
 	icon_state = "mousetrap"
 	item_state = "mousetrap"
 	w_class = W_CLASS_TINY
+	default_material = "wood"
+	material_amt = MATERIAL::AMOUNT::SHEET * 2
 	item_function_flags = OBVIOUS_INTERACTION_BAR //no hidden placement of armed mousetraps in other peoples backpacks
 	force = null
 	throwforce = null

--- a/code/obj/item/toys.dm
+++ b/code/obj/item/toys.dm
@@ -339,6 +339,7 @@ ADMIN_INTERACT_PROCS(/obj/item/ghostboard, proc/admin_command_speak)
 	icon_state = "lboard"
 	inhand_image_icon = 'icons/mob/inhand/hand_books.dmi'
 	item_state = "ouijaboard"
+	default_material = "wood"
 	w_class = W_CLASS_NORMAL
 	var/emoji_prob = 30
 	var/emoji_min = 1

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -475,6 +475,7 @@
 	desc = "A wooden crate."
 	icon = 'icons/obj/storage/crate_wood.dmi'
 	icon_state = "woodencrate1"
+	default_material = "wood"
 	New()
 		var/n = rand(1,9)
 		switch(n)


### PR DESCRIPTION
## About the PR
- Sets the default material of various objects to wood.

## Why's this needed?
- Things that look like they are made out of wood should be made of wood.

## Testing
<img width="226" height="226" alt="Screenshot 2026-09-06 083642" src="https://github.com/user-attachments/assets/6cd47671-daa1-4dc6-acd4-de62e7ede216" />

## Changelog
```changelog
(u)LorrMaster
(+)Various objects that should be made of wood now have wood as their default material.
```
