### PR TITLE
Gives oshan bartenders a chemmaster again

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -47310,6 +47310,11 @@
 	},
 /area/station/crew_quarters/hop)
 "uAB" = (
+/obj/machinery/chem_master{
+	dir = 4;
+	pixel_x = -8;
+	pixel_y = 1
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/baroffice)
 "uBa" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Turns out I managed to remove their chem master during the oshan cafeteria remodel (or maybe they never had one)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consistency, standard piece of equipment that's useful for antag and non antag bartenders. Oopsie.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

