### PR TITLE
split Eat() logic into do_eat(), can_eat(), and is_edible()

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -3436,7 +3436,7 @@ TYPEINFO(/mob)
 		if (A)
 			src.client?.Click(A, get_turf(A))
 
-/mob/proc/can_eat(var/atom/A)
+/mob/proc/can_eat(var/atom/A, var/mob/fed_by)
 	return 1
 
 /mob/proc/on_eat(var/atom/A)

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -275,118 +275,46 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 		if (!src.Eat(target, user))
 			return ..()
 
-	Eat(var/mob/M as mob, var/mob/user, var/bypass_utensils = FALSE)
-		// in this case m is the consumer and user is the one holding it
-		if(!M?.bioHolder.HasEffect("mattereater") && ON_COOLDOWN(M, "eat", EAT_COOLDOWN))
-			return 0
+	do_eat(var/mob/M, var/mob/user)
+		src.take_a_bite(M, user)
+
+	is_edible(var/mob/M as mob, var/mob/user, var/by_matter_eater = FALSE, var/force_edible=FALSE)
+		// general
+		var/bypass_utensils = by_matter_eater
+
 		if (!src.bites_left)
 			boutput(user, SPAN_ALERT("None of [src] left, oh no!"))
 			user.u_equip(src)
 			qdel(src)
-			return 0
-		if (M == user)
-			//can this person eat this food?
-			if(!M.can_eat(src))
-				boutput(M, SPAN_ALERT("You can't eat [src]!"))
-				return 0
-			if (!bypass_utensils)
-				var/utensil = null
+			return FALSE
 
-				if ((src.required_utensil == REQUIRED_UTENSIL_FORK || src.required_utensil == REQUIRED_UTENSIL_FORK_OR_SPOON) && user.find_type_in_hand(/obj/item/kitchen/utensil/fork))
-					utensil = user.find_type_in_hand(/obj/item/kitchen/utensil/fork)
-				else if ((src.required_utensil == REQUIRED_UTENSIL_SPOON || src.required_utensil == REQUIRED_UTENSIL_FORK_OR_SPOON) && isspooningtool(user.equipped()))
-					utensil = user.equipped()
+		if (!bypass_utensils)
+			var/utensil = null
+			if ((src.required_utensil == REQUIRED_UTENSIL_FORK || src.required_utensil == REQUIRED_UTENSIL_FORK_OR_SPOON) && user.find_type_in_hand(/obj/item/kitchen/utensil/fork))
+				utensil = user.find_type_in_hand(/obj/item/kitchen/utensil/fork)
+			else if ((src.required_utensil == REQUIRED_UTENSIL_SPOON || src.required_utensil == REQUIRED_UTENSIL_FORK_OR_SPOON) && isspooningtool(user.equipped()))
+				utensil = user.equipped()
 
-				// If it's a plastic fork we've found then test if we've broken it
-				var/obj/item/kitchen/utensil/fork/plastic/plastic_fork = utensil
-				if (istype(plastic_fork))
-					if (prob(20))
-						plastic_fork.break_utensil(M)
-						utensil = null
+			// If it's a plastic spoon/fork we've found then test if we've broken it
+			var/obj/item/kitchen/utensil/breakable_utensil = utensil
+			if (istype(breakable_utensil, /obj/item/kitchen/utensil/fork/plastic) || istype(breakable_utensil, /obj/item/kitchen/utensil/spoon/plastic))
+				if (prob(20))
+					breakable_utensil.break_utensil(M)
+					utensil = null
 
-				// If it's a plastic spoon we've found then test if we've broken it
-				var/obj/item/kitchen/utensil/spoon/plastic/plastic_spoon = utensil
-				if (istype(plastic_spoon))
-					if (prob(20))
-						plastic_spoon.break_utensil(M)
-						utensil = null
+			if (!utensil && (src.required_utensil))
+				switch(src.required_utensil)
+					if (REQUIRED_UTENSIL_FORK_OR_SPOON)
+						boutput(M, SPAN_ALERT("You need a fork or spoon to eat [src]!"))
+					if (REQUIRED_UTENSIL_FORK)
+						boutput(M, SPAN_ALERT("You need a fork to eat [src]!"))
+					if (REQUIRED_UTENSIL_SPOON)
+						boutput(M, SPAN_ALERT("You need a spoon to eat [src]!"))
 
-				if (!utensil && (src.required_utensil))
-					switch(src.required_utensil)
-						if (REQUIRED_UTENSIL_FORK_OR_SPOON)
-							boutput(M, SPAN_ALERT("You need a fork or spoon to eat [src]!"))
-						if (REQUIRED_UTENSIL_FORK)
-							boutput(M, SPAN_ALERT("You need a fork to eat [src]!"))
-						if (REQUIRED_UTENSIL_SPOON)
-							boutput(M, SPAN_ALERT("You need a spoon to eat [src]!"))
+				M.visible_message(SPAN_ALERT("[user] stares glumly at [src]."))
+				return FALSE
 
-					M.visible_message(SPAN_ALERT("[user] stares glumly at [src]."))
-					return
-
-			//no or broken stomach
-			if (ishuman(M))
-				var/mob/living/carbon/human/H = M
-				var/obj/item/organ/stomach/tummy = H.get_organ("stomach")
-				if (!istype(tummy) || (tummy.broken || tummy.get_damage() > tummy.max_damage) || M?.bioHolder.HasEffect("rot_curse"))
-					M.visible_message(SPAN_NOTICE("[M] tries to take a bite of [src], but can't swallow!"),\
-					SPAN_NOTICE("You try to take a bite of [src], but can't swallow!"))
-					return 0
-				if (tummy.calculate_fullness() > tummy.capacity)
-					M.show_message(SPAN_ALERT("You're just too full to take another bite!"))
-					return 0
-				if (!H.organHolder.head)
-					M.visible_message(SPAN_NOTICE("[M] tries to take a bite of [src], but they have no head!"),\
-					SPAN_NOTICE("You try to take a bite of [src], but you have no head to chew with!"))
-					return 0
-				if (H.traitHolder.hasTrait("picky_eater"))
-					var/datum/trait/picky_eater/eater_trait = H.traitHolder.getTrait("picky_eater")
-					if (length(eater_trait.fav_foods) > 0)
-						if (H.sims)
-							if (!check_favorite_food(H))
-								if (H.sims.getValue("Hunger") > SIMS_HUNGER_FAMISHED)
-									M.visible_message(SPAN_NOTICE("[M] looks at [src] with a disgusted expression!"),\
-									SPAN_NOTICE("You won't eat [src], it just seems too disgusting to you! You're not hungry or desperate enough to eat that."))
-									return 0
-								else
-									boutput(H, SPAN_NOTICE("Famished, starving, you reluctantly take a bite of [src]."))
-						else if (!check_favorite_food(H))
-							M.visible_message(SPAN_NOTICE("[M] looks at [src] with a disgusted expression!"),\
-							SPAN_NOTICE("You won't eat [src], it just seems too disgusting to you!"))
-							return 0
-
-			src.take_a_bite(M, user)
-			return 1
-		if (check_target_immunity(M))
-			user.visible_message(SPAN_ALERT("[user] tries to feed [M] [src], but fails!"), SPAN_ALERT("You try to feed [M] [src], but fail!"))
-			return 0
-		else if(!M.can_eat(src))
-			user.tri_message(M, SPAN_ALERT("<b>[user]</b> tries to feed [M] [src], but they can't eat that!"),\
-				SPAN_ALERT("You try to feed [M] [src], but they can't eat that!"),\
-				SPAN_ALERT("<b>[user]</b> tries to feed you [src], but you can't eat that!"))
-			return 0
-		else
-			user.tri_message(M, SPAN_ALERT("<b>[user]</b> tries to feed [M] [src]!"),\
-				SPAN_ALERT("You try to feed [M] [src]!"),\
-				SPAN_ALERT("<b>[user]</b> tries to feed you [src]!"))
-			logTheThing(LOG_COMBAT, user, "attempts to feed [constructTarget(M,"combat")] [src] [log_reagents(src)] at [log_loc(user)].")
-
-			//no or broken stomach
-			if (ishuman(M))
-				var/mob/living/carbon/human/H = M
-				var/obj/item/organ/stomach/tummy = H.get_organ("stomach")
-				if (!istype(tummy) || (tummy.broken || tummy.get_damage() > tummy.max_damage) || M?.bioHolder.HasEffect("rot_curse"))
-					user.tri_message(M, SPAN_ALERT("<b>[user]</b>tries to feed [M] [src], but can't make [him_or_her(M)] swallow!"),\
-						SPAN_ALERT("You try to feed [M] [src], but can't make [him_or_her(M)] swallow!"),\
-						SPAN_ALERT("<b>[user]</b> tries to feed you [src], but you can't swallow!!"))
-					return 0
-				if (!H.organHolder.head)
-					user.tri_message(M, SPAN_ALERT("<b>[user]</b>tries to feed [M] [src], but [he_or_she(M)] has no head!!"),\
-						SPAN_ALERT("You try to feed [M] [src], but [he_or_she(M)] has no head!"),\
-						SPAN_ALERT("<b>[user]</b> tries to feed you [src], but you don't have a head!"))
-					return 0
-
-			actions.start(new/datum/action/bar/icon/forcefeed(M, src, src.icon, src.icon_state), user)
-			return 1
+		return ..()
 
 	///Called when we successfully take a bite of something (or make someone else take a bite of something)
 	proc/take_a_bite(var/mob/consumer, var/mob/feeder)

--- a/code/modules/fishing/fishing_gear.dm
+++ b/code/modules/fishing/fishing_gear.dm
@@ -750,8 +750,8 @@ TYPEINFO(/obj/item/syndie_fishing_rod)
 		else
 			return FALSE
 
-	Eat(mob/M, mob/user, by_matter_eater)
-		. = ..()
+	do_eat(mob/M, mob/user)
+		..()
 		M.emote("scream")
 		M.TakeDamage("chest", 25, 0, 0, DAMAGE_CUT)
 		M.visible_message("\The [src] tears a bunch of gore out of [M.name]!")

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -221,12 +221,18 @@ ABSTRACT_TYPE(/datum/bioEffect/power)
 			return CAST_ATTEMPT_SUCCESS
 		// Finally, ensure that the item is deleted regardless of what it is
 		var/obj/item/I = the_object
-		if(I.Eat(src.owner, src.owner, TRUE)) //eating can return false to indicate it failed
-			I.storage?.hide_hud(src.owner)
-			// Organs and body parts have special behaviors we need to account for
-			if (!handle_organs(the_object))
-				handle_parts(the_object)
-		else //Eat() handles qdel, visible message and sound playing, so only do that when we don't have Eat()
+		if(istype(I))
+			if (I.Eat(src.owner, src.owner, TRUE)) //eating can return false to indicate it failed
+				I.storage?.hide_hud(src.owner)
+				// Organs and body parts have special behaviors we need to account for
+				if (!handle_organs(the_object))
+					handle_parts(the_object)
+			else
+				// we failed to eat it.
+				src.using = FALSE
+				return CAST_ATTEMPT_FAIL_CAST_FAILURE
+		else
+			//Eat() handles qdel, visible message and sound playing, so only do that when we don't have Eat()
 			src.owner.visible_message(SPAN_ALERT("[src.owner] eats [the_object]."))
 			playsound(src.owner.loc, 'sound/items/eatfood.ogg', 50, FALSE)
 			qdel(the_object)

--- a/code/modules/ranch/ranch_critter_base.dm
+++ b/code/modules/ranch/ranch_critter_base.dm
@@ -304,7 +304,7 @@
 	proc/create_child(var/mob/M)
 		return
 
-	can_eat(var/atom/A)
+	can_eat(var/atom/A, var/mob/fed_by)
 		if(isalive(src))
 			if(istype(A,/obj/item/reagent_containers/food/snacks/ranch_feed_bag))
 				return 1

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -533,7 +533,7 @@ ABSTRACT_TYPE(/obj/item)
 	return TRUE
 
 // putting this here so its next to where its used.
-/mob/living/carbon/human/can_eat(atom/A)
+/mob/living/carbon/human/can_eat(atom/A, mob/fed_by)
 
 	var/obj/item/organ/stomach/tummy = src.get_organ("stomach")
 	if (!istype(tummy) || (tummy.broken || tummy.get_damage() > tummy.max_damage) || src.bioHolder?.HasEffect("rot_curse"))
@@ -548,28 +548,29 @@ ABSTRACT_TYPE(/obj/item)
 		SPAN_NOTICE("You try to take a bite of [A], but you have no head to chew with!"))
 		return FALSE
 
-	if (src.traitHolder?.hasTrait("picky_eater"))
-		var/datum/trait/picky_eater/eater_trait = src.traitHolder.getTrait("picky_eater")
-		var/obj/item/reagent_containers/food/snacks/food = A
-		if (length(eater_trait.fav_foods) > 0)
+	if (fed_by == src)
+		if (src.traitHolder?.hasTrait("picky_eater"))
+			var/datum/trait/picky_eater/eater_trait = src.traitHolder.getTrait("picky_eater")
+			var/obj/item/reagent_containers/food/snacks/food = A
+			if (length(eater_trait.fav_foods) > 0)
 
-			var/acceptable = FALSE
-			if (istype(food))
-				acceptable = food.check_favorite_food(src)
+				var/acceptable = FALSE
+				if (istype(food))
+					acceptable = food.check_favorite_food(src)
 
-			if (src.sims)
-				if (!acceptable)
-					if (src.sims.getValue("Hunger") > SIMS_HUNGER_FAMISHED)
-						src.visible_message(SPAN_NOTICE("[src] looks at [food] with a disgusted expression!"),\
-						SPAN_NOTICE("You won't eat [food], it just seems too disgusting to you! You're not hungry or desperate enough to eat that."))
-						return FALSE
-					else
-						boutput(src, SPAN_NOTICE("Famished, starving, you reluctantly take a bite of [food]."))
+				if (src.sims)
+					if (!acceptable)
+						if (src.sims.getValue("Hunger") > SIMS_HUNGER_FAMISHED)
+							src.visible_message(SPAN_NOTICE("[src] looks at [food] with a disgusted expression!"),\
+							SPAN_NOTICE("You won't eat [food], it just seems too disgusting to you! You're not hungry or desperate enough to eat that."))
+							return FALSE
+						else
+							boutput(src, SPAN_NOTICE("Famished, starving, you reluctantly take a bite of [food]."))
 
-			else if (!acceptable)
-				src.visible_message(SPAN_NOTICE("[src] looks at [food] with a disgusted expression!"),\
-				SPAN_NOTICE("You won't eat [food], it just seems too disgusting to you!"))
-				return FALSE
+				else if (!acceptable)
+					src.visible_message(SPAN_NOTICE("[src] looks at [food] with a disgusted expression!"),\
+					SPAN_NOTICE("You won't eat [food], it just seems too disgusting to you!"))
+					return FALSE
 
 	if (!(..(A)))
 		boutput(src, SPAN_ALERT("You can't eat [A]!"))
@@ -585,7 +586,7 @@ ABSTRACT_TYPE(/obj/item)
 		return FALSE
 
 	if (M == user)
-		if(!M.can_eat(src))
+		if(!M.can_eat(src, user))
 			return FALSE
 		src.do_eat(M, user)
 
@@ -594,7 +595,7 @@ ABSTRACT_TYPE(/obj/item)
 		if (check_target_immunity(M))
 			user.visible_message(SPAN_ALERT("[user] tries to feed [M] [src], but fails!"), SPAN_ALERT("You try to feed [M] [src], but fail!"))
 			return FALSE
-		else if(!M.can_eat(src))
+		else if(!M.can_eat(src, user))
 			user.tri_message(M, SPAN_ALERT("<b>[user]</b> tries to feed [M] [src], but they can't eat that!"),\
 				SPAN_ALERT("You try to feed [M] [src], but they can't eat that!"),\
 				SPAN_ALERT("<b>[user]</b> tries to feed you [src], but you can't eat that!"))

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -469,80 +469,53 @@ ABSTRACT_TYPE(/obj/item)
 	..()
 
 
-/obj/item/proc/eat_msg(mob/M)
-	M.visible_message(SPAN_NOTICE("[M] takes a bite of [src]!"),\
-		SPAN_NOTICE("You take a bite of [src]!"))
+/obj/item/proc/eat_msg(mob/M, mob/user)
+	if (user == M)
+		M.visible_message(SPAN_NOTICE("[M] takes a bite of [src]!"),\
+			SPAN_NOTICE("You take a bite of [src]!"))
+	else
+		user.tri_message(M, SPAN_ALERT("<b>[user]</b> feeds [M] [src]!"),\
+			SPAN_ALERT("You feed [M] [src]!"),\
+			SPAN_ALERT("<b>[user]</b> feeds you [src]!"))
 
-//disgusting proc. merge with foods later. PLEASE
-/obj/item/proc/Eat(var/mob/M as mob, var/mob/user, var/by_matter_eater=FALSE, var/force_edible = FALSE)
+/// determines whether an item is edible
+/obj/item/proc/is_edible(var/mob/M as mob, var/mob/user, var/by_matter_eater=FALSE, var/force_edible = FALSE)
 	if (!iscarbon(M) && !ismobcritter(M))
 		return FALSE
+	// matter eater cooldown
 	if (M?.bioHolder && !M.bioHolder.HasEffect("mattereater"))
 		if(ON_COOLDOWN(M, "eat", EAT_COOLDOWN))
 			return FALSE
+
 	var/edibility_override = SEND_SIGNAL(M, COMSIG_MOB_ITEM_CONSUMED_PRE, user, src) || SEND_SIGNAL(src, COMSIG_ITEM_CONSUMED_PRE, M, user)
 	var/can_matter_eat = by_matter_eater && (M == user) && M.bioHolder.HasEffect("mattereater")
-	var/edible_check = src.edible || (src.material?.getEdible()) || (edibility_override & FORCE_EDIBILITY)
-	if (!edible_check && !can_matter_eat)
+	var/edible_check = src.edible || (src.material?.getEdible()) || (edibility_override & FORCE_EDIBILITY) || can_matter_eat
+	if (!edible_check)
 		return FALSE
 
-	if (M == user)
-		src.eat_msg(M)
-		if (src.material && (src.material.getEdible() || edibility_override))
-			src.material.triggerEat(M, src)
+	return TRUE
 
-		if (src.reagents && src.reagents.total_volume)
-			src.reagents.reaction(M, INGEST)
-			SPAWN(0.5 SECONDS) // Necessary.
-				src.reagents.trans_to(M, src.reagents.total_volume/src.amount)
+/// handles the actual eating of an item
+/obj/item/proc/do_eat(var/mob/M, var/mob/user)
 
-		playsound(M.loc, src.eat_sound, rand(10, 50), 1)
-		eat_twitch(M)
-		SPAWN(0.6 SECOND)
-			if (!src || !M || !user)
-				return
-			SEND_SIGNAL(M, COMSIG_MOB_ITEM_CONSUMED, user, src) //one to the mob
-			SEND_SIGNAL(src, COMSIG_ITEM_CONSUMED, M, src) //one to the item
-			if (src.amount > 1)
-				src.change_stack_amount(-1)
-				return
-			user.u_equip(src)
-			if (!istype(src, /obj/item/reagent_containers/food) && isliving(user))
-				var/mob/living/L = user
-				if (L.organHolder.stomach)
-					L.organHolder.stomach.consume(src)
-					return
-			qdel(src)
-		return TRUE
+	if (M != user)
+		if (BOUNDS_DIST(user, M) > 0)
+			return FALSE
+		logTheThing(LOG_COMBAT, user, "feeds [constructTarget(M,"combat")] [src] [log_reagents(src)]")
 
-	else
-		user.tri_message(M, SPAN_ALERT("<b>[user]</b> tries to feed [M] [src]!"),\
-			SPAN_ALERT("You try to feed [M] [src]!"),\
-			SPAN_ALERT("<b>[user]</b> tries to feed you [src]!"))
-		logTheThing(LOG_COMBAT, user, "attempts to feed [constructTarget(M,"combat")] [src] [log_reagents(src)]")
-
-		SETUP_GENERIC_ACTIONBAR(user, M, 3 SECONDS, /mob/proc/accept_forcefeed, list(src, user, edibility_override), src.icon, src.icon_state, null, INTERRUPT_MOVE | INTERRUPT_STUNNED)
-		return TRUE
-
-/obj/item/proc/forcefeed(mob/M, mob/user, edibility_override)
-	if (BOUNDS_DIST(user, M) > 0)
-		return TRUE
-	user.tri_message(M, SPAN_ALERT("<b>[user]</b> feeds [M] [src]!"),\
-		SPAN_ALERT("You feed [M] [src]!"),\
-		SPAN_ALERT("<b>[user]</b> feeds you [src]!"))
-	logTheThing(LOG_COMBAT, user, "feeds [constructTarget(M,"combat")] [src] [log_reagents(src)]")
-
-	if (src.material && (src.material.getEdible() || edibility_override))
+	src.eat_msg(M, user)
+	if (src.material && (src.material.getEdible()))
 		src.material.triggerEat(M, src)
 
 	if (src.reagents && src.reagents.total_volume)
 		src.reagents.reaction(M, INGEST)
 		SPAWN(0.5 SECONDS) // Necessary.
-			src.reagents.trans_to(M, src.reagents.total_volume)
+			src.reagents.trans_to(M, src.reagents.total_volume/src.amount)
 
 	playsound(M.loc, src.eat_sound, rand(10, 50), 1)
 	eat_twitch(M)
-	SPAWN(1 SECOND)
+
+	SPAWN(0.6 SECOND)
 		if (!src || !M || !user)
 			return
 		SEND_SIGNAL(M, COMSIG_MOB_ITEM_CONSUMED, user, src) //one to the mob
@@ -552,11 +525,96 @@ ABSTRACT_TYPE(/obj/item)
 			return
 		user.u_equip(src)
 		if (!istype(src, /obj/item/reagent_containers/food) && isliving(user))
-			var/mob/living/L = M
+			var/mob/living/L = user
 			if (L.organHolder.stomach)
 				L.organHolder.stomach.consume(src)
 				return
 		qdel(src)
+	return TRUE
+
+// putting this here so its next to where its used.
+/mob/living/carbon/human/can_eat(atom/A)
+
+	var/obj/item/organ/stomach/tummy = src.get_organ("stomach")
+	if (!istype(tummy) || (tummy.broken || tummy.get_damage() > tummy.max_damage) || src.bioHolder?.HasEffect("rot_curse"))
+		src.visible_message(SPAN_NOTICE("[src] tries to take a bite of [A], but can't swallow!"),\
+		SPAN_NOTICE("You try to take a bite of [A], but can't swallow!"))
+		return FALSE
+	if (tummy.calculate_fullness() > tummy.capacity)
+		src.show_message(SPAN_ALERT("You're just too full to take another bite!"))
+		return FALSE
+	if (!src.organHolder?.head)
+		src.visible_message(SPAN_NOTICE("[src] tries to take a bite of [A], but they have no head!"),\
+		SPAN_NOTICE("You try to take a bite of [A], but you have no head to chew with!"))
+		return FALSE
+
+	if (src.traitHolder?.hasTrait("picky_eater"))
+		var/datum/trait/picky_eater/eater_trait = src.traitHolder.getTrait("picky_eater")
+		var/obj/item/reagent_containers/food/snacks/food = A
+		if (length(eater_trait.fav_foods) > 0)
+
+			var/acceptable = FALSE
+			if (istype(food))
+				acceptable = food.check_favorite_food(src)
+
+			if (src.sims)
+				if (!acceptable)
+					if (src.sims.getValue("Hunger") > SIMS_HUNGER_FAMISHED)
+						src.visible_message(SPAN_NOTICE("[src] looks at [food] with a disgusted expression!"),\
+						SPAN_NOTICE("You won't eat [food], it just seems too disgusting to you! You're not hungry or desperate enough to eat that."))
+						return FALSE
+					else
+						boutput(src, SPAN_NOTICE("Famished, starving, you reluctantly take a bite of [food]."))
+
+			else if (!acceptable)
+				src.visible_message(SPAN_NOTICE("[src] looks at [food] with a disgusted expression!"),\
+				SPAN_NOTICE("You won't eat [food], it just seems too disgusting to you!"))
+				return FALSE
+
+	if (!(..(A)))
+		boutput(src, SPAN_ALERT("You can't eat [A]!"))
+		return FALSE
+
+	return TRUE
+
+//disgusting proc. merge with foods later. PLEASE
+/obj/item/proc/Eat(var/mob/M as mob, var/mob/user, var/by_matter_eater=FALSE, var/force_edible = FALSE)
+	// check general edibility
+	var/edible_check = src.is_edible(M, user, by_matter_eater, force_edible)
+	if (!edible_check)
+		return FALSE
+
+	if (M == user)
+		if(!M.can_eat(src))
+			return FALSE
+		src.do_eat(M, user)
+
+		return TRUE
+	else
+		if (check_target_immunity(M))
+			user.visible_message(SPAN_ALERT("[user] tries to feed [M] [src], but fails!"), SPAN_ALERT("You try to feed [M] [src], but fail!"))
+			return FALSE
+		else if(!M.can_eat(src))
+			user.tri_message(M, SPAN_ALERT("<b>[user]</b> tries to feed [M] [src], but they can't eat that!"),\
+				SPAN_ALERT("You try to feed [M] [src], but they can't eat that!"),\
+				SPAN_ALERT("<b>[user]</b> tries to feed you [src], but you can't eat that!"))
+			return FALSE
+		else
+			user.tri_message(M, SPAN_ALERT("<b>[user]</b> tries to feed [M] [src]!"),\
+				SPAN_ALERT("You try to feed [M] [src]!"),\
+				SPAN_ALERT("<b>[user]</b> tries to feed you [src]!"))
+			logTheThing(LOG_COMBAT, user, "attempts to feed [constructTarget(M,"combat")] [src] [log_reagents(src)] at [log_loc(user)].")
+
+		// use the action bar if we can, otherwise fall back gracefully
+		if (istype(src, /obj/item/reagent_containers/food/snacks))
+			actions.start(new/datum/action/bar/icon/forcefeed(M, src, src.icon, src.icon_state), user)
+		else
+			SETUP_GENERIC_ACTIONBAR(user, M, 3 SECONDS, /mob/proc/accept_forcefeed, list(src, user, edible_check), src.icon, src.icon_state, null, INTERRUPT_MOVE | INTERRUPT_STUNNED)
+
+		return TRUE
+
+/obj/item/proc/forcefeed(mob/M, mob/user, edibility_override)
+	src.do_eat(M, user)
 	return TRUE
 
 /obj/item/proc/take_damage(brute, burn, tox, disallow_limb_loss)

--- a/code/obj/item/organs/brain.dm
+++ b/code/obj/item/organs/brain.dm
@@ -41,19 +41,26 @@
 	Eat(mob/M, mob/user)
 		if(isghostcritter(M) || isghostcritter(user))
 			return FALSE
+		if(isghostdrone(M) || isghostdrone(user)) // no. just no.
+			return FALSE
+
+		// do_eat now handles range checks and logging, so we only need to worry about the dialog box and any additional safety checks
 		if(M == user)
 			if(tgui_alert(user, "Are you sure you want to eat [src]?", "Eat brain?", list("Yes", "No")) == "Yes")
-				if (!(src in user.equipped_list())) //stop remotely eating people's brains please
-					return TRUE
-				logTheThing(LOG_COMBAT, user, "tries to eat [src] (owner's ckey [owner ? owner.ckey : null]).")
 				return ..()
 		else
 			if(tgui_alert(user, "Are you sure you want to feed [src] to [M]?", "Feed brain?", list("Yes", "No")) == "Yes")
-				if (!(src in user.equipped_list()))
-					return TRUE
-				logTheThing(LOG_COMBAT, user, "tries to feed [src] (owner's ckey [owner ? owner.ckey : null]) to [constructName(M)].")
 				return ..()
+
 		return FALSE
+
+	// make ABSOLUTELY SURE that the brain logging happens
+	do_eat(mob/M, mob/user)
+		if(M == user)
+			logTheThing(LOG_COMBAT, user, "eats [src] (owner's ckey [owner ? owner.ckey : null]).")
+		else
+			logTheThing(LOG_COMBAT, user, "feeds [src] (owner's ckey [owner ? owner.ckey : null]) to [constructName(M)].")
+		..()
 
 	get_desc()
 		if (usr && (usr.traitHolder?.hasTrait("training_medical") || GET_ATOM_PROPERTY(usr,PROP_MOB_EXAMINE_HEALTH)))

--- a/code/obj/item/sponge_capsule.dm
+++ b/code/obj/item/sponge_capsule.dm
@@ -61,8 +61,15 @@
 	else
 		return
 
-/obj/item/toy/sponge_capsule/eat_msg(mob/M)
-	M.visible_message(SPAN_NOTICE("[M] stuffs [src] into [his_or_her(M)] mouth and and eats it."))
+/obj/item/toy/sponge_capsule/eat_msg(mob/M, mob/user)
+
+	if (user == M)
+		M.visible_message(SPAN_NOTICE("[M] stuffs [src] into [his_or_her(M)] mouth and and eats it."),\
+			SPAN_NOTICE("You stuff [src] into your mouth and and eat it."))
+	else
+		user.tri_message(M, SPAN_ALERT("<b>[user]</b> stuffs [src] into [M]'s mouth and forces [M] to eat [src]."),\
+			SPAN_ALERT("You stuff [src] into [M]'s mouth and forces [M] to eat [src]."),\
+			SPAN_ALERT("<b>[user]</b> stuffs [src] into your mouth and and forces you to eat it."))
 
 /obj/item/toy/sponge_capsule/proc/add_water()
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
kills off the snack version of /obj/item/Eat()

- adds /obj/item `do_eat` proc, which does the sound, plays the eating animation
   - do_eat does not replace the existing bite code for food items

- moves human related edibility checks into human `can_eat` and item related checks into /obj/item `is_edible` procs
    - one effect of doing this is that **all** items outside the picky eater trait whitelist are considered inedible

- fixes #27717
    - matter eater no longer qdels items if Eat() returns false.
    - this will now only happen if matter eater attempts to eat a non item somehow.

this might need to be testmerged to verify i havent accidentally broken anything when splitting it up
if i've done this all correctly, this should cause little to no player facing changes


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
having two implementations of the exact same code bad

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="414" height="47" alt="image" src="https://github.com/user-attachments/assets/6bc433aa-6082-4716-bbe8-3716705f5b69" />

spawned in items to eat on devtest with and without the picky eater trait

verified picky eater worked as expected, including with matter eater

verified normal food items also worked.

