### PR TITLE
remove accidental blackbox comment

### DIFF
--- a/code/z_adventurezones/polaris.dm
+++ b/code/z_adventurezones/polaris.dm
@@ -109,7 +109,7 @@
 	item_state = "energy"
 	force = 5
 
-/obj/item/blackbox // Not actually *in* polaris but part of the concept of polaris.
+/obj/item/blackbox
 	name = "flight recorder of NSS Polaris"
 	inhand_image_icon = 'icons/mob/inhand/hand_general.dmi'
 	icon = 'icons/obj/items/items.dmi'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I accidentally added a false comment on the blackbox cause i just missed it & thought it was the removed manta puzzle. Oopsie
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I dont wanna spread missinformatiom online :(
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Its a comment removal
