### PR TITLE
add safety checks to spatial tears, make them less moveable

### DIFF
--- a/code/modules/events/spatial_tear.dm
+++ b/code/modules/events/spatial_tear.dm
@@ -43,7 +43,7 @@
 	density = 1
 	var/stabilized = 0
 	plane = PLANE_ABOVE_LIGHTING
-	event_handler_flags = IMMUNE_OCEAN_PUSH | IMMUNE_TRENCH_WARP | IMMUNE_MINERAL_MAGNET
+	event_handler_flags = IMMUNE_SINGULARITY | IMMUNE_OCEAN_PUSH | IMMUNE_TRENCH_WARP | IMMUNE_MINERAL_MAGNET
 
 	New(var/loc,var/duration)
 		..()

--- a/code/modules/events/spatial_tear.dm
+++ b/code/modules/events/spatial_tear.dm
@@ -12,17 +12,25 @@
 		var/picky = rand(75,140)
 		var/btype = rand(1,2)
 		var/count = btype == 1 ? world.maxy : world.maxx // could just set it to our current mapsize (300) but this should help in case that changes again in the future or we go with non-square maps for some reason??  :v
+
+		var/turf/tear_loc = null
 		if (btype == 1)
 			// Vertical
 			while (count > 0)
-				var/obj/forcefield/event/B = new /obj/forcefield/event(locate(pickx,count,1),barrier_duration)
-				B.icon_state = "spat-v"
+				tear_loc = locate(pickx,count,1)
+				// we want to avoid placing on cordons, but still decrement
+				if (tear_loc && !istype(tear_loc, /turf/cordon))
+					var/obj/forcefield/event/B = new /obj/forcefield/event(tear_loc,barrier_duration)
+					B.icon_state = "spat-v"
 				count -= 1
 		else
 			// Horizontal
 			while (count > 0)
-				var/obj/forcefield/event/B = new /obj/forcefield/event(locate(count,picky,1),barrier_duration)
-				B.icon_state = "spat-h"
+				tear_loc = locate(count,picky,1)
+				// we want to avoid placing on cordons, but still decrement
+				if (tear_loc && !istype(tear_loc, /turf/cordon))
+					var/obj/forcefield/event/B = new /obj/forcefield/event(tear_loc,barrier_duration)
+					B.icon_state = "spat-h"
 				count -= 1
 
 /obj/forcefield/event
@@ -30,11 +38,12 @@
 	desc = "A breach in the spatial fabric. Extremely difficult to pass."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "spat-h"
-	anchored = ANCHORED
+	anchored = ANCHORED_ALWAYS
 	opacity = 1
 	density = 1
 	var/stabilized = 0
 	plane = PLANE_ABOVE_LIGHTING
+	event_handler_flags = IMMUNE_OCEAN_PUSH | IMMUNE_TRENCH_WARP | IMMUNE_MINERAL_MAGNET
 
 	New(var/loc,var/duration)
 		..()

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -178,6 +178,8 @@ ABSTRACT_TYPE(/obj/machinery/computer/transit_shuttle)
 					continue
 				if (istype(AM, /obj/effects/precipitation))
 					continue
+				if (istype(AM, /obj/forcefield/event))
+					continue // no moving spatial tears
 				var/turf/ejectT
 				switch(ejectdir) // find the spot to push everything
 					if (NORTH)

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -541,6 +541,7 @@ proc/reachable_in_n_steps(turf/from, turf/target, n_steps, use_gas_cross=FALSE)
 		for (var/atom/movable/AM as anything in S)
 			if (istype(AM, /obj/effects/precipitation)) continue
 			if (istype(AM, /obj/overlay/tile_effect)) continue
+			if (istype(AM, /obj/forcefield/event)) continue
 			if (!ignore_fluid && istype(AM, /obj/fluid)) continue
 			if (istype(AM, /obj/decal/tile_edge) && istypes(S, turf_to_skip)) continue
 			AM.set_loc(T)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
should fix #27791 by marking the spatial tear as magnet immune

should fix #14652 by making the spatial tear event avoid placing tears on cordon tiles.

sets spatial tears as anchored always, as well as immovable by shuttles for good measure.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

people having less unintended ways to bypass spatial tears good.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

tested by spawning spatial tear events until one hits a mining magnet, then verifying the magnet cannot destroy it.
<img width="607" height="342" alt="image" src="https://github.com/user-attachments/assets/3f247d0e-9590-4830-9283-797d73252a14" />

attempted moving the spatial tear with the mining shuttle, tear did not move
<img width="520" height="483" alt="image" src="https://github.com/user-attachments/assets/f3d997c0-5c70-486b-9f3d-98e7bb889db0" />
<img width="648" height="501" alt="image" src="https://github.com/user-attachments/assets/de12c6a7-d376-4c43-a848-45efdb22108e" />



