### PR TITLE
prevent wrenching glued mechcomp components

### DIFF
--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -120,6 +120,8 @@
 	#define COMSIG_MOVABLE_CONTRABAND_CHANGED "mov_contraband_changed"
 	/// when an AM is revealed from under a floor tile (turf revealed from)
 	#define COMSIG_MOVABLE_FLOOR_REVEALED "mov_floor_revealed"
+	/// When an AM does something that should intentionally disrupt glue, ex: anchoring items
+	#define COMSIG_MOVABLE_DISRUPT_GLUE "mov_disrupt_glue"
 
 // ---- turf signals ----
 	/// when an atom inside the turfs contents changes opacity (turf, previous_opacity, thing)

--- a/code/datums/DCS/components/glued.dm
+++ b/code/datums/DCS/components/glued.dm
@@ -55,6 +55,7 @@ TYPEINFO(/datum/component/glued)
 	RegisterSignal(parent, COMSIG_MOVABLE_SET_LOC, PROC_REF(on_set_loc))
 	RegisterSignals(parent, list(COMSIG_ATOM_EXPLODE, COMSIG_ATOM_EXPLODE_INSIDE), PROC_REF(on_explode))
 	RegisterSignal(parent, COMSIG_ATOM_HITBY_PROJ, PROC_REF(on_hitby_proj))
+	RegisterSignal(parent, COMSIG_MOVABLE_DISRUPT_GLUE, PROC_REF(on_disrupt))
 	if(isliving(parent))
 		RegisterSignal(parent, COMSIG_MOB_RESIST, PROC_REF(on_resist))
 
@@ -120,6 +121,12 @@ TYPEINFO(/datum/component/glued)
 				T?.visible_message(SPAN_NOTICE("\The [parent] is ripped off from [glued_to]."))
 				qdel(src)
 
+/datum/component/glued/proc/on_disrupt(atom/movable/parent)
+	var/turf/T = get_turf(parent)
+	parent.unglue_attached_to()
+	T?.visible_message(SPAN_NOTICE("\The [parent] is ripped off from [glued_to]."))
+	qdel(src)
+
 /datum/component/glued/proc/on_explode(atom/movable/parent, list/explode_args)
 	// explode_args format: list(atom/source, turf/epicenter, power, brisance = 1, angle = 0, width = 360, turf_safe=FALSE)
 	explode_args[3] /= 3 // reduce explosion size by a factor of 3
@@ -128,7 +135,7 @@ TYPEINFO(/datum/component/glued)
 /datum/component/glued/UnregisterFromParent()
 	var/atom/movable/parent = src.parent
 	UnregisterSignal(parent, list(COMSIG_ATTACKHAND, COMSIG_ATTACKBY, COMSIG_MOVABLE_PRE_MOVE, COMSIG_MOVABLE_SET_LOC, COMSIG_ATOM_EXPLODE,
-		COMSIG_ATOM_EXPLODE_INSIDE, COMSIG_ATOM_HITBY_PROJ, COMSIG_MOB_RESIST))
+		COMSIG_ATOM_EXPLODE_INSIDE, COMSIG_ATOM_HITBY_PROJ, COMSIG_MOB_RESIST, COMSIG_MOVABLE_DISRUPT_GLUE))
 	UnregisterSignal(glued_to, COMSIG_PARENT_PRE_DISPOSING)
 	parent.remove_filter("glued_outline")
 	parent.animate_movement = src.original_animate_movement

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -501,9 +501,6 @@ TYPEINFO(/obj/item/mechanics)
 		src.set_dir(turn(src.dir, -90))
 
 	proc/check_wrenching_conditions(var/mob/user)
-		if (src.GetComponent(/datum/component/glued))
-			return FALSE // no. just no.
-
 		//We need only to check conditions when the object is non-wrenched. Because else it can always be loosened
 		if(src.level == OVERFLOOR)
 			if(!isturf(src.loc) && !(IN_CABINET)) // allow items to be deployed inside housings, but not in other stuff like toolboxes
@@ -555,7 +552,7 @@ TYPEINFO(/obj/item/mechanics)
 				logTheThing(LOG_STATION, user, "attaches a <b>[src]</b> to the [istype(src.stored?.linked_item,/obj/item/storage/mechanics) ? "housing" : "underfloor"]  at [log_loc(src)].")
 				level = UNDERFLOOR
 				anchored = ANCHORED
-				src.unglue_attached_to()
+				SEND_SIGNAL(src, COMSIG_MOVABLE_DISRUPT_GLUE) // disrupt its connection to whatever its glued to
 				set_owner(user)
 				secure()
 		var/turf/T = src.loc

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -501,6 +501,9 @@ TYPEINFO(/obj/item/mechanics)
 		src.set_dir(turn(src.dir, -90))
 
 	proc/check_wrenching_conditions(var/mob/user)
+		if (src.GetComponent(/datum/component/glued))
+			return FALSE // no. just no.
+
 		//We need only to check conditions when the object is non-wrenched. Because else it can always be loosened
 		if(src.level == OVERFLOOR)
 			if(!isturf(src.loc) && !(IN_CABINET)) // allow items to be deployed inside housings, but not in other stuff like toolboxes


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds a check to prevent wrenching a mechcomp component if its glued to something


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
glue + mechcomp is an unholy combination that consistently grows in number of bugs found each day

including:
- the sequel to organ stealing plates
- mechcomp flying machines
- teleporters that trap people in limbo

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="456" height="60" alt="image" src="https://github.com/user-attachments/assets/ee5afbee-6867-4b19-9830-cc85e35e72dd" />

tested by spawning a mechcomp component and gluing it to myself. then hitting it with a wrench and seeing if it succeeds.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Skeletonman0
(+)Mechcomp components will now be unglued when attempting to wrench them down.
```
