### PR TITLE
New "tool_anchor_toggle" component (and also (un)anchorable linen bins)

### DIFF
--- a/code/datums/DCS/components/glued.dm
+++ b/code/datums/DCS/components/glued.dm
@@ -147,5 +147,3 @@ TYPEINFO(/datum/component/glued)
 	parent.set_loc(get_turf(parent))
 	src.glued_to = null
 	. = ..()
-
-#undef MAGIC_GLUE_ANCHORED

--- a/code/datums/DCS/components/tool_anchor_toggle.dm
+++ b/code/datums/DCS/components/tool_anchor_toggle.dm
@@ -48,7 +48,6 @@ TYPEINFO(/datum/component/assembly)
 /datum/component/tool_anchor_toggle/UnregisterFromParent()
 	. = ..()
 	src.UnregisterSignal(parent, COMSIG_ATTACKBY)
-	actionbar.stop(actionbar, src.parent_atom)
 
 /datum/component/tool_anchor_toggle/proc/attackby(datum/source, obj/item/W, mob/user)
 	if(!istool(W, src.tool_type))

--- a/code/datums/DCS/components/tool_anchor_toggle.dm
+++ b/code/datums/DCS/components/tool_anchor_toggle.dm
@@ -25,11 +25,31 @@ TYPEINFO(/datum/component/tool_anchor_toggle)
 	src.actionbar_time = action_time
 	src.cooldown = cooldown_time
 	src.parent_atom = parent
-	RegisterSignal(parent, COMSIG_ATTACKBY, PROC_REF(attackby))
+	src.RegisterSignal(parent, COMSIG_ATTACKBY, PROC_REF(attackby))
+	src.RegisterHelpMessageHandler(src.parent_atom, PROC_REF(help_message_handler))
 
 /datum/component/tool_anchor_toggle/UnregisterFromParent()
 	. = ..()
 	src.UnregisterSignal(parent, COMSIG_ATTACKBY)
+	src.UnregisterHelpMessageHandler(atom_parent)
+
+/datum/component/tool_anchor_toggle/proc/help_message_handler(datum/source, mob/user, list/return_list)
+	var/list/tool_list = new
+	if(src.tool_types & TOOL_SCREWING)
+		tool_list += "<b>screwdriver</b>"
+	if(src.tool_types & TOOL_WRENCHING)
+		tool_list += "<b>wrench</b>"
+	if(src.tool_types & TOOL_WELDING)
+		tool_list += "<b>welding tool</b>"
+	var/tool_names = ""
+	if(tool_list.len == 1)
+		tool_names = "a [tool_list[1]]"
+	else
+		var/final_index_before_and_slash_or = tool_list.len - 1
+		for(var/index = 1 to final_index_before_and_slash_or)
+			tool_names += "a [tool_list[index]], "
+		tool_names += "and/or a [tool_list[tool_list.len]]"
+	return_list += "You can (un)anchor [src.parent] using [tool_names]."
 
 /datum/component/tool_anchor_toggle/proc/attackby(datum/source, obj/item/W, mob/user)
 	if(!istool(W, src.tool_types))

--- a/code/datums/DCS/components/tool_anchor_toggle.dm
+++ b/code/datums/DCS/components/tool_anchor_toggle.dm
@@ -1,4 +1,4 @@
-TYPEINFO(/datum/component/assembly)
+TYPEINFO(/datum/component/tool_anchor_toggle)
 	initialization_args = list(
 		ARG_INFO("tool", DATA_INPUT_BITFIELD, "The tool type needed to (un)anchor the atom. Takes tool bitflags, like TOOL_WELDING", TOOL_SCREWING),
 		ARG_INFO("action_time", DATA_INPUT_NUM, "How much time (un)anchoring the atom should take, if any at all.", 0),
@@ -53,11 +53,15 @@ TYPEINFO(/datum/component/assembly)
 	if(!istool(W, src.tool_type))
 		return
 	. = 1 // we want to stop atom/attackby() to avoid this tool doing anything but toggling anchor
-	if(src.cooldown)
-		if(ON_COOLDOWN(src.parent_atom, "toggle_anchor", src.cooldown))
-			return
+	if(src.cooldown && ON_COOLDOWN(src.parent_atom, "toggle_anchor", src.cooldown))
+		return
 	if(!isturf(src.parent_atom.loc))
 		boutput(user, SPAN_ALERT("[src.parent] needs to be on the ground to do that!"))
+		return
+	if(src.parent_atom.anchored == MAGIC_GLUE_ANCHORED)
+		boutput(user, SPAN_ALERT("[src.parent] is glued in place, you can't just secure or free it with [src.parent]!"))
+		return
+	if(src.parent_atom.anchored => ANCHORED_ALWAYS)
 		return
 	if(isweldingtool(W))
 		if(!W:try_weld(user))
@@ -73,10 +77,8 @@ TYPEINFO(/datum/component/assembly)
 
 /datum/component/tool_anchor_toggle/proc/toggle_anchor(obj/item/W, mob/user)
 	if(src.parent_atom.anchored == ANCHORED)
-		if(user)
-			user.visible_message(SPAN_NOTICE("<b>[user.name]</b> [src.unanchor_prefix] [src.parent] free."))
+		if(user?.visible_message(SPAN_NOTICE("<b>[user.name]</b> [src.unanchor_prefix] [src.parent] free.")))
 		src.parent_atom.anchored = UNANCHORED
 	else
-		if(user)
-			user.visible_message(SPAN_NOTICE("<b>[user.name]</b> [src.anchor_prefix] [src.parent] into place."))
+		if(user?.visible_message(SPAN_NOTICE("<b>[user.name]</b> [src.anchor_prefix] [src.parent] into place.")))
 		src.parent_atom.anchored = ANCHORED

--- a/code/datums/DCS/components/tool_anchor_toggle.dm
+++ b/code/datums/DCS/components/tool_anchor_toggle.dm
@@ -45,6 +45,11 @@ TYPEINFO(/datum/component/assembly)
 	// If the tool you need isn't here, you're welcome to add it
 	CRASH("[tool] is not a valid tool for component/tool_anchor_toggle!")
 
+/datum/component/tool_anchor_toggle/UnregisterFromParent()
+	. = ..()
+	src.UnregisterSignal(parent, COMSIG_ATTACKBY)
+	actionbar.stop(actionbar, src.parent_atom)
+
 /datum/component/tool_anchor_toggle/proc/attackby(datum/source, obj/item/W, mob/user)
 	if(!istool(W, src.tool_type))
 		return

--- a/code/datums/DCS/components/tool_anchor_toggle.dm
+++ b/code/datums/DCS/components/tool_anchor_toggle.dm
@@ -1,0 +1,74 @@
+TYPEINFO(/datum/component/assembly)
+	initialization_args = list(
+		ARG_INFO("tool", DATA_INPUT_BITFIELD, "The tool type needed to (un)anchor the atom. Takes tool bitflags, like TOOL_WELDING", TOOL_SCREWING),
+		ARG_INFO("action_time", DATA_INPUT_NUM, "How much time (un)anchoring the atom should take, if any at all.", 0),
+		ARG_INFO("cooldown_time", DATA_INPUT_NUM, "How much time must elapse between (un)anchorings, to prevent spam if desired.", 0),
+	)
+
+/// Allows atom/movables to be (un)anchored using the specified tool, with optional actionbar and cooldown
+/datum/component/tool_anchor_toggle
+	/// What type of tool will (un)anchor our parent? (Default: Screwdriver)
+	var/tool_type = null
+	var/sound2play = 'sound/items/Screwdriver.ogg'
+	var/anchor_prefix = "screws"
+	var/unanchor_prefix = "unscrews"
+	var/actionbar_time = 0
+	var/cooldown = 0
+	var/atom/movable/parent_atom = null
+	var/datum/action/bar/icon/callback/actionbar
+
+/datum/component/tool_anchor_toggle/Initialize(tool = TOOL_SCREWING, action_time = 0, cooldown_time = 0)
+	if(!ismovable(src.parent))
+		return COMPONENT_INCOMPATIBLE
+	. = ..()
+	src.tool_type = tool
+	src.actionbar_time = action_time
+	src.cooldown = cooldown_time
+	src.parent_atom = parent
+	RegisterSignal(parent, COMSIG_ATTACKBY, PROC_REF(attackby))
+	switch(tool)
+		if(TOOL_SCREWING)
+			src.sound2play = 'sound/items/Screwdriver.ogg'
+			src.anchor_prefix = "screws"
+			src.unanchor_prefix = "unscrews"
+			return
+		if(TOOL_WRENCHING)
+			src.sound2play = 'sound/items/Ratchet.ogg'
+			src.anchor_prefix = "wrenches"
+			src.unanchor_prefix = "unwrenches"
+			return
+		if(TOOL_WELDING)
+			src.sound2play = 'sound/items/Welder.ogg'
+			src.anchor_prefix = "welds"
+			src.unanchor_prefix = "cuts"
+			return
+	// If the tool you need isn't here, you're welcome to add it
+	CRASH("[tool] is not a valid tool for component/tool_anchor_toggle!")
+
+/datum/component/tool_anchor_toggle/proc/attackby(datum/source, obj/item/W, mob/user)
+	if(!istool(W, src.tool_type))
+		return
+	. = 1 // we want to stop atom/attackby() to avoid this tool doing anything but toggling anchor
+	if(src.cooldown)
+		if(ON_COOLDOWN(src.parent_atom, "toggle_anchor", src.cooldown))
+			return
+	if(!isturf(src.parent_atom.loc))
+		boutput(user, SPAN_ALERT("[src.parent] needs to be on the ground to do that!"))
+		return
+	playsound(src.parent_atom.loc, src.sound2play, 50, 1)
+	if(src.actionbar_time)
+		src.actionbar = SETUP_GENERIC_ACTIONBAR(user, src.parent_atom, src.actionbar_time, PROC_REF(toggle_anchor), list(W, user), \
+			W.icon, W.icon_state, null, INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_ATTACKED | INTERRUPT_STUNNED | INTERRUPT_ACTION)
+		src.actionbar.call_proc_on = src
+	else
+		src.toggle_anchor(W, user)
+
+/datum/component/tool_anchor_toggle/proc/toggle_anchor(obj/item/W, mob/user)
+	if(src.parent_atom.anchored == ANCHORED)
+		if(user)
+			user.visible_message(SPAN_NOTICE("<b>[user.name]</b> [src.unanchor_prefix] [src.parent] free."))
+		src.parent_atom.anchored = UNANCHORED
+	else
+		if(user)
+			user.visible_message(SPAN_NOTICE("<b>[user.name]</b> [src.anchor_prefix] [src.parent] into place."))
+		src.parent_atom.anchored = ANCHORED

--- a/code/datums/DCS/components/tool_anchor_toggle.dm
+++ b/code/datums/DCS/components/tool_anchor_toggle.dm
@@ -1,14 +1,14 @@
 TYPEINFO(/datum/component/tool_anchor_toggle)
 	initialization_args = list(
-		ARG_INFO("tool", DATA_INPUT_BITFIELD, "The tool type needed to (un)anchor the atom. Takes tool bitflags, like TOOL_WELDING", TOOL_SCREWING),
+		ARG_INFO("tools", DATA_INPUT_BITFIELD, "The tool type(s) needed to (un)anchor the atom. Takes tool bitflags, like TOOL_WELDING", TOOL_SCREWING),
 		ARG_INFO("action_time", DATA_INPUT_NUM, "How much time (un)anchoring the atom should take, if any at all.", 0),
 		ARG_INFO("cooldown_time", DATA_INPUT_NUM, "How much time must elapse between (un)anchorings, to prevent spam if desired.", 0),
 	)
 
-/// Allows atom/movables to be (un)anchored using the specified tool, with optional actionbar and cooldown
+/// Allows atom/movables to be (un)anchored using the specified tool(s), with optional actionbar and cooldown
 /datum/component/tool_anchor_toggle
-	/// What type of tool will (un)anchor our parent? (Default: Screwdriver)
-	var/tool_type = null
+	/// What tool flags will (un)anchor our parent? (Default: Screwdriver)
+	var/tool_types = null
 	var/sound2play = 'sound/items/Screwdriver.ogg'
 	var/anchor_prefix = "screws"
 	var/unanchor_prefix = "unscrews"
@@ -17,40 +17,22 @@ TYPEINFO(/datum/component/tool_anchor_toggle)
 	var/atom/movable/parent_atom = null
 	var/datum/action/bar/icon/callback/actionbar
 
-/datum/component/tool_anchor_toggle/Initialize(tool = TOOL_SCREWING, action_time = 0, cooldown_time = 0)
+/datum/component/tool_anchor_toggle/Initialize(tools = TOOL_SCREWING, action_time = 0, cooldown_time = 0)
 	if(!ismovable(src.parent))
 		return COMPONENT_INCOMPATIBLE
 	. = ..()
-	src.tool_type = tool
+	src.tool_types = tools
 	src.actionbar_time = action_time
 	src.cooldown = cooldown_time
 	src.parent_atom = parent
 	RegisterSignal(parent, COMSIG_ATTACKBY, PROC_REF(attackby))
-	switch(tool)
-		if(TOOL_SCREWING)
-			src.sound2play = 'sound/items/Screwdriver.ogg'
-			src.anchor_prefix = "screws"
-			src.unanchor_prefix = "unscrews"
-			return
-		if(TOOL_WRENCHING)
-			src.sound2play = 'sound/items/Ratchet.ogg'
-			src.anchor_prefix = "wrenches"
-			src.unanchor_prefix = "unwrenches"
-			return
-		if(TOOL_WELDING)
-			// welders make their own sound from try_weld()
-			src.anchor_prefix = "welds"
-			src.unanchor_prefix = "cuts"
-			return
-	// If the tool you need isn't here, you're welcome to add it
-	CRASH("[tool] is not a valid tool for component/tool_anchor_toggle!")
 
 /datum/component/tool_anchor_toggle/UnregisterFromParent()
 	. = ..()
 	src.UnregisterSignal(parent, COMSIG_ATTACKBY)
 
 /datum/component/tool_anchor_toggle/proc/attackby(datum/source, obj/item/W, mob/user)
-	if(!istool(W, src.tool_type))
+	if(!istool(W, src.tool_types))
 		return
 	. = 1 // we want to stop atom/attackby() to avoid this tool doing anything but toggling anchor
 	if(src.cooldown && ON_COOLDOWN(src.parent_atom, "toggle_anchor", src.cooldown))
@@ -61,7 +43,11 @@ TYPEINFO(/datum/component/tool_anchor_toggle)
 	if(src.parent_atom.anchored == MAGIC_GLUE_ANCHORED)
 		boutput(user, SPAN_ALERT("[src.parent] is glued in place, you can't just secure or free it with [src.parent]!"))
 		return
-	if(src.parent_atom.anchored => ANCHORED_ALWAYS)
+	if(src.parent_atom.anchored >= ANCHORED_ALWAYS)
+		return
+	if(!src.cache_effects(W, user))
+		logTheThing(LOG_DEBUG, src, "Invalid tool type ([W]) used on [src.parent]. [src] does not support this tool yet.")
+		// adding new tools is easy, just go to cache_effects() and add your prefix/suffix/sound to the if/else sequence
 		return
 	if(isweldingtool(W))
 		if(!W:try_weld(user))
@@ -75,10 +61,28 @@ TYPEINFO(/datum/component/tool_anchor_toggle)
 	else
 		src.toggle_anchor(W, user)
 
+/datum/component/tool_anchor_toggle/proc/cache_effects(obj/item/W, mob/user)
+	. = FALSE
+	if(istool(W, TOOL_SCREWING))
+		src.sound2play = 'sound/items/Screwdriver.ogg'
+		src.anchor_prefix = "screws"
+		src.unanchor_prefix = "unscrews"
+		. = TRUE
+	else if(istool(W, TOOL_WRENCHING))
+		src.sound2play = 'sound/items/Ratchet.ogg'
+		src.anchor_prefix = "wrenches"
+		src.unanchor_prefix = "unwrenches"
+		. = TRUE
+	else if(istool(W, TOOL_WELDING))
+		src.sound2play = null // welders make their own sound from try_weld()
+		src.anchor_prefix = "welds"
+		src.unanchor_prefix = "cuts"
+		. = TRUE
+
 /datum/component/tool_anchor_toggle/proc/toggle_anchor(obj/item/W, mob/user)
 	if(src.parent_atom.anchored == ANCHORED)
-		if(user?.visible_message(SPAN_NOTICE("<b>[user.name]</b> [src.unanchor_prefix] [src.parent] free.")))
+		user?.visible_message(SPAN_NOTICE("<b>[user.name]</b> [src.unanchor_prefix] [src.parent] free."))
 		src.parent_atom.anchored = UNANCHORED
 	else
-		if(user?.visible_message(SPAN_NOTICE("<b>[user.name]</b> [src.anchor_prefix] [src.parent] into place.")))
+		user?.visible_message(SPAN_NOTICE("<b>[user.name]</b> [src.anchor_prefix] [src.parent] into place."))
 		src.parent_atom.anchored = ANCHORED

--- a/code/datums/DCS/components/tool_anchor_toggle.dm
+++ b/code/datums/DCS/components/tool_anchor_toggle.dm
@@ -38,7 +38,7 @@ TYPEINFO(/datum/component/assembly)
 			src.unanchor_prefix = "unwrenches"
 			return
 		if(TOOL_WELDING)
-			src.sound2play = 'sound/items/Welder.ogg'
+			// welders make their own sound from try_weld()
 			src.anchor_prefix = "welds"
 			src.unanchor_prefix = "cuts"
 			return
@@ -59,7 +59,11 @@ TYPEINFO(/datum/component/assembly)
 	if(!isturf(src.parent_atom.loc))
 		boutput(user, SPAN_ALERT("[src.parent] needs to be on the ground to do that!"))
 		return
-	playsound(src.parent_atom.loc, src.sound2play, 50, 1)
+	if(isweldingtool(W))
+		if(!W:try_weld(user))
+			return
+	else //try_weld() already does sound
+		playsound(src.parent_atom.loc, src.sound2play, 50, 1)
 	if(src.actionbar_time)
 		src.actionbar = SETUP_GENERIC_ACTIONBAR(user, src.parent_atom, src.actionbar_time, PROC_REF(toggle_anchor), list(W, user), \
 			W.icon, W.icon_state, null, INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_ATTACKED | INTERRUPT_STUNNED | INTERRUPT_ACTION)

--- a/code/datums/DCS/components/tool_anchor_toggle.dm
+++ b/code/datums/DCS/components/tool_anchor_toggle.dm
@@ -1,6 +1,6 @@
 TYPEINFO(/datum/component/tool_anchor_toggle)
 	initialization_args = list(
-		ARG_INFO("tools", DATA_INPUT_BITFIELD, "The tool type(s) needed to (un)anchor the atom. Takes tool bitflags, like TOOL_WELDING", TOOL_SCREWING),
+		ARG_INFO("tool_types", DATA_INPUT_BITFIELD, "The tool type(s) needed to (un)anchor the atom. Takes tool bitflags, like TOOL_WELDING", TOOL_SCREWING),
 		ARG_INFO("action_time", DATA_INPUT_NUM, "How much time (un)anchoring the atom should take, if any at all.", 0),
 		ARG_INFO("cooldown_time", DATA_INPUT_NUM, "How much time must elapse between (un)anchorings, to prevent spam if desired.", 0),
 	)

--- a/code/obj/linen_bin.dm
+++ b/code/obj/linen_bin.dm
@@ -17,6 +17,13 @@ ABSTRACT_TYPE(/obj/linen_bin)
 		boutput(user, "You place \the [I] into \the [src].")
 		if (old_amount <= 0)
 			src.UpdateIcon()
+	else if (isscrewingtool(I))
+		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
+		user.visible_message(SPAN_NOTICE("<b>[user.name]</b> [src.anchored ? "unscrews" : "screws down"] [src]."))
+		if(src.anchored == ANCHORED)
+			src.anchored = UNANCHORED
+		else
+			src.anchored = ANCHORED
 
 /obj/linen_bin/attack_hand(mob/user)
 	add_fingerprint(user)

--- a/code/obj/linen_bin.dm
+++ b/code/obj/linen_bin.dm
@@ -9,6 +9,10 @@ ABSTRACT_TYPE(/obj/linen_bin)
 	var/amount = 23
 	var/obj/item/stored_itempath = null
 
+/obj/linen_bin/New()
+	. = ..()
+	src.AddComponent(/datum/component/tool_anchor_toggle, TOOL_SCREWING)
+
 /obj/linen_bin/attackby(obj/item/I, mob/user)
 	if (istype(I, src.stored_itempath))
 		var/old_amount = src.amount
@@ -17,13 +21,6 @@ ABSTRACT_TYPE(/obj/linen_bin)
 		boutput(user, "You place \the [I] into \the [src].")
 		if (old_amount <= 0)
 			src.UpdateIcon()
-	else if (isscrewingtool(I))
-		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-		user.visible_message(SPAN_NOTICE("<b>[user.name]</b> [src.anchored ? "unscrews" : "screws down"] [src]."))
-		if(src.anchored == ANCHORED)
-			src.anchored = UNANCHORED
-		else
-			src.anchored = ANCHORED
 
 /obj/linen_bin/attack_hand(mob/user)
 	add_fingerprint(user)

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -372,6 +372,7 @@
 #include "code\datums\DCS\components\throw_eat.dm"
 #include "code\datums\DCS\components\toggle_coat.dm"
 #include "code\datums\DCS\components\toggle_hood.dm"
+#include "code\datums\DCS\components\tool_anchor_toggle.dm"
 #include "code\datums\DCS\components\tracker_hud.dm"
 #include "code\datums\DCS\components\train.dm"
 #include "code\datums\DCS\components\transfer_on_attack.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the component `tool_anchor_toggle` which may be added to any `atom/movable` to let it be (un)anchored by the provided tool type(s). The component does basic sanity checks, produces effects (sound & alert), and appends to the help message of the fact that it can be (un)anchored using [tool type(s)]. Linen/towel bins have been given this component as proof-of-concept.
Initialization args:
`tool_types` (bitfield): The tool type(s) needed to (un)anchor the atom. Takes tool bitflags, like TOOL_WELDING. Currently there's no support for sequential steps - all provided tool flags will toggle anchor.
`action_time` (num): How much time (un)anchoring the atom should take, if any at all.
`cooldown_time` (num): How much time must elapse between (un)anchorings, to prevent spam if desired.
Currently, only TOOL_SCREWING, TOOL_WRENCHING, and TOOL_WELDING are supported. More can be added just by expanding the if/else sequence in `cache_effects()` and the if statements in `help_message_handler()`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
> We really really need to componentize this at some point

(So so so many things have their own implementation of this that it'd be nice to have a simple standardized proc for it)

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Linen bins can be screwdrivered to move and anchor them. Adding the component to test items also confirms that the action bar, cooldown, sanity checks, and multiple tool types work. Does not seem to work on mobs, but that may have been IMCODER's magboots.

<img width="364" height="117" alt="image" src="https://github.com/user-attachments/assets/8f120b1c-7570-4061-aa95-05162d6dac37" />

also the help messages do indeed append properly, even on test items that normally don't have this component

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Nexusuxen
(+)You can move linen bins with a screwdriver, now.
```
