### PR TITLE
Reverts roundstart timer to 180 on classic

### DIFF
--- a/_std/setup.dm
+++ b/_std/setup.dm
@@ -107,7 +107,11 @@ var/ZLOG_START_TIME
 #endif
 
 //Amount of 1 Second ticks to spend in the pregame lobby before roundstart. Has been 150 seconds for a couple years.
+#ifndef RP_MODE
+#define PREGAME_LOBBY_TICKS 180	// reverted to 180 on classic cause 2 slo
+#else
 #define PREGAME_LOBBY_TICKS 300	// raised from 180 to 300 by popular demand
+#endif
 
 //The value of mapvotes. A passive vote is one done through player preferences, an active vote is one where the player actively chooses a map
 #define MAPVOTE_PASSIVE_WEIGHT 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Faster paced restart for faster paced rounds.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Cheekybrdy
(*)Roundstart timer is 180 again on classic.
```
