### PR TITLE
Fixes #26660

### DIFF
--- a/code/modules/medical/implants/projectile_implants.dm
+++ b/code/modules/medical/implants/projectile_implants.dm
@@ -160,6 +160,7 @@
 
 		blowdart
 			name = "blowdart"
+			pull_out_name = "dart"
 			desc = "a sharp little dart with a little poison reservoir."
 			icon_state = "blowdart"
 			leaves_wound = FALSE


### PR DESCRIPTION
## About the PR
Gives an implant a pull_out_name which was mission one, making the relevant text appear to miss it.

## Why's this needed?
The message looks weird otherwise.

## Testing 
Shot myself with a flute and tried to pull it out, the message appeared.