### PR TITLE
Fixes #27032

### DIFF
--- a/code/obj/bookcase.dm
+++ b/code/obj/bookcase.dm
@@ -191,3 +191,4 @@ TYPEINFO(/obj/item/furniture_parts/bookshelf)
 	icon_state = "bookshelf_parts"
 	furniture_type = /obj/bookshelf
 	furniture_name = "bookshelf"
+	default_material = "wood"


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives bookshelf parts the default material wood.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They become metal when deconstructed otherwise.

## Testing
Deconstructed them into wood.