### PR TITLE
Tweaks QM trader dialogue to be clearer when traders run out of haggling patience

### DIFF
--- a/code/modules/economy/traders/trader.dm
+++ b/code/modules/economy/traders/trader.dm
@@ -179,11 +179,15 @@
 				goods.price = round(middleground + 1)
 			else
 				goods.price = round(middleground - rand(0,negotiate))
-		src.current_message = pick(src.dialogue_haggle_accept)
+		var/rand_index = rand(1, src.dialogue_haggle_accept.len - 1)
+		src.current_message = src.dialogue_haggle_accept[rand_index] // last one is only for the warning!
 		src.patience--
 		// warn the player if the trader isn't going to take any more haggling
-		if (src.patience == 0)
+		if (src.patience == 1)
 			src.current_message = src.dialogue_haggle_accept[src.dialogue_haggle_accept.len]
+		// dialogue is still visible, may as well tell the player they fucked up
+		else if (src.patience <= 0)
+			src.current_message = "\[ERROR: Connection lost!\]"
 
 	proc/buy_from()
 		src.currently_selling = 1

--- a/code/modules/economy/traders/trader.dm
+++ b/code/modules/economy/traders/trader.dm
@@ -179,8 +179,7 @@
 				goods.price = round(middleground + 1)
 			else
 				goods.price = round(middleground - rand(0,negotiate))
-		var/rand_index = rand(1, src.dialogue_haggle_accept.len - 1)
-		src.current_message = src.dialogue_haggle_accept[rand_index] // last one is only for the warning!
+		src.current_message = pick(src.dialogue_haggle_accept)
 		src.patience--
 		// warn the player if the trader isn't going to take any more haggling
 		if (src.patience == 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This does ~3~ 2 things to make trader patience a little more consistent:
- ~The usual haggle-accepted dialogue can now no longer be the 'final offer' dialogue (which is the last entry in each haggle dialogue accept list), so that the player is clearly told when they cannot haggle anymore~
- The 'final offer' dialogue occurs when patience is at 1 instead of 0, as several parts of the code (TGUI and the haggle button) treat `patience == 0` as "trader has fucked off and left"
- New dialogue for when patience is at (or somehow below) 0: "[ERROR: Connection lost!]". The dialogue remains visible on the trader screen, so may as well put something there to reinforce the 'you fucked up' signal to the player

Fixes #27802

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug and inconsistency bad

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="695" height="498" alt="image" src="https://github.com/user-attachments/assets/444b819b-7b63-4495-b72b-554aa1d40a3b" />

<img width="691" height="482" alt="image" src="https://github.com/user-attachments/assets/e9d81aeb-dce2-42a2-84eb-28b0cc25d149" />

yea
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->