### PR TITLE
Coin trickshots (adopted)

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1025,8 +1025,6 @@
 
 		SEND_SIGNAL(src, COMSIG_MOB_TRIGGER_THREAT)
 
-		src.next_click = world.time + src.combat_click_delay
-
 /mob/living/carbon/human/click(atom/target, list/params)
 	if (src.client)
 		if (src.client.experimental_intents)

--- a/code/modules/projectiles/_projectile_utils.dm
+++ b/code/modules/projectiles/_projectile_utils.dm
@@ -282,6 +282,8 @@
 	var/mob/closest = null
 	var/closest_dist = INFINITY
 	for (var/mob/M in view(5, reflector))
+		if (isintangible(M) || isobserver(M))
+			continue
 		var/dist = GET_DIST(reflector, M)
 		if (dist < closest_dist)
 			closest = M

--- a/code/modules/projectiles/_projectile_utils.dm
+++ b/code/modules/projectiles/_projectile_utils.dm
@@ -36,30 +36,30 @@
 		return shoot_projectile_ST_pixel_spread(S, DATA, T, alter_proj = alter_proj, called_target = called_target, remote_sound_source = remote_sound_source)
 	return null
 
-/proc/shoot_projectile_ST_pixel_spread(var/atom/movable/S, var/datum/projectile/DATA, var/T, var/pox, var/poy, var/spread_angle, var/datum/callback/alter_proj = null, var/atom/called_target = null, var/atom/movable/remote_sound_source = null)
+/proc/shoot_projectile_ST_pixel_spread(var/atom/movable/S, var/datum/projectile/DATA, var/T, var/pox, var/poy, var/spread_angle, var/datum/callback/alter_proj = null, var/atom/called_target = null, var/atom/movable/remote_sound_source = null, var/play_shot_sound = TRUE)
 	if (!S)
 		return
 	if (!isturf(S) && !isturf(S.loc))
 		return null
-	var/obj/projectile/Q = shoot_projectile_relay_pixel_spread(S, DATA, T, pox, poy, spread_angle, alter_proj = alter_proj, called_target = called_target, remote_sound_source = remote_sound_source)
+	var/obj/projectile/Q = shoot_projectile_relay_pixel_spread(S, DATA, T, pox, poy, spread_angle, alter_proj = alter_proj, called_target = called_target, remote_sound_source = remote_sound_source, play_shot_sound = play_shot_sound)
 	if (DATA.shot_number > 1)
 		SPAWN(-1)
 			for (var/i = 2, i <= DATA.shot_number, i++)
 				sleep(DATA.shot_delay)
-				shoot_projectile_relay_pixel_spread(S, DATA, T, pox, poy, spread_angle, alter_proj = alter_proj, called_target = called_target, remote_sound_source = remote_sound_source)
+				shoot_projectile_relay_pixel_spread(S, DATA, T, pox, poy, spread_angle, alter_proj = alter_proj, called_target = called_target, remote_sound_source = remote_sound_source, play_shot_sound = play_shot_sound)
 	return Q
 
-/proc/shoot_projectile_relay_pixel_spread(var/atom/movable/S, var/datum/projectile/DATA, var/T, var/pox, var/poy, var/spread_angle, var/datum/callback/alter_proj = null, var/atom/called_target = null, var/atom/movable/remote_sound_source = null)
+/proc/shoot_projectile_relay_pixel_spread(var/atom/movable/S, var/datum/projectile/DATA, var/T, var/pox, var/poy, var/spread_angle, var/datum/callback/alter_proj = null, var/atom/called_target = null, var/atom/movable/remote_sound_source = null, var/play_shot_sound = TRUE)
 	if (!S)
 		return
 	if (!isturf(S) && !isturf(S.loc))
 		return
-	var/obj/projectile/P = initialize_projectile_pixel_spread(S, DATA, T, pox, poy, spread_angle, alter_proj = alter_proj, called_target = called_target, remote_sound_source = remote_sound_source)
+	var/obj/projectile/P = initialize_projectile_pixel_spread(S, DATA, T, pox, poy, spread_angle, alter_proj = alter_proj, called_target = called_target, remote_sound_source = remote_sound_source, play_shot_sound = play_shot_sound)
 	if (P)
 		P.launch()
 	return P
 
-/proc/initialize_projectile_pixel_spread(var/atom/movable/S, var/datum/projectile/DATA, var/T, var/pox, var/poy, var/spread_angle, var/datum/callback/alter_proj = null, var/atom/called_target = null, var/atom/movable/remote_sound_source = null)
+/proc/initialize_projectile_pixel_spread(var/atom/movable/S, var/datum/projectile/DATA, var/T, var/pox, var/poy, var/spread_angle, var/datum/callback/alter_proj = null, var/atom/called_target = null, var/atom/movable/remote_sound_source = null, var/play_shot_sound = TRUE)
 	if (!S)
 		return
 	if (!isturf(S) && !isturf(S.loc))
@@ -68,7 +68,7 @@
 	var/turf/Q2 = get_turf(T)
 	if (!(Q1 && Q2))
 		return
-	var/obj/projectile/P = initialize_projectile(Q1, DATA, (Q2.x - Q1.x) * 32 + pox, (Q2.y - Q1.y) * 32 + poy, S, alter_proj = alter_proj, called_target = called_target, remote_sound_source = remote_sound_source)
+	var/obj/projectile/P = initialize_projectile(Q1, DATA, (Q2.x - Q1.x) * 32 + pox, (Q2.y - Q1.y) * 32 + poy, S, alter_proj = alter_proj, called_target = called_target, remote_sound_source = remote_sound_source, play_shot_sound = play_shot_sound)
 	if (P && spread_angle)
 		if (spread_angle < 0)
 			spread_angle = -spread_angle
@@ -277,3 +277,19 @@
 	Q.name = "reflected [Q.name]"
 	Q.launch(do_delay = (Q.reflectcount % 5 == 0))
 	return Q
+
+/proc/shoot_reflected_trickshot(var/obj/projectile/P, var/obj/reflector, range = 5)
+	var/mob/closest = null
+	var/closest_dist = INFINITY
+	for (var/mob/M in view(5, reflector))
+		var/dist = GET_DIST(reflector, M)
+		if (dist < closest_dist)
+			closest = M
+			closest_dist = dist
+
+	var/atom/target = closest
+	if (!target)
+		target = get_step(reflector, pick(alldirs))
+
+	playsound(P, "sound/weapons/ricochet/ricochet-[rand(1, 4)].ogg", 40, TRUE)
+	shoot_projectile_ST_pixel_spread(reflector, P.proj_data, target, play_shot_sound = FALSE)

--- a/code/obj/item/coin.dm
+++ b/code/obj/item/coin.dm
@@ -13,16 +13,8 @@
 	throw_speed = 0.3
 	var/emagged = FALSE
 	/// Does this coin count as in the air for the purposes of ricochet?
-	var/in_air = FALSE
-
-//debug macro :3
-#ifdef LIVE_SERVER
-#define SET_AIR(value) src.in_air = value;
-#else
-#define SET_AIR(value)\
-	src.in_air = value;\
-	src.color = src.in_air ? "red" : null
-#endif
+	/// This is a counter var but can be treated as a boolean
+	var/in_air = 0
 
 /obj/item/coin/attack_self(mob/user as mob)
 	boutput(user, SPAN_NOTICE("You flip the coin..."))
@@ -42,13 +34,13 @@
 
 	//This looks complicated but works out to the coin counting as in the air after 2 ticks on the first throw and 1 tick on the second
 	SPAWN(2 DECI SECONDS)
-		SET_AIR(TRUE)
+		src.change_air_state(1)
 		sleep(8 DECI SECONDS)
-		SET_AIR(FALSE)
+		src.change_air_state(-1)
 		sleep(3 DECI SECONDS)
-		SET_AIR(TRUE)
+		src.change_air_state(1)
 		sleep(4 DECI SECONDS)
-		SET_AIR(FALSE)
+		src.change_air_state(-1)
 
 	sleep(18 DECI SECOND)
 
@@ -56,14 +48,17 @@
 		playsound(src.loc, 'sound/items/coindrop.ogg', 30, 1)
 		flip()
 
+/obj/item/coin/proc/change_air_state(value)
+	src.in_air += value
+
 /obj/item/coin/throw_begin(atom/target, turf/thrown_from, mob/thrown_by)
 	. = ..()
-	SET_AIR(TRUE)
+	src.change_air_state(1)
 
 /obj/item/coin/throw_end(list/params, turf/thrown_from)
 	. = ..()
 	SPAWN(3 DECI SECONDS)
-		SET_AIR(FALSE)
+		src.change_air_state(-1)
 
 /obj/item/coin/Cross(atom/movable/mover)
 	// we only want to interrupt projectiles if we're being flipped
@@ -138,4 +133,12 @@
 	qdel(src)
 	return 1
 
-#undef SET_AIR
+//debug coin :3
+/obj/item/coin/debug
+
+/obj/item/coin/debug/change_air_state(value)
+	..()
+	if (src.in_air)
+		src.color = "red"
+	else
+		src.color = null

--- a/code/obj/item/coin.dm
+++ b/code/obj/item/coin.dm
@@ -9,7 +9,20 @@
 	stamina_cost = 0
 	flags = TABLEPASS  | ATTACK_SELF_DELAY
 	click_delay = 1 SECOND
+	pass_unstable = TRUE
+	throw_speed = 0.3
 	var/emagged = FALSE
+	/// Does this coin count as in the air for the purposes of ricochet?
+	var/in_air = FALSE
+
+//debug macro :3
+#ifdef LIVE_SERVER
+#define SET_AIR(value) src.in_air = value;
+#else
+#define SET_AIR(value)\
+	src.in_air = value;\
+	src.color = src.in_air ? "red" : null
+#endif
 
 /obj/item/coin/attack_self(mob/user as mob)
 	boutput(user, SPAN_NOTICE("You flip the coin..."))
@@ -26,15 +39,49 @@
 	animate(src, time = 12 DECI SECONDS,  flags = ANIMATION_PARALLEL)
 	animate(time= 3 DECI SECONDS, pixel_y = 4, easing = SINE_EASING | EASE_OUT)
 	animate(time = 3 DECI SECONDS, pixel_y = 0, , easing = SINE_EASING | EASE_IN)
+
+	//This looks complicated but works out to the coin counting as in the air after 2 ticks on the first throw and 1 tick on the second
+	SPAWN(2 DECI SECONDS)
+		SET_AIR(TRUE)
+		sleep(8 DECI SECONDS)
+		SET_AIR(FALSE)
+		sleep(3 DECI SECONDS)
+		SET_AIR(TRUE)
+		sleep(4 DECI SECONDS)
+		SET_AIR(FALSE)
+
 	sleep(18 DECI SECOND)
+
 	if(!istype(src.loc, /mob/))	//Hot dog, you caught it midair!
 		playsound(src.loc, 'sound/items/coindrop.ogg', 30, 1)
 		flip()
+
+/obj/item/coin/throw_begin(atom/target, turf/thrown_from, mob/thrown_by)
+	. = ..()
+	SET_AIR(TRUE)
+
+/obj/item/coin/throw_end(list/params, turf/thrown_from)
+	. = ..()
+	SPAWN(3 DECI SECONDS)
+		SET_AIR(FALSE)
+
+/obj/item/coin/Cross(atom/movable/mover)
+	// we only want to interrupt projectiles if we're being flipped
+	if(src.in_air && istype(mover, /obj/projectile))
+		return FALSE
+	return ..()
 
 /obj/item/coin/throw_impact(atom/hit_atom, datum/thrown_thing/thr)
 	..(hit_atom)
 	flip()
 
+/obj/item/coin/bullet_act(obj/projectile/P)
+	var/obj/itemspecialeffect/glare/effect = new
+	effect.color = "#FFFFFF"
+	effect.setup(src.loc)
+	src.visible_message(SPAN_BOLD(SPAN_ALERT("[P] ricochets [pick("crazily", "skillfully", "straight")] off [src]!")))
+
+	shoot_reflected_trickshot(P, src, 4)
 
 /obj/item/coin/emag_act(var/mob/user, var/obj/item/card/emag/E)
 	..()
@@ -85,3 +132,5 @@
 	user.take_oxygen_deprivation(175)
 	qdel(src)
 	return 1
+
+#undef SET_AIR

--- a/code/obj/item/coin.dm
+++ b/code/obj/item/coin.dm
@@ -7,7 +7,7 @@
 	w_class = W_CLASS_TINY
 	stamina_damage = 0
 	stamina_cost = 0
-	flags = TABLEPASS  | ATTACK_SELF_DELAY
+	flags = TABLEPASS
 	click_delay = 1 SECOND
 	pass_unstable = TRUE
 	throw_speed = 0.3

--- a/code/obj/item/coin.dm
+++ b/code/obj/item/coin.dm
@@ -15,6 +15,8 @@
 	/// Does this coin count as in the air for the purposes of ricochet?
 	/// This is a counter var but can be treated as a boolean
 	var/in_air = 0
+	/// When in the air, who is throwing this?
+	var/mob/thrower = null
 
 /obj/item/coin/attack_self(mob/user as mob)
 	boutput(user, SPAN_NOTICE("You flip the coin..."))
@@ -31,7 +33,7 @@
 	animate(src, time = 12 DECI SECONDS,  flags = ANIMATION_PARALLEL)
 	animate(time= 3 DECI SECONDS, pixel_y = 4, easing = SINE_EASING | EASE_OUT)
 	animate(time = 3 DECI SECONDS, pixel_y = 0, , easing = SINE_EASING | EASE_IN)
-
+	src.thrower = user
 	//This looks complicated but works out to the coin counting as in the air after 2 ticks on the first throw and 1 tick on the second
 	SPAWN(2 DECI SECONDS)
 		src.change_air_state(1)
@@ -44,6 +46,8 @@
 
 	sleep(18 DECI SECOND)
 
+	src.thrower = null
+
 	if(!istype(src.loc, /mob/))	//Hot dog, you caught it midair!
 		playsound(src.loc, 'sound/items/coindrop.ogg', 30, 1)
 		flip()
@@ -53,16 +57,19 @@
 
 /obj/item/coin/throw_begin(atom/target, turf/thrown_from, mob/thrown_by)
 	. = ..()
+	src.thrower = thrown_by
 	src.change_air_state(1)
 
 /obj/item/coin/throw_end(list/params, turf/thrown_from)
 	. = ..()
 	SPAWN(3 DECI SECONDS)
+		src.thrower = null
 		src.change_air_state(-1)
 
-/obj/item/coin/Cross(atom/movable/mover)
+/obj/item/coin/Cross(obj/projectile/mover)
 	// we only want to interrupt projectiles if we're being flipped
-	if(src.in_air && istype(mover, /obj/projectile))
+	// AND if we've been thrown by the shooter, no using coins as budget deflector shields
+	if(src.in_air && istype(mover) && mover.shooter == src.thrower)
 		return FALSE
 	return ..()
 

--- a/code/obj/item/coin.dm
+++ b/code/obj/item/coin.dm
@@ -81,7 +81,12 @@
 	effect.setup(src.loc)
 	src.visible_message(SPAN_BOLD(SPAN_ALERT("[P] ricochets [pick("crazily", "skillfully", "straight")] off [src]!")))
 
+	var/atom/shooter = P.shooter
 	shoot_reflected_trickshot(P, src, 4)
+	var/turf/coin_target = get_steps(src, get_dir_accurate(shooter, src), src.throw_range)
+	animate(src)
+	src.throwing = FALSE
+	src.throw_at(coin_target, src.throw_range, 2)
 
 /obj/item/coin/emag_act(var/mob/user, var/obj/item/card/emag/E)
 	..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adopted from #27807 as Skeletonman appears to have done his disappearing act again. Recoded from scratch because I wanted to do it a bit differently.
Adds coin trickshots: shoot a coin in the air to ricochet the shot into the nearest mob (within 4 tiles)
Also slows down coin throws considerably to allow this to be reasonably possible and removes combat click delay from human throws because it felt really clunky and I don't really know why they had them in the first place. Critter throws never did afaik.
Only works on coins thrown by you, no throwing coins at nukies to deflect RPGs.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- Blatant Ultrakill reference
- Cool trickshots
- Probably not actually very useful? There are ways to nerf this if it turns out to be really strong somehow.
- Shoot people around corners.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
<img width="809" height="323" alt="image" src="https://github.com/user-attachments/assets/e878fe97-a8a6-4c51-ba67-60c2239568b5" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)LeahTheTech + Skeletonman0
(*)Shooting a coin in mid-air will now ricochet the projectile at the nearest mob (within 4 tiles).
```
