### PR TITLE
More reward customization

### DIFF
--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -1357,8 +1357,10 @@
 		var/confirm = null
 		if (S.claim_text)
 			confirm = tgui_alert(usr, S.desc + "\n(Earned through [S.claim_text])", "Claim this Reward?", list("Yes", "No"))
-		else
+		else if (S.required_medal)
 			confirm = tgui_alert(usr, S.desc + "\n(Earned through the \"[S.required_medal]\" Medal)", "Claim this Reward?", list("Yes", "No"))
+		else
+			confirm = tgui_alert(usr, S.desc, " Claim this Reward?", list("Yes", "No"))
 		src.verbs += /client/verb/claimreward
 		if(confirm == "Yes")
 			var/worked = S.rewardActivate(src.mob)

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -1318,11 +1318,11 @@
 		for(var/A in rewardDB)
 			var/result = null
 			var/datum/achievementReward/D = rewardDB[A]
-			if(!D.required_medal && D.custom_reward_requirement(src.mob))
+			if(!D.required_medal && D.custom_reward_requirement(src.mob) == "Success")
 				result = 1
-			else if (D.custom_reward_requirement(src.mob))
+			else if (D.custom_reward_requirement(src.mob) == "Success")
 				result = usr.has_medal(D.required_medal)
-			else
+			else if (!D.custom_reward_requirement(src.mob))
 				result = usr.has_medal(D.required_medal)
 			if(result == 1)
 				if((D.once_per_round && !src.player.claimed_rewards.Find(D.type)) || !D.once_per_round)

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -5,8 +5,8 @@
 	var/claim_text = null //Allows for a custom reason it can be claimed
 	var/once_per_round = 1   //Can only be claimed once per round.
 	var/mobonly = 1 //If the reward can only be redeemed if the player has a /mob/living.
-
-
+	proc/custom_reward_requirement(var/mob/activator)
+		return
 	///Called when the reward is claimed from the locker. Spawn item here / give verbs here / do whatever for reward. Return 1 on success or bugs will happen.
 	proc/rewardActivate(var/mob/activator)
 		boutput(activator, "This reward is undefined. Please inform a coder.")
@@ -1318,9 +1318,9 @@
 		for(var/A in rewardDB)
 			var/result = null
 			var/datum/achievementReward/D = rewardDB[A]
-			if(D.required_medal == TRUE)
+			if(!D.required_medal && D.custom_reward_requirement(src.mob))
 				result = 1
-			else
+			else if (D.required_medal)
 				result = usr.has_medal(D.required_medal)
 			if(result == 1)
 				if((D.once_per_round && !src.player.claimed_rewards.Find(D.type)) || !D.once_per_round)

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -2,6 +2,7 @@
 	var/title = ""
 	var/desc = ""
 	var/required_medal = null
+	var/claim_text = null //Allows for a custom reason it can be claimed
 	var/once_per_round = 1   //Can only be claimed once per round.
 	var/mobonly = 1 //If the reward can only be redeemed if the player has a /mob/living.
 
@@ -1296,6 +1297,54 @@
 			boutput( usr, SPAN_ALERT("Hmm.. I can't set the scream sound of that!") )
 			return 0
 
+/datum/achievementReward/mentorcostume
+	title = "(Skin) Mentor mouse costume"
+	desc = "Turns the mouse costume into a Mentor mouse costume"
+	claim_text = "being a Mentor"
+	required_medal = TRUE
+
+	rewardActivate(var/mob/activator)
+		if (ishuman(activator))
+			var/mob/living/carbon/human/H = activator
+			if (H.wear_suit && H.wear_suit.type == /obj/item/clothing/suit/gimmick/mouse)
+				var/obj/item/clothing/suit/gimmick/mouse/suit_target = H.wear_suit
+				var/obj/item/clothing/suit/gimmick/mouse/mentor/new_suit = new /obj/item/clothing/suit/gimmick/mouse/mentor(get_turf(H))
+				new_suit.forensic_holder = suit_target.forensic_holder
+				qdel(suit_target)
+				H.equip_if_possible(new_suit, SLOT_WEAR_SUIT)
+				return 1
+			else
+				boutput(activator, SPAN_ALERT("Unable to redeem... You need to be wearing a mouse costume."))
+				return
+		else
+			boutput(activator, SPAN_ALERT("Unable to redeem... You need to be human to redeem this."))
+			return
+
+
+/datum/achievementReward/admincostume
+	title = "(Skin) Admin mouse costume"
+	desc = "Turns the mouse costume into a Admin mouse costume"
+	claim_text = "being an Admin"
+	required_medal = TRUE
+
+	rewardActivate(var/mob/activator)
+		if (ishuman(activator))
+			var/mob/living/carbon/human/H = activator
+			if (H.wear_suit && H.wear_suit.type == /obj/item/clothing/suit/gimmick/mouse)
+				var/obj/item/clothing/suit/gimmick/mouse/suit_target = H.wear_suit
+				var/obj/item/clothing/suit/gimmick/mouse/admin/new_suit = new /obj/item/clothing/suit/gimmick/mouse/admin(get_turf(H))
+				new_suit.forensic_holder = suit_target.forensic_holder
+				qdel(suit_target)
+				H.equip_if_possible(new_suit, SLOT_WEAR_SUIT)
+				return 1
+			else
+				boutput(activator, SPAN_ALERT("Unable to redeem... You need to be wearing a mouse costume."))
+				return
+		else
+			boutput(activator, SPAN_ALERT("Unable to redeem... You need to be human to redeem this."))
+			return
+
+
 /// Keeps track of once-per-round rewards
 /datum/player/var/list/claimed_rewards = list()
 
@@ -1315,8 +1364,12 @@
 		boutput(usr, SPAN_ALERT("Checking your eligibility. There might be a short delay, please wait."))
 		var/list/eligible = list()
 		for(var/A in rewardDB)
+			var/result = null
 			var/datum/achievementReward/D = rewardDB[A]
-			var/result = usr.has_medal(D.required_medal)
+			if(D.required_medal == TRUE)
+				result = 1
+			else
+				result = usr.has_medal(D.required_medal)
 			if(result == 1)
 				if((D.once_per_round && !src.player.claimed_rewards.Find(D.type)) || !D.once_per_round)
 					if( D.mobonly && !istype( src.mob, /mob/living ) ) continue
@@ -1349,8 +1402,11 @@
 		if(S.once_per_round && src.player.claimed_rewards.Find(S.type))
 			boutput(usr, SPAN_ALERT("You already claimed this!"))
 			return
-
-		var/confirm = tgui_alert(usr, S.desc + "\n(Earned through the \"[S.required_medal]\" Medal)", "Claim this Reward?", list("Yes", "No"))
+		var/confirm = null
+		if (S.claim_text)
+			confirm = tgui_alert(usr, S.desc + "\n(Earned through \"[S.claim_text]\")", "Claim this Reward?", list("Yes", "No"))
+		else
+			confirm = tgui_alert(usr, S.desc + "\n(Earned through the \"[S.required_medal]\" Medal)", "Claim this Reward?", list("Yes", "No"))
 		src.verbs += /client/verb/claimreward
 		if(confirm == "Yes")
 			var/worked = S.rewardActivate(src.mob)

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -1356,7 +1356,7 @@
 			return
 		var/confirm = null
 		if (S.claim_text)
-			confirm = tgui_alert(usr, S.desc + "\n(Earned through \"[S.claim_text]\")", "Claim this Reward?", list("Yes", "No"))
+			confirm = tgui_alert(usr, S.desc + "\n(Earned through [S.claim_text])", "Claim this Reward?", list("Yes", "No"))
 		else
 			confirm = tgui_alert(usr, S.desc + "\n(Earned through the \"[S.required_medal]\" Medal)", "Claim this Reward?", list("Yes", "No"))
 		src.verbs += /client/verb/claimreward

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -1320,7 +1320,9 @@
 			var/datum/achievementReward/D = rewardDB[A]
 			if(!D.required_medal && D.custom_reward_requirement(src.mob))
 				result = 1
-			else if (D.required_medal)
+			else if (D.custom_reward_requirement(src.mob))
+				result = usr.has_medal(D.required_medal)
+			else
 				result = usr.has_medal(D.required_medal)
 			if(result == 1)
 				if((D.once_per_round && !src.player.claimed_rewards.Find(D.type)) || !D.once_per_round)

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -1297,54 +1297,6 @@
 			boutput( usr, SPAN_ALERT("Hmm.. I can't set the scream sound of that!") )
 			return 0
 
-/datum/achievementReward/mentorcostume
-	title = "(Skin) Mentor mouse costume"
-	desc = "Turns the mouse costume into a Mentor mouse costume"
-	claim_text = "being a Mentor"
-	required_medal = TRUE
-
-	rewardActivate(var/mob/activator)
-		if (ishuman(activator))
-			var/mob/living/carbon/human/H = activator
-			if (H.wear_suit && H.wear_suit.type == /obj/item/clothing/suit/gimmick/mouse)
-				var/obj/item/clothing/suit/gimmick/mouse/suit_target = H.wear_suit
-				var/obj/item/clothing/suit/gimmick/mouse/mentor/new_suit = new /obj/item/clothing/suit/gimmick/mouse/mentor(get_turf(H))
-				new_suit.forensic_holder = suit_target.forensic_holder
-				qdel(suit_target)
-				H.equip_if_possible(new_suit, SLOT_WEAR_SUIT)
-				return 1
-			else
-				boutput(activator, SPAN_ALERT("Unable to redeem... You need to be wearing a mouse costume."))
-				return
-		else
-			boutput(activator, SPAN_ALERT("Unable to redeem... You need to be human to redeem this."))
-			return
-
-
-/datum/achievementReward/admincostume
-	title = "(Skin) Admin mouse costume"
-	desc = "Turns the mouse costume into a Admin mouse costume"
-	claim_text = "being an Admin"
-	required_medal = TRUE
-
-	rewardActivate(var/mob/activator)
-		if (ishuman(activator))
-			var/mob/living/carbon/human/H = activator
-			if (H.wear_suit && H.wear_suit.type == /obj/item/clothing/suit/gimmick/mouse)
-				var/obj/item/clothing/suit/gimmick/mouse/suit_target = H.wear_suit
-				var/obj/item/clothing/suit/gimmick/mouse/admin/new_suit = new /obj/item/clothing/suit/gimmick/mouse/admin(get_turf(H))
-				new_suit.forensic_holder = suit_target.forensic_holder
-				qdel(suit_target)
-				H.equip_if_possible(new_suit, SLOT_WEAR_SUIT)
-				return 1
-			else
-				boutput(activator, SPAN_ALERT("Unable to redeem... You need to be wearing a mouse costume."))
-				return
-		else
-			boutput(activator, SPAN_ALERT("Unable to redeem... You need to be human to redeem this."))
-			return
-
-
 /// Keeps track of once-per-round rewards
 /datum/player/var/list/claimed_rewards = list()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows for more reward customization, including a custom claim reason besides having the medal, and allows for rewards to not require medals.

Also adds the ability to have special Reward requirements, outside of medals.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Atomized for a future PR that requires it, and allows for more easily added rewards in the future if they do not/should not require medals, also allows for additional requirements that need to be met on top of a medal.
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Tested setting a reward to not require a medal.
Tested setting a reward to require a medal, then obtaining the medal
Tested custom messages working
Tested medal claim messages working
Tested setting a custom requirement for a medal
Tested fallback message if the reward doesnt have a medal, or a claim message

https://github.com/user-attachments/assets/5d2fb366-eeda-455f-a03f-65c75ab34335


<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->
