### PR TITLE
Fix mouse costume bugs

### DIFF
--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -1766,27 +1766,30 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 
 		pickup(mob/user)
 			..()
-			if (user?.client && user.client.is_mentor())
+			if (user?.client && user.client.is_mentor()|| isadmin(user))
 				return
-			boutput(user, SPAN_ALERT("The suit disintegrates from your un-mentorly touch!"))
+			SPAWN(0.1)
+				boutput(user, SPAN_ALERT("The suit disintegrates from your un-mentorly touch!"))
 
-			user.u_equip(src)
-			src.set_loc(get_turf(src))
+				user.u_equip(src)
+				src.set_loc(get_turf(src))
 
-			// turn to dust
-			dothepixelthing(src)
+				// turn to dust
+				dothepixelthing(src)
 
 		equipped(mob/user)
 			..()
-			if (user?.client && user.client.is_mentor())
+			if (user?.client && user.client.is_mentor() || isadmin(user))
 				return
-			boutput(user, SPAN_ALERT("The suit disintegrates from your un-mentorly touch!"))
+			SPAWN(0.1)
+				boutput(user, SPAN_ALERT("The suit disintegrates from your un-mentorly touch!"))
 
-			user.u_equip(src)
-			src.set_loc(get_turf(src))
+				user.u_equip(src)
+				src.set_loc(get_turf(src))
 
-			// turn to dust
-			dothepixelthing(src)
+				// turn to dust
+				dothepixelthing(src)
+
 	admin
 		name = "admin mouse suit"
 		desc = "On close inspection, you estimate wearing this suit grants you the proportional strength of ten admin mice."
@@ -1818,25 +1821,27 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 			..()
 			if (user?.client && isadmin(user))
 				return
-			boutput(user, SPAN_ALERT("The suit disintegrates from your un-[src.icon_state == "glorpsuit" ? "glorply" : "adminly" ]touch!"))
+			SPAWN(0.1)
+				boutput(user, SPAN_ALERT("The suit disintegrates from your un-[src.icon_state == "glorpsuit" ? "glorply" : "adminly" ]touch!"))
 
-			user.u_equip(src)
-			src.set_loc(get_turf(src))
+				user.u_equip(src)
+				src.set_loc(get_turf(src))
 
-			// turn to dust
-			dothepixelthing(src)
+				// turn to dust
+				dothepixelthing(src)
 
 		equipped(mob/user)
 			..()
 			if (user?.client && isadmin(user))
 				return
-			boutput(user, SPAN_ALERT("The suit disintegrates from your un-[src.icon_state == "glorpsuit" ? "glorply" : "adminly" ]touch!"))
+			SPAWN(0.1)
+				boutput(user, SPAN_ALERT("The suit disintegrates from your un-[src.icon_state == "glorpsuit" ? "glorply" : "adminly" ]touch!"))
 
-			user.u_equip(src)
-			src.set_loc(get_turf(src))
+				user.u_equip(src)
+				src.set_loc(get_turf(src))
 
-			// turn to dust
-			dothepixelthing(src)
+				// turn to dust
+				dothepixelthing(src)
 
 /obj/item/clothing/suit/gimmick/pickle
 	name = "pickle suit"

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -1768,7 +1768,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 			..()
 			if (user?.client && user.client.is_mentor()|| isadmin(user))
 				return
-			SPAWN(0.1)
+			SPAWN(0.1) //Delay required to not cause a visual bug
 				boutput(user, SPAN_ALERT("The suit disintegrates from your un-mentorly touch!"))
 
 				user.u_equip(src)
@@ -1781,7 +1781,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 			..()
 			if (user?.client && user.client.is_mentor() || isadmin(user))
 				return
-			SPAWN(0.1)
+			SPAWN(0.1) //Delay required to not cause a visual bug
 				boutput(user, SPAN_ALERT("The suit disintegrates from your un-mentorly touch!"))
 
 				user.u_equip(src)
@@ -1821,7 +1821,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 			..()
 			if (user?.client && isadmin(user))
 				return
-			SPAWN(0.1)
+			SPAWN(0.1) //Delay required to not cause a visual bug
 				boutput(user, SPAN_ALERT("The suit disintegrates from your un-[src.icon_state == "glorpsuit" ? "glorply" : "adminly" ]touch!"))
 
 				user.u_equip(src)
@@ -1834,7 +1834,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 			..()
 			if (user?.client && isadmin(user))
 				return
-			SPAWN(0.1)
+			SPAWN(0.1) //Delay required to not cause a visual bug
 				boutput(user, SPAN_ALERT("The suit disintegrates from your un-[src.icon_state == "glorpsuit" ? "glorply" : "adminly" ]touch!"))
 
 				user.u_equip(src)

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -1766,7 +1766,7 @@ TYPEINFO(/obj/item/clothing/under/gimmick/shirtnjeans)
 
 		pickup(mob/user)
 			..()
-			if (user?.client && user.client.is_mentor()|| isadmin(user))
+			if (user?.client && user.client.is_mentor() || isadmin(user))
 				return
 			SPAWN(0.1) //Delay required to not cause a visual bug
 				boutput(user, SPAN_ALERT("The suit disintegrates from your un-mentorly touch!"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes 2 bugs where admins cannot hold mentor costumes, and where admin and mentor costumes glue themselves to the player when they are meant to melt
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #27832
Fixes #27831
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Grabbed a mentor costume and an admin costume while deadminned, didnt stick
Grabbed a mentor costume as an admin didnt melt
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->