### PR TITLE
Non seasonal trees

### DIFF
--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -65,7 +65,7 @@
 #ifdef SEASON_AUTUMN
 	New()
 		..()
-		if(season_affected)
+		if(src.season_affected)
 			icon_state = pick("tree_red", "tree_yellow", "tree_orange")
 #endif
 

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -60,11 +60,13 @@
 	var/falling = FALSE
 	var/fallen = FALSE
 	var/fall_time = 2 SECONDS
+	var/season_affected = TRUE
 
 #ifdef SEASON_AUTUMN
 	New()
 		..()
-		icon_state = pick("tree_red", "tree_yellow", "tree_orange")
+		if(season_affected)
+			icon_state = pick("tree_red", "tree_yellow", "tree_orange")
 #endif
 
 	attackby(obj/item/I, mob/user)
@@ -113,6 +115,7 @@
 		icon_state = "snowtree"
 		layer = EFFECTS_LAYER_UNDER_1 // match shrubs
 		pixel_x = -32
+		season_affected = FALSE
 		New()
 			. = ..()
 			src.dir = pick(cardinal)

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -66,7 +66,7 @@
 	New()
 		..()
 		if(src.season_affected)
-			icon_state = pick("tree_red", "tree_yellow", "tree_orange")
+			src.icon_state = pick("tree_red", "tree_yellow", "tree_orange")
 #endif
 
 	attackby(obj/item/I, mob/user)

--- a/code/z_adventurezones/carcosa.dm
+++ b/code/z_adventurezones/carcosa.dm
@@ -32,6 +32,7 @@ Dirt
 	icon_state = "tree1"
 	bound_height = 32
 	bound_width = 64
+	season_affected = FALSE
 /obj/tree/carcosa/one
 	icon_state = "tree1"
 /obj/tree/carcosa/two

--- a/code/z_adventurezones/gannets_dojozone.dm
+++ b/code/z_adventurezones/gannets_dojozone.dm
@@ -318,6 +318,7 @@ Contents:
 	desc = "A pretty japanese cherry tree. You don't find a lot of these away from earth."
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "sakuratree"
+	season_affected = FALSE
 
 /obj/tree/sakura_tree/tree_2
 	icon_state = "sakuratree2"


### PR DESCRIPTION
## About the PR
Gives trees the seasonal_affected variable, which can be set to false if you don't want your tree to turn into the default autumn tree in autumn.

## Why's this needed?
Some tree don't have/need autumn variants.

## Testing
Spawned a generic tree and a sakura tree in autumn, the sakura tree has its intended sprite.