### PR TITLE
Deactivated cameras dont show on camera lists

### DIFF
--- a/code/mob/living/silicon/ai/camera_handling.dm
+++ b/code/mob/living/silicon/ai/camera_handling.dm
@@ -119,13 +119,18 @@
 	var/list/D = list()
 	var/counter = 1
 	for (var/obj/machinery/camera/C in L)
-		if ((C.network in src.camera_networks) && get_z(C) == Z_LEVEL_STATION)
-			var/T = text("[][]", C.c_tag, (C.camera_status ? null : " (Deactivated)"))
-			if(D[T])
-				D["[T] #[counter++]"] = C
-			else
-				D[T] = C
-				counter = 1
+		if(!C.network in src.camera_networks)
+			continue
+		if(get_z(C) != Z_LEVEL_STATION)
+			continue
+		if(!C.camera_status)
+			continue
+		var/camera_tag = C.c_tag
+		if(D[camera_tag])
+			D["[camera_tag] #[counter++]"] = C
+		else
+			D[camera_tag] = C
+			counter = 1
 
 	var/t = tgui_input_list(user, "Which camera should you change to?", "View Camera", D)
 

--- a/code/modules/camera/monitor.dm
+++ b/code/modules/camera/monitor.dm
@@ -55,8 +55,10 @@ TYPEINFO(/obj/item/device/camera_viewer)
 		var/list/displayed_cameras = list()
 
 		for (var/obj/machinery/camera/camera as anything in cameras)
+			if(!camera.camera_status)
+				continue
 			if (camera.network in src.camera_networks)
-				displayed_cameras[text("[][]", camera.c_tag, (camera.camera_status ? null : " (Deactivated)"))] = camera
+				displayed_cameras[camera.c_tag] = camera
 
 		var/selected_camera = tgui_input_list(user, "Which camera should you change to?", "Camera Selection", sortList(displayed_cameras, /proc/cmp_text_asc))
 

--- a/code/obj/machinery/computer/security.dm
+++ b/code/obj/machinery/computer/security.dm
@@ -148,7 +148,9 @@
 	var/list/displayed_cameras = list()
 
 	for (var/obj/machinery/camera/camera as anything in cameras)
-		displayed_cameras[text("[][]", camera.c_tag, (camera.camera_status ? null : " (Deactivated)"))] = camera
+		if(!camera.camera_status)
+			continue
+		displayed_cameras[camera.c_tag] = camera
 
 	if (length(displayed_cameras) == 0)
 		boutput(user, SPAN_ALERT("There are no cameras connected to this television!"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cut cameras will no longer show as "(Deactivated)" on any camera list, instead not appearing at all. (with the exception of the security tgui camera viewer, but those dont show up as deactivated in the list anyway)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The AI can currently immediately identify every cut camera by searching "Deactivated" in their camera list meaning if you want to properly stop an AI poking around you need to fully deconstruct the camera which shouldn't be necessary

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
Note dev zone 10 and dev zone 11 are missing because they are cut.
<img width="190" height="102" alt="image" src="https://github.com/user-attachments/assets/b1d96cc1-f51c-4421-97cb-e5f8b786b6b6" />

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)JORJ949
(*)Camera lists will no longer include deactivated cameras.
```
