### PR TITLE
Arcfiend Arcflash Aim Assist (+ aim assist support for targeted abilities)

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -878,6 +878,8 @@
 	var/ignore_sticky_cooldown = FALSE		//! If TRUE, Ability will stick to cursor even if ability goes on cooldown after first cast.
 	var/interrupt_action_bars = TRUE 		//! If TRUE, we will interrupt any action bars running with the INTERRUPT_ACT flag
 	var/cooldown_after_action = FALSE		//! if TRUE, cooldowns will be handled after action bars have ended. Needs action to call afterAction() on end.
+	var/aim_assist_radius = null			//! If we don't click on a mob, how many tiles away do we search to find a mob to target? If null, don't try at all
+	var/aim_assist_ignore_owner = TRUE		//! Should we ignore our owner when searching for nearby mobs with aim assist?
 
 	var/action_key_number = -1 //Number hotkey assigned to this ability. Only used if > 0
 	var/waiting_for_hotkey = FALSE //If TRUE, the next number hotkey pressed will be bound to this.
@@ -923,6 +925,7 @@
 
 	proc
 		handleCast(atom/target, params)
+			target = src.aim_assist_retargeting(target, params)
 			var/result = tryCast(target, params)
 #ifdef NO_COOLDOWNS
 			result = TRUE
@@ -1123,6 +1126,18 @@
 
 		flip_callback()
 			.= 0
+
+		aim_assist_retargeting(atom/target, params)
+			. = target
+			if (isnull(src.aim_assist_radius) || ismob(target))
+				return
+			var/list/mob_list = get_nearest_mobs_list(target, params, aim_assist_radius)
+			if(!mob_list)
+				return
+			for (var/mob/mob_target in mob_list)
+				if((mob_target == src.holder.owner) && src.aim_assist_ignore_owner)
+					continue
+				return mob_target
 
 /atom/movable/screen/pseudo_overlay
 	// this is hack as all get out

--- a/code/modules/antagonists/arcfiend/abilities/arc_flash.dm
+++ b/code/modules/antagonists/arcfiend/abilities/arc_flash.dm
@@ -7,6 +7,7 @@
 	pointCost = 50
 	target_anything = TRUE
 	targeted = TRUE
+	aim_assist_radius = 1
 
 	/// The amount of power used when shocking a mob.
 	var/wattage = 600 KILO WATT

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2839,7 +2839,7 @@ proc/get_nearest_mobs_list(atom/clicked_on, list/params, range = 1, always_inclu
 	var/pixel_x = 0
 	var/pixel_y = 0
 	if(params) // params means this came from a click, so we gotta figure out where exactly user clicked relative to tile
-		pixel_x += text2num(params["icon_x"])
+		pixel_x += text2num(params["icon-x"])
 		pixel_y += text2num(params["icon-y"])
 		pixel_x += clicked_on.pixel_x
 		pixel_y += clicked_on.pixel_y

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2827,3 +2827,44 @@ proc/area_table_spawn(area_type, spawn_type)
 	if (istype(parent, type))
 		return parent
 	return null
+
+/**
+ * Returns an ordered associative list [mob = distance (euclidean)] (ascending) of all mobs within a target radius.
+ * If given params (from click() procs), it will offset the center of the search area by where the user clicked.
+ * range (also euclidean) should be a positive real number. The search radius can in fact be a 1.337 tile radius, if you so desire.
+ * The center of the turf a mob is occupying must fall within the specified range for it to consider that mob 'in range'.
+ * May behave unexpectedly if clicked_on has significant transformations applied (blame nex for failing to figure out matrix math.)
+ */
+proc/get_nearest_mobs_list(atom/clicked_on, list/params, range = 1, always_include_same_tile = TRUE)
+	var/pixel_x = 0
+	var/pixel_y = 0
+	if(params) // params means this came from a click, so we gotta figure out where exactly user clicked relative to tile
+		pixel_x += text2num(params["icon_x"])
+		pixel_y += text2num(params["icon-y"])
+		pixel_x += clicked_on.pixel_x
+		pixel_y += clicked_on.pixel_y
+	var/step_x = floor(pixel_x / 32)
+	var/step_y = floor(pixel_y / 32)
+	// there's a chance some dork will have 50 million stickers on them (or there's a very large icon somewhere)
+	// and our cursor will subsequently be multiple tiles away from clicked_on.
+	var/turf/clicked_over_turf = locate(clicked_on.x + step_x, clicked_on.y + step_y, clicked_on.z)
+	pixel_x -= 16 // offsets to pretend like 0,0 corresponds to the center of a tile
+	pixel_y -= 16 // instead of the bottom left corner
+	var/clicked_scaled_x = (clicked_on.x * 32) + pixel_x
+	var/clicked_scaled_y = (clicked_on.y * 32) + pixel_y
+	var/list/return_list = list()
+	// we increase search range to make extra sure we catch everything, since we filter out invalid results later anyways
+	for(var/mob/target in range(ceil(range + 1), clicked_over_turf))
+	// nothing is stopping us from searching for any arbitary atom type, the use case is just for mobs right now
+		var/target_scaled_x = target.x * 32
+		var/target_scaled_y = target.y * 32
+		// we calculate the distance from our click to the center of the tile each nearby mob occupies
+		// we could probably get said mob's pixel_x/y, but we don't care about that nearly as much as we do a user's input coords
+		var/scaled_distance = sqrt(((target_scaled_x - clicked_scaled_x)**2) + ((target_scaled_y - clicked_scaled_y)**2))
+		var/distance = scaled_distance / 32 // back down to each unit being 1 tile instead of 1 pixel
+		if((distance > range) && (!always_include_same_tile || (origin_turf != get_turf(target))))
+			continue
+		return_list[target] = distance
+	if(return_list.len)
+		sortList(L = return_list, cmp=/proc/cmp_numeric_asc, associative = TRUE)
+		return return_list

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2862,7 +2862,7 @@ proc/get_nearest_mobs_list(atom/clicked_on, list/params, range = 1, always_inclu
 		// we could probably get said mob's pixel_x/y, but we don't care about that nearly as much as we do a user's input coords
 		var/scaled_distance = sqrt(((target_scaled_x - clicked_scaled_x)**2) + ((target_scaled_y - clicked_scaled_y)**2))
 		var/distance = scaled_distance / 32 // back down to each unit being 1 tile instead of 1 pixel
-		if((distance > range) && (!always_include_same_tile || (origin_turf != get_turf(target))))
+		if((distance > range) && (!always_include_same_tile || (clicked_over_turf != get_turf(target))))
 			continue
 		return_list[target] = distance
 	if(return_list.len)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that you only have to click close to a mob to hit them with arcflash. As a visual aid:
<img width="391" height="407" alt="image" src="https://github.com/user-attachments/assets/4c123463-f5a8-424b-9c02-f7e61a54a764" />
Any clicks within the yellow highlighted area (including on the stickers) would hit the test subject, and anywhere in the red will miss. Yes, even if one clicks on the objects or the bush - as long as their cursor is within the highlighted area, it'll hit the guy. (The highlight is not representative of anything in-game besides where the player needs to click)

All abilities support this functionality, with it being tied to two new variables: `aim_assist_radius = null` and `aim_assist_ignore_owner = TRUE`. If `aim_assist_radius` is set to any positive number, the target of the ability will try to change from a non-mob to the nearest valid mob within that radius. This does not trigger if the target is already a mob. Note that a radius of 0 will look for all mobs on the same tile under the mouse.

Two new global procs, `get_nearest_mobs_list()` and `get_turf_pixel_clicked_over()`, handle most of this functionality. `get_nearest_mobs_list()` can be used to get the mob closest to exactly where a player clicked - which can be determined using `get_turf_pixel_clicked_over()`. `get_nearest_mobs_list()` may be given just a turf to search from the center of, or also given pixel_x and pixel_y offsets to specify a more precise search center (such as from where a user clicked.)

`get_turf_pixel_clicked_over()` directly copies existing functionality from cable_placement.dm to translate "screen-loc" from params from a user's click into real coordinates. This is now a global proc, and returns the coordinates in the form of a list: list("turf" = turf, "pixel_x" = pixel_x, "pixel_y" = pixel_y). cable_placement.dm has been modified to use this.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I can't aim for shit and need to build an aimbot into the game so I can win.

More seriously though, some abilities can be very frustrating to try and hit on the tiny fast-moving targets on your screen. This acts as both an accessibility feature, and helps to level the playing field between players a bit. Also having the `get_turf_pixel_clicked_over()` being globally accessible means less copy/pasting the same code. Also also similar functionality could in theory be extended to anything that's contingent on directly clicking on a player.

## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->

https://github.com/user-attachments/assets/fa9cd75c-e8e1-4274-98e8-4a434c0f764a

Not sure why it didn't record the text feed, but I was spam-clicking the ability pretty heavily, such that you'd be able to see exactly when it'd start zapping.

## Notes
Ideally two things would be implemented at some point:
1. The ability to completely disable this functionality in user preferences (or perhaps as some kind of toggle on the abilities themselves?)
2. Expanded targeting reticules on the cursor to indicate the extra search range. Got this fully working on another branch for anything with exactly 1 tile radius search area. If this PR gets merged I'll make a new PR afterwards to add those (unless reviewers would like me to add that to this branch prior)

Both of these aren't necessary for this to be a welcome addition to the game (in my biased opinion), but would be very nice to see at some point.

BIG NOTE: Some players claim this will push arcfiend into being far too overtuned. If desired, I can include some kind of nerf to compensate. But, that can (and probably should) come with another PR. Alternatively, another ability could be chosen for the proof-of-concept application.

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Nexusuxen
(*)Arcfiend's Arcflash ability now comes with aim assist, and will target mobs within roughly half a tile of where you click if you fail to directly click on someone. More abilities may get this feature in the future!
```
(yes the changelog is technically inaccurate but _effectively_ it looks like an extra half tile range so, good enough)