### PR TITLE
Mouse costume rewards

### DIFF
--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -1301,9 +1301,9 @@
 
 	custom_reward_requirement(var/mob/activator)
 		if (activator?.client && activator.client.is_mentor() || isadmin(activator))
-			return 1
+			return "Success"
 		else
-			return
+			return "Fail"
 
 	rewardActivate(var/mob/activator)
 		if (ishuman(activator))
@@ -1330,9 +1330,9 @@
 
 	custom_reward_requirement(var/mob/activator)
 		if (activator?.client && isadmin(activator))
-			return 1
+			return "Success"
 		else
-			return
+			return "Fail"
 
 	rewardActivate(var/mob/activator)
 		if (ishuman(activator))

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -2,6 +2,7 @@
 	var/title = ""
 	var/desc = ""
 	var/required_medal = null
+	var/claim_text = null //Allows for a custom reason it can be claimed
 	var/once_per_round = 1   //Can only be claimed once per round.
 	var/mobonly = 1 //If the reward can only be redeemed if the player has a /mob/living.
 
@@ -1296,6 +1297,54 @@
 			boutput( usr, SPAN_ALERT("Hmm.. I can't set the scream sound of that!") )
 			return 0
 
+/datum/achievementReward/mentorcostume
+	title = "(Skin) Mentor mouse costume"
+	desc = "Turns the mouse costume into a Mentor mouse costume"
+	claim_text = "being a Mentor"
+	required_medal = TRUE
+
+	rewardActivate(var/mob/activator)
+		if (ishuman(activator))
+			var/mob/living/carbon/human/H = activator
+			if (H.wear_suit && H.wear_suit.type == /obj/item/clothing/suit/gimmick/mouse)
+				var/obj/item/clothing/suit/gimmick/mouse/suit_target = H.wear_suit
+				var/obj/item/clothing/suit/gimmick/mouse/mentor/new_suit = new /obj/item/clothing/suit/gimmick/mouse/mentor(get_turf(H))
+				new_suit.forensic_holder = suit_target.forensic_holder
+				qdel(suit_target)
+				H.equip_if_possible(new_suit, SLOT_WEAR_SUIT)
+				return 1
+			else
+				boutput(activator, SPAN_ALERT("Unable to redeem... You need to be wearing a mouse costume."))
+				return
+		else
+			boutput(activator, SPAN_ALERT("Unable to redeem... You need to be human to redeem this."))
+			return
+
+
+/datum/achievementReward/admincostume
+	title = "(Skin) Admin mouse costume"
+	desc = "Turns the mouse costume into a Admin mouse costume"
+	claim_text = "being an Admin"
+	required_medal = TRUE
+
+	rewardActivate(var/mob/activator)
+		if (ishuman(activator))
+			var/mob/living/carbon/human/H = activator
+			if (H.wear_suit && H.wear_suit.type == /obj/item/clothing/suit/gimmick/mouse)
+				var/obj/item/clothing/suit/gimmick/mouse/suit_target = H.wear_suit
+				var/obj/item/clothing/suit/gimmick/mouse/admin/new_suit = new /obj/item/clothing/suit/gimmick/mouse/admin(get_turf(H))
+				new_suit.forensic_holder = suit_target.forensic_holder
+				qdel(suit_target)
+				H.equip_if_possible(new_suit, SLOT_WEAR_SUIT)
+				return 1
+			else
+				boutput(activator, SPAN_ALERT("Unable to redeem... You need to be wearing a mouse costume."))
+				return
+		else
+			boutput(activator, SPAN_ALERT("Unable to redeem... You need to be human to redeem this."))
+			return
+
+
 /// Keeps track of once-per-round rewards
 /datum/player/var/list/claimed_rewards = list()
 
@@ -1315,8 +1364,12 @@
 		boutput(usr, SPAN_ALERT("Checking your eligibility. There might be a short delay, please wait."))
 		var/list/eligible = list()
 		for(var/A in rewardDB)
+			var/result = null
 			var/datum/achievementReward/D = rewardDB[A]
-			var/result = usr.has_medal(D.required_medal)
+			if(D.required_medal == TRUE)
+				result = 1
+			else
+				result = usr.has_medal(D.required_medal)
 			if(result == 1)
 				if((D.once_per_round && !src.player.claimed_rewards.Find(D.type)) || !D.once_per_round)
 					if( D.mobonly && !istype( src.mob, /mob/living ) ) continue
@@ -1349,8 +1402,11 @@
 		if(S.once_per_round && src.player.claimed_rewards.Find(S.type))
 			boutput(usr, SPAN_ALERT("You already claimed this!"))
 			return
-
-		var/confirm = tgui_alert(usr, S.desc + "\n(Earned through the \"[S.required_medal]\" Medal)", "Claim this Reward?", list("Yes", "No"))
+		var/confirm = null
+		if (S.claim_text)
+			confirm = tgui_alert(usr, S.desc + "\n(Earned through \"[S.claim_text]\")", "Claim this Reward?", list("Yes", "No"))
+		else
+			confirm = tgui_alert(usr, S.desc + "\n(Earned through the \"[S.required_medal]\" Medal)", "Claim this Reward?", list("Yes", "No"))
 		src.verbs += /client/verb/claimreward
 		if(confirm == "Yes")
 			var/worked = S.rewardActivate(src.mob)

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -2,11 +2,8 @@
 	var/title = ""
 	var/desc = ""
 	var/required_medal = null
-	var/claim_text = null //Allows for a custom reason it can be claimed
 	var/once_per_round = 1   //Can only be claimed once per round.
 	var/mobonly = 1 //If the reward can only be redeemed if the player has a /mob/living.
-
-
 	///Called when the reward is claimed from the locker. Spawn item here / give verbs here / do whatever for reward. Return 1 on success or bugs will happen.
 	proc/rewardActivate(var/mob/activator)
 		boutput(activator, "This reward is undefined. Please inform a coder.")
@@ -1301,7 +1298,6 @@
 	title = "(Skin) Mentor mouse costume"
 	desc = "Turns the mouse costume into a Mentor mouse costume"
 	claim_text = "being a Mentor"
-	required_medal = TRUE
 
 	custom_reward_requirement(var/mob/activator)
 		if (activator?.client && activator.client.is_mentor() || isadmin(activator))
@@ -1331,7 +1327,6 @@
 	title = "(Skin) Admin mouse costume"
 	desc = "Turns the mouse costume into a Admin mouse costume"
 	claim_text = "being an Admin"
-	required_medal = TRUE
 
 	custom_reward_requirement(var/mob/activator)
 		if (activator?.client && isadmin(activator))
@@ -1376,12 +1371,8 @@
 		boutput(usr, SPAN_ALERT("Checking your eligibility. There might be a short delay, please wait."))
 		var/list/eligible = list()
 		for(var/A in rewardDB)
-			var/result = null
 			var/datum/achievementReward/D = rewardDB[A]
-			if(D.required_medal == TRUE)
-				result = 1
-			else
-				result = usr.has_medal(D.required_medal)
+			var/result = usr.has_medal(D.required_medal)
 			if(result == 1)
 				if((D.once_per_round && !src.player.claimed_rewards.Find(D.type)) || !D.once_per_round)
 					if( D.mobonly && !istype( src.mob, /mob/living ) ) continue
@@ -1414,11 +1405,8 @@
 		if(S.once_per_round && src.player.claimed_rewards.Find(S.type))
 			boutput(usr, SPAN_ALERT("You already claimed this!"))
 			return
-		var/confirm = null
-		if (S.claim_text)
-			confirm = tgui_alert(usr, S.desc + "\n(Earned through [S.claim_text])", "Claim this Reward?", list("Yes", "No"))
-		else
-			confirm = tgui_alert(usr, S.desc + "\n(Earned through the \"[S.required_medal]\" Medal)", "Claim this Reward?", list("Yes", "No"))
+
+		var/confirm = tgui_alert(usr, S.desc + "\n(Earned through the \"[S.required_medal]\" Medal)", "Claim this Reward?", list("Yes", "No"))
 		src.verbs += /client/verb/claimreward
 		if(confirm == "Yes")
 			var/worked = S.rewardActivate(src.mob)

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -1303,6 +1303,12 @@
 	claim_text = "being a Mentor"
 	required_medal = TRUE
 
+	custom_reward_requirement(var/mob/activator)
+		if (activator?.client && activator.client.is_mentor() || isadmin(activator))
+			return 1
+		else
+			return
+
 	rewardActivate(var/mob/activator)
 		if (ishuman(activator))
 			var/mob/living/carbon/human/H = activator
@@ -1326,6 +1332,12 @@
 	desc = "Turns the mouse costume into a Admin mouse costume"
 	claim_text = "being an Admin"
 	required_medal = TRUE
+
+	custom_reward_requirement(var/mob/activator)
+		if (activator?.client && isadmin(activator))
+			return 1
+		else
+			return
 
 	rewardActivate(var/mob/activator)
 		if (ishuman(activator))

--- a/code/modules/medals/rewardsLocker.dm
+++ b/code/modules/medals/rewardsLocker.dm
@@ -1404,7 +1404,7 @@
 			return
 		var/confirm = null
 		if (S.claim_text)
-			confirm = tgui_alert(usr, S.desc + "\n(Earned through \"[S.claim_text]\")", "Claim this Reward?", list("Yes", "No"))
+			confirm = tgui_alert(usr, S.desc + "\n(Earned through [S.claim_text])", "Claim this Reward?", list("Yes", "No"))
 		else
 			confirm = tgui_alert(usr, S.desc + "\n(Earned through the \"[S.required_medal]\" Medal)", "Claim this Reward?", list("Yes", "No"))
 		src.verbs += /client/verb/claimreward


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes Mentor mouse costume available through regular gameplay, and adds another way for admin to obtain the admin costume to pair with the mentor one
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows players to see mentor costumes during gameplay, and makes it not require admins to see
## Testing <!-- Please provide at least one screenshot of your changes working if appropriate, or a description of how you've tested them if not. -->
All testing done while merged with #27830
https://github.com/user-attachments/assets/4e1fd34a-ac57-4047-95e5-0561dd5040b3
Tested claiming these new rewards
<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)Mike was taken
(+)Mentor mouse costumes can now be seen without admins
```
