### PR TITLE
Replaces red oxygen canister with HPD on Engineer spawn

### DIFF
--- a/code/datums/jobs/jobs_engineering.dm
+++ b/code/datums/jobs/jobs_engineering.dm
@@ -25,7 +25,7 @@ ABSTRACT_TYPE(/datum/job/engineering)
 #ifdef HOTSPOTS_ENABLED
 	items_in_backpack = list(/obj/item/paper/book/from_file/pocketguide/engineering, /obj/item/clothing/shoes/stomp_boots)
 #else
-	items_in_backpack = list(/obj/item/paper/book/from_file/pocketguide/engineering, /obj/item/old_grenade/oxygen)
+	items_in_backpack = list(/obj/item/paper/book/from_file/pocketguide/engineering, /obj/item/places_pipes)
 #endif
 	wiki_link = "https://wiki.ss13.co/Engineer"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->

## About the PR Replaces Red O2 Canister with HPD on non-geothermal maps

## Why's this needed? More options, more funs, more tools to play with. Less rolling CE meta (CE should be a command role anyway). Engine setup typically happens at start of round, while breach fixing later, so having engine setup tools at the start instead of breach fixing one makes sense imo

## Testing I went into the singelplayer world and I opened my backpack and the HPD was there in place of the Red O2 :) 

<!-- !!! PRs that are opened without being properly tested may be reverted to draft or closed without warning !!! -->

## Changelog <!-- If necessary, put your changelog entry below. Otherwise, /please/ delete this entire section. -->

<!-- Put how you want to be credited in the changelog in place of CodeDude. -->
<!-- Use (*) for major changes and (+) for minor changes. See the contributor guide for details. For example: -->

```changelog
(u)tamakona
(*)Replaces red oxygen canister with HPD on Engineer spawn
(+)Go lay your pipes!
```
