### PR TITLE
Fixes #27409

### DIFF
--- a/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
+++ b/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
@@ -830,7 +830,10 @@ ABSTRACT_TYPE(/obj/deployable_turret/pod_wars)
 	proc/pokey(mob/target, poke_chance=33)
 		if(prob(poke_chance))
 			if(ON_COOLDOWN(target, "BARB_\ref[src]", src.cooldown_time)) return
-			target.visible_message("[target] gets caught up in [src]", "You get caught up in [src] and notice it has drawn blood.")
+			if(issilicon(target))
+				target.visible_message("[target] gets caught up in [src]", "You get caught up in [src] and it scratches your parts a little bit.")
+			else
+				target.visible_message("[target] gets caught up in [src]", "You get caught up in [src] and notice it has drawn blood.")
 			take_bleeding_damage(target, null, rand(3,7), DAMAGE_STAB)
 			return TRUE
 


### PR DESCRIPTION
## About the PR 
Makes the barbed wire proc take into account silicons and robocritters.

## Why's this needed?
The text shouldn't lie to you.

## Testing
Walked into barbed wire as a borgo and as a human.
